### PR TITLE
docs: expand website into searchable protocol documentation library

### DIFF
--- a/.github/workflows/visidelta-preview.yml
+++ b/.github/workflows/visidelta-preview.yml
@@ -111,6 +111,14 @@ jobs:
             }
           };
 
+          const routeToIndexPath = (rootDir, route) => {
+            const routePath = (route || "/").replace(/^\/+|\/+$/g, "");
+            if (!routePath) {
+              return path.join(rootDir, "index.html");
+            }
+            return path.join(rootDir, routePath, "index.html");
+          };
+
           let materialized = 0;
 
           for (const item of routes) {
@@ -118,9 +126,8 @@ jobs:
               continue;
             }
 
-            const routeSegment = (item.route || "/").replace(/^\/+|\/+$/g, "") || "index";
-            const oldOut = path.join(outDir, "old", routeSegment, "index.html");
-            const newOut = path.join(outDir, "new", routeSegment, "index.html");
+            const oldOut = routeToIndexPath(path.join(outDir, "old"), item.route);
+            const newOut = routeToIndexPath(path.join(outDir, "new"), item.route);
 
             const baseMarkdown = readBaseFile(item.file);
             const newMarkdown = fs.existsSync(item.file)
@@ -137,6 +144,47 @@ jobs:
           }
 
           console.log(`Materialized markdown route pages: ${materialized}`);
+
+          // Ensure every route has old/new pages so VisiDelta links never 404,
+          // including root route (`/`) compares.
+          let placeholders = 0;
+          for (const item of routes) {
+            const oldOut = routeToIndexPath(path.join(outDir, "old"), item.route);
+            const newOut = routeToIndexPath(path.join(outDir, "new"), item.route);
+
+            const addPath = path.join(outDir, "diffs", `${item.id}.add.txt`);
+            const delPath = path.join(outDir, "diffs", `${item.id}.del.txt`);
+            const addPreview = fs.existsSync(addPath) ? fs.readFileSync(addPath, "utf8") : "";
+            const delPreview = fs.existsSync(delPath) ? fs.readFileSync(delPath, "utf8") : "";
+
+            if (!fs.existsSync(oldOut)) {
+              fs.mkdirSync(path.dirname(oldOut), { recursive: true });
+              fs.writeFileSync(
+                oldOut,
+                renderMarkdownSnapshot(
+                  `Old snapshot unavailable - ${item.file}`,
+                  delPreview || `No rendered old snapshot was generated for route ${item.route || "/"}.\n`
+                ),
+                "utf8"
+              );
+              placeholders += 1;
+            }
+
+            if (!fs.existsSync(newOut)) {
+              fs.mkdirSync(path.dirname(newOut), { recursive: true });
+              fs.writeFileSync(
+                newOut,
+                renderMarkdownSnapshot(
+                  `New snapshot unavailable - ${item.file}`,
+                  addPreview || `No rendered new snapshot was generated for route ${item.route || "/"}.\n`
+                ),
+                "utf8"
+              );
+              placeholders += 1;
+            }
+          }
+
+          console.log(`Materialized fallback route snapshots: ${placeholders}`);
           NODE
 
       - name: Compute Preview URL

--- a/.github/workflows/visidelta-preview.yml
+++ b/.github/workflows/visidelta-preview.yml
@@ -225,27 +225,27 @@ jobs:
 
             if (!fs.existsSync(oldOut)) {
               fs.mkdirSync(path.dirname(oldOut), { recursive: true });
-              fs.writeFileSync(
-                oldOut,
-                renderMarkdownSnapshot(
-                  `Old snapshot unavailable - ${item.file}`,
-                  delPreview || `No rendered old snapshot was generated for route ${item.route || "/"}.\n`
-                ),
-                "utf8"
-              );
+                  fs.writeFileSync(
+                    oldOut,
+                    renderMarkdownSnapshot(
+                      `Old snapshot unavailable - ${item.file || item.route || "/"}`,
+                      delPreview || `No rendered old snapshot was generated for route ${item.route || "/"}.\n`
+                    ),
+                    "utf8"
+                  );
               placeholders += 1;
             }
 
             if (!fs.existsSync(newOut)) {
               fs.mkdirSync(path.dirname(newOut), { recursive: true });
-              fs.writeFileSync(
-                newOut,
-                renderMarkdownSnapshot(
-                  `New snapshot unavailable - ${item.file}`,
-                  addPreview || `No rendered new snapshot was generated for route ${item.route || "/"}.\n`
-                ),
-                "utf8"
-              );
+                  fs.writeFileSync(
+                    newOut,
+                    renderMarkdownSnapshot(
+                      `New snapshot unavailable - ${item.file || item.route || "/"}`,
+                      addPreview || `No rendered new snapshot was generated for route ${item.route || "/"}.\n`
+                    ),
+                    "utf8"
+                  );
               placeholders += 1;
             }
           }

--- a/.github/workflows/visidelta-preview.yml
+++ b/.github/workflows/visidelta-preview.yml
@@ -73,7 +73,7 @@ jobs:
             process.exit(0);
           }
 
-          const routes = JSON.parse(fs.readFileSync(routesPath, "utf8"));
+          const loadedRoutes = JSON.parse(fs.readFileSync(routesPath, "utf8"));
 
           const escapeHtml = (value) =>
             value
@@ -100,15 +100,53 @@ jobs:
             </body>
           </html>`;
 
-          const readBaseFile = (filePath) => {
+          const readBaseFileBuffer = (filePath) => {
             try {
-              return cp.execSync(`git show ${baseRef}:${filePath}`, {
-                encoding: "utf8",
+              return cp.execFileSync("git", ["show", `${baseRef}:${filePath}`], {
                 stdio: ["ignore", "pipe", "ignore"]
               });
             } catch {
               return null;
             }
+          };
+
+          const readBaseFile = (filePath) => {
+            const buffer = readBaseFileBuffer(filePath);
+            if (buffer === null) {
+              return null;
+            }
+            return buffer.toString("utf8");
+          };
+
+          const listBaseFiles = (pathSpec) => {
+            try {
+              const output = cp.execFileSync("git", ["ls-tree", "-r", "--name-only", baseRef, pathSpec], {
+                encoding: "utf8",
+                stdio: ["ignore", "pipe", "ignore"]
+              });
+              return output.split(/\r?\n/).map((value) => value.trim()).filter(Boolean);
+            } catch {
+              return [];
+            }
+          };
+
+          const listCurrentFiles = (dirPath) => {
+            if (!fs.existsSync(dirPath)) {
+              return [];
+            }
+            const files = [];
+            const walk = (inputDir) => {
+              for (const dirent of fs.readdirSync(inputDir, { withFileTypes: true })) {
+                const resolved = path.join(inputDir, dirent.name);
+                if (dirent.isDirectory()) {
+                  walk(resolved);
+                } else if (dirent.isFile()) {
+                  files.push(resolved.replace(/\\/g, "/"));
+                }
+              }
+            };
+            walk(dirPath);
+            return files;
           };
 
           const resolveRouteCandidates = (item) => {
@@ -120,6 +158,7 @@ jobs:
             if (!routePath) {
               candidates.push("public/index.html");
             } else {
+              candidates.push(`public/${routePath}`);
               candidates.push(`public/${routePath}.html`);
               candidates.push(`public/${routePath}/index.html`);
             }
@@ -155,23 +194,149 @@ jobs:
             return renderMarkdownSnapshot(`${label} - ${resolved.filePath}`, resolved.content);
           };
 
-          const routeToIndexPath = (rootDir, route) => {
-            const routePath = (route || "/").replace(/^\/+|\/+$/g, "");
+          const routeToOutputPath = (rootDir, route) => {
+            const routePath = (route || "/").replace(/^\/+/g, "");
             if (!routePath) {
               return path.join(rootDir, "index.html");
             }
-            return path.join(rootDir, routePath, "index.html");
+            if (routePath.endsWith(".html")) {
+              return path.join(rootDir, routePath);
+            }
+            return path.join(rootDir, routePath.replace(/\/+$/g, ""), "index.html");
+          };
+
+          const normalizeRoute = (routeValue) => {
+            if (!routeValue || routeValue === "") {
+              return "/";
+            }
+            return routeValue.startsWith("/") ? routeValue : `/${routeValue}`;
+          };
+
+          const routeFromPublicHtml = (filePath) => {
+            if (filePath === "public/index.html") {
+              return "/";
+            }
+            return `/${filePath.replace(/^public\//, "")}`;
+          };
+
+          const usedIds = new Set(loadedRoutes.map((item) => item.id).filter(Boolean));
+          let generatedIdCounter = 1;
+          const nextGeneratedId = () => {
+            let candidate = `h${String(generatedIdCounter).padStart(3, "0")}`;
+            while (usedIds.has(candidate)) {
+              generatedIdCounter += 1;
+              candidate = `h${String(generatedIdCounter).padStart(3, "0")}`;
+            }
+            usedIds.add(candidate);
+            generatedIdCounter += 1;
+            return candidate;
+          };
+
+          const routeMap = new Map();
+          for (const item of loadedRoutes) {
+            const routeKey = normalizeRoute(item.route);
+            if (!routeMap.has(routeKey)) {
+              routeMap.set(routeKey, { ...item, route: routeKey });
+            }
+          }
+
+          const currentHtmlFiles = listCurrentFiles("public").filter((value) => value.endsWith(".html"));
+          const baseHtmlFiles = listBaseFiles("public").filter((value) => value.endsWith(".html"));
+          const htmlUnion = new Set([...currentHtmlFiles, ...baseHtmlFiles]);
+          for (const filePath of htmlUnion) {
+            const routeValue = routeFromPublicHtml(filePath);
+            if (!routeMap.has(routeValue)) {
+              routeMap.set(routeValue, {
+                id: nextGeneratedId(),
+                file: filePath,
+                route: routeValue
+              });
+            }
+          }
+
+          const routes = Array.from(routeMap.values()).sort((left, right) => {
+            const a = normalizeRoute(left.route);
+            const b = normalizeRoute(right.route);
+            if (a === "/" && b !== "/") {
+              return -1;
+            }
+            if (b === "/" && a !== "/") {
+              return 1;
+            }
+            return a.localeCompare(b);
+          });
+
+          fs.writeFileSync(routesPath, `${JSON.stringify(routes, null, 2)}\n`, "utf8");
+
+          // Mirror current site files into `new` snapshots so route-local assets resolve.
+          if (fs.existsSync("public")) {
+            fs.cpSync("public", path.join(outDir, "new"), { recursive: true });
+          }
+
+          // Mirror base ref site files into `old` snapshots.
+          for (const baseFile of listBaseFiles("public")) {
+            const contents = readBaseFileBuffer(baseFile);
+            if (contents === null) {
+              continue;
+            }
+            const outPath = path.join(outDir, "old", baseFile.replace(/^public\//, ""));
+            fs.mkdirSync(path.dirname(outPath), { recursive: true });
+            fs.writeFileSync(outPath, contents);
+          }
+
+          const normalizeDiffLine = (value) => value.replace(/\s+/g, " ").trim().toLowerCase();
+
+          const extractComparableLines = (resolved) => {
+            if (!resolved || !resolved.content) {
+              return [];
+            }
+            let text = resolved.content;
+            if (resolved.filePath.endsWith(".html")) {
+              text = text
+                .replace(/<script[\s\S]*?<\/script>/gi, " ")
+                .replace(/<style[\s\S]*?<\/style>/gi, " ")
+                .replace(/<\/(p|div|li|h1|h2|h3|h4|h5|h6|section|article|header|footer|main|nav)>/gi, "\n")
+                .replace(/<[^>]+>/g, " ");
+            }
+            return text
+              .split(/\r?\n/)
+              .map((line) => line.replace(/\s+/g, " ").trim())
+              .filter((line) => line.length >= 8);
+          };
+
+          const computeSimpleDiff = (oldLines, newLines) => {
+            const oldMap = new Map();
+            const newMap = new Map();
+            for (const line of oldLines) {
+              oldMap.set(normalizeDiffLine(line), line);
+            }
+            for (const line of newLines) {
+              newMap.set(normalizeDiffLine(line), line);
+            }
+            const additions = [];
+            const deletions = [];
+            for (const [key, line] of newMap.entries()) {
+              if (!oldMap.has(key)) {
+                additions.push(line);
+              }
+            }
+            for (const [key, line] of oldMap.entries()) {
+              if (!newMap.has(key)) {
+                deletions.push(line);
+              }
+            }
+            return { additions, deletions };
           };
 
           let materialized = 0;
 
           for (const item of routes) {
-            if (!item.file || !item.file.endsWith(".md")) {
+            if (!item.route) {
               continue;
             }
 
-            const oldOut = routeToIndexPath(path.join(outDir, "old"), item.route);
-            const newOut = routeToIndexPath(path.join(outDir, "new"), item.route);
+            const oldOut = routeToOutputPath(path.join(outDir, "old"), item.route);
+            const newOut = routeToOutputPath(path.join(outDir, "new"), item.route);
 
             const candidates = resolveRouteCandidates(item);
             const baseResolved = readBaseResolved(candidates);
@@ -206,17 +371,28 @@ jobs:
               );
             }
 
+            const addPath = path.join(outDir, "diffs", `${item.id}.add.txt`);
+            const delPath = path.join(outDir, "diffs", `${item.id}.del.txt`);
+            if (!fs.existsSync(addPath) || !fs.existsSync(delPath)) {
+              fs.mkdirSync(path.dirname(addPath), { recursive: true });
+              const oldLines = extractComparableLines(baseResolved);
+              const newLines = extractComparableLines(currentResolved);
+              const { additions, deletions } = computeSimpleDiff(oldLines, newLines);
+              fs.writeFileSync(addPath, additions.join("\n"), "utf8");
+              fs.writeFileSync(delPath, deletions.join("\n"), "utf8");
+            }
+
             materialized += 1;
           }
 
-          console.log(`Materialized markdown route pages: ${materialized}`);
+          console.log(`Materialized route pages: ${materialized}`);
 
           // Ensure every route has old/new pages so VisiDelta links never 404,
           // including root route (`/`) compares.
           let placeholders = 0;
           for (const item of routes) {
-            const oldOut = routeToIndexPath(path.join(outDir, "old"), item.route);
-            const newOut = routeToIndexPath(path.join(outDir, "new"), item.route);
+            const oldOut = routeToOutputPath(path.join(outDir, "old"), item.route);
+            const newOut = routeToOutputPath(path.join(outDir, "new"), item.route);
 
             const addPath = path.join(outDir, "diffs", `${item.id}.add.txt`);
             const delPath = path.join(outDir, "diffs", `${item.id}.del.txt`);

--- a/.github/workflows/visidelta-preview.yml
+++ b/.github/workflows/visidelta-preview.yml
@@ -268,6 +268,28 @@ jobs:
 
           fs.writeFileSync(routesPath, `${JSON.stringify(routes, null, 2)}\n`, "utf8");
 
+          // VisiDelta's default viewer normalizes every route with a trailing slash.
+          // That breaks routes that intentionally end with `.html` (e.g. `/docs/index.html`).
+          // Patch viewer route normalization so `.html` routes stay file-based.
+          const viewerPath = path.join(outDir, "viewer.html");
+          if (fs.existsSync(viewerPath)) {
+            const viewerSource = fs.readFileSync(viewerPath, "utf8");
+            const normalizeRouteOriginal = `function normalizeRoute(path) {\n        if (!path) return "/";\n        const withLeading = path.startsWith("/") ? path : \`/\${path}\`;\n        return withLeading.endsWith("/") ? withLeading : \`\${withLeading}/\`;\n      }`;
+            const normalizeRoutePatched = `function normalizeRoute(path) {\n        if (!path) return "/";\n        const withLeading = path.startsWith("/") ? path : \`/\${path}\`;\n        if (withLeading === "/") return "/";\n        if (withLeading.endsWith(".html")) return withLeading;\n        return withLeading.endsWith("/") ? withLeading : \`\${withLeading}/\`;\n      }`;
+            if (viewerSource.includes(normalizeRouteOriginal)) {
+              fs.writeFileSync(
+                viewerPath,
+                viewerSource.replace(normalizeRouteOriginal, normalizeRoutePatched),
+                "utf8"
+              );
+              console.log("Patched viewer route normalization for .html paths.");
+            } else {
+              console.log("Viewer normalization patch skipped (pattern not found).");
+            }
+          } else {
+            console.log("viewer.html not present; skipping route normalization patch.");
+          }
+
           // Mirror current site files into `new` snapshots so route-local assets resolve.
           if (fs.existsSync("public")) {
             fs.cpSync("public", path.join(outDir, "new"), { recursive: true });

--- a/.github/workflows/visidelta-preview.yml
+++ b/.github/workflows/visidelta-preview.yml
@@ -107,8 +107,52 @@ jobs:
                 stdio: ["ignore", "pipe", "ignore"]
               });
             } catch {
-              return `File not present in base ref (${baseRef}): ${filePath}\n`;
+              return null;
             }
+          };
+
+          const resolveRouteCandidates = (item) => {
+            const routePath = (item.route || "/").replace(/^\/+|\/+$/g, "");
+            const candidates = [];
+            if (item.file) {
+              candidates.push(item.file);
+            }
+            if (!routePath) {
+              candidates.push("public/index.html");
+            } else {
+              candidates.push(`public/${routePath}.html`);
+              candidates.push(`public/${routePath}/index.html`);
+            }
+            return [...new Set(candidates)];
+          };
+
+          const readCurrentResolved = (candidates) => {
+            for (const filePath of candidates) {
+              if (fs.existsSync(filePath)) {
+                return { filePath, content: fs.readFileSync(filePath, "utf8") };
+              }
+            }
+            return null;
+          };
+
+          const readBaseResolved = (candidates) => {
+            for (const filePath of candidates) {
+              const content = readBaseFile(filePath);
+              if (content !== null) {
+                return { filePath, content };
+              }
+            }
+            return null;
+          };
+
+          const renderResolvedSnapshot = (label, resolved) => {
+            if (resolved.filePath.endsWith(".html")) {
+              return resolved.content;
+            }
+            if (resolved.filePath.endsWith(".md")) {
+              return renderMarkdownSnapshot(`${label} - ${resolved.filePath}`, resolved.content);
+            }
+            return renderMarkdownSnapshot(`${label} - ${resolved.filePath}`, resolved.content);
           };
 
           const routeToIndexPath = (rootDir, route) => {
@@ -129,16 +173,38 @@ jobs:
             const oldOut = routeToIndexPath(path.join(outDir, "old"), item.route);
             const newOut = routeToIndexPath(path.join(outDir, "new"), item.route);
 
-            const baseMarkdown = readBaseFile(item.file);
-            const newMarkdown = fs.existsSync(item.file)
-              ? fs.readFileSync(item.file, "utf8")
-              : `File not present in current branch: ${item.file}\n`;
+            const candidates = resolveRouteCandidates(item);
+            const baseResolved = readBaseResolved(candidates);
+            const currentResolved = readCurrentResolved(candidates);
 
             fs.mkdirSync(path.dirname(oldOut), { recursive: true });
             fs.mkdirSync(path.dirname(newOut), { recursive: true });
 
-            fs.writeFileSync(oldOut, renderMarkdownSnapshot(`Old - ${item.file}`, baseMarkdown), "utf8");
-            fs.writeFileSync(newOut, renderMarkdownSnapshot(`New - ${item.file}`, newMarkdown), "utf8");
+            if (baseResolved) {
+              fs.writeFileSync(oldOut, renderResolvedSnapshot("Old", baseResolved), "utf8");
+            } else {
+              fs.writeFileSync(
+                oldOut,
+                renderMarkdownSnapshot(
+                  `Old snapshot unavailable - ${item.file || item.route || "/"}`,
+                  `No source file found in base ref (${baseRef}) for route ${item.route || "/"}.\nTried:\n${candidates.join("\n")}\n`
+                ),
+                "utf8"
+              );
+            }
+
+            if (currentResolved) {
+              fs.writeFileSync(newOut, renderResolvedSnapshot("New", currentResolved), "utf8");
+            } else {
+              fs.writeFileSync(
+                newOut,
+                renderMarkdownSnapshot(
+                  `New snapshot unavailable - ${item.file || item.route || "/"}`,
+                  `No source file found in current branch for route ${item.route || "/"}.\nTried:\n${candidates.join("\n")}\n`
+                ),
+                "utf8"
+              );
+            }
 
             materialized += 1;
           }

--- a/README.md
+++ b/README.md
@@ -7,9 +7,10 @@ Static website for the MCP-AQL public draft documentation portal.
 This repository hosts browse-first web documentation for MCP-AQL so users can:
 
 - Understand protocol goals and launch positioning
-- Navigate integration guidance without cloning the spec repo
-- Follow live readiness gates through linked issues
+- Navigate protocol, security, conformance, and implementation guidance without cloning repos
+- Track launch readiness through public-facing status pages
 - Discover canonical spec docs and practical implementation references
+- Search documentation content directly within the site
 
 ## Source Of Truth
 
@@ -21,10 +22,13 @@ This repository hosts browse-first web documentation for MCP-AQL so users can:
 
 All web assets are under `public/`:
 
-- `public/index.html`: launch overview, readiness gates, repo map
-- `public/launch-checklist.html`: public-facing launch-readiness summary
+- `public/index.html`: portal home and repository map
+- `public/docs/*.html`: protocol library pages (core, security, conformance, profiles, roadmap)
+- `public/launch-checklist.html`: public launch readiness summary
 - `public/apis/*.html`: integration-surface guidance pages
 - `public/css/style.css`: shared styles and responsive layout
+- `public/js/search.js`: client-side documentation search
+- `public/data/search-index.json`: search index catalog
 - `docs/prelaunch-readiness-review.md`: launch readiness assessment and guidance
 
 ## Local Preview

--- a/docs/prelaunch-readiness-review.md
+++ b/docs/prelaunch-readiness-review.md
@@ -1,6 +1,5 @@
 # MCP-AQL Pre-Launch Readiness Review
 
-Reviewed: 2026-03-09
 Scope: `MCPAQL/spec`, `MCPAQL/website`, Dollhouse practical profile alignment (public-facing view)
 
 ## Executive Status
@@ -15,10 +14,10 @@ Overall status: **Yellow (near-launch with explicit draft framing)**
 
 Live issue state indicates remaining pre-launch work:
 
-- [MCPAQL/spec#193](https://github.com/MCPAQL/spec/issues/193): MCP capability audit
-- [MCPAQL/spec#197](https://github.com/MCPAQL/spec/issues/197): batch/resource safeguards
-- [MCPAQL/spec#199](https://github.com/MCPAQL/spec/issues/199): structured error alignment
-- [MCPAQL/spec#194](https://github.com/MCPAQL/spec/issues/194): release epic coordination
+- `MCPAQL/spec#193`: MCP capability audit
+- `MCPAQL/spec#197`: batch/resource safeguards
+- `MCPAQL/spec#199`: structured error alignment
+- `MCPAQL/spec#194`: release epic coordination
 
 Recommendation:
 

--- a/public/apis/application.html
+++ b/public/apis/application.html
@@ -19,7 +19,7 @@
                     <li><a href="../index.html">Home</a></li>
                     <li><a href="../docs/index.html">Docs</a></li>
                     <li><a href="../launch-checklist.html">Launch Checklist</a></li>
-                    <li><a href="../docs/implementation-profiles.html">Profiles</a></li>
+                    <li><a href="mcp-server.html">Adapter Patterns</a></li>
                 </ul>
             </nav>
         </div>

--- a/public/apis/application.html
+++ b/public/apis/application.html
@@ -16,10 +16,10 @@
             <nav>
                 <a class="logo" href="../index.html"><span class="logo-mark"></span>MCP-AQL</a>
                 <ul class="nav-links">
-                    <li><a href="../index.html#overview">Overview</a></li>
-                    <li><a href="../index.html#flow">How It Works</a></li>
-                    <li><a href="../index.html#readiness">Readiness</a></li>
-                    <li><a href="../index.html#repos">Repositories</a></li>
+                    <li><a href="../index.html">Home</a></li>
+                    <li><a href="../docs/index.html">Docs</a></li>
+                    <li><a href="../launch-checklist.html">Launch Checklist</a></li>
+                    <li><a href="../docs/implementation-profiles.html">Profiles</a></li>
                 </ul>
             </nav>
         </div>
@@ -82,7 +82,7 @@
             <p>&copy; 2026 DollhouseMCP Inc. d/b/a Dollhouse Research. MCP-AQL public draft documentation portal.</p>
             <div class="footer-links">
                 <a href="https://github.com/MCPAQL">MCPAQL Organization</a>
-                <a href="https://github.com/MCPAQL/spec/issues">Spec Issues</a>
+                <a href="../docs/index.html">Documentation Library</a>
             </div>
         </div>
     </footer>

--- a/public/apis/cloud-service.html
+++ b/public/apis/cloud-service.html
@@ -19,7 +19,7 @@
                     <li><a href="../index.html">Home</a></li>
                     <li><a href="../docs/index.html">Docs</a></li>
                     <li><a href="../launch-checklist.html">Launch Checklist</a></li>
-                    <li><a href="../docs/implementation-profiles.html">Profiles</a></li>
+                    <li><a href="mcp-server.html">Adapter Patterns</a></li>
                 </ul>
             </nav>
         </div>

--- a/public/apis/cloud-service.html
+++ b/public/apis/cloud-service.html
@@ -16,10 +16,10 @@
             <nav>
                 <a class="logo" href="../index.html"><span class="logo-mark"></span>MCP-AQL</a>
                 <ul class="nav-links">
-                    <li><a href="../index.html#overview">Overview</a></li>
-                    <li><a href="../index.html#flow">How It Works</a></li>
-                    <li><a href="../index.html#readiness">Readiness</a></li>
-                    <li><a href="../index.html#repos">Repositories</a></li>
+                    <li><a href="../index.html">Home</a></li>
+                    <li><a href="../docs/index.html">Docs</a></li>
+                    <li><a href="../launch-checklist.html">Launch Checklist</a></li>
+                    <li><a href="../docs/implementation-profiles.html">Profiles</a></li>
                 </ul>
             </nav>
         </div>
@@ -82,7 +82,7 @@
             <p>&copy; 2026 DollhouseMCP Inc. d/b/a Dollhouse Research. MCP-AQL public draft documentation portal.</p>
             <div class="footer-links">
                 <a href="https://github.com/MCPAQL">MCPAQL Organization</a>
-                <a href="https://github.com/MCPAQL/spec/issues">Spec Issues</a>
+                <a href="../docs/index.html">Documentation Library</a>
             </div>
         </div>
     </footer>

--- a/public/apis/mcp-server.html
+++ b/public/apis/mcp-server.html
@@ -19,7 +19,7 @@
                     <li><a href="../index.html">Home</a></li>
                     <li><a href="../docs/index.html">Docs</a></li>
                     <li><a href="../launch-checklist.html">Launch Checklist</a></li>
-                    <li><a href="../docs/implementation-profiles.html">Profiles</a></li>
+                    <li><a href="mcp-server.html">Adapter Patterns</a></li>
                 </ul>
             </nav>
         </div>

--- a/public/apis/mcp-server.html
+++ b/public/apis/mcp-server.html
@@ -16,10 +16,10 @@
             <nav>
                 <a class="logo" href="../index.html"><span class="logo-mark"></span>MCP-AQL</a>
                 <ul class="nav-links">
-                    <li><a href="../index.html#overview">Overview</a></li>
-                    <li><a href="../index.html#flow">How It Works</a></li>
-                    <li><a href="../index.html#readiness">Readiness</a></li>
-                    <li><a href="../index.html#repos">Repositories</a></li>
+                    <li><a href="../index.html">Home</a></li>
+                    <li><a href="../docs/index.html">Docs</a></li>
+                    <li><a href="../launch-checklist.html">Launch Checklist</a></li>
+                    <li><a href="../docs/implementation-profiles.html">Profiles</a></li>
                 </ul>
             </nav>
         </div>
@@ -83,9 +83,9 @@
                     <article class="card">
                         <h3>Spec</h3>
                         <ul>
-                            <li><a href="https://github.com/MCPAQL/spec/blob/develop/docs/versions/v1.0.0-draft.md">Normative draft</a></li>
-                            <li><a href="https://github.com/MCPAQL/spec/blob/develop/docs/introspection.md">Introspection model</a></li>
-                            <li><a href="https://github.com/MCPAQL/spec/blob/develop/docs/operations.md">Operation guidance</a></li>
+                            <li><a href="https://github.com/MCPAQL/spec/blob/main/docs/versions/v1.0.0-draft.md">Normative draft</a></li>
+                            <li><a href="https://github.com/MCPAQL/spec/blob/main/docs/introspection.md">Introspection model</a></li>
+                            <li><a href="https://github.com/MCPAQL/spec/blob/main/docs/operations.md">Operation guidance</a></li>
                         </ul>
                     </article>
                     <article class="card">
@@ -109,7 +109,7 @@
             <p>&copy; 2026 DollhouseMCP Inc. d/b/a Dollhouse Research. MCP-AQL public draft documentation portal.</p>
             <div class="footer-links">
                 <a href="https://github.com/MCPAQL">MCPAQL Organization</a>
-                <a href="https://github.com/MCPAQL/spec/issues">Spec Issues</a>
+                <a href="../docs/index.html">Documentation Library</a>
             </div>
         </div>
     </footer>

--- a/public/apis/operating-system.html
+++ b/public/apis/operating-system.html
@@ -19,7 +19,7 @@
                     <li><a href="../index.html">Home</a></li>
                     <li><a href="../docs/index.html">Docs</a></li>
                     <li><a href="../launch-checklist.html">Launch Checklist</a></li>
-                    <li><a href="../docs/implementation-profiles.html">Profiles</a></li>
+                    <li><a href="mcp-server.html">Adapter Patterns</a></li>
                 </ul>
             </nav>
         </div>

--- a/public/apis/operating-system.html
+++ b/public/apis/operating-system.html
@@ -16,10 +16,10 @@
             <nav>
                 <a class="logo" href="../index.html"><span class="logo-mark"></span>MCP-AQL</a>
                 <ul class="nav-links">
-                    <li><a href="../index.html#overview">Overview</a></li>
-                    <li><a href="../index.html#flow">How It Works</a></li>
-                    <li><a href="../index.html#readiness">Readiness</a></li>
-                    <li><a href="../index.html#repos">Repositories</a></li>
+                    <li><a href="../index.html">Home</a></li>
+                    <li><a href="../docs/index.html">Docs</a></li>
+                    <li><a href="../launch-checklist.html">Launch Checklist</a></li>
+                    <li><a href="../docs/implementation-profiles.html">Profiles</a></li>
                 </ul>
             </nav>
         </div>
@@ -83,7 +83,7 @@
             <p>&copy; 2026 DollhouseMCP Inc. d/b/a Dollhouse Research. MCP-AQL public draft documentation portal.</p>
             <div class="footer-links">
                 <a href="https://github.com/MCPAQL">MCPAQL Organization</a>
-                <a href="https://github.com/MCPAQL/spec/issues">Spec Issues</a>
+                <a href="../docs/index.html">Documentation Library</a>
             </div>
         </div>
     </footer>

--- a/public/apis/website.html
+++ b/public/apis/website.html
@@ -19,7 +19,7 @@
                     <li><a href="../index.html">Home</a></li>
                     <li><a href="../docs/index.html">Docs</a></li>
                     <li><a href="../launch-checklist.html">Launch Checklist</a></li>
-                    <li><a href="../docs/implementation-profiles.html">Profiles</a></li>
+                    <li><a href="mcp-server.html">Adapter Patterns</a></li>
                 </ul>
             </nav>
         </div>

--- a/public/apis/website.html
+++ b/public/apis/website.html
@@ -16,10 +16,10 @@
             <nav>
                 <a class="logo" href="../index.html"><span class="logo-mark"></span>MCP-AQL</a>
                 <ul class="nav-links">
-                    <li><a href="../index.html#overview">Overview</a></li>
-                    <li><a href="../index.html#flow">How It Works</a></li>
-                    <li><a href="../index.html#readiness">Readiness</a></li>
-                    <li><a href="../index.html#repos">Repositories</a></li>
+                    <li><a href="../index.html">Home</a></li>
+                    <li><a href="../docs/index.html">Docs</a></li>
+                    <li><a href="../launch-checklist.html">Launch Checklist</a></li>
+                    <li><a href="../docs/implementation-profiles.html">Profiles</a></li>
                 </ul>
             </nav>
         </div>
@@ -82,7 +82,7 @@
             <p>&copy; 2026 DollhouseMCP Inc. d/b/a Dollhouse Research. MCP-AQL public draft documentation portal.</p>
             <div class="footer-links">
                 <a href="https://github.com/MCPAQL">MCPAQL Organization</a>
-                <a href="https://github.com/MCPAQL/spec/issues">Spec Issues</a>
+                <a href="../docs/index.html">Documentation Library</a>
             </div>
         </div>
     </footer>

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -155,6 +155,90 @@ nav {
   color: var(--ink-900);
 }
 
+.site-search {
+  max-width: 290px;
+  position: relative;
+  width: 100%;
+}
+
+.site-search input {
+  background: var(--white);
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  color: var(--ink-900);
+  font-size: 0.86rem;
+  outline: none;
+  padding: 0.5rem 0.72rem;
+  width: 100%;
+}
+
+.site-search input:focus {
+  border-color: #99b7dc;
+  box-shadow: 0 0 0 2px rgba(15, 118, 110, 0.12);
+}
+
+.search-count {
+  color: var(--slate-500);
+  display: inline-flex;
+  font-size: 0.72rem;
+  margin-top: 0.2rem;
+}
+
+.search-results {
+  background: var(--white);
+  border: 1px solid var(--line);
+  border-radius: 11px;
+  box-shadow: var(--shadow-soft);
+  list-style: none;
+  margin-top: 0.28rem;
+  max-height: 320px;
+  overflow-y: auto;
+  padding: 0.35rem;
+  position: absolute;
+  right: 0;
+  width: 100%;
+  z-index: 40;
+}
+
+.search-result-item a {
+  border-radius: 8px;
+  color: var(--ink-900);
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  padding: 0.48rem 0.52rem;
+}
+
+.search-result-item a:hover {
+  background: var(--paper-100);
+}
+
+.search-result-item strong {
+  font-size: 0.82rem;
+}
+
+.search-result-item span,
+.search-result-empty {
+  color: var(--slate-500);
+  font-size: 0.76rem;
+}
+
+.search-result-empty {
+  padding: 0.48rem 0.52rem;
+}
+
+.sr-only {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
 main {
   padding: 2.2rem 0 4rem;
 }
@@ -433,6 +517,94 @@ footer {
   padding: 0.8rem;
 }
 
+.docs-shell {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: 240px minmax(0, 1fr);
+}
+
+.docs-side {
+  align-self: start;
+  background: rgba(255, 255, 255, 0.75);
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  padding: 0.9rem;
+  position: sticky;
+  top: 88px;
+}
+
+.docs-side h2 {
+  color: var(--ink-900);
+  font-size: 0.86rem;
+  margin-bottom: 0.45rem;
+  text-transform: uppercase;
+}
+
+.docs-side ul {
+  list-style: none;
+}
+
+.docs-side li + li {
+  margin-top: 0.32rem;
+}
+
+.docs-side a {
+  border-radius: 7px;
+  display: block;
+  font-size: 0.86rem;
+  font-weight: 600;
+  padding: 0.28rem 0.4rem;
+}
+
+.docs-side a:hover {
+  background: var(--paper-100);
+}
+
+.docs-main {
+  min-width: 0;
+}
+
+.docs-main section {
+  margin-top: 1.4rem;
+}
+
+.docs-hero {
+  margin-top: 0;
+}
+
+.table-card {
+  overflow-x: auto;
+  padding: 0;
+}
+
+.data-table {
+  border-collapse: collapse;
+  min-width: 640px;
+  width: 100%;
+}
+
+.data-table th,
+.data-table td {
+  border-bottom: 1px solid var(--line);
+  padding: 0.72rem 0.9rem;
+  text-align: left;
+  vertical-align: top;
+}
+
+.data-table th {
+  background: #f8fbff;
+  color: var(--ink-900);
+  font-family: "Space Grotesk", "IBM Plex Sans", sans-serif;
+  font-size: 0.8rem;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+.data-table td {
+  color: var(--ink-800);
+  font-size: 0.9rem;
+}
+
 @keyframes rise {
   from {
     opacity: 0;
@@ -464,6 +636,10 @@ footer {
     gap: 0.55rem;
   }
 
+  .site-search {
+    max-width: 100%;
+  }
+
   .hero {
     padding: 1.35rem;
   }
@@ -471,5 +647,17 @@ footer {
   .grid.cols-2,
   .grid.cols-3 {
     grid-template-columns: 1fr;
+  }
+
+  .docs-shell {
+    grid-template-columns: 1fr;
+  }
+
+  .docs-side {
+    position: static;
+  }
+
+  .data-table {
+    min-width: 0;
   }
 }

--- a/public/data/search-index.json
+++ b/public/data/search-index.json
@@ -1,0 +1,104 @@
+[
+  {
+    "title": "MCP-AQL Portal Home",
+    "url": "/index.html",
+    "excerpt": "Public draft portal overview, launch posture, repository map, and start-here navigation.",
+    "keywords": ["home", "overview", "public draft", "portal", "launch"]
+  },
+  {
+    "title": "Docs Library",
+    "url": "/docs/index.html",
+    "excerpt": "Structured documentation map for normative spec, implementation guidance, examples, tooling, and governance.",
+    "keywords": ["docs", "documentation", "library", "spec map", "reference"]
+  },
+  {
+    "title": "Protocol Core",
+    "url": "/docs/protocol-core.html",
+    "excerpt": "Normative foundations: CRUDE model, endpoint modes, request and response contracts, introspection, and operation routing.",
+    "keywords": ["crude", "single mode", "request", "response", "introspect", "operation"]
+  },
+  {
+    "title": "Security Model",
+    "url": "/docs/security-model.html",
+    "excerpt": "Gatekeeper trust levels, danger handling, confirmation token flows, and execution safety boundaries.",
+    "keywords": ["security", "gatekeeper", "danger", "confirmation token", "trust", "safety"]
+  },
+  {
+    "title": "Conformance And Validation",
+    "url": "/docs/conformance.html",
+    "excerpt": "Current conformance requirements, validation scope, and planned validator tooling for implementers.",
+    "keywords": ["conformance", "validator", "validation", "testing", "compliance", "on-spec"]
+  },
+  {
+    "title": "Implementation Profiles",
+    "url": "/docs/implementation-profiles.html",
+    "excerpt": "Canonical protocol vs practical profile boundaries across spec, adapter runtime, examples, and production references.",
+    "keywords": ["profile", "dollhouse", "reference", "adapter", "runtime", "implementation"]
+  },
+  {
+    "title": "Roadmap",
+    "url": "/docs/roadmap.html",
+    "excerpt": "Protocol and ecosystem roadmap with current execution focus and phased delivery tracks.",
+    "keywords": ["roadmap", "phase", "launch", "readiness", "ecosystem", "timeline"]
+  },
+  {
+    "title": "Launch Checklist",
+    "url": "/launch-checklist.html",
+    "excerpt": "Public-facing preliminary launch checklist for readiness visibility and scope control.",
+    "keywords": ["launch", "checklist", "readiness", "public draft"]
+  },
+  {
+    "title": "MCP Server Adapter Pattern",
+    "url": "/apis/mcp-server.html",
+    "excerpt": "Draft guidance for adapting MCP servers to MCP-AQL through introspection and CRUDE operation mapping.",
+    "keywords": ["mcp server", "adapter pattern", "mapping", "introspection"]
+  },
+  {
+    "title": "Operating System Adapter Pattern",
+    "url": "/apis/operating-system.html",
+    "excerpt": "Draft guidance for operating-system integrations with permission and safety-aware boundaries.",
+    "keywords": ["operating system", "permissions", "local operations", "safety"]
+  },
+  {
+    "title": "Application Adapter Pattern",
+    "url": "/apis/application.html",
+    "excerpt": "Draft guidance for desktop and application API integration into MCP-AQL contracts.",
+    "keywords": ["application", "desktop", "app api", "integration"]
+  },
+  {
+    "title": "Cloud Service Adapter Pattern",
+    "url": "/apis/cloud-service.html",
+    "excerpt": "Draft guidance for cloud API adaptation, rate limits, and resilient operation handling.",
+    "keywords": ["cloud", "service", "rate limit", "external api"]
+  },
+  {
+    "title": "Website Adapter Pattern",
+    "url": "/apis/website.html",
+    "excerpt": "Draft guidance for website-facing integrations and retrieval/action patterns.",
+    "keywords": ["website", "web", "retrieval", "action"]
+  },
+  {
+    "title": "Spec Repository",
+    "url": "https://github.com/MCPAQL/spec",
+    "excerpt": "Canonical source for normative protocol text, schemas, and versioned specification draft.",
+    "keywords": ["spec", "normative", "schema", "version", "protocol"]
+  },
+  {
+    "title": "Adapter Runtime Repository",
+    "url": "https://github.com/MCPAQL/mcpaql-adapter",
+    "excerpt": "Reference implementation guidance for schema-driven dispatch and plugin runtime architecture.",
+    "keywords": ["runtime", "plugin", "dispatch", "implementation"]
+  },
+  {
+    "title": "Examples Repository",
+    "url": "https://github.com/MCPAQL/examples",
+    "excerpt": "Reference adapter examples demonstrating practical API adaptation patterns.",
+    "keywords": ["examples", "reference adapters", "sample"]
+  },
+  {
+    "title": "Tools Repository",
+    "url": "https://github.com/MCPAQL/tools",
+    "excerpt": "Planned conformance and on-spec validator tooling for MCP-AQL implementations.",
+    "keywords": ["tools", "validator", "conformance cli", "on-spec"]
+  }
+]

--- a/public/docs/conformance.html
+++ b/public/docs/conformance.html
@@ -1,0 +1,142 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="MCP-AQL conformance overview, current validator status, and launch-phase testing posture.">
+  <title>MCP-AQL Docs | Conformance</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../css/style.css">
+</head>
+<body>
+  <header>
+    <div class="container">
+      <nav>
+        <a class="logo" href="../index.html"><span class="logo-mark"></span>MCP-AQL</a>
+        <ul class="nav-links">
+          <li><a href="../index.html">Home</a></li>
+          <li><a href="index.html">Docs</a></li>
+          <li><a href="protocol-core.html">Protocol Core</a></li>
+          <li><a href="roadmap.html">Roadmap</a></li>
+        </ul>
+        <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
+          <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
+          <input id="site-search-input" data-search-input type="search" placeholder="Search conformance topics...">
+          <span class="search-count" data-search-count></span>
+          <ul class="search-results" data-search-results hidden></ul>
+        </form>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <div class="container docs-shell">
+      <aside class="docs-side">
+        <h2>In This Library</h2>
+        <ul>
+          <li><a href="protocol-core.html">Protocol Core</a></li>
+          <li><a href="security-model.html">Security Model</a></li>
+          <li><a href="conformance.html">Conformance</a></li>
+          <li><a href="implementation-profiles.html">Implementation Profiles</a></li>
+          <li><a href="roadmap.html">Roadmap</a></li>
+        </ul>
+      </aside>
+
+      <article class="docs-main">
+        <section class="hero docs-hero">
+          <div class="hero-inner">
+            <span class="status-pill">CONFORMANCE</span>
+            <h1>Compatibility And Validation</h1>
+            <p class="lede">
+              MCP-AQL conformance is currently defined by normative behavior requirements in the specification and an in-progress validation track.
+              This page clarifies what can be asserted today versus what is still being built.
+            </p>
+            <div class="hero-actions">
+              <a class="btn btn-primary" href="https://github.com/MCPAQL/spec/blob/main/docs/conformance-testing.md">Conformance Doc</a>
+              <a class="btn btn-secondary" href="https://github.com/MCPAQL/tools">Validator Tooling Repo</a>
+            </div>
+          </div>
+        </section>
+
+        <section>
+          <h2 class="section-title">Baseline Requirements</h2>
+          <div class="card">
+            <ul>
+              <li>Implement runtime introspection for operation discovery</li>
+              <li>Expose CRUDE or single-endpoint mode routing</li>
+              <li>Return discriminated success/error response unions</li>
+              <li>Document operation contracts in introspection output</li>
+            </ul>
+          </div>
+        </section>
+
+        <section>
+          <h2 class="section-title">Current Validation Posture</h2>
+          <div class="grid cols-2">
+            <article class="card">
+              <h3>Available Now</h3>
+              <span class="state-chip live">Ready</span>
+              <ul>
+                <li>Normative spec-backed conformance requirements</li>
+                <li>Schema validation workflows in specification repo</li>
+                <li>Manual profile review against spec requirements</li>
+              </ul>
+            </article>
+            <article class="card">
+              <h3>In Progress</h3>
+              <span class="state-chip pending">Active workstream</span>
+              <ul>
+                <li>Dedicated conformance validator CLI</li>
+                <li>MVP "on-spec" validator profile for third-party servers</li>
+                <li>Expanded semantic evaluation and usability-focused tests</li>
+              </ul>
+            </article>
+          </div>
+        </section>
+
+        <section>
+          <h2 class="section-title">Launch Guidance</h2>
+          <div class="card">
+            <p>
+              For preliminary public launch, implementations should be positioned as draft-compatible with transparent known gaps.
+              The site should distinguish between:
+            </p>
+            <ul>
+              <li><strong>Normative requirements</strong> (must follow to claim compatibility)</li>
+              <li><strong>Operational maturity signals</strong> (what testing and tooling already exists)</li>
+              <li><strong>Remaining hardening work</strong> (what is explicitly not final yet)</li>
+            </ul>
+          </div>
+        </section>
+
+        <section>
+          <h2 class="section-title">Validator Track</h2>
+          <div class="card">
+            <p>
+              The validator track is being developed in <code>MCPAQL/tools</code>. Current planning includes both a general conformance CLI
+              and an MVP profile specifically targeting "on-spec" checks for third-party MCP-AQL implementations.
+            </p>
+            <p class="callout">
+              Public messaging should avoid implying final certification until validator and conformance tracks are complete.
+            </p>
+          </div>
+        </section>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div class="container">
+      <p>&copy; 2026 DollhouseMCP Inc. d/b/a Dollhouse Research. MCP-AQL public draft documentation portal.</p>
+      <div class="footer-links">
+        <a href="index.html">Docs Library</a>
+        <a href="../launch-checklist.html">Launch Checklist</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../js/search.js"></script>
+</body>
+</html>

--- a/public/docs/conformance.html
+++ b/public/docs/conformance.html
@@ -18,8 +18,8 @@
         <ul class="nav-links">
           <li><a href="../index.html">Home</a></li>
           <li><a href="index.html">Docs</a></li>
-          <li><a href="protocol-core.html">Protocol Core</a></li>
-          <li><a href="roadmap.html">Roadmap</a></li>
+          <li><a href="../launch-checklist.html">Launch Checklist</a></li>
+          <li><a href="../apis/mcp-server.html">Adapter Patterns</a></li>
         </ul>
         <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>

--- a/public/docs/implementation-profiles.html
+++ b/public/docs/implementation-profiles.html
@@ -1,0 +1,151 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="MCP-AQL implementation profile boundaries: canonical specification vs practical reference profiles.">
+  <title>MCP-AQL Docs | Implementation Profiles</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../css/style.css">
+</head>
+<body>
+  <header>
+    <div class="container">
+      <nav>
+        <a class="logo" href="../index.html"><span class="logo-mark"></span>MCP-AQL</a>
+        <ul class="nav-links">
+          <li><a href="../index.html">Home</a></li>
+          <li><a href="index.html">Docs</a></li>
+          <li><a href="protocol-core.html">Protocol Core</a></li>
+          <li><a href="roadmap.html">Roadmap</a></li>
+        </ul>
+        <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
+          <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
+          <input id="site-search-input" data-search-input type="search" placeholder="Search implementation topics...">
+          <span class="search-count" data-search-count></span>
+          <ul class="search-results" data-search-results hidden></ul>
+        </form>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <div class="container docs-shell">
+      <aside class="docs-side">
+        <h2>In This Library</h2>
+        <ul>
+          <li><a href="protocol-core.html">Protocol Core</a></li>
+          <li><a href="security-model.html">Security Model</a></li>
+          <li><a href="conformance.html">Conformance</a></li>
+          <li><a href="implementation-profiles.html">Implementation Profiles</a></li>
+          <li><a href="roadmap.html">Roadmap</a></li>
+        </ul>
+      </aside>
+
+      <article class="docs-main">
+        <section class="hero docs-hero">
+          <div class="hero-inner">
+            <span class="status-pill">IMPLEMENTATION PROFILES</span>
+            <h1>Canonical Spec vs Practical Profiles</h1>
+            <p class="lede">
+              MCP-AQL intentionally separates normative protocol authority from practical, evolving reference profiles.
+              This boundary prevents implementation details from being mistaken as protocol law.
+            </p>
+            <div class="hero-actions">
+              <a class="btn btn-primary" href="https://github.com/MCPAQL/spec">Canonical Spec Source</a>
+              <a class="btn btn-secondary" href="https://github.com/DollhouseMCP/mcp-server">Dollhouse Practical Profile</a>
+            </div>
+          </div>
+        </section>
+
+        <section>
+          <h2 class="section-title">Boundary Model</h2>
+          <div class="card table-card">
+            <table class="data-table">
+              <thead>
+                <tr>
+                  <th>Layer</th>
+                  <th>Authority</th>
+                  <th>Role</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Normative protocol text</td>
+                  <td>spec repository</td>
+                  <td>Defines conformance requirements and behavior contracts</td>
+                </tr>
+                <tr>
+                  <td>Reference runtime guidance</td>
+                  <td>mcpaql-adapter repository</td>
+                  <td>Implementation architecture and plugin/runtime patterns</td>
+                </tr>
+                <tr>
+                  <td>Example mappings</td>
+                  <td>examples repository</td>
+                  <td>Domain adaptation patterns for API surfaces</td>
+                </tr>
+                <tr>
+                  <td>Practical production profile</td>
+                  <td>DollhouseMCP production server</td>
+                  <td>Large real-world validation of protocol viability</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <section>
+          <h2 class="section-title">Reference Repositories</h2>
+          <div class="grid cols-2">
+            <article class="card">
+              <h3>Implementation Guidance</h3>
+              <ul>
+                <li><a href="https://github.com/MCPAQL/mcpaql-adapter/blob/main/docs/architecture/overview.md">Architecture overview</a></li>
+                <li><a href="https://github.com/MCPAQL/mcpaql-adapter/blob/main/docs/architecture/runtime.md">Runtime model</a></li>
+                <li><a href="https://github.com/MCPAQL/mcpaql-adapter/blob/main/docs/architecture/plugin-system.md">Plugin system</a></li>
+                <li><a href="https://github.com/MCPAQL/mcpaql-adapter/blob/main/docs/guides/development.md">Development guide</a></li>
+              </ul>
+            </article>
+            <article class="card">
+              <h3>Example And Tooling Tracks</h3>
+              <ul>
+                <li><a href="https://github.com/MCPAQL/examples">Examples repository</a></li>
+                <li><a href="https://github.com/MCPAQL/examples/blob/main/adapters/github-api-adapter.md">GitHub adapter example</a></li>
+                <li><a href="https://github.com/MCPAQL/adapter-generator/blob/main/OUTPUT-POLICY.md">Generator output policy</a></li>
+                <li><a href="https://github.com/MCPAQL/tools">Validator tools repository</a></li>
+              </ul>
+            </article>
+          </div>
+        </section>
+
+        <section>
+          <h2 class="section-title">Public Messaging Guidance</h2>
+          <div class="card">
+            <ul>
+              <li>State clearly that <strong>spec is canonical</strong> and implementation profiles are practical references.</li>
+              <li>Describe practical profiles as evidence of viability, not as normative definition.</li>
+              <li>Call out known-open areas as launch-draft scope, not hidden debt.</li>
+              <li>Publish examples as they become available and keep status explicit (draft vs production).</li>
+            </ul>
+          </div>
+        </section>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div class="container">
+      <p>&copy; 2026 DollhouseMCP Inc. d/b/a Dollhouse Research. MCP-AQL public draft documentation portal.</p>
+      <div class="footer-links">
+        <a href="index.html">Docs Library</a>
+        <a href="../index.html">Portal Home</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../js/search.js"></script>
+</body>
+</html>

--- a/public/docs/implementation-profiles.html
+++ b/public/docs/implementation-profiles.html
@@ -18,8 +18,8 @@
         <ul class="nav-links">
           <li><a href="../index.html">Home</a></li>
           <li><a href="index.html">Docs</a></li>
-          <li><a href="protocol-core.html">Protocol Core</a></li>
-          <li><a href="roadmap.html">Roadmap</a></li>
+          <li><a href="../launch-checklist.html">Launch Checklist</a></li>
+          <li><a href="../apis/mcp-server.html">Adapter Patterns</a></li>
         </ul>
         <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>

--- a/public/docs/index.html
+++ b/public/docs/index.html
@@ -1,0 +1,175 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="MCP-AQL documentation library with protocol, security, conformance, implementation profiles, and roadmap coverage.">
+  <title>MCP-AQL Docs | Library</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../css/style.css">
+</head>
+<body>
+  <header>
+    <div class="container">
+      <nav>
+        <a class="logo" href="../index.html"><span class="logo-mark"></span>MCP-AQL</a>
+        <ul class="nav-links">
+          <li><a href="../index.html">Home</a></li>
+          <li><a href="index.html">Docs</a></li>
+          <li><a href="../launch-checklist.html">Launch Checklist</a></li>
+          <li><a href="../apis/mcp-server.html">Adapter Patterns</a></li>
+        </ul>
+        <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
+          <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
+          <input id="site-search-input" data-search-input type="search" placeholder="Search protocol topics...">
+          <span class="search-count" data-search-count></span>
+          <ul class="search-results" data-search-results hidden></ul>
+        </form>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <div class="container">
+      <section class="hero">
+        <div class="hero-inner">
+          <span class="status-pill">DOCUMENTATION LIBRARY</span>
+          <h1>Browse MCP-AQL By Domain</h1>
+          <p class="lede">
+            This library organizes source material from the MCPAQL repositories into a protocol-site shape: core specification,
+            security model, conformance expectations, implementation profiles, and ecosystem roadmap.
+          </p>
+          <div class="hero-actions">
+            <a class="btn btn-primary" href="protocol-core.html">Protocol Core</a>
+            <a class="btn btn-secondary" href="security-model.html">Security Model</a>
+            <a class="btn btn-secondary" href="conformance.html">Conformance</a>
+          </div>
+        </div>
+      </section>
+
+      <section>
+        <h2 class="section-title">Core Documentation Tracks</h2>
+        <p class="section-subtitle">Each track is mapped to canonical source repositories and intended launch visibility.</p>
+        <div class="grid cols-3">
+          <article class="card">
+            <h3>Protocol Core</h3>
+            <span class="state-chip live">Required</span>
+            <p>Normative request/response model, endpoint semantics, introspection contract, and operation model.</p>
+            <ul>
+              <li><a href="protocol-core.html">Site summary page</a></li>
+              <li><a href="https://github.com/MCPAQL/spec/blob/main/docs/versions/v1.0.0-draft.md">Normative source</a></li>
+            </ul>
+          </article>
+          <article class="card">
+            <h3>Security Model</h3>
+            <span class="state-chip live">Required</span>
+            <p>Gatekeeper boundaries, confirmation tokens, danger handling, and safety-loop alignment.</p>
+            <ul>
+              <li><a href="security-model.html">Site summary page</a></li>
+              <li><a href="https://github.com/MCPAQL/spec/blob/main/docs/security/gatekeeper.md">Canonical security docs</a></li>
+            </ul>
+          </article>
+          <article class="card">
+            <h3>Conformance</h3>
+            <span class="state-chip pending">In progress</span>
+            <p>Compatibility baseline, validation posture, and planned validator tooling.</p>
+            <ul>
+              <li><a href="conformance.html">Site summary page</a></li>
+              <li><a href="https://github.com/MCPAQL/spec/blob/main/docs/conformance-testing.md">Canonical conformance doc</a></li>
+            </ul>
+          </article>
+          <article class="card">
+            <h3>Implementation Profiles</h3>
+            <span class="state-chip live">Required</span>
+            <p>Boundary between canonical specification and practical production profile behavior.</p>
+            <ul>
+              <li><a href="implementation-profiles.html">Site summary page</a></li>
+              <li><a href="https://github.com/MCPAQL/mcpaql-adapter">Reference runtime repo</a></li>
+            </ul>
+          </article>
+          <article class="card">
+            <h3>Roadmap</h3>
+            <span class="state-chip live">Public planning</span>
+            <p>Phase-based protocol and ecosystem trajectory with current focus areas.</p>
+            <ul>
+              <li><a href="roadmap.html">Site summary page</a></li>
+              <li><a href="https://github.com/MCPAQL/spec">Spec issue tracker source</a></li>
+            </ul>
+          </article>
+          <article class="card">
+            <h3>Launch Checklist</h3>
+            <span class="state-chip live">Public control</span>
+            <p>Public-facing readiness checklist and launch-scope guardrails.</p>
+            <ul>
+              <li><a href="../launch-checklist.html">Checklist page</a></li>
+              <li><a href="https://github.com/MCPAQL/spec/blob/main/docs/process/preliminary-public-launch-checklist.md">Canonical checklist source</a></li>
+            </ul>
+          </article>
+        </div>
+      </section>
+
+      <section>
+        <h2 class="section-title">Repository Source Matrix</h2>
+        <p class="section-subtitle">The site intentionally reflects all primary MCPAQL repositories and their documentation role.</p>
+        <div class="card table-card">
+          <table class="data-table">
+            <thead>
+              <tr>
+                <th>Repository</th>
+                <th>Website Role</th>
+                <th>Primary Surface</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><a href="https://github.com/MCPAQL/spec">MCPAQL/spec</a></td>
+                <td>Normative authority</td>
+                <td>Protocol definitions and conformance requirements</td>
+              </tr>
+              <tr>
+                <td><a href="https://github.com/MCPAQL/mcpaql-adapter">MCPAQL/mcpaql-adapter</a></td>
+                <td>Reference implementation guidance</td>
+                <td>Architecture, runtime, plugin, and dispatch documentation</td>
+              </tr>
+              <tr>
+                <td><a href="https://github.com/MCPAQL/examples">MCPAQL/examples</a></td>
+                <td>Example patterns</td>
+                <td>Reference adapter configuration examples</td>
+              </tr>
+              <tr>
+                <td><a href="https://github.com/MCPAQL/adapter-generator">MCPAQL/adapter-generator</a></td>
+                <td>Generation policy</td>
+                <td>Output licensing and provenance constraints</td>
+              </tr>
+              <tr>
+                <td><a href="https://github.com/MCPAQL/tools">MCPAQL/tools</a></td>
+                <td>Validator/tooling track</td>
+                <td>Conformance CLI and on-spec validator workstream</td>
+              </tr>
+              <tr>
+                <td><a href="https://github.com/MCPAQL/website">MCPAQL/website</a></td>
+                <td>Public docs delivery</td>
+                <td>Readable/searchable protocol website</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+  </main>
+
+  <footer>
+    <div class="container">
+      <p>&copy; 2026 DollhouseMCP Inc. d/b/a Dollhouse Research. MCP-AQL public draft documentation portal.</p>
+      <div class="footer-links">
+        <a href="../index.html">Portal Home</a>
+        <a href="../launch-checklist.html">Launch Checklist</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../js/search.js"></script>
+</body>
+</html>

--- a/public/docs/protocol-core.html
+++ b/public/docs/protocol-core.html
@@ -18,8 +18,8 @@
         <ul class="nav-links">
           <li><a href="../index.html">Home</a></li>
           <li><a href="index.html">Docs</a></li>
-          <li><a href="security-model.html">Security</a></li>
-          <li><a href="conformance.html">Conformance</a></li>
+          <li><a href="../launch-checklist.html">Launch Checklist</a></li>
+          <li><a href="../apis/mcp-server.html">Adapter Patterns</a></li>
         </ul>
         <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>

--- a/public/docs/protocol-core.html
+++ b/public/docs/protocol-core.html
@@ -1,0 +1,195 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="MCP-AQL protocol core: normative scope, CRUDE model, endpoint modes, introspection, and response contracts.">
+  <title>MCP-AQL Docs | Protocol Core</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../css/style.css">
+</head>
+<body>
+  <header>
+    <div class="container">
+      <nav>
+        <a class="logo" href="../index.html"><span class="logo-mark"></span>MCP-AQL</a>
+        <ul class="nav-links">
+          <li><a href="../index.html">Home</a></li>
+          <li><a href="index.html">Docs</a></li>
+          <li><a href="security-model.html">Security</a></li>
+          <li><a href="conformance.html">Conformance</a></li>
+        </ul>
+        <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
+          <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
+          <input id="site-search-input" data-search-input type="search" placeholder="Search protocol topics...">
+          <span class="search-count" data-search-count></span>
+          <ul class="search-results" data-search-results hidden></ul>
+        </form>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <div class="container docs-shell">
+      <aside class="docs-side">
+        <h2>In This Library</h2>
+        <ul>
+          <li><a href="protocol-core.html">Protocol Core</a></li>
+          <li><a href="security-model.html">Security Model</a></li>
+          <li><a href="conformance.html">Conformance</a></li>
+          <li><a href="implementation-profiles.html">Implementation Profiles</a></li>
+          <li><a href="roadmap.html">Roadmap</a></li>
+        </ul>
+      </aside>
+
+      <article class="docs-main">
+        <section class="hero docs-hero">
+          <div class="hero-inner">
+            <span class="status-pill">PROTOCOL CORE</span>
+            <h1>Normative Foundations</h1>
+            <p class="lede">
+              MCP-AQL defines a protocol layer for operation consolidation and runtime discovery. Canonical authority is the
+              versioned specification in <code>MCPAQL/spec</code>; this page is a readable map of the same core requirements.
+            </p>
+            <div class="hero-actions">
+              <a class="btn btn-primary" href="https://github.com/MCPAQL/spec/blob/main/docs/versions/v1.0.0-draft.md">Normative Spec</a>
+              <a class="btn btn-secondary" href="https://github.com/MCPAQL/spec/blob/main/docs/README.md">Spec Docs Index</a>
+            </div>
+          </div>
+        </section>
+
+        <section>
+          <h2 class="section-title">Protocol Scope</h2>
+          <div class="card">
+            <p>
+              MCP-AQL specifies wire-level operation request/response behavior, endpoint semantics, introspection shape,
+              and operation classification guidance. It intentionally does not prescribe domain-specific operation sets.
+            </p>
+            <ul>
+              <li>Authority source: versioned specification document</li>
+              <li>Informative docs: support design and implementation choices</li>
+              <li>Adapter-specific operations: declared by each implementation</li>
+            </ul>
+          </div>
+        </section>
+
+        <section>
+          <h2 class="section-title">CRUDE Endpoint Model</h2>
+          <div class="card table-card">
+            <table class="data-table">
+              <thead>
+                <tr>
+                  <th>Endpoint</th>
+                  <th>Intent</th>
+                  <th>Safety posture</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Create</td>
+                  <td>Additive operations creating new state</td>
+                  <td>Non-destructive</td>
+                </tr>
+                <tr>
+                  <td>Read</td>
+                  <td>Safe queries without side effects</td>
+                  <td>Read-only</td>
+                </tr>
+                <tr>
+                  <td>Update</td>
+                  <td>Operations modifying existing state</td>
+                  <td>Mutating</td>
+                </tr>
+                <tr>
+                  <td>Delete</td>
+                  <td>Removal operations</td>
+                  <td>Destructive</td>
+                </tr>
+                <tr>
+                  <td>Execute</td>
+                  <td>Runtime lifecycle and side-effectful flows</td>
+                  <td>Stateful / non-idempotent</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <section>
+          <h2 class="section-title">Endpoint Modes</h2>
+          <div class="grid cols-2">
+            <article class="card">
+              <h3>CRUDE Mode (5 endpoints)</h3>
+              <p>Semantic separation by operation effect category. Maximizes explicit routing intent.</p>
+              <pre class="code-box">mcp_aql_create
+mcp_aql_read
+mcp_aql_update
+mcp_aql_delete
+mcp_aql_execute</pre>
+            </article>
+            <article class="card">
+              <h3>Single Mode (1 endpoint)</h3>
+              <p>One entrypoint for all operations, with internal routing based on operation metadata.</p>
+              <pre class="code-box">mcp_aql</pre>
+            </article>
+          </div>
+        </section>
+
+        <section>
+          <h2 class="section-title">Request And Response Contract</h2>
+          <div class="grid cols-2">
+            <article class="card">
+              <h3>Request Shape</h3>
+              <pre class="code-box">{
+  "operation": "introspect",
+  "params": { "query": "operations" }
+}</pre>
+              <p>
+                Public parameter names are snake_case. Runtime values are passed in <code>params</code> and aligned to
+                introspection-declared parameter definitions.
+              </p>
+            </article>
+            <article class="card">
+              <h3>Response Shape</h3>
+              <pre class="code-box">{ "success": true,  "data": { ... } }
+{ "success": false, "error": { ... } }</pre>
+              <p>
+                Conforming implementations use discriminated response unions so clients can branch behavior predictably.
+              </p>
+            </article>
+          </div>
+        </section>
+
+        <section>
+          <h2 class="section-title">Runtime Discovery</h2>
+          <div class="card">
+            <p>
+              The introspection system is required for runtime capability discovery and is central to reducing up-front tool-definition token load.
+              Clients query operations, parameters, and element types on demand instead of loading static schema sprawl into context.
+            </p>
+            <ul>
+              <li><a href="https://github.com/MCPAQL/spec/blob/main/docs/introspection.md">Introspection specification</a></li>
+              <li><a href="https://github.com/MCPAQL/spec/blob/main/docs/operations.md">Operation design guide</a></li>
+              <li><a href="https://github.com/MCPAQL/spec/blob/main/docs/error-codes.md">Structured error model</a></li>
+            </ul>
+          </div>
+        </section>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div class="container">
+      <p>&copy; 2026 DollhouseMCP Inc. d/b/a Dollhouse Research. MCP-AQL public draft documentation portal.</p>
+      <div class="footer-links">
+        <a href="index.html">Docs Library</a>
+        <a href="https://github.com/MCPAQL/spec">Canonical Spec Repo</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../js/search.js"></script>
+</body>
+</html>

--- a/public/docs/roadmap.html
+++ b/public/docs/roadmap.html
@@ -1,0 +1,171 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="MCP-AQL roadmap and launch readiness trajectory across protocol, adapters, examples, tooling, and website delivery.">
+  <title>MCP-AQL Docs | Roadmap</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../css/style.css">
+</head>
+<body>
+  <header>
+    <div class="container">
+      <nav>
+        <a class="logo" href="../index.html"><span class="logo-mark"></span>MCP-AQL</a>
+        <ul class="nav-links">
+          <li><a href="../index.html">Home</a></li>
+          <li><a href="index.html">Docs</a></li>
+          <li><a href="conformance.html">Conformance</a></li>
+          <li><a href="../launch-checklist.html">Launch Checklist</a></li>
+        </ul>
+        <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
+          <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
+          <input id="site-search-input" data-search-input type="search" placeholder="Search roadmap topics...">
+          <span class="search-count" data-search-count></span>
+          <ul class="search-results" data-search-results hidden></ul>
+        </form>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <div class="container docs-shell">
+      <aside class="docs-side">
+        <h2>In This Library</h2>
+        <ul>
+          <li><a href="protocol-core.html">Protocol Core</a></li>
+          <li><a href="security-model.html">Security Model</a></li>
+          <li><a href="conformance.html">Conformance</a></li>
+          <li><a href="implementation-profiles.html">Implementation Profiles</a></li>
+          <li><a href="roadmap.html">Roadmap</a></li>
+        </ul>
+      </aside>
+
+      <article class="docs-main">
+        <section class="hero docs-hero">
+          <div class="hero-inner">
+            <span class="status-pill">ROADMAP</span>
+            <h1>Launch And Post-Launch Trajectory</h1>
+            <p class="lede">
+              MCP-AQL development is staged across protocol quality, adapter maturity, examples, validator tooling, and ecosystem adoption.
+              This page translates those tracks into a public roadmap view.
+            </p>
+          </div>
+        </section>
+
+        <section>
+          <h2 class="section-title">Phase Model</h2>
+          <div class="card table-card">
+            <table class="data-table">
+              <thead>
+                <tr>
+                  <th>Phase</th>
+                  <th>Focus</th>
+                  <th>Public Draft Relevance</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Phase 0</td>
+                  <td>Infrastructure and repository foundations</td>
+                  <td>Completed baseline</td>
+                </tr>
+                <tr>
+                  <td>Phase 1</td>
+                  <td>Core protocol semantics and endpoint model</td>
+                  <td>Core of current public draft</td>
+                </tr>
+                <tr>
+                  <td>Phase 2</td>
+                  <td>Quality, conformance, and testing depth</td>
+                  <td>Primary in-progress launch hardening</td>
+                </tr>
+                <tr>
+                  <td>Phase 3</td>
+                  <td>Adapter specs and interface maturation</td>
+                  <td>Reference profile stabilization</td>
+                </tr>
+                <tr>
+                  <td>Phase 4+</td>
+                  <td>Advanced features and ecosystem expansion</td>
+                  <td>Post-launch expansion track</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <section>
+          <h2 class="section-title">Current Active Focus</h2>
+          <div class="grid cols-2">
+            <article class="card">
+              <h3>Spec Readiness</h3>
+              <span class="state-chip pending">Active</span>
+              <ul>
+                <li>MCP capability alignment audit</li>
+                <li>Batch/resource safeguard clarity</li>
+                <li>Structured error alignment and consistency</li>
+                <li>Conformance framework formalization</li>
+              </ul>
+            </article>
+            <article class="card">
+              <h3>Validation And Tooling</h3>
+              <span class="state-chip pending">Active</span>
+              <ul>
+                <li>Conformance validator CLI track</li>
+                <li>MVP on-spec validator profile for third-party servers</li>
+                <li>Expanded semantic evaluation for discoverability/usability</li>
+              </ul>
+            </article>
+            <article class="card">
+              <h3>Examples And Adapter Surface</h3>
+              <span class="state-chip pending">Active</span>
+              <ul>
+                <li>Identify high-value adapter candidates</li>
+                <li>Publish representative integration surfaces</li>
+                <li>Harden reference runtime docs and examples</li>
+              </ul>
+            </article>
+            <article class="card">
+              <h3>Website Maturity</h3>
+              <span class="state-chip live">Under delivery</span>
+              <ul>
+                <li>Browse-first documentation structure</li>
+                <li>Searchable protocol and implementation pages</li>
+                <li>Public launch readiness framing and checklist</li>
+              </ul>
+            </article>
+          </div>
+        </section>
+
+        <section>
+          <h2 class="section-title">Public Draft Scope Guardrails</h2>
+          <div class="card">
+            <ul>
+              <li>Publish clearly as preliminary draft, not final certification baseline.</li>
+              <li>Keep canonical-vs-profile boundaries explicit in every major page.</li>
+              <li>Avoid hidden dependencies on private issue trackers for public comprehension.</li>
+              <li>Provide direct, readable status language for what is available now vs still in progress.</li>
+            </ul>
+          </div>
+        </section>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div class="container">
+      <p>&copy; 2026 DollhouseMCP Inc. d/b/a Dollhouse Research. MCP-AQL public draft documentation portal.</p>
+      <div class="footer-links">
+        <a href="../launch-checklist.html">Launch Checklist</a>
+        <a href="index.html">Docs Library</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../js/search.js"></script>
+</body>
+</html>

--- a/public/docs/roadmap.html
+++ b/public/docs/roadmap.html
@@ -18,8 +18,8 @@
         <ul class="nav-links">
           <li><a href="../index.html">Home</a></li>
           <li><a href="index.html">Docs</a></li>
-          <li><a href="conformance.html">Conformance</a></li>
           <li><a href="../launch-checklist.html">Launch Checklist</a></li>
+          <li><a href="../apis/mcp-server.html">Adapter Patterns</a></li>
         </ul>
         <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>

--- a/public/docs/security-model.html
+++ b/public/docs/security-model.html
@@ -1,0 +1,140 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="MCP-AQL security model: trust levels, gatekeeper controls, confirmation tokens, and execution safety.">
+  <title>MCP-AQL Docs | Security Model</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../css/style.css">
+</head>
+<body>
+  <header>
+    <div class="container">
+      <nav>
+        <a class="logo" href="../index.html"><span class="logo-mark"></span>MCP-AQL</a>
+        <ul class="nav-links">
+          <li><a href="../index.html">Home</a></li>
+          <li><a href="index.html">Docs</a></li>
+          <li><a href="protocol-core.html">Protocol Core</a></li>
+          <li><a href="conformance.html">Conformance</a></li>
+        </ul>
+        <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
+          <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
+          <input id="site-search-input" data-search-input type="search" placeholder="Search security topics...">
+          <span class="search-count" data-search-count></span>
+          <ul class="search-results" data-search-results hidden></ul>
+        </form>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <div class="container docs-shell">
+      <aside class="docs-side">
+        <h2>In This Library</h2>
+        <ul>
+          <li><a href="protocol-core.html">Protocol Core</a></li>
+          <li><a href="security-model.html">Security Model</a></li>
+          <li><a href="conformance.html">Conformance</a></li>
+          <li><a href="implementation-profiles.html">Implementation Profiles</a></li>
+          <li><a href="roadmap.html">Roadmap</a></li>
+        </ul>
+      </aside>
+
+      <article class="docs-main">
+        <section class="hero docs-hero">
+          <div class="hero-inner">
+            <span class="status-pill">SECURITY MODEL</span>
+            <h1>Trust And Safety Controls</h1>
+            <p class="lede">
+              MCP-AQL security is designed around operation risk, trust-level mediation, and explicit confirmation for dangerous actions.
+              This page maps the current security model used in draft protocol and practical profiles.
+            </p>
+            <div class="hero-actions">
+              <a class="btn btn-primary" href="https://github.com/MCPAQL/spec/blob/main/docs/security/gatekeeper.md">Gatekeeper Spec</a>
+              <a class="btn btn-secondary" href="https://github.com/MCPAQL/spec/blob/main/docs/security/confirmation-tokens.md">Confirmation Tokens</a>
+              <a class="btn btn-secondary" href="https://github.com/MCPAQL/spec/blob/main/docs/security/execution-safety-loop.md">Execution Safety Loop</a>
+            </div>
+          </div>
+        </section>
+
+        <section>
+          <h2 class="section-title">Trust-Level Mediation</h2>
+          <div class="card">
+            <p>
+              Implementations classify requester trust and apply policy gates before operation dispatch. The exact trust taxonomy is adapter-defined,
+              but the enforcement pattern is protocol-aligned: low-trust contexts default toward read-only or restricted mutations.
+            </p>
+            <ul>
+              <li>Trust-level checks happen before execution</li>
+              <li>Dangerous operations require stronger policy context</li>
+              <li>Policies should be introspectable where feasible</li>
+            </ul>
+          </div>
+        </section>
+
+        <section>
+          <h2 class="section-title">Danger Classification</h2>
+          <div class="grid cols-2">
+            <article class="card">
+              <h3>Operation Risk Labels</h3>
+              <p>
+                Operations can be tagged by danger class to support UI and agent policy decisions. Draft specification work tracks stronger
+                requirements for danger metadata alignment with runtime surfaces.
+              </p>
+            </article>
+            <article class="card">
+              <h3>Confirmation Handshake</h3>
+              <p>
+                For destructive or high-impact operations, adapters can require a confirmation token round-trip so intent is explicit and auditable.
+              </p>
+            </article>
+          </div>
+        </section>
+
+        <section>
+          <h2 class="section-title">Execution Safety Loop</h2>
+          <div class="card">
+            <p>
+              Stateful execute flows must support lifecycle controls (start, continue, complete, abort) and maintain safe transitions.
+              Session-bound controls should prevent stale token reuse or operation drift across disconnected contexts.
+            </p>
+            <pre class="code-box">execute_agent -> record_execution_step -> continue_execution
+                 \-> pause/confirm -> complete_execution or abort_execution</pre>
+          </div>
+        </section>
+
+        <section>
+          <h2 class="section-title">Open Security Hardening Tracks</h2>
+          <div class="card">
+            <p>
+              Public launch posture should explicitly label in-progress hardening work. Current priority categories include batch safeguards,
+              structured error alignment, and conformance validation depth for policy-sensitive operations.
+            </p>
+            <ul>
+              <li>Batch/resource exhaustion protections</li>
+              <li>Structured error surface consistency</li>
+              <li>Conformance coverage for security and safety behaviors</li>
+            </ul>
+          </div>
+        </section>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div class="container">
+      <p>&copy; 2026 DollhouseMCP Inc. d/b/a Dollhouse Research. MCP-AQL public draft documentation portal.</p>
+      <div class="footer-links">
+        <a href="index.html">Docs Library</a>
+        <a href="conformance.html">Conformance Status</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../js/search.js"></script>
+</body>
+</html>

--- a/public/docs/security-model.html
+++ b/public/docs/security-model.html
@@ -18,8 +18,8 @@
         <ul class="nav-links">
           <li><a href="../index.html">Home</a></li>
           <li><a href="index.html">Docs</a></li>
-          <li><a href="protocol-core.html">Protocol Core</a></li>
-          <li><a href="conformance.html">Conformance</a></li>
+          <li><a href="../launch-checklist.html">Launch Checklist</a></li>
+          <li><a href="../apis/mcp-server.html">Adapter Patterns</a></li>
         </ul>
         <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>

--- a/public/index.html
+++ b/public/index.html
@@ -1,219 +1,202 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="MCP-AQL public draft hub: protocol overview, readiness gates, and implementation links.">
-    <title>MCP-AQL | Public Draft Portal</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="css/style.css">
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="MCP-AQL documentation portal for protocol specification, implementation profiles, conformance guidance, and launch readiness.">
+  <title>MCP-AQL | Protocol Documentation Portal</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
-    <header>
-        <div class="container">
-            <nav>
-                <a class="logo" href="index.html"><span class="logo-mark"></span>MCP-AQL</a>
-                <ul class="nav-links">
-                    <li><a href="#overview">Overview</a></li>
-                    <li><a href="#flow">How It Works</a></li>
-                    <li><a href="#readiness">Readiness</a></li>
-                    <li><a href="#repos">Repositories</a></li>
-                    <li><a href="#learn">Learn</a></li>
-                </ul>
-            </nav>
+  <header>
+    <div class="container">
+      <nav>
+        <a class="logo" href="index.html"><span class="logo-mark"></span>MCP-AQL</a>
+        <ul class="nav-links">
+          <li><a href="index.html">Home</a></li>
+          <li><a href="docs/index.html">Docs</a></li>
+          <li><a href="launch-checklist.html">Launch Checklist</a></li>
+          <li><a href="apis/mcp-server.html">Adapter Patterns</a></li>
+        </ul>
+        <form class="site-search" data-search-form data-index-url="data/search-index.json" role="search">
+          <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
+          <input id="site-search-input" data-search-input type="search" placeholder="Search docs, features, and repos...">
+          <span class="search-count" data-search-count></span>
+          <ul class="search-results" data-search-results hidden></ul>
+        </form>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <div class="container">
+      <section class="hero">
+        <div class="hero-inner">
+          <span class="status-pill">PRELIMINARY PUBLIC DRAFT</span>
+          <h1>MCP-AQL Protocol Website</h1>
+          <p class="lede">
+            This site is the browse-first documentation surface for MCP-AQL. It tracks canonical protocol definitions,
+            implementation profiles, conformance expectations, and launch readiness in one readable structure.
+          </p>
+          <div class="hero-actions">
+            <a class="btn btn-primary" href="docs/index.html">Open Documentation Library</a>
+            <a class="btn btn-secondary" href="https://github.com/MCPAQL/spec">Canonical Spec Repository</a>
+            <a class="btn btn-secondary" href="launch-checklist.html">Public Launch Checklist</a>
+          </div>
         </div>
-    </header>
+      </section>
 
-    <main>
-        <div class="container">
-            <section class="hero" id="overview">
-                <div class="hero-inner">
-                    <span class="status-pill">PRELIMINARY PUBLIC DRAFT</span>
-                    <h1>MCP-AQL Documentation Portal</h1>
-                    <p class="lede">
-                        MCP-AQL is a protocol for reducing tool-surface token bloat by consolidating operations into a predictable query and endpoint model.
-                        This site is the browse-first companion to the spec repository and launch readiness work.
-                    </p>
-                    <div class="hero-actions">
-                        <a class="btn btn-primary" href="https://github.com/MCPAQL/spec/blob/develop/docs/versions/v1.0.0-draft.md">Read The Normative Draft</a>
-                        <a class="btn btn-secondary" href="https://github.com/MCPAQL/spec">Spec Repository</a>
-                        <a class="btn btn-secondary" href="launch-checklist.html">Launch Checklist</a>
-                    </div>
-                </div>
-            </section>
-
-            <section>
-                <h2 class="section-title">Launch Positioning</h2>
-                <p class="section-subtitle">
-                    Protocol authority and implementation reality are intentionally separated for draft launch clarity.
-                </p>
-                <div class="grid cols-2">
-                    <article class="card">
-                        <h3>Canonical Protocol Source</h3>
-                        <p>
-                            Normative behavior is defined in <code>MCPAQL/spec</code>, especially the versioned draft document.
-                            Informative docs support implementation but do not override normative requirements.
-                        </p>
-                        <ul>
-                            <li><a href="https://github.com/MCPAQL/spec/blob/develop/docs/versions/v1.0.0-draft.md">Normative: v1.0.0-draft</a></li>
-                            <li><a href="https://github.com/MCPAQL/spec/blob/develop/docs/README.md">Docs map and authority model</a></li>
-                        </ul>
-                    </article>
-                    <article class="card">
-                        <h3>Practical Reference Profile</h3>
-                        <p>
-                            DollhouseMCP production is treated as a practical reference profile that validates the protocol in a large, real system.
-                            It is not the canonical definition.
-                        </p>
-                        <ul>
-                            <li><a href="https://github.com/DollhouseMCP/mcp-server">DollhouseMCP production server</a></li>
-                            <li><a href="https://dollhouseresearch.com">Dollhouse research site</a></li>
-                        </ul>
-                    </article>
-                </div>
-            </section>
-
-            <section id="flow">
-                <h2 class="section-title">How MCP-AQL Works</h2>
-                <p class="section-subtitle">
-                    A typical request path starts with introspection and ends with operation dispatch through CRUDE/single mode.
-                </p>
-                <div class="grid cols-3">
-                    <article class="card">
-                        <h3>1. Discover</h3>
-                        <p>Clients call <code>introspect</code> to discover supported operations and parameter contracts at runtime.</p>
-                    </article>
-                    <article class="card">
-                        <h3>2. Route</h3>
-                        <p>Operations are routed through semantic endpoints (Create, Read, Update, Delete, Execute) or single-endpoint mode.</p>
-                    </article>
-                    <article class="card">
-                        <h3>3. Enforce</h3>
-                        <p>Adapters apply validation, safety, and policy controls before execution (including gatekeeper-style modules).</p>
-                    </article>
-                </div>
-                <div class="card" style="margin-top: 1rem;">
-                    <h3>Example Query Shape</h3>
-                    <pre class="code-box">{
-  "operation": "introspect",
-  "params": { "query": "operations" }
-}</pre>
-                </div>
-            </section>
-
-            <section id="readiness">
-                <h2 class="section-title">Current Launch Gates</h2>
-                <p class="section-subtitle">
-                    This is a public draft status snapshot for people evaluating MCP-AQL readiness and current scope.
-                </p>
-                <div class="grid cols-3">
-                    <article class="card">
-                        <h3>Spec Core Robustness</h3>
-                        <div class="status-row"><span class="dot warn"></span><strong>In Progress</strong></div>
-                        <ul>
-                            <li><a href="https://github.com/MCPAQL/spec/issues/193">#193 MCP protocol capability audit</a></li>
-                            <li><a href="https://github.com/MCPAQL/spec/issues/197">#197 batch/resource safeguards</a></li>
-                            <li><a href="https://github.com/MCPAQL/spec/issues/199">#199 structured error alignment</a></li>
-                            <li><a href="https://github.com/MCPAQL/spec/issues/194">#194 draft release epic</a></li>
-                        </ul>
-                    </article>
-                    <article class="card">
-                        <h3>Dollhouse Profile Alignment</h3>
-                        <div class="status-row"><span class="dot warn"></span><strong>In Progress</strong></div>
-                        <ul>
-                            <li>Production adapter profile documentation is being tightened for launch.</li>
-                            <li>Structured error surfacing and batch safety limits remain active priorities.</li>
-                            <li>Public launch messaging keeps protocol-vs-profile boundaries explicit.</li>
-                        </ul>
-                    </article>
-                    <article class="card">
-                        <h3>Public Documentation Presence</h3>
-                        <div class="status-row"><span class="dot warn"></span><strong>Now Being Built</strong></div>
-                        <ul>
-                            <li>This website is the browse-first documentation surface.</li>
-                            <li>Spec repo remains source of truth for normative text.</li>
-                            <li>Additional walkthrough pages should continue post-launch.</li>
-                        </ul>
-                    </article>
-                </div>
-                <p class="callout">
-                    Launch recommendation: publish as a clearly labeled draft with explicit known-open items, not as a final conformance baseline.
-                </p>
-                <p class="callout">
-                    For a full public-facing checklist view, use the <a href="launch-checklist.html">Launch Checklist page</a> in this site.
-                </p>
-            </section>
-
-            <section id="learn">
-                <h2 class="section-title">Browse By Integration Surface</h2>
-                <p class="section-subtitle">These pages currently provide draft integration guidance. Public reference adapters are not yet published.</p>
-                <div class="grid cols-3">
-                    <a class="card" href="apis/mcp-server.html"><h3>MCP Server</h3><span class="state-chip pending">Draft guidance only</span><p>Native protocol adapter design and operation introspection.</p></a>
-                    <a class="card" href="apis/operating-system.html"><h3>Operating System</h3><span class="state-chip pending">Draft guidance only</span><p>Permission-sensitive local operations and safety boundary design.</p></a>
-                    <a class="card" href="apis/application.html"><h3>Application</h3><span class="state-chip pending">Draft guidance only</span><p>Desktop/mobile automation and app-local command surfaces.</p></a>
-                    <a class="card" href="apis/cloud-service.html"><h3>Cloud Service</h3><span class="state-chip pending">Draft guidance only</span><p>External API orchestration with rate/cost constraints.</p></a>
-                    <a class="card" href="apis/website.html"><h3>Website</h3><span class="state-chip pending">Draft guidance only</span><p>Web integration patterns for retrieval, extraction, and action flows.</p></a>
-                </div>
-            </section>
-
-            <section>
-                <h2 class="section-title">Public Adapter Examples</h2>
-                <p class="section-subtitle">None are published yet. Once adapters are released, this section will list them with runnable references.</p>
-                <div class="grid cols-2">
-                    <article class="card">
-                        <h3>MCP Server Reference Adapter</h3>
-                        <span class="state-chip pending">Not published yet</span>
-                        <p>
-                            Planned first example area. The intent is to provide a concrete adapter that maps a known MCP server into MCP-AQL operation contracts.
-                        </p>
-                    </article>
-                    <article class="card">
-                        <h3>What You Can Do Today</h3>
-                        <ul>
-                            <li>Review the normative spec draft and issue tracker.</li>
-                            <li>Evaluate draft integration-surface guidance pages.</li>
-                            <li>Prototype adapters and share implementation feedback.</li>
-                        </ul>
-                    </article>
-                </div>
-            </section>
-
-            <section id="repos">
-                <h2 class="section-title">Repository Map</h2>
-                <p class="section-subtitle">Primary MCP-AQL and related implementation repositories.</p>
-                <div class="grid cols-2 repo-list">
-                    <article class="card">
-                        <h3>MCPAQL Organization</h3>
-                        <ul>
-                            <li><a href="https://github.com/MCPAQL/spec">spec</a></li>
-                            <li><a href="https://github.com/MCPAQL/website">website</a></li>
-                            <li><a href="https://github.com/MCPAQL/examples">examples</a></li>
-                            <li><a href="https://github.com/MCPAQL/adapter-generator">adapter-generator</a></li>
-                            <li><a href="https://github.com/MCPAQL/mcpaql-adapter">mcpaql-adapter</a></li>
-                        </ul>
-                    </article>
-                    <article class="card">
-                        <h3>Dollhouse Research Context</h3>
-                        <ul>
-                            <li><a href="https://github.com/DollhouseMCP/mcp-server">DollhouseMCP production server</a></li>
-                            <li><a href="https://dollhouseresearch.com">Dollhouse Research site</a></li>
-                        </ul>
-                    </article>
-                </div>
-            </section>
+      <section>
+        <h2 class="section-title">Start Here</h2>
+        <p class="section-subtitle">
+          If you are new to MCP-AQL, this sequence gives you the protocol baseline and the implementation context without repo spelunking.
+        </p>
+        <div class="grid cols-3">
+          <article class="card">
+            <h3>1. Read The Normative Draft</h3>
+            <p>The protocol authority starts with the versioned specification and core endpoint semantics.</p>
+            <ul>
+              <li><a href="https://github.com/MCPAQL/spec/blob/main/docs/versions/v1.0.0-draft.md">Specification v1.0.0-draft</a></li>
+              <li><a href="https://github.com/MCPAQL/spec/blob/main/docs/crude-pattern.md">CRUDE Pattern</a></li>
+              <li><a href="https://github.com/MCPAQL/spec/blob/main/docs/introspection.md">Introspection</a></li>
+            </ul>
+          </article>
+          <article class="card">
+            <h3>2. Understand Profiles</h3>
+            <p>MCP-AQL separates canonical protocol requirements from practical implementation profiles.</p>
+            <ul>
+              <li><a href="docs/implementation-profiles.html">Canonical vs Practical Profiles</a></li>
+              <li><a href="https://github.com/DollhouseMCP/mcp-server">DollhouseMCP Production Profile</a></li>
+              <li><a href="https://dollhouseresearch.com">Dollhouse Research Context</a></li>
+            </ul>
+          </article>
+          <article class="card">
+            <h3>3. Validate Readiness</h3>
+            <p>Use the conformance and launch pages to track what is publish-ready versus explicitly in-progress.</p>
+            <ul>
+              <li><a href="docs/conformance.html">Conformance and Validator Status</a></li>
+              <li><a href="docs/roadmap.html">Protocol Roadmap</a></li>
+              <li><a href="launch-checklist.html">Public Launch Checklist</a></li>
+            </ul>
+          </article>
         </div>
-    </main>
+      </section>
 
-    <footer>
-        <div class="container">
-            <p>&copy; 2026 DollhouseMCP Inc. d/b/a Dollhouse Research. MCP-AQL public draft documentation portal.</p>
-            <div class="footer-links">
-                <a href="https://github.com/MCPAQL">MCPAQL Organization</a>
-                <a href="https://github.com/MCPAQL/spec/issues">Spec Issues</a>
-            </div>
+      <section>
+        <h2 class="section-title">Protocol Coverage</h2>
+        <p class="section-subtitle">Website coverage is organized to mirror how production protocol sites are typically navigated: core, security, validation, implementation, ecosystem.</p>
+        <div class="grid cols-2">
+          <article class="card">
+            <h3>Core Protocol Surface</h3>
+            <ul>
+              <li>Request and response contract model</li>
+              <li>CRUDE and single-endpoint operation routing</li>
+              <li>Runtime introspection for discoverability</li>
+              <li>Type, warning, and structured-error framing</li>
+            </ul>
+            <a href="docs/protocol-core.html">Open Protocol Core</a>
+          </article>
+          <article class="card">
+            <h3>Security And Safety Surface</h3>
+            <ul>
+              <li>Gatekeeper trust-level mediation</li>
+              <li>Danger-level and confirmation token flows</li>
+              <li>Execution loop controls and safety boundaries</li>
+              <li>Batch/resource exhaustion protections</li>
+            </ul>
+            <a href="docs/security-model.html">Open Security Model</a>
+          </article>
+          <article class="card">
+            <h3>Conformance And Tooling Surface</h3>
+            <ul>
+              <li>Required behavior for claiming MCP-AQL compatibility</li>
+              <li>Current conformance test and validator status</li>
+              <li>MVP "on-spec" validator roadmap in tools repo</li>
+            </ul>
+            <a href="docs/conformance.html">Open Conformance Guide</a>
+          </article>
+          <article class="card">
+            <h3>Implementation And Ecosystem Surface</h3>
+            <ul>
+              <li>Reference runtime and plugin architecture docs</li>
+              <li>Example adapter strategy and launch candidates</li>
+              <li>Generator/output-policy and provenance requirements</li>
+            </ul>
+            <a href="docs/implementation-profiles.html">Open Implementation Profiles</a>
+          </article>
         </div>
-    </footer>
+      </section>
+
+      <section>
+        <h2 class="section-title">Repository Map</h2>
+        <p class="section-subtitle">Each repository has a distinct role in launch readiness. The website summarizes and links all of them in one public path.</p>
+        <div class="grid cols-3 repo-list">
+          <article class="card">
+            <h3>spec</h3>
+            <span class="state-chip live">Canonical</span>
+            <p>Normative protocol text, schemas, and versioned draft authority.</p>
+            <a href="https://github.com/MCPAQL/spec">Open Repository</a>
+          </article>
+          <article class="card">
+            <h3>mcpaql-adapter</h3>
+            <span class="state-chip pending">Reference Runtime</span>
+            <p>Schema-driven dispatch, runtime architecture, and plugin contracts in practice.</p>
+            <a href="https://github.com/MCPAQL/mcpaql-adapter">Open Repository</a>
+          </article>
+          <article class="card">
+            <h3>examples</h3>
+            <span class="state-chip pending">Reference Adapters</span>
+            <p>Pattern examples and candidate public adapters for launch-phase demonstration.</p>
+            <a href="https://github.com/MCPAQL/examples">Open Repository</a>
+          </article>
+          <article class="card">
+            <h3>adapter-generator</h3>
+            <span class="state-chip pending">Generator Track</span>
+            <p>Output policy, provenance, and generation constraints for derived adapters.</p>
+            <a href="https://github.com/MCPAQL/adapter-generator">Open Repository</a>
+          </article>
+          <article class="card">
+            <h3>tools</h3>
+            <span class="state-chip pending">Validation Track</span>
+            <p>Conformance CLI and on-spec validator workstream for third-party implementations.</p>
+            <a href="https://github.com/MCPAQL/tools">Open Repository</a>
+          </article>
+          <article class="card">
+            <h3>website</h3>
+            <span class="state-chip live">Documentation Portal</span>
+            <p>Public-facing browse and search layer for protocol launch and post-launch evolution.</p>
+            <a href="https://github.com/MCPAQL/website">Open Repository</a>
+          </article>
+        </div>
+      </section>
+
+      <section>
+        <h2 class="section-title">Adapter Pattern Pages</h2>
+        <p class="section-subtitle">Pattern pages remain draft guidance until concrete public adapters are published.</p>
+        <div class="grid cols-3">
+          <a class="card" href="apis/mcp-server.html"><h3>MCP Server Pattern</h3><span class="state-chip pending">Draft guidance</span><p>Native MCP server consolidation patterns.</p></a>
+          <a class="card" href="apis/operating-system.html"><h3>Operating System Pattern</h3><span class="state-chip pending">Draft guidance</span><p>Permission-aware local execution boundaries.</p></a>
+          <a class="card" href="apis/application.html"><h3>Application Pattern</h3><span class="state-chip pending">Draft guidance</span><p>Application APIs mapped into semantic operations.</p></a>
+          <a class="card" href="apis/cloud-service.html"><h3>Cloud Service Pattern</h3><span class="state-chip pending">Draft guidance</span><p>External API adaptation with quota and resilience posture.</p></a>
+          <a class="card" href="apis/website.html"><h3>Website Pattern</h3><span class="state-chip pending">Draft guidance</span><p>Web retrieval and action orchestration guidance.</p></a>
+        </div>
+      </section>
+    </div>
+  </main>
+
+  <footer>
+    <div class="container">
+      <p>&copy; 2026 DollhouseMCP Inc. d/b/a Dollhouse Research. MCP-AQL public draft documentation portal.</p>
+      <div class="footer-links">
+        <a href="docs/index.html">Documentation Library</a>
+        <a href="https://github.com/MCPAQL">MCPAQL Organization</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="js/search.js"></script>
 </body>
 </html>

--- a/public/js/search.js
+++ b/public/js/search.js
@@ -1,0 +1,130 @@
+(function () {
+  function normalize(value) {
+    return (value || "").toLowerCase().trim();
+  }
+
+  function scoreItem(item, query) {
+    const q = normalize(query);
+    if (!q) return 0;
+
+    const title = normalize(item.title);
+    const excerpt = normalize(item.excerpt);
+    const keywords = normalize((item.keywords || []).join(" "));
+    const url = normalize(item.url);
+
+    let score = 0;
+    if (title.includes(q)) score += 8;
+    if (excerpt.includes(q)) score += 4;
+    if (keywords.includes(q)) score += 5;
+    if (url.includes(q)) score += 2;
+
+    return score;
+  }
+
+  function renderResultItem(item) {
+    const li = document.createElement("li");
+    li.className = "search-result-item";
+
+    const link = document.createElement("a");
+    link.href = item.url;
+
+    const title = document.createElement("strong");
+    title.textContent = item.title;
+
+    const excerpt = document.createElement("span");
+    excerpt.textContent = item.excerpt;
+
+    link.appendChild(title);
+    link.appendChild(excerpt);
+
+    li.appendChild(link);
+    return li;
+  }
+
+  function mountSearch(form) {
+    const input = form.querySelector("[data-search-input]");
+    const resultBox = form.querySelector("[data-search-results]");
+    const count = form.querySelector("[data-search-count]");
+    const indexUrl = form.getAttribute("data-index-url");
+
+    if (!input || !resultBox || !indexUrl) return;
+
+    fetch(indexUrl)
+      .then(function (resp) {
+        if (!resp.ok) throw new Error("Search index fetch failed");
+        return resp.json();
+      })
+      .then(function (index) {
+        function closeResults() {
+          resultBox.hidden = true;
+          resultBox.innerHTML = "";
+          if (count) count.textContent = "";
+        }
+
+        function updateResults() {
+          const query = input.value.trim();
+          if (!query) {
+            closeResults();
+            return;
+          }
+
+          const ranked = index
+            .map(function (item) {
+              return { item: item, score: scoreItem(item, query) };
+            })
+            .filter(function (entry) {
+              return entry.score > 0;
+            })
+            .sort(function (a, b) {
+              return b.score - a.score;
+            })
+            .slice(0, 8)
+            .map(function (entry) {
+              return entry.item;
+            });
+
+          resultBox.innerHTML = "";
+
+          if (!ranked.length) {
+            const empty = document.createElement("li");
+            empty.className = "search-result-empty";
+            empty.textContent = "No matches yet. Try protocol terms like introspect, conformance, gatekeeper, or adapter.";
+            resultBox.appendChild(empty);
+            resultBox.hidden = false;
+            if (count) count.textContent = "0 results";
+            return;
+          }
+
+          ranked.forEach(function (item) {
+            resultBox.appendChild(renderResultItem(item));
+          });
+
+          resultBox.hidden = false;
+          if (count) count.textContent = ranked.length + " result" + (ranked.length === 1 ? "" : "s");
+        }
+
+        input.addEventListener("input", updateResults);
+        input.addEventListener("focus", updateResults);
+
+        document.addEventListener("click", function (event) {
+          if (!form.contains(event.target)) {
+            closeResults();
+          }
+        });
+
+        document.addEventListener("keydown", function (event) {
+          if (event.key === "Escape") {
+            closeResults();
+            input.blur();
+          }
+        });
+      })
+      .catch(function () {
+        if (count) count.textContent = "Search unavailable";
+      });
+  }
+
+  document.addEventListener("DOMContentLoaded", function () {
+    document.querySelectorAll("[data-search-form]").forEach(mountSearch);
+  });
+})();

--- a/public/launch-checklist.html
+++ b/public/launch-checklist.html
@@ -18,8 +18,8 @@
         <ul class="nav-links">
           <li><a href="index.html">Home</a></li>
           <li><a href="docs/index.html">Docs</a></li>
-          <li><a href="docs/conformance.html">Conformance</a></li>
-          <li><a href="docs/roadmap.html">Roadmap</a></li>
+          <li><a href="launch-checklist.html">Launch Checklist</a></li>
+          <li><a href="apis/mcp-server.html">Adapter Patterns</a></li>
         </ul>
         <form class="site-search" data-search-form data-index-url="data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>

--- a/public/launch-checklist.html
+++ b/public/launch-checklist.html
@@ -1,114 +1,140 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="Public launch checklist for MCP-AQL draft readiness.">
-    <title>Launch Checklist | MCP-AQL</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="css/style.css">
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Public-facing launch checklist for MCP-AQL preliminary draft readiness.">
+  <title>Launch Checklist | MCP-AQL</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
-    <header>
-        <div class="container">
-            <nav>
-                <a class="logo" href="index.html"><span class="logo-mark"></span>MCP-AQL</a>
-                <ul class="nav-links">
-                    <li><a href="index.html#overview">Overview</a></li>
-                    <li><a href="index.html#flow">How It Works</a></li>
-                    <li><a href="index.html#readiness">Readiness</a></li>
-                    <li><a href="index.html#repos">Repositories</a></li>
-                </ul>
-            </nav>
+  <header>
+    <div class="container">
+      <nav>
+        <a class="logo" href="index.html"><span class="logo-mark"></span>MCP-AQL</a>
+        <ul class="nav-links">
+          <li><a href="index.html">Home</a></li>
+          <li><a href="docs/index.html">Docs</a></li>
+          <li><a href="docs/conformance.html">Conformance</a></li>
+          <li><a href="docs/roadmap.html">Roadmap</a></li>
+        </ul>
+        <form class="site-search" data-search-form data-index-url="data/search-index.json" role="search">
+          <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
+          <input id="site-search-input" data-search-input type="search" placeholder="Search launch topics...">
+          <span class="search-count" data-search-count></span>
+          <ul class="search-results" data-search-results hidden></ul>
+        </form>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <div class="container">
+      <section class="hero">
+        <div class="hero-inner">
+          <span class="status-pill">PRELIMINARY PUBLIC DRAFT</span>
+          <h1>MCP-AQL Launch Checklist</h1>
+          <p class="lede">
+            Public launch readiness should be explicit, auditable, and understandable without private tracker access.
+            This checklist reflects what is available now, what is actively in progress, and what remains pre-final.
+          </p>
         </div>
-    </header>
+      </section>
 
-    <main>
-        <div class="container">
-            <section class="hero">
-                <div class="hero-inner">
-                    <span class="status-pill">PUBLIC DRAFT CHECKLIST</span>
-                    <h1>MCP-AQL Launch Checklist</h1>
-                    <p class="lede">
-                        This page is the public-facing summary of launch readiness. It is designed for implementers, reviewers, and ecosystem partners tracking draft maturity.
-                    </p>
-                </div>
-            </section>
-
-            <section>
-                <h2 class="section-title">Checklist Status</h2>
-                <p class="section-subtitle">Current status is based on active public tracking in the spec and production-profile repositories.</p>
-                <div class="grid cols-3">
-                    <article class="card">
-                        <h3>Track A: Spec Draft Core</h3>
-                        <span class="state-chip pending">In progress</span>
-                        <ul>
-                            <li><a href="https://github.com/MCPAQL/spec/issues/193">MCP capability audit</a></li>
-                            <li><a href="https://github.com/MCPAQL/spec/issues/197">Batch/resource safeguards</a></li>
-                            <li><a href="https://github.com/MCPAQL/spec/issues/199">Structured error alignment</a></li>
-                            <li><a href="https://github.com/MCPAQL/spec/issues/194">Draft release epic</a></li>
-                        </ul>
-                    </article>
-                    <article class="card">
-                        <h3>Track B: Practical Profile</h3>
-                        <span class="state-chip pending">In progress</span>
-                        <ul>
-                            <li>Dollhouse production profile docs are being tightened for launch.</li>
-                            <li>Machine-readable error behavior remains active work.</li>
-                            <li>Batch safety boundaries remain active work.</li>
-                        </ul>
-                    </article>
-                    <article class="card">
-                        <h3>Track C: Public Docs Surface</h3>
-                        <span class="state-chip pending">In progress</span>
-                        <ul>
-                            <li>This website now hosts public launch/readiness context.</li>
-                            <li>Integration pages are currently draft guidance only.</li>
-                            <li>Public adapter examples are not yet published.</li>
-                        </ul>
-                    </article>
-                </div>
-            </section>
-
-            <section>
-                <h2 class="section-title">What This Means For Visitors</h2>
-                <div class="grid cols-2">
-                    <article class="card">
-                        <h3>Safe To Use For</h3>
-                        <ul>
-                            <li>Understanding protocol direction and architecture.</li>
-                            <li>Early implementation experiments and feedback loops.</li>
-                            <li>Evaluating token-efficiency and introspection model tradeoffs.</li>
-                        </ul>
-                    </article>
-                    <article class="card">
-                        <h3>Not Yet Finalized</h3>
-                        <ul>
-                            <li>Finalized conformance-grade launch criteria.</li>
-                            <li>Published public reference adapters.</li>
-                            <li>Complete closure of robustness and error-surface work.</li>
-                        </ul>
-                    </article>
-                </div>
-                <p class="callout">This checklist intentionally reflects a preliminary public draft state, not a final certification state.</p>
-            </section>
-
-            <section>
-                <a class="btn btn-secondary" href="index.html">&larr; Back to portal</a>
-            </section>
+      <section>
+        <h2 class="section-title">Readiness Tracks</h2>
+        <div class="grid cols-3">
+          <article class="card">
+            <h3>Track A: Spec Core</h3>
+            <span class="state-chip pending">In progress</span>
+            <ul>
+              <li>MCP capability alignment audit</li>
+              <li>Batch/resource safeguard clarity</li>
+              <li>Structured error alignment</li>
+              <li>Conformance framework formalization</li>
+            </ul>
+          </article>
+          <article class="card">
+            <h3>Track B: Practical Profiles</h3>
+            <span class="state-chip pending">In progress</span>
+            <ul>
+              <li>Dollhouse profile documentation refinement</li>
+              <li>Security loop documentation hardening</li>
+              <li>Error and batch behavior alignment</li>
+              <li>Profile-to-spec boundary clarity</li>
+            </ul>
+          </article>
+          <article class="card">
+            <h3>Track C: Public Website</h3>
+            <span class="state-chip live">Active delivery</span>
+            <ul>
+              <li>Browse-first documentation library</li>
+              <li>Searchable protocol and profile pages</li>
+              <li>Launch and roadmap visibility pages</li>
+              <li>Draft adapter pattern guidance pages</li>
+            </ul>
+          </article>
         </div>
-    </main>
+      </section>
 
-    <footer>
-        <div class="container">
-            <p>&copy; 2026 DollhouseMCP Inc. d/b/a Dollhouse Research. MCP-AQL public draft documentation portal.</p>
-            <div class="footer-links">
-                <a href="https://github.com/MCPAQL">MCPAQL Organization</a>
-                <a href="https://github.com/MCPAQL/spec/issues">Spec Issues</a>
-            </div>
+      <section>
+        <h2 class="section-title">Publish-Now vs Publish-Later</h2>
+        <div class="grid cols-2">
+          <article class="card">
+            <h3>Publish In Preliminary Draft</h3>
+            <ul>
+              <li>Normative protocol draft and core semantics</li>
+              <li>Security and safety model overview</li>
+              <li>Practical profile framing and boundaries</li>
+              <li>Conformance posture with known-open work clearly labeled</li>
+            </ul>
+          </article>
+          <article class="card">
+            <h3>Hold For Final Certification Posture</h3>
+            <ul>
+              <li>Full validator-backed compatibility claims</li>
+              <li>Comprehensive public adapter catalog</li>
+              <li>Closure of all robustness and validation hardening tracks</li>
+              <li>Finalized certification governance language</li>
+            </ul>
+          </article>
         </div>
-    </footer>
+      </section>
+
+      <section>
+        <h2 class="section-title">Checklist Controls</h2>
+        <div class="card">
+          <ul>
+            <li>Never blur canonical protocol with one implementation profile.</li>
+            <li>Never hide known-open work in private references only.</li>
+            <li>Always label public pages with draft/final status.</li>
+            <li>Keep validator and conformance maturity language precise.</li>
+          </ul>
+          <p class="callout">
+            This checklist is intentionally for a preliminary public draft launch. It is not a final compliance certification declaration.
+          </p>
+        </div>
+      </section>
+
+      <section>
+        <a class="btn btn-secondary" href="index.html">&larr; Back to Portal Home</a>
+      </section>
+    </div>
+  </main>
+
+  <footer>
+    <div class="container">
+      <p>&copy; 2026 DollhouseMCP Inc. d/b/a Dollhouse Research. MCP-AQL public draft documentation portal.</p>
+      <div class="footer-links">
+        <a href="docs/index.html">Documentation Library</a>
+        <a href="https://github.com/MCPAQL">MCPAQL Organization</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="js/search.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace the portal homepage with a fuller protocol-site structure
- add a multi-page docs library (core protocol, security model, conformance, implementation profiles, roadmap)
- add client-side site search with searchable index
- update launch checklist to public-facing readiness framing
- scrub direct issue/PR links from public pages
- update adapter pattern nav/footer links to match new information architecture

## Source grounding
This content pass was built from repository docs across:
- MCPAQL/spec (normative + informative protocol docs)
- MCPAQL/mcpaql-adapter (implementation guidance)
- MCPAQL/examples (example adapter patterns)
- MCPAQL/adapter-generator (output policy/provenance constraints)
- MCPAQL/tools (validator track)

## Validation
- local HTTP status checks returned 200 for core pages
- Playwright browser pass over local preview returned BAD_COUNT 0
- search input returns indexed doc results
