### PR TITLE
feat: expand website docs coverage and repo workflows

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @mickdarling

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,59 @@
+name: Bug report
+description: Report a broken page, link, layout issue, or behavior bug on the MCP-AQL website.
+title: "bug: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a website bug. Please include enough context for someone else to reproduce it quickly.
+  - type: input
+    id: page_url
+    attributes:
+      label: Affected page or URL
+      description: Include the page path or full URL.
+      placeholder: /docs/protocol-core.html
+    validations:
+      required: true
+  - type: dropdown
+    id: bug_type
+    attributes:
+      label: What kind of issue is this?
+      options:
+        - Broken content or factual mismatch
+        - Layout or responsive issue
+        - Accessibility problem
+        - Broken link or asset
+        - Search or navigation problem
+        - CI or deployment issue
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: Describe the problem and the expected result.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Open ...
+        2. Click ...
+        3. Observe ...
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Browser, device, viewport, or screen reader details if relevant.
+      placeholder: Safari 18 on macOS, iPhone 15 Safari, NVDA + Firefox
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Screenshots or links
+      description: Paste screenshots, error output, or related issue links if available.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: MCP-AQL specification repository
+    url: https://github.com/MCPAQL/spec
+    about: Report canonical spec issues in the spec repository when the problem is not website-specific.

--- a/.github/ISSUE_TEMPLATE/content-request.yml
+++ b/.github/ISSUE_TEMPLATE/content-request.yml
@@ -1,0 +1,50 @@
+name: Content request
+description: Request a new page, section, or spec-alignment update for the MCP-AQL website.
+title: "content: "
+labels:
+  - documentation
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for new documentation coverage, source-of-truth updates, or missing content from the spec.
+  - type: input
+    id: page_area
+    attributes:
+      label: Target area
+      description: Which page or section should change?
+      placeholder: Docs library / new error-model page
+    validations:
+      required: true
+  - type: textarea
+    id: request
+    attributes:
+      label: Requested content
+      description: Describe what should be added or clarified.
+    validations:
+      required: true
+  - type: textarea
+    id: sources
+    attributes:
+      label: Source material
+      description: Link the canonical docs, spec sections, or issues this should reflect.
+      placeholder: |
+        https://github.com/MCPAQL/spec/blob/main/docs/error-codes.md
+        https://github.com/MCPAQL/spec/issues/199
+    validations:
+      required: true
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options:
+        - Launch blocker
+        - Important for draft clarity
+        - Nice to have
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Done looks like
+      description: Describe the outcome that would satisfy the request.

--- a/.github/ISSUE_TEMPLATE/improvement.yml
+++ b/.github/ISSUE_TEMPLATE/improvement.yml
@@ -1,0 +1,37 @@
+name: Improvement
+description: Suggest a UX, information architecture, design, or workflow improvement for the MCP-AQL website.
+title: "improvement: "
+labels:
+  - enhancement
+body:
+  - type: input
+    id: area
+    attributes:
+      label: Improvement area
+      placeholder: Search, navigation, docs structure, workflows
+    validations:
+      required: true
+  - type: textarea
+    id: current_problem
+    attributes:
+      label: Current problem
+      description: What is not working well today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed improvement
+      description: Describe the change you want to see.
+    validations:
+      required: true
+  - type: textarea
+    id: rationale
+    attributes:
+      label: Why this helps
+      description: Explain the user or maintainer benefit.
+  - type: textarea
+    id: notes
+    attributes:
+      label: Related links or mockups
+      description: Include relevant issues, screenshots, or source material.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+## Summary
+
+- What changed?
+- Why was it needed?
+
+## Testing
+
+- [ ] HTML/content reviewed locally
+- [ ] Relevant links checked
+- [ ] Search index updated if navigation or page coverage changed
+- [ ] CI expectations reviewed
+
+## Accessibility
+
+- [ ] Semantic structure preserved or improved
+- [ ] Keyboard and responsive impact considered
+- [ ] Color/contrast impact considered
+
+## Visuals
+
+- [ ] Screenshots included for visible UI changes
+- [ ] No screenshots needed
+
+## Related
+
+- Closes #

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,0 +1,35 @@
+name: Lighthouse CI
+
+on:
+  pull_request:
+    paths:
+      - "public/**"
+      - ".github/workflows/lighthouse.yml"
+      - ".lighthouserc.json"
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  lighthouse:
+    name: Audit key pages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Run Lighthouse CI
+        uses: treosh/lighthouse-ci-action@v12
+        with:
+          configPath: ./.lighthouserc.json
+          uploadArtifacts: true
+          temporaryPublicStorage: true

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,30 @@
+name: Link Check
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - develop
+  schedule:
+    - cron: "0 15 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  links:
+    name: Check links
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check links
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: --config .lychee.toml --no-progress --verbose "README.md" "docs/prelaunch-readiness-review.md" "public/**/*.html"
+          fail: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,12 +1,11 @@
-# Simple workflow for deploying static content to GitHub Pages
-name: Deploy static content to Pages
+name: Build and deploy static content to Pages
 
 on:
-  # Runs on pushes targeting the default branch
   push:
-    branches: ["main"]
-
-  # Allows you to run this workflow manually from the Actions tab
+    branches:
+      - main
+      - develop
+  pull_request:
   workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
@@ -22,8 +21,29 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  # Single deploy job since we're just deploying
+  build:
+    name: Build static site artifact
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate static site inputs
+        run: |
+          test -d public
+          test -f public/index.html
+
+      - name: Upload preview artifact
+        if: github.event_name == 'pull_request' || github.ref == 'refs/heads/develop'
+        uses: actions/upload-artifact@v4
+        with:
+          name: website-public
+          path: ./public
+
   deploy:
+    name: Deploy production site
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: build
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -38,7 +58,6 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          # Upload only static site files (update the path as needed)
           path: './public'
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/website-quality.yml
+++ b/.github/workflows/website-quality.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - develop
   workflow_dispatch:
 
 permissions:
@@ -47,18 +48,3 @@ jobs:
 
       - name: Lint HTML
         run: htmlhint --config .htmlhintrc "public/**/*.html"
-
-  links:
-    name: Link Check
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Check Links
-        uses: lycheeverse/lychee-action@v2
-        with:
-          args: --config .lychee.toml --no-progress --verbose "README.md" "docs/prelaunch-readiness-review.md" "public/**/*.html"
-          fail: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.lighthouserc.json
+++ b/.lighthouserc.json
@@ -1,0 +1,47 @@
+{
+  "ci": {
+    "collect": {
+      "staticDistDir": "./public",
+      "numberOfRuns": 1,
+      "url": [
+        "/index.html",
+        "/docs/index.html",
+        "/docs/protocol-core.html",
+        "/docs/error-model.html",
+        "/docs/adapter-contracts.html",
+        "/launch-checklist.html"
+      ]
+    },
+    "assert": {
+      "assertions": {
+        "categories:performance": [
+          "error",
+          {
+            "minScore": 0.9
+          }
+        ],
+        "categories:accessibility": [
+          "error",
+          {
+            "minScore": 1
+          }
+        ],
+        "categories:best-practices": [
+          "error",
+          {
+            "minScore": 0.9
+          }
+        ],
+        "categories:seo": [
+          "error",
+          {
+            "minScore": 0.9
+          }
+        ]
+      }
+    },
+    "upload": {
+      "target": "temporary-public-storage"
+    }
+  }
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,33 @@
 # Contributing
 
-Thank you for your interest in contributing to MCP-AQL.
+Thank you for your interest in contributing to the MCP-AQL website.
+
+## Workflow
+
+- `main` is the production branch. GitHub Pages deploys from `main`.
+- `develop` is reserved for shared staging and integration work when the repository maintainers enable it.
+- Use a short-lived feature branch for changes. Prefixes such as `codex/`, `feature/`, `fix/`, or `docs/` are all acceptable.
+- Open a pull request for review instead of pushing directly to `main`.
+- Visual changes should include screenshots or rendered diff context when practical.
+
+## Branching guidance
+
+1. Branch from `main` for isolated fixes.
+2. Keep pull requests focused on one content or infrastructure change.
+3. Re-run local checks after editing HTML, Markdown, workflows, or search data.
+4. Merge to `main` only after CI is green.
+
+Preview strategy:
+
+- Pull requests run repository quality checks.
+- Pull requests that change site content also run VisiDelta preview generation for rendered diffs.
+- `develop` pushes are intended for shared preview/build validation once the branch is created and protected on GitHub.
 
 ## Contribution requirements
 
 - By submitting a pull request, you agree to the MCP-AQL CLA: `CLA.md`
+- Keep public copy accurate to the current spec draft. Do not imply final certification or closed launch gates unless the source repositories show that status.
+- Preserve the website's existing documentation voice: concise, public-facing, and explicit about canonical versus practical profile boundaries.
 
 ## Licensing
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 Static website for the MCP-AQL public draft documentation portal.
 
+[![Pages deploy](https://github.com/MCPAQL/website/actions/workflows/static.yml/badge.svg)](https://github.com/MCPAQL/website/actions/workflows/static.yml)
+[![Website quality](https://github.com/MCPAQL/website/actions/workflows/website-quality.yml/badge.svg)](https://github.com/MCPAQL/website/actions/workflows/website-quality.yml)
+[![Link check](https://github.com/MCPAQL/website/actions/workflows/link-check.yml/badge.svg)](https://github.com/MCPAQL/website/actions/workflows/link-check.yml)
+[![Lighthouse CI](https://github.com/MCPAQL/website/actions/workflows/lighthouse.yml/badge.svg)](https://github.com/MCPAQL/website/actions/workflows/lighthouse.yml)
+
 ## Purpose
 
 This repository hosts browse-first web documentation for MCP-AQL so users can:
@@ -23,7 +28,7 @@ This repository hosts browse-first web documentation for MCP-AQL so users can:
 All web assets are under `public/`:
 
 - `public/index.html`: portal home and repository map
-- `public/docs/*.html`: protocol library pages (core, security, conformance, profiles, roadmap)
+- `public/docs/*.html`: protocol library pages (getting started, core, error model, security, conformance, adapter contracts, profiles, roadmap, release notes)
 - `public/launch-checklist.html`: public launch readiness summary
 - `public/apis/*.html`: integration-surface guidance pages
 - `public/css/style.css`: shared styles and responsive layout
@@ -45,13 +50,28 @@ Then open <http://localhost:8000>.
 GitHub Pages deploys automatically from `main` using `.github/workflows/static.yml`.
 The workflow publishes only the `public/` directory.
 
+Preview/build behavior:
+
+- Pull requests build the static site artifact and run CI checks.
+- Content PRs also run `visidelta-preview.yml` for rendered diff previews.
+- `develop` is reserved for shared preview integration once the branch and protections are enabled on GitHub.
+
 ## CI Checks
 
-Pull requests and pushes to `main` run `.github/workflows/website-quality.yml`:
+Pull requests and pushes to `main` or `develop` run `.github/workflows/website-quality.yml`:
 
 - Markdown linting (`markdownlint-cli2`)
 - HTML linting for files under `public/` (`htmlhint`)
+
+Pull requests, pushes to `main` or `develop`, and weekly scheduled runs execute `.github/workflows/link-check.yml`:
+
 - Link checks across Markdown and HTML (`lychee`)
+- Weekly drift detection for external and internal links
+
+Pull requests touching site content and pushes to `main` run `.github/workflows/lighthouse.yml`:
+
+- Lighthouse CI audits for performance, accessibility, best practices, and SEO
+- Artifact upload plus temporary public report storage for review
 
 Pull requests that modify site content also run `.github/workflows/visidelta-preview.yml`:
 

--- a/README.md
+++ b/README.md
@@ -29,12 +29,39 @@ All web assets are under `public/`:
 
 - `public/index.html`: portal home and repository map
 - `public/docs/*.html`: protocol library pages (getting started, core, error model, security, conformance, adapter contracts, profiles, roadmap, release notes)
+- `public/spec/**/*.html`: repo-synced spec pages generated from `../spec/docs`
 - `public/launch-checklist.html`: public launch readiness summary
 - `public/apis/*.html`: integration-surface guidance pages
 - `public/css/style.css`: shared styles and responsive layout
 - `public/js/search.js`: client-side documentation search
 - `public/data/search-index.json`: search index catalog
+- `source/search-index.base.json`: hand-authored search entries merged with generated spec entries
+- `scripts/generate-spec-docs.mjs`: Markdown-to-HTML generator for the full website-hosted spec reference
 - `docs/prelaunch-readiness-review.md`: launch readiness assessment and guidance
+
+## Repo-Synced Spec Generation
+
+The website now carries a full spec reference generated from the sibling `MCPAQL/spec` checkout. This lets the public site host the deeper protocol material directly instead of only linking readers back to GitHub.
+
+Generation inputs:
+
+- source Markdown: `../spec/docs/**/*.md`
+- canonical versioned draft: `../spec/docs/versions/v1.0.0-draft.md`
+- generated output: `public/spec/**/*.html`
+- generated index: `public/spec/index.html`
+- merged search output: `public/data/search-index.json`
+
+Generate or refresh the spec mirror:
+
+```bash
+npm run generate:spec-docs
+```
+
+Check whether generated files are up to date:
+
+```bash
+npm run generate:spec-docs:check
+```
 
 ## Local Preview
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "mcpaql-website",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "generate:spec-docs": "node scripts/generate-spec-docs.mjs",
+    "generate:spec-docs:check": "node scripts/generate-spec-docs.mjs --check"
+  }
+}

--- a/public/apis/application.html
+++ b/public/apis/application.html
@@ -1,93 +1,157 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="MCP-AQL application integration guidance.">
-    <title>Application Integration | MCP-AQL</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="../css/style.css">
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="MCP-AQL application integration guidance.">
+  <title>Application Integration | MCP-AQL</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../css/style.css">
 </head>
 <body>
-    <header>
-        <div class="container">
-            <nav>
-                <a class="logo" href="../index.html"><span class="logo-mark"></span>MCP-AQL</a>
-                <ul class="nav-links">
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../docs/index.html">Docs</a></li>
-                    <li><a href="../launch-checklist.html">Launch Checklist</a></li>
-                    <li><a href="mcp-server.html">Adapter Patterns</a></li>
-                </ul>
-            </nav>
-        </div>
-    </header>
+  <header>
+    <div class="container">
+      <nav>
+        <a class="logo" href="../index.html"><span class="logo-mark"></span>MCP-AQL</a>
+        <ul class="nav-links">
+          <li><a href="../index.html">Home</a></li>
+          <li><a href="../docs/index.html">Docs</a></li>
+          <li><a href="../launch-checklist.html">Launch Checklist</a></li>
+          <li><a href="mcp-server.html">Adapter Patterns</a></li>
+        </ul>
+        <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
+          <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
+          <input id="site-search-input" data-search-input type="search" placeholder="Search MCP-AQL docs, spec pages, and adapter patterns...">
+          <span class="search-count" data-search-count></span>
+          <ul class="search-results" data-search-results hidden></ul>
+        </form>
+      </nav>
+    </div>
+  </header>
 
-    <main class="api-layout">
-        <div class="container">
-            <section class="hero api-hero">
-                <div class="hero-inner">
-                    <span class="status-pill">DRAFT GUIDANCE - NO PUBLIC ADAPTER YET</span>
-                    <h1>Application API Patterns</h1>
-                    <p class="lede">Desktop and mobile app adapters benefit from operation consolidation when feature surfaces are broad and evolve rapidly.</p>
-                    <p class="callout">This is conceptual guidance. A public application adapter reference is not published yet.</p>
-                </div>
-            </section>
+  <main>
+    <div class="container docs-shell">
+      <aside class="docs-side">
+        <h2>Adapter Patterns</h2>
+        <p class="docs-side-note">Conceptual integration profiles that connect the protocol rules to common target-system shapes.</p>
+        <ul>
+          <li><a href="mcp-server.html">MCP Server</a></li>
+          <li><a class="current" aria-current="page" href="application.html">Application</a></li>
+          <li><a href="cloud-service.html">Cloud Service</a></li>
+          <li><a href="operating-system.html">Operating System</a></li>
+          <li><a href="website.html">Website / Web API</a></li>
+        </ul>
+      </aside>
 
-            <section>
-                <h2 class="section-title">Design Guidance</h2>
-                <div class="grid cols-2">
-                    <article class="card">
-                        <h3>Modeling</h3>
-                        <ul>
-                            <li>Expose user-facing actions as named operations.</li>
-                            <li>Prefer explicit parameter schemas over opaque payload blobs.</li>
-                            <li>Use introspection for dynamic capability discovery.</li>
-                        </ul>
-                    </article>
-                    <article class="card">
-                        <h3>Runtime Behavior</h3>
-                        <ul>
-                            <li>Document operation side effects clearly.</li>
-                            <li>Normalize validation and error handling across endpoints.</li>
-                            <li>Add idempotency semantics where retries are expected.</li>
-                        </ul>
-                    </article>
-                </div>
-            </section>
+      <article class="docs-main">
+        <nav class="breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../index.html">Home</a></li>
+            <li><a href="../docs/index.html">Docs</a></li>
+            <li><a href="mcp-server.html">Adapter Patterns</a></li>
+            <li><span class="current">Application</span></li>
+          </ol>
+        </nav>
 
-            <section>
-                <h2 class="section-title">Conceptual Example</h2>
-                <div class="card">
-                    <pre class="code-box">{
+        <section class="hero docs-hero api-hero">
+          <div class="hero-inner">
+            <span class="status-pill">DRAFT GUIDANCE - NO PUBLIC ADAPTER YET</span>
+            <h1>Application API Patterns</h1>
+            <p class="lede">Desktop and mobile app adapters benefit from operation consolidation when feature surfaces are broad and evolve rapidly.</p>
+            <p class="callout">This is conceptual guidance. A public application adapter reference is not published yet.</p>
+            <div class="hero-actions">
+              <a class="btn btn-primary" href="../docs/adapter-contracts.html">Adapter Contracts</a>
+              <a class="btn btn-secondary" href="../docs/implementation-profiles.html">Implementation Profiles</a>
+            </div>
+          </div>
+        </section>
+
+        <section class="topic-bridge">
+          <h2 class="sr-only">Related reading</h2>
+          <div class="grid cols-2">
+            <article class="card">
+              <h3>Read the formal docs</h3>
+              <p>These docs fill in the public contract details that sit behind this pattern page.</p>
+              <ul>
+                <li><a href="../docs/adapter-contracts.html">Adapter Contracts</a></li>
+                <li><a href="../docs/implementation-profiles.html">Implementation Profiles</a></li>
+                <li><a href="../spec/adapter/element-type.html">Element Type Specification</a></li>
+                <li><a href="../spec/adapter/generator.html">Generator Specification</a></li>
+              </ul>
+            </article>
+            <article class="card">
+              <h3>Explore more patterns</h3>
+              <p>Compare how the same core rules behave in server, OS, cloud, and web-facing adapter shapes.</p>
+              <ul>
+                <li><a href="mcp-server.html">MCP Server</a></li>
+                <li><a href="cloud-service.html">Cloud Service</a></li>
+                <li><a href="operating-system.html">Operating System</a></li>
+                <li><a href="website.html">Website / Web API</a></li>
+              </ul>
+            </article>
+          </div>
+        </section>
+
+        <section>
+          <h2 class="section-title">Design Guidance</h2>
+          <div class="grid cols-2">
+            <article class="card">
+              <h3>Modeling</h3>
+              <ul>
+                <li>Expose user-facing actions as named operations.</li>
+                <li>Prefer explicit parameter schemas over opaque payload blobs.</li>
+                <li>Use introspection for dynamic capability discovery.</li>
+              </ul>
+            </article>
+            <article class="card">
+              <h3>Runtime Behavior</h3>
+              <ul>
+                <li>Document operation side effects clearly.</li>
+                <li>Normalize validation and error handling across endpoints.</li>
+                <li>Add idempotency semantics where retries are expected.</li>
+              </ul>
+            </article>
+          </div>
+        </section>
+
+        <section>
+          <h2 class="section-title">Conceptual Example</h2>
+          <div class="card">
+            <pre class="code-box">{
   "operation": "create_ticket",
   "params": {
     "title": "Spec website gap",
     "priority": "high"
   }
 }</pre>
-                </div>
-            </section>
+          </div>
+        </section>
 
-            <section>
-                <a class="btn btn-secondary" href="../index.html">&larr; Back to portal</a>
-            </section>
-        </div>
-    </main>
+        <section>
+          <div class="hero-actions">
+            <a class="btn btn-secondary" href="../docs/index.html">Back to docs library</a>
+            <a class="btn btn-secondary" href="../index.html">&larr; Back to portal</a>
+          </div>
+        </section>
+      </article>
+    </div>
+  </main>
 
-    <footer>
-        <div class="container">
-            <p>&copy; 2026 DollhouseMCP Inc. d/b/a Dollhouse Research. MCP-AQL public draft documentation portal.</p>
-            <div class="footer-links">
-                <a href="../docs/index.html">Documentation Library</a>
-                <a href="../index.html">Portal Home</a>
-                <a href="https://github.com/MCPAQL">MCPAQL Organization</a>
-                <a href="https://dollhouseresearch.com">Dollhouse Research</a>
-                <a href="https://github.com/DollhouseMCP/mcp-server">DollhouseMCP Production Profile</a>
-            </div>
-        </div>
-    </footer>
+  <footer>
+    <div class="container">
+      <p>&copy; 2026 DollhouseMCP Inc. d/b/a Dollhouse Research. MCP-AQL public draft documentation portal.</p>
+      <div class="footer-links">
+        <a href="../docs/index.html">Documentation Library</a>
+        <a href="../index.html">Portal Home</a>
+        <a href="https://github.com/MCPAQL">MCPAQL Organization</a>
+        <a href="https://dollhouseresearch.com">Dollhouse Research</a>
+        <a href="https://github.com/DollhouseMCP/mcp-server">DollhouseMCP Production Profile</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../js/search.js"></script>
 </body>
 </html>

--- a/public/apis/cloud-service.html
+++ b/public/apis/cloud-service.html
@@ -1,93 +1,157 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="MCP-AQL cloud service integration guidance.">
-    <title>Cloud Service Integration | MCP-AQL</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="../css/style.css">
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="MCP-AQL cloud service integration guidance.">
+  <title>Cloud Service Integration | MCP-AQL</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../css/style.css">
 </head>
 <body>
-    <header>
-        <div class="container">
-            <nav>
-                <a class="logo" href="../index.html"><span class="logo-mark"></span>MCP-AQL</a>
-                <ul class="nav-links">
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../docs/index.html">Docs</a></li>
-                    <li><a href="../launch-checklist.html">Launch Checklist</a></li>
-                    <li><a href="mcp-server.html">Adapter Patterns</a></li>
-                </ul>
-            </nav>
-        </div>
-    </header>
+  <header>
+    <div class="container">
+      <nav>
+        <a class="logo" href="../index.html"><span class="logo-mark"></span>MCP-AQL</a>
+        <ul class="nav-links">
+          <li><a href="../index.html">Home</a></li>
+          <li><a href="../docs/index.html">Docs</a></li>
+          <li><a href="../launch-checklist.html">Launch Checklist</a></li>
+          <li><a href="mcp-server.html">Adapter Patterns</a></li>
+        </ul>
+        <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
+          <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
+          <input id="site-search-input" data-search-input type="search" placeholder="Search MCP-AQL docs, spec pages, and adapter patterns...">
+          <span class="search-count" data-search-count></span>
+          <ul class="search-results" data-search-results hidden></ul>
+        </form>
+      </nav>
+    </div>
+  </header>
 
-    <main class="api-layout">
-        <div class="container">
-            <section class="hero api-hero">
-                <div class="hero-inner">
-                    <span class="status-pill">DRAFT GUIDANCE - NO PUBLIC ADAPTER YET</span>
-                    <h1>Cloud Service Integrations</h1>
-                    <p class="lede">Cloud adapters should optimize for bounded cost, predictable quotas, and clear failure semantics under provider throttling.</p>
-                    <p class="callout">This is conceptual guidance. A public cloud-service adapter reference is not published yet.</p>
-                </div>
-            </section>
+  <main>
+    <div class="container docs-shell">
+      <aside class="docs-side">
+        <h2>Adapter Patterns</h2>
+        <p class="docs-side-note">Conceptual integration profiles that connect the protocol rules to common target-system shapes.</p>
+        <ul>
+          <li><a href="mcp-server.html">MCP Server</a></li>
+          <li><a href="application.html">Application</a></li>
+          <li><a class="current" aria-current="page" href="cloud-service.html">Cloud Service</a></li>
+          <li><a href="operating-system.html">Operating System</a></li>
+          <li><a href="website.html">Website / Web API</a></li>
+        </ul>
+      </aside>
 
-            <section>
-                <h2 class="section-title">Design Guidance</h2>
-                <div class="grid cols-2">
-                    <article class="card">
-                        <h3>Operational Controls</h3>
-                        <ul>
-                            <li>Expose pagination and limit controls consistently.</li>
-                            <li>Separate read/list from state-changing operations.</li>
-                            <li>Return provider-context metadata in structured errors.</li>
-                        </ul>
-                    </article>
-                    <article class="card">
-                        <h3>Resilience</h3>
-                        <ul>
-                            <li>Document retryability per operation.</li>
-                            <li>Surface rate-limit and quota conditions explicitly.</li>
-                            <li>Bound batch and fan-out behavior to avoid exhaustion.</li>
-                        </ul>
-                    </article>
-                </div>
-            </section>
+      <article class="docs-main">
+        <nav class="breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../index.html">Home</a></li>
+            <li><a href="../docs/index.html">Docs</a></li>
+            <li><a href="mcp-server.html">Adapter Patterns</a></li>
+            <li><span class="current">Cloud Service</span></li>
+          </ol>
+        </nav>
 
-            <section>
-                <h2 class="section-title">Conceptual Example</h2>
-                <div class="card">
-                    <pre class="code-box">{
+        <section class="hero docs-hero api-hero">
+          <div class="hero-inner">
+            <span class="status-pill">DRAFT GUIDANCE - NO PUBLIC ADAPTER YET</span>
+            <h1>Cloud Service Integrations</h1>
+            <p class="lede">Cloud adapters should optimize for bounded cost, predictable quotas, and clear failure semantics under provider throttling.</p>
+            <p class="callout">This is conceptual guidance. A public cloud-service adapter reference is not published yet.</p>
+            <div class="hero-actions">
+              <a class="btn btn-primary" href="../docs/adapter-contracts.html">Adapter Contracts</a>
+              <a class="btn btn-secondary" href="../spec/adapter/rate-limiting.html">Rate-Limiting Spec</a>
+            </div>
+          </div>
+        </section>
+
+        <section class="topic-bridge">
+          <h2 class="sr-only">Related reading</h2>
+          <div class="grid cols-2">
+            <article class="card">
+              <h3>Read the formal docs</h3>
+              <p>The protocol-level details for quotas, batches, and output contracts live in the deeper documentation set.</p>
+              <ul>
+                <li><a href="../docs/adapter-contracts.html">Adapter Contracts</a></li>
+                <li><a href="../spec/adapter/rate-limiting.html">Rate-Limiting Specification</a></li>
+                <li><a href="../spec/features/pagination.html">Pagination Specification</a></li>
+                <li><a href="../spec/error-codes.html">Structured Error Codes</a></li>
+              </ul>
+            </article>
+            <article class="card">
+              <h3>Explore more patterns</h3>
+              <p>These neighboring patterns show how similar controls change with server, app, OS, and web surfaces.</p>
+              <ul>
+                <li><a href="mcp-server.html">MCP Server</a></li>
+                <li><a href="application.html">Application</a></li>
+                <li><a href="operating-system.html">Operating System</a></li>
+                <li><a href="website.html">Website / Web API</a></li>
+              </ul>
+            </article>
+          </div>
+        </section>
+
+        <section>
+          <h2 class="section-title">Design Guidance</h2>
+          <div class="grid cols-2">
+            <article class="card">
+              <h3>Operational Controls</h3>
+              <ul>
+                <li>Expose pagination and limit controls consistently.</li>
+                <li>Separate read/list from state-changing operations.</li>
+                <li>Return provider-context metadata in structured errors.</li>
+              </ul>
+            </article>
+            <article class="card">
+              <h3>Resilience</h3>
+              <ul>
+                <li>Document retryability per operation.</li>
+                <li>Surface rate-limit and quota conditions explicitly.</li>
+                <li>Bound batch and fan-out behavior to avoid exhaustion.</li>
+              </ul>
+            </article>
+          </div>
+        </section>
+
+        <section>
+          <h2 class="section-title">Conceptual Example</h2>
+          <div class="card">
+            <pre class="code-box">{
   "operation": "list_instances",
   "params": {
     "region": "us-east-1",
     "limit": 50
   }
 }</pre>
-                </div>
-            </section>
+          </div>
+        </section>
 
-            <section>
-                <a class="btn btn-secondary" href="../index.html">&larr; Back to portal</a>
-            </section>
-        </div>
-    </main>
+        <section>
+          <div class="hero-actions">
+            <a class="btn btn-secondary" href="../docs/index.html">Back to docs library</a>
+            <a class="btn btn-secondary" href="../index.html">&larr; Back to portal</a>
+          </div>
+        </section>
+      </article>
+    </div>
+  </main>
 
-    <footer>
-        <div class="container">
-            <p>&copy; 2026 DollhouseMCP Inc. d/b/a Dollhouse Research. MCP-AQL public draft documentation portal.</p>
-            <div class="footer-links">
-                <a href="../docs/index.html">Documentation Library</a>
-                <a href="../index.html">Portal Home</a>
-                <a href="https://github.com/MCPAQL">MCPAQL Organization</a>
-                <a href="https://dollhouseresearch.com">Dollhouse Research</a>
-                <a href="https://github.com/DollhouseMCP/mcp-server">DollhouseMCP Production Profile</a>
-            </div>
-        </div>
-    </footer>
+  <footer>
+    <div class="container">
+      <p>&copy; 2026 DollhouseMCP Inc. d/b/a Dollhouse Research. MCP-AQL public draft documentation portal.</p>
+      <div class="footer-links">
+        <a href="../docs/index.html">Documentation Library</a>
+        <a href="../index.html">Portal Home</a>
+        <a href="https://github.com/MCPAQL">MCPAQL Organization</a>
+        <a href="https://dollhouseresearch.com">Dollhouse Research</a>
+        <a href="https://github.com/DollhouseMCP/mcp-server">DollhouseMCP Production Profile</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../js/search.js"></script>
 </body>
 </html>

--- a/public/apis/mcp-server.html
+++ b/public/apis/mcp-server.html
@@ -1,120 +1,183 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="MCP-AQL integration guide for MCP Server adapters.">
-    <title>MCP Server Integration | MCP-AQL</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="../css/style.css">
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="MCP-AQL integration guide for MCP Server adapters.">
+  <title>MCP Server Integration | MCP-AQL</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../css/style.css">
 </head>
 <body>
-    <header>
-        <div class="container">
-            <nav>
-                <a class="logo" href="../index.html"><span class="logo-mark"></span>MCP-AQL</a>
-                <ul class="nav-links">
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../docs/index.html">Docs</a></li>
-                    <li><a href="../launch-checklist.html">Launch Checklist</a></li>
-                    <li><a href="mcp-server.html">Adapter Patterns</a></li>
-                </ul>
-            </nav>
-        </div>
-    </header>
+  <header>
+    <div class="container">
+      <nav>
+        <a class="logo" href="../index.html"><span class="logo-mark"></span>MCP-AQL</a>
+        <ul class="nav-links">
+          <li><a href="../index.html">Home</a></li>
+          <li><a href="../docs/index.html">Docs</a></li>
+          <li><a href="../launch-checklist.html">Launch Checklist</a></li>
+          <li><a href="mcp-server.html">Adapter Patterns</a></li>
+        </ul>
+        <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
+          <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
+          <input id="site-search-input" data-search-input type="search" placeholder="Search MCP-AQL docs, spec pages, and adapter patterns...">
+          <span class="search-count" data-search-count></span>
+          <ul class="search-results" data-search-results hidden></ul>
+        </form>
+      </nav>
+    </div>
+  </header>
 
-    <main class="api-layout">
-        <div class="container">
-            <section class="hero api-hero">
-                <div class="hero-inner">
-                    <span class="status-pill">DRAFT GUIDANCE - NO PUBLIC ADAPTER YET</span>
-                    <h1>MCP Server Adapter Pattern</h1>
-                    <p class="lede">
-                        MCP-AQL is primarily designed to consolidate and expose MCP server operations through a consistent query contract with runtime introspection.
-                    </p>
-                    <p class="callout">Public MCP server adapter examples are planned, but not yet published.</p>
-                </div>
-            </section>
+  <main>
+    <div class="container docs-shell">
+      <aside class="docs-side">
+        <h2>Adapter Patterns</h2>
+        <p class="docs-side-note">Conceptual integration profiles that connect the protocol rules to common target-system shapes.</p>
+        <ul>
+          <li><a class="current" aria-current="page" href="mcp-server.html">MCP Server</a></li>
+          <li><a href="application.html">Application</a></li>
+          <li><a href="cloud-service.html">Cloud Service</a></li>
+          <li><a href="operating-system.html">Operating System</a></li>
+          <li><a href="website.html">Website / Web API</a></li>
+        </ul>
+      </aside>
 
-            <section>
-                <h2 class="section-title">Recommended Baseline</h2>
-                <div class="grid cols-2">
-                    <article class="card">
-                        <h3>Protocol Shape</h3>
-                        <ul>
-                            <li>Expose <code>introspect</code> as mandatory discovery entrypoint.</li>
-                            <li>Route operations via CRUDE endpoints or single mode.</li>
-                            <li>Return discriminated union responses: success/data or success/error.</li>
-                            <li>Keep operation metadata and execution behavior aligned.</li>
-                        </ul>
-                    </article>
-                    <article class="card">
-                        <h3>Safety & Runtime</h3>
-                        <ul>
-                            <li>Validate unknown parameters explicitly.</li>
-                            <li>Apply structured error codes for machine readability.</li>
-                            <li>Bound batch sizes and execution resource usage.</li>
-                            <li>Optionally enforce policy modules (gatekeeper/danger-zone style).</li>
-                        </ul>
-                    </article>
-                </div>
-            </section>
+      <article class="docs-main">
+        <nav class="breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../index.html">Home</a></li>
+            <li><a href="../docs/index.html">Docs</a></li>
+            <li><span class="current">MCP Server Pattern</span></li>
+          </ol>
+        </nav>
 
-            <section>
-                <h2 class="section-title">Conceptual Example</h2>
-                <div class="card">
-                    <pre class="code-box">{
+        <section class="hero docs-hero api-hero">
+          <div class="hero-inner">
+            <span class="status-pill">DRAFT GUIDANCE - NO PUBLIC ADAPTER YET</span>
+            <h1>MCP Server Adapter Pattern</h1>
+            <p class="lede">
+              MCP-AQL is primarily designed to consolidate and expose MCP server operations through a consistent query contract with runtime introspection.
+            </p>
+            <p class="callout">Public MCP server adapter examples are planned, but not yet published.</p>
+            <div class="hero-actions">
+              <a class="btn btn-primary" href="../docs/adapter-contracts.html">Adapter Contracts</a>
+              <a class="btn btn-secondary" href="../spec/mcp-integration.html">MCP Integration Spec</a>
+            </div>
+          </div>
+        </section>
+
+        <section class="topic-bridge">
+          <h2 class="sr-only">Related reading</h2>
+          <div class="grid cols-2">
+            <article class="card">
+              <h3>Read the formal docs</h3>
+              <p>Use these pages when you want the contract details behind this pattern instead of just the high-level guidance.</p>
+              <ul>
+                <li><a href="../docs/adapter-contracts.html">Adapter Contracts</a></li>
+                <li><a href="../spec/mcp-integration.html">MCP Integration Specification</a></li>
+                <li><a href="../spec/introspection.html">Introspection Specification</a></li>
+                <li><a href="../spec/operations.html">Operations Specification</a></li>
+              </ul>
+            </article>
+            <article class="card">
+              <h3>Explore more patterns</h3>
+              <p>These related profiles show how the same protocol ideas shift across different target environments.</p>
+              <ul>
+                <li><a href="application.html">Application APIs</a></li>
+                <li><a href="cloud-service.html">Cloud Services</a></li>
+                <li><a href="operating-system.html">Operating System Flows</a></li>
+                <li><a href="website.html">Website / Web API Flows</a></li>
+              </ul>
+            </article>
+          </div>
+        </section>
+
+        <section>
+          <h2 class="section-title">Recommended Baseline</h2>
+          <div class="grid cols-2">
+            <article class="card">
+              <h3>Protocol Shape</h3>
+              <ul>
+                <li>Expose <code>introspect</code> as mandatory discovery entrypoint.</li>
+                <li>Route operations via CRUDE endpoints or single mode.</li>
+                <li>Return discriminated union responses: success/data or success/error.</li>
+                <li>Keep operation metadata and execution behavior aligned.</li>
+              </ul>
+            </article>
+            <article class="card">
+              <h3>Safety & Runtime</h3>
+              <ul>
+                <li>Validate unknown parameters explicitly.</li>
+                <li>Apply structured error codes for machine readability.</li>
+                <li>Bound batch sizes and execution resource usage.</li>
+                <li>Optionally enforce policy modules (gatekeeper/danger-zone style).</li>
+              </ul>
+            </article>
+          </div>
+        </section>
+
+        <section>
+          <h2 class="section-title">Conceptual Example</h2>
+          <div class="card">
+            <pre class="code-box">{
   "operation": "get_element",
   "params": {
     "element_name": "api-architecture-expert"
   }
 }</pre>
-                    <p class="callout">
-                        The operation name and parameters are adapter-defined; clients should discover valid operations via <code>introspect</code> before execution. This page is guidance, not a published adapter implementation.
-                    </p>
-                </div>
-            </section>
+            <p class="callout">
+              The operation name and parameters are adapter-defined; clients should discover valid operations via <code>introspect</code> before execution. This page is guidance, not a published adapter implementation.
+            </p>
+          </div>
+        </section>
 
-            <section>
-                <h2 class="section-title">Related Sources</h2>
-                <div class="grid cols-2">
-                    <article class="card">
-                        <h3>Spec</h3>
-                        <ul>
-                            <li><a href="https://github.com/MCPAQL/spec/blob/main/docs/versions/v1.0.0-draft.md">Normative draft</a></li>
-                            <li><a href="https://github.com/MCPAQL/spec/blob/main/docs/introspection.md">Introspection model</a></li>
-                            <li><a href="https://github.com/MCPAQL/spec/blob/main/docs/operations.md">Operation guidance</a></li>
-                        </ul>
-                    </article>
-                    <article class="card">
-                        <h3>Practical Profile</h3>
-                        <ul>
-                            <li><a href="https://github.com/DollhouseMCP/mcp-server">DollhouseMCP production server</a></li>
-                            <li><a href="https://dollhouseresearch.com">Dollhouse research site</a></li>
-                        </ul>
-                    </article>
-                </div>
-            </section>
+        <section>
+          <h2 class="section-title">Related Sources</h2>
+          <div class="grid cols-2">
+            <article class="card">
+              <h3>Spec</h3>
+              <ul>
+                <li><a href="../spec/versions/v1.0.0-draft.html">Normative draft</a></li>
+                <li><a href="../spec/introspection.html">Introspection model</a></li>
+                <li><a href="../spec/operations.html">Operation guidance</a></li>
+              </ul>
+            </article>
+            <article class="card">
+              <h3>Practical Profile</h3>
+              <ul>
+                <li><a href="https://github.com/DollhouseMCP/mcp-server">DollhouseMCP production server</a></li>
+                <li><a href="https://dollhouseresearch.com">Dollhouse research site</a></li>
+              </ul>
+            </article>
+          </div>
+        </section>
 
-            <section>
-                <a class="btn btn-secondary" href="../index.html">&larr; Back to portal</a>
-            </section>
-        </div>
-    </main>
+        <section>
+          <div class="hero-actions">
+            <a class="btn btn-secondary" href="../docs/index.html">Back to docs library</a>
+            <a class="btn btn-secondary" href="../index.html">&larr; Back to portal</a>
+          </div>
+        </section>
+      </article>
+    </div>
+  </main>
 
-    <footer>
-        <div class="container">
-            <p>&copy; 2026 DollhouseMCP Inc. d/b/a Dollhouse Research. MCP-AQL public draft documentation portal.</p>
-            <div class="footer-links">
-                <a href="../docs/index.html">Documentation Library</a>
-                <a href="../index.html">Portal Home</a>
-                <a href="https://github.com/MCPAQL">MCPAQL Organization</a>
-                <a href="https://dollhouseresearch.com">Dollhouse Research</a>
-                <a href="https://github.com/DollhouseMCP/mcp-server">DollhouseMCP Production Profile</a>
-            </div>
-        </div>
-    </footer>
+  <footer>
+    <div class="container">
+      <p>&copy; 2026 DollhouseMCP Inc. d/b/a Dollhouse Research. MCP-AQL public draft documentation portal.</p>
+      <div class="footer-links">
+        <a href="../docs/index.html">Documentation Library</a>
+        <a href="../index.html">Portal Home</a>
+        <a href="https://github.com/MCPAQL">MCPAQL Organization</a>
+        <a href="https://dollhouseresearch.com">Dollhouse Research</a>
+        <a href="https://github.com/DollhouseMCP/mcp-server">DollhouseMCP Production Profile</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../js/search.js"></script>
 </body>
 </html>

--- a/public/apis/operating-system.html
+++ b/public/apis/operating-system.html
@@ -1,94 +1,158 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="MCP-AQL operating system integration guidance.">
-    <title>Operating System Integration | MCP-AQL</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="../css/style.css">
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="MCP-AQL operating system integration guidance.">
+  <title>Operating System Integration | MCP-AQL</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../css/style.css">
 </head>
 <body>
-    <header>
-        <div class="container">
-            <nav>
-                <a class="logo" href="../index.html"><span class="logo-mark"></span>MCP-AQL</a>
-                <ul class="nav-links">
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../docs/index.html">Docs</a></li>
-                    <li><a href="../launch-checklist.html">Launch Checklist</a></li>
-                    <li><a href="mcp-server.html">Adapter Patterns</a></li>
-                </ul>
-            </nav>
-        </div>
-    </header>
+  <header>
+    <div class="container">
+      <nav>
+        <a class="logo" href="../index.html"><span class="logo-mark"></span>MCP-AQL</a>
+        <ul class="nav-links">
+          <li><a href="../index.html">Home</a></li>
+          <li><a href="../docs/index.html">Docs</a></li>
+          <li><a href="../launch-checklist.html">Launch Checklist</a></li>
+          <li><a href="mcp-server.html">Adapter Patterns</a></li>
+        </ul>
+        <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
+          <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
+          <input id="site-search-input" data-search-input type="search" placeholder="Search MCP-AQL docs, spec pages, and adapter patterns...">
+          <span class="search-count" data-search-count></span>
+          <ul class="search-results" data-search-results hidden></ul>
+        </form>
+      </nav>
+    </div>
+  </header>
 
-    <main class="api-layout">
-        <div class="container">
-            <section class="hero api-hero">
-                <div class="hero-inner">
-                    <span class="status-pill">DRAFT GUIDANCE - NO PUBLIC ADAPTER YET</span>
-                    <h1>Operating System Operations</h1>
-                    <p class="lede">OS-adjacent adapters should treat safety boundaries as first-class protocol concerns, especially for write and execute flows.</p>
-                    <p class="callout">This page describes a design pattern. A public operating-system adapter is not published yet.</p>
-                </div>
-            </section>
+  <main>
+    <div class="container docs-shell">
+      <aside class="docs-side">
+        <h2>Adapter Patterns</h2>
+        <p class="docs-side-note">Conceptual integration profiles that connect the protocol rules to common target-system shapes.</p>
+        <ul>
+          <li><a href="mcp-server.html">MCP Server</a></li>
+          <li><a href="application.html">Application</a></li>
+          <li><a href="cloud-service.html">Cloud Service</a></li>
+          <li><a class="current" aria-current="page" href="operating-system.html">Operating System</a></li>
+          <li><a href="website.html">Website / Web API</a></li>
+        </ul>
+      </aside>
 
-            <section>
-                <h2 class="section-title">Design Guidance</h2>
-                <div class="grid cols-2">
-                    <article class="card">
-                        <h3>Operation Grouping</h3>
-                        <ul>
-                            <li>Separate read-only file queries from mutating file actions.</li>
-                            <li>Use explicit execute operations for process starts/stops.</li>
-                            <li>Document required permissions in introspection metadata.</li>
-                        </ul>
-                    </article>
-                    <article class="card">
-                        <h3>Safety Model</h3>
-                        <ul>
-                            <li>Add batch/resource limits for potentially expensive scans.</li>
-                            <li>Require confirmations for destructive operations.</li>
-                            <li>Expose machine-readable error codes for policy engines.</li>
-                        </ul>
-                    </article>
-                </div>
-            </section>
+      <article class="docs-main">
+        <nav class="breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../index.html">Home</a></li>
+            <li><a href="../docs/index.html">Docs</a></li>
+            <li><a href="mcp-server.html">Adapter Patterns</a></li>
+            <li><span class="current">Operating System</span></li>
+          </ol>
+        </nav>
 
-            <section>
-                <h2 class="section-title">Conceptual Example</h2>
-                <div class="card">
-                    <pre class="code-box">{
+        <section class="hero docs-hero api-hero">
+          <div class="hero-inner">
+            <span class="status-pill">DRAFT GUIDANCE - NO PUBLIC ADAPTER YET</span>
+            <h1>Operating System Operations</h1>
+            <p class="lede">OS-adjacent adapters should treat safety boundaries as first-class protocol concerns, especially for write and execute flows.</p>
+            <p class="callout">This page describes a design pattern. A public operating-system adapter is not published yet.</p>
+            <div class="hero-actions">
+              <a class="btn btn-primary" href="../docs/security-model.html">Security Model</a>
+              <a class="btn btn-secondary" href="../spec/security/gatekeeper.html">Gatekeeper Spec</a>
+            </div>
+          </div>
+        </section>
+
+        <section class="topic-bridge">
+          <h2 class="sr-only">Related reading</h2>
+          <div class="grid cols-2">
+            <article class="card">
+              <h3>Read the formal docs</h3>
+              <p>These sources carry the policy and execution-safety detail behind this pattern.</p>
+              <ul>
+                <li><a href="../docs/security-model.html">Security Model</a></li>
+                <li><a href="../spec/security/gatekeeper.html">Gatekeeper</a></li>
+                <li><a href="../spec/security/confirmation-tokens.html">Confirmation Tokens</a></li>
+                <li><a href="../spec/security/execution-safety-loop.html">Execution Safety Loop</a></li>
+              </ul>
+            </article>
+            <article class="card">
+              <h3>Explore more patterns</h3>
+              <p>Compare the safety posture here with the surrounding cloud, server, app, and web patterns.</p>
+              <ul>
+                <li><a href="mcp-server.html">MCP Server</a></li>
+                <li><a href="application.html">Application</a></li>
+                <li><a href="cloud-service.html">Cloud Service</a></li>
+                <li><a href="website.html">Website / Web API</a></li>
+              </ul>
+            </article>
+          </div>
+        </section>
+
+        <section>
+          <h2 class="section-title">Design Guidance</h2>
+          <div class="grid cols-2">
+            <article class="card">
+              <h3>Operation Grouping</h3>
+              <ul>
+                <li>Separate read-only file queries from mutating file actions.</li>
+                <li>Use explicit execute operations for process starts/stops.</li>
+                <li>Document required permissions in introspection metadata.</li>
+              </ul>
+            </article>
+            <article class="card">
+              <h3>Safety Model</h3>
+              <ul>
+                <li>Add batch/resource limits for potentially expensive scans.</li>
+                <li>Require confirmations for destructive operations.</li>
+                <li>Expose machine-readable error codes for policy engines.</li>
+              </ul>
+            </article>
+          </div>
+        </section>
+
+        <section>
+          <h2 class="section-title">Conceptual Example</h2>
+          <div class="card">
+            <pre class="code-box">{
   "operation": "list_files",
   "params": {
     "path": "/workspace",
     "limit": 100
   }
 }</pre>
-                    <p class="callout">Keep high-risk operations (delete, execute) policy-gated and auditable by default.</p>
-                </div>
-            </section>
+            <p class="callout">Keep high-risk operations (delete, execute) policy-gated and auditable by default.</p>
+          </div>
+        </section>
 
-            <section>
-                <a class="btn btn-secondary" href="../index.html">&larr; Back to portal</a>
-            </section>
-        </div>
-    </main>
+        <section>
+          <div class="hero-actions">
+            <a class="btn btn-secondary" href="../docs/index.html">Back to docs library</a>
+            <a class="btn btn-secondary" href="../index.html">&larr; Back to portal</a>
+          </div>
+        </section>
+      </article>
+    </div>
+  </main>
 
-    <footer>
-        <div class="container">
-            <p>&copy; 2026 DollhouseMCP Inc. d/b/a Dollhouse Research. MCP-AQL public draft documentation portal.</p>
-            <div class="footer-links">
-                <a href="../docs/index.html">Documentation Library</a>
-                <a href="../index.html">Portal Home</a>
-                <a href="https://github.com/MCPAQL">MCPAQL Organization</a>
-                <a href="https://dollhouseresearch.com">Dollhouse Research</a>
-                <a href="https://github.com/DollhouseMCP/mcp-server">DollhouseMCP Production Profile</a>
-            </div>
-        </div>
-    </footer>
+  <footer>
+    <div class="container">
+      <p>&copy; 2026 DollhouseMCP Inc. d/b/a Dollhouse Research. MCP-AQL public draft documentation portal.</p>
+      <div class="footer-links">
+        <a href="../docs/index.html">Documentation Library</a>
+        <a href="../index.html">Portal Home</a>
+        <a href="https://github.com/MCPAQL">MCPAQL Organization</a>
+        <a href="https://dollhouseresearch.com">Dollhouse Research</a>
+        <a href="https://github.com/DollhouseMCP/mcp-server">DollhouseMCP Production Profile</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../js/search.js"></script>
 </body>
 </html>

--- a/public/apis/website.html
+++ b/public/apis/website.html
@@ -1,93 +1,157 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="MCP-AQL website and web API integration guidance.">
-    <title>Website Integration | MCP-AQL</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="../css/style.css">
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="MCP-AQL website and web API integration guidance.">
+  <title>Website Integration | MCP-AQL</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../css/style.css">
 </head>
 <body>
-    <header>
-        <div class="container">
-            <nav>
-                <a class="logo" href="../index.html"><span class="logo-mark"></span>MCP-AQL</a>
-                <ul class="nav-links">
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../docs/index.html">Docs</a></li>
-                    <li><a href="../launch-checklist.html">Launch Checklist</a></li>
-                    <li><a href="mcp-server.html">Adapter Patterns</a></li>
-                </ul>
-            </nav>
-        </div>
-    </header>
+  <header>
+    <div class="container">
+      <nav>
+        <a class="logo" href="../index.html"><span class="logo-mark"></span>MCP-AQL</a>
+        <ul class="nav-links">
+          <li><a href="../index.html">Home</a></li>
+          <li><a href="../docs/index.html">Docs</a></li>
+          <li><a href="../launch-checklist.html">Launch Checklist</a></li>
+          <li><a href="mcp-server.html">Adapter Patterns</a></li>
+        </ul>
+        <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
+          <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
+          <input id="site-search-input" data-search-input type="search" placeholder="Search MCP-AQL docs, spec pages, and adapter patterns...">
+          <span class="search-count" data-search-count></span>
+          <ul class="search-results" data-search-results hidden></ul>
+        </form>
+      </nav>
+    </div>
+  </header>
 
-    <main class="api-layout">
-        <div class="container">
-            <section class="hero api-hero">
-                <div class="hero-inner">
-                    <span class="status-pill">DRAFT GUIDANCE - NO PUBLIC ADAPTER YET</span>
-                    <h1>Website and Web API Flows</h1>
-                    <p class="lede">Web integrations can use MCP-AQL as a stable command layer for retrieval, extraction, and structured actions across HTTP-facing systems.</p>
-                    <p class="callout">This is conceptual guidance. A public website/web API adapter reference is not published yet.</p>
-                </div>
-            </section>
+  <main>
+    <div class="container docs-shell">
+      <aside class="docs-side">
+        <h2>Adapter Patterns</h2>
+        <p class="docs-side-note">Conceptual integration profiles that connect the protocol rules to common target-system shapes.</p>
+        <ul>
+          <li><a href="mcp-server.html">MCP Server</a></li>
+          <li><a href="application.html">Application</a></li>
+          <li><a href="cloud-service.html">Cloud Service</a></li>
+          <li><a href="operating-system.html">Operating System</a></li>
+          <li><a class="current" aria-current="page" href="website.html">Website / Web API</a></li>
+        </ul>
+      </aside>
 
-            <section>
-                <h2 class="section-title">Design Guidance</h2>
-                <div class="grid cols-2">
-                    <article class="card">
-                        <h3>Read-Oriented Workflows</h3>
-                        <ul>
-                            <li>Model fetch and parse operations as explicit READ actions.</li>
-                            <li>Document expected response shapes through introspection.</li>
-                            <li>Use field-selection patterns to reduce payload size.</li>
-                        </ul>
-                    </article>
-                    <article class="card">
-                        <h3>Action-Oriented Workflows</h3>
-                        <ul>
-                            <li>Use EXECUTE operations for actions with side effects.</li>
-                            <li>Gate destructive web actions with confirmation requirements.</li>
-                            <li>Map HTTP failures to protocol-level structured errors.</li>
-                        </ul>
-                    </article>
-                </div>
-            </section>
+      <article class="docs-main">
+        <nav class="breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../index.html">Home</a></li>
+            <li><a href="../docs/index.html">Docs</a></li>
+            <li><a href="mcp-server.html">Adapter Patterns</a></li>
+            <li><span class="current">Website / Web API</span></li>
+          </ol>
+        </nav>
 
-            <section>
-                <h2 class="section-title">Conceptual Example</h2>
-                <div class="card">
-                    <pre class="code-box">{
+        <section class="hero docs-hero api-hero">
+          <div class="hero-inner">
+            <span class="status-pill">DRAFT GUIDANCE - NO PUBLIC ADAPTER YET</span>
+            <h1>Website and Web API Flows</h1>
+            <p class="lede">Web integrations can use MCP-AQL as a stable command layer for retrieval, extraction, and structured actions across HTTP-facing systems.</p>
+            <p class="callout">This is conceptual guidance. A public website/web API adapter reference is not published yet.</p>
+            <div class="hero-actions">
+              <a class="btn btn-primary" href="../docs/adapter-contracts.html">Adapter Contracts</a>
+              <a class="btn btn-secondary" href="../spec/features/field-selection.html">Field Selection Spec</a>
+            </div>
+          </div>
+        </section>
+
+        <section class="topic-bridge">
+          <h2 class="sr-only">Related reading</h2>
+          <div class="grid cols-2">
+            <article class="card">
+              <h3>Read the formal docs</h3>
+              <p>These references carry the deeper constraints behind read-heavy and action-heavy web integrations.</p>
+              <ul>
+                <li><a href="../docs/adapter-contracts.html">Adapter Contracts</a></li>
+                <li><a href="../spec/features/field-selection.html">Field Selection Specification</a></li>
+                <li><a href="../spec/error-codes.html">Structured Error Codes</a></li>
+                <li><a href="../spec/operations.html">Operations Specification</a></li>
+              </ul>
+            </article>
+            <article class="card">
+              <h3>Explore more patterns</h3>
+              <p>Use the neighboring patterns to compare web APIs with server, app, cloud, and OS command surfaces.</p>
+              <ul>
+                <li><a href="mcp-server.html">MCP Server</a></li>
+                <li><a href="application.html">Application</a></li>
+                <li><a href="cloud-service.html">Cloud Service</a></li>
+                <li><a href="operating-system.html">Operating System</a></li>
+              </ul>
+            </article>
+          </div>
+        </section>
+
+        <section>
+          <h2 class="section-title">Design Guidance</h2>
+          <div class="grid cols-2">
+            <article class="card">
+              <h3>Read-Oriented Workflows</h3>
+              <ul>
+                <li>Model fetch and parse operations as explicit READ actions.</li>
+                <li>Document expected response shapes through introspection.</li>
+                <li>Use field-selection patterns to reduce payload size.</li>
+              </ul>
+            </article>
+            <article class="card">
+              <h3>Action-Oriented Workflows</h3>
+              <ul>
+                <li>Use EXECUTE operations for actions with side effects.</li>
+                <li>Gate destructive web actions with confirmation requirements.</li>
+                <li>Map HTTP failures to protocol-level structured errors.</li>
+              </ul>
+            </article>
+          </div>
+        </section>
+
+        <section>
+          <h2 class="section-title">Conceptual Example</h2>
+          <div class="card">
+            <pre class="code-box">{
   "operation": "get_page_summary",
   "params": {
     "url": "https://mcpaql.org",
     "format": "markdown"
   }
 }</pre>
-                </div>
-            </section>
+          </div>
+        </section>
 
-            <section>
-                <a class="btn btn-secondary" href="../index.html">&larr; Back to portal</a>
-            </section>
-        </div>
-    </main>
+        <section>
+          <div class="hero-actions">
+            <a class="btn btn-secondary" href="../docs/index.html">Back to docs library</a>
+            <a class="btn btn-secondary" href="../index.html">&larr; Back to portal</a>
+          </div>
+        </section>
+      </article>
+    </div>
+  </main>
 
-    <footer>
-        <div class="container">
-            <p>&copy; 2026 DollhouseMCP Inc. d/b/a Dollhouse Research. MCP-AQL public draft documentation portal.</p>
-            <div class="footer-links">
-                <a href="../docs/index.html">Documentation Library</a>
-                <a href="../index.html">Portal Home</a>
-                <a href="https://github.com/MCPAQL">MCPAQL Organization</a>
-                <a href="https://dollhouseresearch.com">Dollhouse Research</a>
-                <a href="https://github.com/DollhouseMCP/mcp-server">DollhouseMCP Production Profile</a>
-            </div>
-        </div>
-    </footer>
+  <footer>
+    <div class="container">
+      <p>&copy; 2026 DollhouseMCP Inc. d/b/a Dollhouse Research. MCP-AQL public draft documentation portal.</p>
+      <div class="footer-links">
+        <a href="../docs/index.html">Documentation Library</a>
+        <a href="../index.html">Portal Home</a>
+        <a href="https://github.com/MCPAQL">MCPAQL Organization</a>
+        <a href="https://dollhouseresearch.com">Dollhouse Research</a>
+        <a href="https://github.com/DollhouseMCP/mcp-server">DollhouseMCP Production Profile</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../js/search.js"></script>
 </body>
 </html>

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -540,6 +540,25 @@ footer {
   text-transform: uppercase;
 }
 
+.docs-side-note {
+  color: var(--ink-700);
+  font-size: 0.83rem;
+  line-height: 1.5;
+  margin-bottom: 0.9rem;
+}
+
+.docs-side-group + .docs-side-group {
+  margin-top: 1rem;
+}
+
+.docs-side-group h3 {
+  color: var(--ink-700);
+  font-size: 0.74rem;
+  letter-spacing: 0.06em;
+  margin-bottom: 0.42rem;
+  text-transform: uppercase;
+}
+
 .docs-side ul {
   list-style: none;
 }
@@ -560,6 +579,11 @@ footer {
   background: var(--paper-100);
 }
 
+.docs-side a.current {
+  background: rgba(11, 93, 176, 0.1);
+  color: var(--brand-700);
+}
+
 .docs-main {
   min-width: 0;
 }
@@ -575,6 +599,98 @@ footer {
 
 .docs-hero {
   margin-top: 0;
+}
+
+.spec-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  margin-top: 1rem;
+}
+
+.spec-source {
+  color: var(--ink-700);
+  font-size: 0.9rem;
+  margin-top: 0.95rem;
+}
+
+.spec-prose > :first-child {
+  margin-top: 0;
+}
+
+.spec-prose h2,
+.spec-prose h3,
+.spec-prose h4 {
+  color: var(--ink-900);
+  font-family: "Space Grotesk", "IBM Plex Sans", sans-serif;
+  line-height: 1.2;
+  margin-top: 1.5rem;
+}
+
+.spec-prose p,
+.spec-prose li,
+.spec-prose blockquote {
+  color: var(--ink-800);
+}
+
+.spec-prose ul,
+.spec-prose ol {
+  margin-left: 1.2rem;
+}
+
+.spec-prose li + li {
+  margin-top: 0.28rem;
+}
+
+.spec-prose code {
+  background: rgba(11, 93, 176, 0.08);
+  border-radius: 0.35rem;
+  font-size: 0.92em;
+  padding: 0.08rem 0.32rem;
+}
+
+.spec-prose pre {
+  background: #0f1b2d;
+  border-radius: 12px;
+  color: #e5eef9;
+  margin: 1rem 0;
+  overflow-x: auto;
+  padding: 1rem;
+}
+
+.spec-prose pre code {
+  background: transparent;
+  color: inherit;
+  padding: 0;
+}
+
+.spec-prose blockquote {
+  border-left: 3px solid rgba(11, 93, 176, 0.28);
+  margin: 1rem 0;
+  padding-left: 1rem;
+}
+
+.spec-prose table {
+  border-collapse: collapse;
+  margin: 1.1rem 0;
+  width: 100%;
+}
+
+.spec-prose th,
+.spec-prose td {
+  border: 1px solid var(--line);
+  padding: 0.65rem 0.8rem;
+  text-align: left;
+  vertical-align: top;
+}
+
+.spec-prose th {
+  background: #f8fbff;
+  color: var(--ink-900);
+}
+
+.spec-index-grid .card {
+  height: 100%;
 }
 
 .table-card {

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -568,6 +568,11 @@ footer {
   margin-top: 1.4rem;
 }
 
+.docs-main section:not(.docs-hero) {
+  contain-intrinsic-size: 1px 520px;
+  content-visibility: auto;
+}
+
 .docs-hero {
   margin-top: 0;
 }

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -749,6 +749,14 @@ footer {
   height: 100%;
 }
 
+.spec-index-grid h3 a {
+  color: inherit;
+}
+
+.spec-index-grid h3 a:hover {
+  color: var(--accent-700);
+}
+
 .table-card {
   overflow-x: auto;
   padding: 0;

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -227,6 +227,62 @@ nav {
   padding: 0.48rem 0.52rem;
 }
 
+.search-page-count {
+  color: var(--ink-700);
+  font-size: 0.94rem;
+  font-weight: 600;
+  margin-top: 0.8rem;
+}
+
+.search-page-layout {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: 280px minmax(0, 1fr);
+}
+
+.search-page-help {
+  align-self: start;
+  position: sticky;
+  top: 88px;
+}
+
+.search-page-help h2,
+.search-page-empty h2 {
+  color: var(--ink-900);
+  font-family: "Space Grotesk", "IBM Plex Sans", sans-serif;
+  font-size: 1.05rem;
+  margin-bottom: 0.5rem;
+}
+
+.search-page-help ul {
+  margin-left: 1rem;
+}
+
+.search-page-help li + li {
+  margin-top: 0.42rem;
+}
+
+.search-page-results {
+  display: grid;
+  gap: 0.9rem;
+  list-style: none;
+}
+
+.search-page-item h3 {
+  font-family: "Space Grotesk", "IBM Plex Sans", sans-serif;
+  font-size: 1.06rem;
+  margin-bottom: 0.35rem;
+}
+
+.search-page-item p + p {
+  margin-top: 0.65rem;
+}
+
+.search-page-meta {
+  color: var(--slate-500);
+  font-size: 0.84rem;
+}
+
 .sr-only {
   border: 0;
   clip: rect(0 0 0 0);
@@ -775,6 +831,14 @@ footer {
   }
 
   .docs-side {
+    position: static;
+  }
+
+  .search-page-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .search-page-help {
     position: static;
   }
 

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -327,6 +327,41 @@ section {
   z-index: 1;
 }
 
+.breadcrumbs {
+  margin-bottom: 1rem;
+}
+
+.breadcrumbs ol {
+  align-items: center;
+  color: var(--slate-500);
+  display: flex;
+  flex-wrap: wrap;
+  font-size: 0.8rem;
+  gap: 0.4rem;
+  list-style: none;
+}
+
+.breadcrumbs li {
+  align-items: center;
+  display: inline-flex;
+  gap: 0.4rem;
+}
+
+.breadcrumbs li + li::before {
+  color: var(--slate-300);
+  content: "/";
+  margin-right: 0.05rem;
+}
+
+.breadcrumbs a {
+  color: var(--ink-700);
+  font-weight: 600;
+}
+
+.breadcrumbs .current {
+  color: var(--slate-500);
+}
+
 .status-pill {
   background: var(--accent-100);
   border: 1px solid #99f6e4;
@@ -418,6 +453,13 @@ h1 {
   border-radius: var(--radius);
   box-shadow: var(--shadow-light);
   padding: 1.15rem;
+  transition: border-color 0.18s ease, box-shadow 0.18s ease, transform 0.18s ease;
+}
+
+.card:hover {
+  border-color: #bfd0e7;
+  box-shadow: var(--shadow-soft);
+  transform: translateY(-2px);
 }
 
 .card:nth-child(2) {
@@ -433,6 +475,14 @@ h1 {
   font-family: "Space Grotesk", "IBM Plex Sans", sans-serif;
   font-size: 1rem;
   margin-bottom: 0.5rem;
+}
+
+.card-title-link {
+  color: inherit;
+}
+
+.card-title-link:hover {
+  color: var(--accent-700);
 }
 
 .card p,
@@ -457,6 +507,18 @@ h1 {
   content: "•";
   left: 0;
   position: absolute;
+}
+
+.card-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+  margin-top: 0.9rem;
+}
+
+.card-actions a {
+  font-size: 0.85rem;
+  font-weight: 700;
 }
 
 .section-title {
@@ -571,6 +633,18 @@ footer {
   font-size: 0.92rem;
   margin-top: 0.8rem;
   padding: 0.8rem;
+}
+
+.topic-bridge {
+  margin-top: 1rem;
+}
+
+.topic-bridge .card h3 {
+  margin-bottom: 0.4rem;
+}
+
+.topic-bridge .card ul {
+  margin-top: 0.55rem;
 }
 
 .docs-shell {

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -711,7 +711,52 @@ footer {
 
 .docs-side a.current {
   background: rgba(11, 93, 176, 0.1);
-  color: var(--brand-700);
+  color: var(--accent-700);
+}
+
+.page-nav {
+  display: grid;
+  gap: 0.9rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.page-nav-link {
+  background: rgba(255, 255, 255, 0.82);
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  box-shadow: var(--shadow-light);
+  color: var(--ink-900);
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  min-height: 100%;
+  padding: 1rem 1.1rem;
+  transition: border-color 0.18s ease, box-shadow 0.18s ease, transform 0.18s ease;
+}
+
+.page-nav-link:hover {
+  border-color: #bfd0e7;
+  box-shadow: var(--shadow-soft);
+  color: var(--ink-950);
+  transform: translateY(-1px);
+}
+
+.page-nav-link.next {
+  text-align: right;
+}
+
+.page-nav-eyebrow {
+  color: var(--slate-500);
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.page-nav-label {
+  color: var(--ink-900);
+  font-family: "Space Grotesk", "IBM Plex Sans", sans-serif;
+  font-size: 1rem;
 }
 
 .docs-main {
@@ -922,6 +967,14 @@ footer {
 
   .search-page-help {
     position: static;
+  }
+
+  .page-nav {
+    grid-template-columns: 1fr;
+  }
+
+  .page-nav-link.next {
+    text-align: left;
   }
 
   .data-table {

--- a/public/data/search-index.json
+++ b/public/data/search-index.json
@@ -267,6 +267,7 @@
     "keywords": [
       "adapter",
       "spec",
+      "docs",
       "danger",
       "levels",
       "dangerous",
@@ -282,6 +283,7 @@
     "keywords": [
       "adapter",
       "spec",
+      "docs",
       "discovery",
       "bundle",
       "mcp",
@@ -295,6 +297,7 @@
     "keywords": [
       "adapter",
       "spec",
+      "docs",
       "element",
       "type",
       "specification"
@@ -307,6 +310,7 @@
     "keywords": [
       "adapter",
       "spec",
+      "docs",
       "generator",
       "specification"
     ]
@@ -318,6 +322,7 @@
     "keywords": [
       "adapter",
       "spec",
+      "docs",
       "rate",
       "limiting",
       "and",
@@ -333,6 +338,7 @@
     "keywords": [
       "adapter",
       "spec",
+      "docs",
       "trust",
       "levels",
       "specification"
@@ -345,6 +351,7 @@
     "keywords": [
       "adrs",
       "spec",
+      "docs",
       "adr",
       "001",
       "crude",
@@ -362,6 +369,7 @@
     "keywords": [
       "adrs",
       "spec",
+      "docs",
       "adr",
       "002",
       "graphql",
@@ -379,6 +387,7 @@
     "keywords": [
       "adrs",
       "spec",
+      "docs",
       "adr",
       "003",
       "snake",
@@ -395,6 +404,7 @@
     "keywords": [
       "adrs",
       "spec",
+      "docs",
       "adr",
       "004",
       "schema",
@@ -411,6 +421,7 @@
     "keywords": [
       "adrs",
       "spec",
+      "docs",
       "adr",
       "005",
       "introspection",
@@ -426,6 +437,7 @@
     "keywords": [
       "adrs",
       "spec",
+      "docs",
       "adr",
       "006",
       "discriminated",
@@ -441,6 +453,7 @@
     "keywords": [
       "adrs",
       "spec",
+      "docs",
       "adr",
       "index",
       "architecture",
@@ -455,6 +468,7 @@
     "keywords": [
       "adrs",
       "spec",
+      "docs",
       "adr",
       "readme",
       "architecture",
@@ -469,6 +483,7 @@
     "keywords": [
       "architecture",
       "spec",
+      "docs",
       "readme",
       "documentation"
     ]
@@ -480,6 +495,7 @@
     "keywords": [
       "core",
       "spec",
+      "docs",
       "conformance",
       "testing",
       "mcp",
@@ -494,6 +510,7 @@
     "keywords": [
       "core",
       "spec",
+      "docs",
       "crude",
       "pattern",
       "mcp",
@@ -508,6 +525,7 @@
     "keywords": [
       "core",
       "spec",
+      "docs",
       "endpoint",
       "modes",
       "mcp",
@@ -522,6 +540,7 @@
     "keywords": [
       "core",
       "spec",
+      "docs",
       "error",
       "codes",
       "structured",
@@ -535,6 +554,7 @@
     "keywords": [
       "features",
       "spec",
+      "docs",
       "field",
       "selection",
       "specification"
@@ -547,6 +567,7 @@
     "keywords": [
       "features",
       "spec",
+      "docs",
       "pagination",
       "cursor",
       "based",
@@ -560,6 +581,7 @@
     "keywords": [
       "features",
       "spec",
+      "docs",
       "warnings",
       "array",
       "specification"
@@ -572,6 +594,7 @@
     "keywords": [
       "guides",
       "spec",
+      "docs",
       "protocol",
       "comparison",
       "guide"
@@ -584,6 +607,7 @@
     "keywords": [
       "guides",
       "spec",
+      "docs",
       "readme",
       "developer"
     ]
@@ -595,6 +619,7 @@
     "keywords": [
       "core",
       "spec",
+      "docs",
       "introspection",
       "mcp",
       "aql",
@@ -608,6 +633,7 @@
     "keywords": [
       "core",
       "spec",
+      "docs",
       "licensing",
       "options",
       "mcp",
@@ -623,6 +649,7 @@
     "keywords": [
       "core",
       "spec",
+      "docs",
       "mcp",
       "integration",
       "specification"
@@ -635,6 +662,7 @@
     "keywords": [
       "core",
       "spec",
+      "docs",
       "operations",
       "mcp",
       "aql",
@@ -648,6 +676,7 @@
     "keywords": [
       "core",
       "spec",
+      "docs",
       "overview",
       "mcp",
       "aql",
@@ -661,6 +690,7 @@
     "keywords": [
       "core",
       "spec",
+      "docs",
       "plugin",
       "contracts",
       "interface"
@@ -673,6 +703,7 @@
     "keywords": [
       "process",
       "spec",
+      "docs",
       "breaking",
       "changes",
       "mcp",
@@ -688,6 +719,7 @@
     "keywords": [
       "process",
       "spec",
+      "docs",
       "preliminary",
       "public",
       "launch",
@@ -701,6 +733,7 @@
     "keywords": [
       "process",
       "spec",
+      "docs",
       "rfc",
       "for",
       "mcp",
@@ -715,6 +748,7 @@
     "keywords": [
       "process",
       "spec",
+      "docs",
       "versioning",
       "strategy"
     ]
@@ -726,6 +760,7 @@
     "keywords": [
       "core",
       "spec",
+      "docs",
       "readme",
       "mcp",
       "aql",
@@ -740,6 +775,7 @@
     "keywords": [
       "reference",
       "spec",
+      "docs",
       "readme",
       "documentation"
     ]
@@ -751,6 +787,7 @@
     "keywords": [
       "research",
       "spec",
+      "docs",
       "mcp",
       "vs",
       "mcpaql",
@@ -767,6 +804,7 @@
     "keywords": [
       "security",
       "spec",
+      "docs",
       "confirmation",
       "tokens",
       "token",
@@ -780,6 +818,7 @@
     "keywords": [
       "security",
       "spec",
+      "docs",
       "execution",
       "safety",
       "loop",
@@ -793,6 +832,7 @@
     "keywords": [
       "security",
       "spec",
+      "docs",
       "gatekeeper",
       "model",
       "specification"
@@ -805,11 +845,35 @@
     "keywords": [
       "versions",
       "spec",
+      "docs",
       "v1.0.0",
       "draft",
       "mcp",
       "aql",
       "specification"
+    ]
+  },
+  {
+    "title": "Spec: MCP-AQL Specification",
+    "url": "/spec/repo/README.html",
+    "excerpt": "Model Context Protocol - Advanced Agent API Adapter Query Language",
+    "keywords": [
+      "core",
+      "spec",
+      "readme",
+      "mcp",
+      "aql",
+      "specification"
+    ]
+  },
+  {
+    "title": "Spec: Changelog",
+    "url": "/spec/repo/CHANGELOG.html",
+    "excerpt": "All notable changes to the MCP-AQL specification will be documented in this file.",
+    "keywords": [
+      "process",
+      "spec",
+      "changelog"
     ]
   }
 ]

--- a/public/data/search-index.json
+++ b/public/data/search-index.json
@@ -3,126 +3,813 @@
     "title": "MCP-AQL Portal Home",
     "url": "/index.html",
     "excerpt": "Public draft portal overview, launch posture, repository map, and start-here navigation.",
-    "keywords": ["home", "overview", "public draft", "portal", "launch"]
+    "keywords": [
+      "home",
+      "overview",
+      "public draft",
+      "portal",
+      "launch"
+    ]
   },
   {
     "title": "Docs Library",
     "url": "/docs/index.html",
     "excerpt": "Structured documentation map for normative spec, implementation guidance, examples, tooling, and governance.",
-    "keywords": ["docs", "documentation", "library", "spec map", "reference"]
+    "keywords": [
+      "docs",
+      "documentation",
+      "library",
+      "spec map",
+      "reference"
+    ]
   },
   {
     "title": "Getting Started",
     "url": "/docs/getting-started.html",
     "excerpt": "Quick-start overview of MCP-AQL, token efficiency, request shape, and reading order for the draft.",
-    "keywords": ["getting started", "overview", "quickstart", "token efficiency", "intro"]
+    "keywords": [
+      "getting started",
+      "overview",
+      "quickstart",
+      "token efficiency",
+      "intro"
+    ]
   },
   {
     "title": "Protocol Core",
     "url": "/docs/protocol-core.html",
     "excerpt": "Normative foundations: CRUDE model, endpoint modes, request and response contracts, introspection, and operation routing.",
-    "keywords": ["crude", "single mode", "request", "response", "introspect", "operation"]
+    "keywords": [
+      "crude",
+      "single mode",
+      "request",
+      "response",
+      "introspect",
+      "operation"
+    ]
   },
   {
     "title": "Error Model",
     "url": "/docs/error-model.html",
     "excerpt": "Structured error envelopes, machine-readable codes, and the current draft work to align error surfaces.",
-    "keywords": ["error", "structured error", "code", "message", "details", "issue 199"]
+    "keywords": [
+      "error",
+      "structured error",
+      "code",
+      "message",
+      "details",
+      "issue 199"
+    ]
   },
   {
     "title": "Security Model",
     "url": "/docs/security-model.html",
     "excerpt": "Gatekeeper trust levels, danger handling, confirmation token flows, and execution safety boundaries.",
-    "keywords": ["security", "gatekeeper", "danger", "confirmation token", "trust", "safety"]
+    "keywords": [
+      "security",
+      "gatekeeper",
+      "danger",
+      "confirmation token",
+      "trust",
+      "safety"
+    ]
   },
   {
     "title": "Conformance And Validation",
     "url": "/docs/conformance.html",
     "excerpt": "Current conformance requirements, validation scope, and planned validator tooling for implementers.",
-    "keywords": ["conformance", "validator", "validation", "testing", "compliance", "on-spec"]
+    "keywords": [
+      "conformance",
+      "validator",
+      "validation",
+      "testing",
+      "compliance",
+      "on-spec"
+    ]
   },
   {
     "title": "Adapter Contracts",
     "url": "/docs/adapter-contracts.html",
     "excerpt": "Adapter schema, plugin contracts, generator outputs, and implementation expectations across the MCP-AQL stack.",
-    "keywords": ["adapter contracts", "plugin", "element type", "generator", "schema", "runtime"]
+    "keywords": [
+      "adapter contracts",
+      "plugin",
+      "element type",
+      "generator",
+      "schema",
+      "runtime"
+    ]
   },
   {
     "title": "Implementation Profiles",
     "url": "/docs/implementation-profiles.html",
     "excerpt": "Canonical protocol vs practical profile boundaries across spec, adapter runtime, examples, and production references.",
-    "keywords": ["profile", "dollhouse", "reference", "adapter", "runtime", "implementation"]
+    "keywords": [
+      "profile",
+      "dollhouse",
+      "reference",
+      "adapter",
+      "runtime",
+      "implementation"
+    ]
   },
   {
     "title": "Roadmap",
     "url": "/docs/roadmap.html",
     "excerpt": "Protocol and ecosystem roadmap with current execution focus and phased delivery tracks.",
-    "keywords": ["roadmap", "phase", "launch", "readiness", "ecosystem", "timeline"]
+    "keywords": [
+      "roadmap",
+      "phase",
+      "launch",
+      "readiness",
+      "ecosystem",
+      "timeline"
+    ]
   },
   {
     "title": "Release Notes",
     "url": "/docs/release-notes.html",
     "excerpt": "Recent draft changes and launch-relevant notes distilled from the MCP-AQL specification changelog.",
-    "keywords": ["release notes", "changelog", "draft changes", "launch", "issue 194"]
+    "keywords": [
+      "release notes",
+      "changelog",
+      "draft changes",
+      "launch",
+      "issue 194"
+    ]
   },
   {
     "title": "Launch Checklist",
     "url": "/launch-checklist.html",
     "excerpt": "Public-facing preliminary launch checklist for readiness visibility and scope control.",
-    "keywords": ["launch", "checklist", "readiness", "public draft"]
+    "keywords": [
+      "launch",
+      "checklist",
+      "readiness",
+      "public draft"
+    ]
   },
   {
     "title": "MCP Server Adapter Pattern",
     "url": "/apis/mcp-server.html",
     "excerpt": "Draft guidance for adapting MCP servers to MCP-AQL through introspection and CRUDE operation mapping.",
-    "keywords": ["mcp server", "adapter pattern", "mapping", "introspection"]
+    "keywords": [
+      "mcp server",
+      "adapter pattern",
+      "mapping",
+      "introspection"
+    ]
   },
   {
     "title": "Operating System Adapter Pattern",
     "url": "/apis/operating-system.html",
     "excerpt": "Draft guidance for operating-system integrations with permission and safety-aware boundaries.",
-    "keywords": ["operating system", "permissions", "local operations", "safety"]
+    "keywords": [
+      "operating system",
+      "permissions",
+      "local operations",
+      "safety"
+    ]
   },
   {
     "title": "Application Adapter Pattern",
     "url": "/apis/application.html",
     "excerpt": "Draft guidance for desktop and application API integration into MCP-AQL contracts.",
-    "keywords": ["application", "desktop", "app api", "integration"]
+    "keywords": [
+      "application",
+      "desktop",
+      "app api",
+      "integration"
+    ]
   },
   {
     "title": "Cloud Service Adapter Pattern",
     "url": "/apis/cloud-service.html",
     "excerpt": "Draft guidance for cloud API adaptation, rate limits, and resilient operation handling.",
-    "keywords": ["cloud", "service", "rate limit", "external api"]
+    "keywords": [
+      "cloud",
+      "service",
+      "rate limit",
+      "external api"
+    ]
   },
   {
     "title": "Website Adapter Pattern",
     "url": "/apis/website.html",
     "excerpt": "Draft guidance for website-facing integrations and retrieval/action patterns.",
-    "keywords": ["website", "web", "retrieval", "action"]
+    "keywords": [
+      "website",
+      "web",
+      "retrieval",
+      "action"
+    ]
   },
   {
     "title": "Spec Repository",
     "url": "https://github.com/MCPAQL/spec",
     "excerpt": "Canonical source for normative protocol text, schemas, and versioned specification draft.",
-    "keywords": ["spec", "normative", "schema", "version", "protocol"]
+    "keywords": [
+      "spec",
+      "normative",
+      "schema",
+      "version",
+      "protocol"
+    ]
   },
   {
     "title": "Adapter Runtime Repository",
     "url": "https://github.com/MCPAQL/mcpaql-adapter",
     "excerpt": "Reference implementation guidance for schema-driven dispatch and plugin runtime architecture.",
-    "keywords": ["runtime", "plugin", "dispatch", "implementation"]
+    "keywords": [
+      "runtime",
+      "plugin",
+      "dispatch",
+      "implementation"
+    ]
   },
   {
     "title": "Examples Repository",
     "url": "https://github.com/MCPAQL/examples",
     "excerpt": "Reference adapter examples demonstrating practical API adaptation patterns.",
-    "keywords": ["examples", "reference adapters", "sample"]
+    "keywords": [
+      "examples",
+      "reference adapters",
+      "sample"
+    ]
   },
   {
     "title": "Tools Repository",
     "url": "https://github.com/MCPAQL/tools",
     "excerpt": "Planned conformance and on-spec validator tooling for MCP-AQL implementations.",
-    "keywords": ["tools", "validator", "conformance cli", "on-spec"]
+    "keywords": [
+      "tools",
+      "validator",
+      "conformance cli",
+      "on-spec"
+    ]
+  },
+  {
+    "title": "Repo-Synced Spec Reference",
+    "url": "/spec/index.html",
+    "excerpt": "Full website-hosted mirror of the MCP-AQL spec docs generated from the spec repository source.",
+    "keywords": [
+      "spec mirror",
+      "repo synced",
+      "full docs",
+      "reference",
+      "generated"
+    ]
+  },
+  {
+    "title": "Spec: Dangerous Operation Classification Specification",
+    "url": "/spec/adapter/danger-levels.html",
+    "excerpt": "This document defines a standard classification system for dangerous operations in MCP-AQL adapters. Danger levels enable automatic lockdown of high-risk actions, consistent confirmation requirements, and trust-based per",
+    "keywords": [
+      "adapter",
+      "spec",
+      "danger",
+      "levels",
+      "dangerous",
+      "operation",
+      "classification",
+      "specification"
+    ]
+  },
+  {
+    "title": "Spec: MCP Server Discovery Bundle",
+    "url": "/spec/adapter/discovery-bundle.html",
+    "excerpt": "Document Status: This document is informative support text for the current MCP-AQL draft. The normative source of truth remains Specification v1.0.0-draft plus the published schemas in spec/schemas/.",
+    "keywords": [
+      "adapter",
+      "spec",
+      "discovery",
+      "bundle",
+      "mcp",
+      "server"
+    ]
+  },
+  {
+    "title": "Spec: Adapter Element Type Specification",
+    "url": "/spec/adapter/element-type.html",
+    "excerpt": "This document defines the Adapter Element Type, a declarative schema format for describing how MCP-AQL CRUDE operations map to target API calls. Adapters are Markdown files with YAML front matter that a universal runtime",
+    "keywords": [
+      "adapter",
+      "spec",
+      "element",
+      "type",
+      "specification"
+    ]
+  },
+  {
+    "title": "Spec: Adapter Generator Specification",
+    "url": "/spec/adapter/generator.html",
+    "excerpt": "This document specifies the requirements and behavior of MCP-AQL adapter generators. An adapter generator takes a schema definition as input and produces compliant adapter code with required licensing artifacts and prove",
+    "keywords": [
+      "adapter",
+      "spec",
+      "generator",
+      "specification"
+    ]
+  },
+  {
+    "title": "Spec: Rate Limiting and Quota Management Specification",
+    "url": "/spec/adapter/rate-limiting.html",
+    "excerpt": "This document defines the rate limiting and quota management system for MCP-AQL adapters. Rate limits enable systems to respect API constraints, prevent runaway costs, and provide graceful degradation under load.",
+    "keywords": [
+      "adapter",
+      "spec",
+      "rate",
+      "limiting",
+      "and",
+      "quota",
+      "management",
+      "specification"
+    ]
+  },
+  {
+    "title": "Spec: Trust Levels Specification",
+    "url": "/spec/adapter/trust-levels.html",
+    "excerpt": "This document defines the trust level system for MCP-AQL adapters. Trust levels indicate the verification and validation status of an adapter, enabling systems to make informed decisions about which operations to permit ",
+    "keywords": [
+      "adapter",
+      "spec",
+      "trust",
+      "levels",
+      "specification"
+    ]
+  },
+  {
+    "title": "Spec: ADR-001: CRUDE Pattern (Extending CRUD with Execute)",
+    "url": "/spec/adr/ADR-001-crude-pattern.html",
+    "excerpt": "Date: 2026-01-16",
+    "keywords": [
+      "adrs",
+      "spec",
+      "adr",
+      "001",
+      "crude",
+      "pattern",
+      "extending",
+      "crud",
+      "with",
+      "execute"
+    ]
+  },
+  {
+    "title": "Spec: ADR-002: GraphQL-Style Input Objects for Updates",
+    "url": "/spec/adr/ADR-002-graphql-style-input.html",
+    "excerpt": "Date: 2026-01-16",
+    "keywords": [
+      "adrs",
+      "spec",
+      "adr",
+      "002",
+      "graphql",
+      "style",
+      "input",
+      "objects",
+      "for",
+      "updates"
+    ]
+  },
+  {
+    "title": "Spec: ADR-003: snake_case Parameter Convention",
+    "url": "/spec/adr/ADR-003-snake-case-parameters.html",
+    "excerpt": "Date: 2026-01-16",
+    "keywords": [
+      "adrs",
+      "spec",
+      "adr",
+      "003",
+      "snake",
+      "case",
+      "parameters",
+      "parameter",
+      "convention"
+    ]
+  },
+  {
+    "title": "Spec: ADR-004: Schema-Driven Operation Definitions",
+    "url": "/spec/adr/ADR-004-schema-driven-operations.html",
+    "excerpt": "Date: 2026-01-16",
+    "keywords": [
+      "adrs",
+      "spec",
+      "adr",
+      "004",
+      "schema",
+      "driven",
+      "operations",
+      "operation",
+      "definitions"
+    ]
+  },
+  {
+    "title": "Spec: ADR-005: GraphQL-Style Introspection System",
+    "url": "/spec/adr/ADR-005-introspection-system.html",
+    "excerpt": "Date: 2026-01-16",
+    "keywords": [
+      "adrs",
+      "spec",
+      "adr",
+      "005",
+      "introspection",
+      "system",
+      "graphql",
+      "style"
+    ]
+  },
+  {
+    "title": "Spec: ADR-006: Discriminated Response Format",
+    "url": "/spec/adr/ADR-006-discriminated-responses.html",
+    "excerpt": "Date: 2026-01-16",
+    "keywords": [
+      "adrs",
+      "spec",
+      "adr",
+      "006",
+      "discriminated",
+      "responses",
+      "response",
+      "format"
+    ]
+  },
+  {
+    "title": "Spec: Architecture Decision Records",
+    "url": "/spec/adr/index.html",
+    "excerpt": "This directory contains Architecture Decision Records (ADRs) documenting significant design decisions in the MCP-AQL protocol specification.",
+    "keywords": [
+      "adrs",
+      "spec",
+      "adr",
+      "index",
+      "architecture",
+      "decision",
+      "records"
+    ]
+  },
+  {
+    "title": "Spec: Architecture Decision Records",
+    "url": "/spec/adr/README.html",
+    "excerpt": "See index.md for the complete list of ADRs.",
+    "keywords": [
+      "adrs",
+      "spec",
+      "adr",
+      "readme",
+      "architecture",
+      "decision",
+      "records"
+    ]
+  },
+  {
+    "title": "Spec: Architecture Documentation",
+    "url": "/spec/architecture/README.html",
+    "excerpt": "Implementation architecture documentation has moved to the mcpaql-adapter repository.",
+    "keywords": [
+      "architecture",
+      "spec",
+      "readme",
+      "documentation"
+    ]
+  },
+  {
+    "title": "Spec: MCP-AQL Conformance Testing Specification",
+    "url": "/spec/conformance-testing.html",
+    "excerpt": "Document Status: This document is an informative conformance framework specification aligned to the normative protocol requirements in docs/versions/v1.0.0-draft.md. Implementation Status: The full mcpaql-conformance run",
+    "keywords": [
+      "core",
+      "spec",
+      "conformance",
+      "testing",
+      "mcp",
+      "aql",
+      "specification"
+    ]
+  },
+  {
+    "title": "Spec: MCP-AQL CRUDE Pattern Specification",
+    "url": "/spec/crude-pattern.html",
+    "excerpt": "Document Status: This document is informative. For normative requirements, see MCP-AQL Specification v1.0.0.",
+    "keywords": [
+      "core",
+      "spec",
+      "crude",
+      "pattern",
+      "mcp",
+      "aql",
+      "specification"
+    ]
+  },
+  {
+    "title": "Spec: MCP-AQL Endpoint Modes Specification",
+    "url": "/spec/endpoint-modes.html",
+    "excerpt": "Document Status: This document is informative. For normative requirements, see MCP-AQL Specification v1.0.0.",
+    "keywords": [
+      "core",
+      "spec",
+      "endpoint",
+      "modes",
+      "mcp",
+      "aql",
+      "specification"
+    ]
+  },
+  {
+    "title": "Spec: Structured Error Codes Specification",
+    "url": "/spec/error-codes.html",
+    "excerpt": "This document defines the structured error code system for MCP-AQL protocol responses. Structured error codes enable machine-readable error handling, consistent error categorization, and reliable error mapping across ada",
+    "keywords": [
+      "core",
+      "spec",
+      "error",
+      "codes",
+      "structured",
+      "specification"
+    ]
+  },
+  {
+    "title": "Spec: Field Selection Specification",
+    "url": "/spec/features/field-selection.html",
+    "excerpt": "This document specifies the optional field selection feature that enables clients to request only specific fields in responses, reducing payload size and token consumption.",
+    "keywords": [
+      "features",
+      "spec",
+      "field",
+      "selection",
+      "specification"
+    ]
+  },
+  {
+    "title": "Spec: Cursor-Based Pagination Specification",
+    "url": "/spec/features/pagination.html",
+    "excerpt": "This document defines cursor-based pagination semantics for MCP-AQL operations that return collections. Cursor pagination enables efficient iteration through large datasets while minimizing token usage in LLM context win",
+    "keywords": [
+      "features",
+      "spec",
+      "pagination",
+      "cursor",
+      "based",
+      "specification"
+    ]
+  },
+  {
+    "title": "Spec: Warnings Array Specification",
+    "url": "/spec/features/warnings.html",
+    "excerpt": "This document specifies the warnings array extension to MCP-AQL's discriminated response format. Warnings provide a mechanism to communicate non-fatal conditions to clients within successful responses, enabling proactive",
+    "keywords": [
+      "features",
+      "spec",
+      "warnings",
+      "array",
+      "specification"
+    ]
+  },
+  {
+    "title": "Spec: Protocol Comparison Guide",
+    "url": "/spec/guides/protocol-comparison.html",
+    "excerpt": "This document helps developers familiar with GraphQL, MongoDB, REST, SQL, or classic MCP understand MCP-AQL by mapping familiar concepts to their MCP-AQL equivalents.",
+    "keywords": [
+      "guides",
+      "spec",
+      "protocol",
+      "comparison",
+      "guide"
+    ]
+  },
+  {
+    "title": "Spec: Developer Guides",
+    "url": "/spec/guides/README.html",
+    "excerpt": "Step-by-step guides for implementing and using MCP-AQL adapters.",
+    "keywords": [
+      "guides",
+      "spec",
+      "readme",
+      "developer"
+    ]
+  },
+  {
+    "title": "Spec: MCP-AQL Introspection Specification",
+    "url": "/spec/introspection.html",
+    "excerpt": "Document Status: This document is informative. For normative requirements, see MCP-AQL Specification v1.0.0.",
+    "keywords": [
+      "core",
+      "spec",
+      "introspection",
+      "mcp",
+      "aql",
+      "specification"
+    ]
+  },
+  {
+    "title": "Spec: MCP-AQL Licensing Options (Working Notes)",
+    "url": "/spec/licensing-options.html",
+    "excerpt": "This document is a discussion aid for deciding how to license the MCP-AQL ecosystem (spec + schema artifacts + tooling + generated adapters + brand/name), while meeting these goals:",
+    "keywords": [
+      "core",
+      "spec",
+      "licensing",
+      "options",
+      "mcp",
+      "aql",
+      "working",
+      "notes"
+    ]
+  },
+  {
+    "title": "Spec: MCP Integration Specification",
+    "url": "/spec/mcp-integration.html",
+    "excerpt": "This document specifies how MCP-AQL adapters integrate with the Model Context Protocol (MCP). It defines tool registration requirements, input schema composition, error mapping between protocols, progress notification ha",
+    "keywords": [
+      "core",
+      "spec",
+      "mcp",
+      "integration",
+      "specification"
+    ]
+  },
+  {
+    "title": "Spec: MCP-AQL Operations Specification",
+    "url": "/spec/operations.html",
+    "excerpt": "Document Status: This document is informative. For normative requirements, see MCP-AQL Specification v1.0.0.",
+    "keywords": [
+      "core",
+      "spec",
+      "operations",
+      "mcp",
+      "aql",
+      "specification"
+    ]
+  },
+  {
+    "title": "Spec: MCP-AQL Protocol Overview",
+    "url": "/spec/overview.html",
+    "excerpt": "MCP-AQL (Model Context Protocol - Agent Query Language) is a protocol that consolidates discrete MCP tools into 5 CRUDE endpoints (Create, Read, Update, Delete, Execute), providing significant token reduction while maint",
+    "keywords": [
+      "core",
+      "spec",
+      "overview",
+      "mcp",
+      "aql",
+      "protocol"
+    ]
+  },
+  {
+    "title": "Spec: Plugin Interface Contracts",
+    "url": "/spec/plugin-contracts.html",
+    "excerpt": "This document defines the normative plugin interface contracts for the MCP-AQL adapter system. Plugins provide modular, composable functionality for transport, protocol, authentication, and serialization. This specificat",
+    "keywords": [
+      "core",
+      "spec",
+      "plugin",
+      "contracts",
+      "interface"
+    ]
+  },
+  {
+    "title": "Spec: MCP-AQL Breaking Change Policy",
+    "url": "/spec/process/breaking-changes.html",
+    "excerpt": "This document defines how breaking changes are handled in the MCP-AQL specification, including change classification, deprecation procedures, migration requirements, and communication standards.",
+    "keywords": [
+      "process",
+      "spec",
+      "breaking",
+      "changes",
+      "mcp",
+      "aql",
+      "change",
+      "policy"
+    ]
+  },
+  {
+    "title": "Spec: Preliminary Public Launch Checklist",
+    "url": "/spec/process/preliminary-public-launch-checklist.html",
+    "excerpt": "This checklist defines the minimum quality bar for a coordinated preliminary public launch of:",
+    "keywords": [
+      "process",
+      "spec",
+      "preliminary",
+      "public",
+      "launch",
+      "checklist"
+    ]
+  },
+  {
+    "title": "Spec: RFC Process for MCP-AQL Specification",
+    "url": "/spec/process/rfc-process.html",
+    "excerpt": "This document describes the formal process for proposing, reviewing, and accepting changes to the MCP-AQL specification through Requests for Comments (RFCs).",
+    "keywords": [
+      "process",
+      "spec",
+      "rfc",
+      "for",
+      "mcp",
+      "aql",
+      "specification"
+    ]
+  },
+  {
+    "title": "Spec: Versioning Strategy",
+    "url": "/spec/process/versioning.html",
+    "excerpt": "This document describes the version numbering scheme and release process for the MCPAQL specification.",
+    "keywords": [
+      "process",
+      "spec",
+      "versioning",
+      "strategy"
+    ]
+  },
+  {
+    "title": "Spec: MCP-AQL Specification Documentation",
+    "url": "/spec/README.html",
+    "excerpt": "This directory contains the MCP-AQL specification set:",
+    "keywords": [
+      "core",
+      "spec",
+      "readme",
+      "mcp",
+      "aql",
+      "specification",
+      "documentation"
+    ]
+  },
+  {
+    "title": "Spec: Reference Documentation",
+    "url": "/spec/reference/README.html",
+    "excerpt": "Detailed specifications for schemas, formats, and protocol structures.",
+    "keywords": [
+      "reference",
+      "spec",
+      "readme",
+      "documentation"
+    ]
+  },
+  {
+    "title": "Spec: Protocol Landscape: MCP vs MCP-AQL vs A2A",
+    "url": "/spec/research/mcp-vs-mcpaql-vs-a2a.html",
+    "excerpt": "A strategic comparison of three protocols shaping how AI agents interact with the world: where they overlap, where they diverge, and where the gaps are.",
+    "keywords": [
+      "research",
+      "spec",
+      "mcp",
+      "vs",
+      "mcpaql",
+      "a2a",
+      "protocol",
+      "landscape",
+      "aql"
+    ]
+  },
+  {
+    "title": "Spec: Confirmation Token Specification",
+    "url": "/spec/security/confirmation-tokens.html",
+    "excerpt": "This document specifies the confirmation token mechanism used by MCP-AQL adapters to gate dangerous operations and quota continuations. Confirmation tokens provide a secure, time-limited method for clients to acknowledge",
+    "keywords": [
+      "security",
+      "spec",
+      "confirmation",
+      "tokens",
+      "token",
+      "specification"
+    ]
+  },
+  {
+    "title": "Spec: Execution Safety Loop Specification",
+    "url": "/spec/security/execution-safety-loop.html",
+    "excerpt": "Informative Document: This is an informative specification that provides detailed guidance for the execution safety loop pattern defined normatively in Section 8.6 of the core specification. In case of conflict, the norm",
+    "keywords": [
+      "security",
+      "spec",
+      "execution",
+      "safety",
+      "loop",
+      "specification"
+    ]
+  },
+  {
+    "title": "Spec: Security Model: Gatekeeper Specification",
+    "url": "/spec/security/gatekeeper.html",
+    "excerpt": "This document specifies an optional security model for MCP-AQL adapters, providing multi-layer access control, confirmation requirements, and audit capabilities.",
+    "keywords": [
+      "security",
+      "spec",
+      "gatekeeper",
+      "model",
+      "specification"
+    ]
+  },
+  {
+    "title": "Spec: MCP-AQL Specification",
+    "url": "/spec/versions/v1.0.0-draft.html",
+    "excerpt": "MCP-AQL (Model Context Protocol - Advanced Agent API Adapter Query Language) is a protocol specification that consolidates multiple MCP tools into semantic CRUDE endpoints, providing significant token reduction while ena",
+    "keywords": [
+      "versions",
+      "spec",
+      "v1.0.0",
+      "draft",
+      "mcp",
+      "aql",
+      "specification"
+    ]
   }
 ]

--- a/public/data/search-index.json
+++ b/public/data/search-index.json
@@ -12,10 +12,22 @@
     "keywords": ["docs", "documentation", "library", "spec map", "reference"]
   },
   {
+    "title": "Getting Started",
+    "url": "/docs/getting-started.html",
+    "excerpt": "Quick-start overview of MCP-AQL, token efficiency, request shape, and reading order for the draft.",
+    "keywords": ["getting started", "overview", "quickstart", "token efficiency", "intro"]
+  },
+  {
     "title": "Protocol Core",
     "url": "/docs/protocol-core.html",
     "excerpt": "Normative foundations: CRUDE model, endpoint modes, request and response contracts, introspection, and operation routing.",
     "keywords": ["crude", "single mode", "request", "response", "introspect", "operation"]
+  },
+  {
+    "title": "Error Model",
+    "url": "/docs/error-model.html",
+    "excerpt": "Structured error envelopes, machine-readable codes, and the current draft work to align error surfaces.",
+    "keywords": ["error", "structured error", "code", "message", "details", "issue 199"]
   },
   {
     "title": "Security Model",
@@ -30,6 +42,12 @@
     "keywords": ["conformance", "validator", "validation", "testing", "compliance", "on-spec"]
   },
   {
+    "title": "Adapter Contracts",
+    "url": "/docs/adapter-contracts.html",
+    "excerpt": "Adapter schema, plugin contracts, generator outputs, and implementation expectations across the MCP-AQL stack.",
+    "keywords": ["adapter contracts", "plugin", "element type", "generator", "schema", "runtime"]
+  },
+  {
     "title": "Implementation Profiles",
     "url": "/docs/implementation-profiles.html",
     "excerpt": "Canonical protocol vs practical profile boundaries across spec, adapter runtime, examples, and production references.",
@@ -40,6 +58,12 @@
     "url": "/docs/roadmap.html",
     "excerpt": "Protocol and ecosystem roadmap with current execution focus and phased delivery tracks.",
     "keywords": ["roadmap", "phase", "launch", "readiness", "ecosystem", "timeline"]
+  },
+  {
+    "title": "Release Notes",
+    "url": "/docs/release-notes.html",
+    "excerpt": "Recent draft changes and launch-relevant notes distilled from the MCP-AQL specification changelog.",
+    "keywords": ["release notes", "changelog", "draft changes", "launch", "issue 194"]
   },
   {
     "title": "Launch Checklist",

--- a/public/docs/adapter-contracts.html
+++ b/public/docs/adapter-contracts.html
@@ -41,7 +41,7 @@
           <li><a href="error-model.html">Error Model</a></li>
           <li><a href="security-model.html">Security Model</a></li>
           <li><a href="conformance.html">Conformance</a></li>
-          <li><a href="adapter-contracts.html">Adapter Contracts</a></li>
+          <li><a class="current" href="adapter-contracts.html">Adapter Contracts</a></li>
           <li><a href="implementation-profiles.html">Implementation Profiles</a></li>
           <li><a href="roadmap.html">Roadmap</a></li>
           <li><a href="release-notes.html">Release Notes</a></li>
@@ -49,6 +49,13 @@
       </aside>
 
       <article class="docs-main">
+        <nav class="breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../index.html">Home</a></li>
+            <li><a href="index.html">Docs</a></li>
+            <li><span class="current">Adapter Contracts</span></li>
+          </ol>
+        </nav>
         <section class="hero docs-hero">
           <div class="hero-inner">
             <span class="status-pill">ADAPTER CONTRACTS</span>
@@ -61,6 +68,31 @@
               <a class="btn btn-primary" href="../spec/plugin-contracts.html">Plugin Contracts</a>
               <a class="btn btn-secondary" href="../spec/adapter/element-type.html">Element Type Spec</a>
             </div>
+          </div>
+        </section>
+
+        <section class="topic-bridge">
+          <div class="grid cols-2">
+            <article class="card">
+              <h3>Go Deeper In The Full Spec</h3>
+              <p>The website-hosted source docs carry the real contract details for schema shape, plugins, and generation behavior.</p>
+              <ul>
+                <li><a href="../spec/plugin-contracts.html">Plugin Interface Contracts</a></li>
+                <li><a href="../spec/adapter/element-type.html">Element Type Specification</a></li>
+                <li><a href="../spec/adapter/generator.html">Generator Specification</a></li>
+                <li><a href="../spec/index.html">Browse the full spec reference</a></li>
+              </ul>
+            </article>
+            <article class="card">
+              <h3>Related Summary Pages</h3>
+              <p>These summaries help connect adapter contracts to conformance and real implementation posture.</p>
+              <ul>
+                <li><a href="implementation-profiles.html">Implementation Profiles</a></li>
+                <li><a href="conformance.html">Conformance</a></li>
+                <li><a href="protocol-core.html">Protocol Core</a></li>
+                <li><a href="index.html">Back to the docs library</a></li>
+              </ul>
+            </article>
           </div>
         </section>
 

--- a/public/docs/adapter-contracts.html
+++ b/public/docs/adapter-contracts.html
@@ -23,7 +23,7 @@
         </ul>
         <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
-          <input id="site-search-input" data-search-input type="search" placeholder="Search adapter-contract topics...">
+          <input id="site-search-input" data-search-input type="search" placeholder="Search MCP-AQL docs, spec pages, and adapter patterns...">
           <span class="search-count" data-search-count></span>
           <ul class="search-results" data-search-results hidden></ul>
         </form>
@@ -72,6 +72,7 @@
         </section>
 
         <section class="topic-bridge">
+          <h2 class="sr-only">Related reading</h2>
           <div class="grid cols-2">
             <article class="card">
               <h3>Go Deeper In The Full Spec</h3>
@@ -154,6 +155,16 @@
             </article>
           </div>
         </section>
+        <nav class="page-nav" aria-label="Page navigation">
+          <a class="page-nav-link prev" href="conformance.html">
+            <span class="page-nav-eyebrow">Previous page</span>
+            <strong class="page-nav-label">Conformance</strong>
+          </a>
+          <a class="page-nav-link next" href="implementation-profiles.html">
+            <span class="page-nav-eyebrow">Next page</span>
+            <strong class="page-nav-label">Implementation Profiles</strong>
+          </a>
+        </nav>
       </article>
     </div>
   </main>

--- a/public/docs/adapter-contracts.html
+++ b/public/docs/adapter-contracts.html
@@ -1,0 +1,144 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="MCP-AQL adapter contracts: plugin types, element schemas, generator outputs, and implementation expectations.">
+  <title>MCP-AQL Docs | Adapter Contracts</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../css/style.css">
+</head>
+<body>
+  <header>
+    <div class="container">
+      <nav>
+        <a class="logo" href="../index.html"><span class="logo-mark"></span>MCP-AQL</a>
+        <ul class="nav-links">
+          <li><a href="../index.html">Home</a></li>
+          <li><a href="index.html">Docs</a></li>
+          <li><a href="../launch-checklist.html">Launch Checklist</a></li>
+          <li><a href="../apis/mcp-server.html">Adapter Patterns</a></li>
+        </ul>
+        <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
+          <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
+          <input id="site-search-input" data-search-input type="search" placeholder="Search adapter-contract topics...">
+          <span class="search-count" data-search-count></span>
+          <ul class="search-results" data-search-results hidden></ul>
+        </form>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <div class="container docs-shell">
+      <aside class="docs-side">
+        <h2>In This Library</h2>
+        <ul>
+          <li><a href="getting-started.html">Getting Started</a></li>
+          <li><a href="protocol-core.html">Protocol Core</a></li>
+          <li><a href="error-model.html">Error Model</a></li>
+          <li><a href="security-model.html">Security Model</a></li>
+          <li><a href="conformance.html">Conformance</a></li>
+          <li><a href="adapter-contracts.html">Adapter Contracts</a></li>
+          <li><a href="implementation-profiles.html">Implementation Profiles</a></li>
+          <li><a href="roadmap.html">Roadmap</a></li>
+          <li><a href="release-notes.html">Release Notes</a></li>
+        </ul>
+      </aside>
+
+      <article class="docs-main">
+        <section class="hero docs-hero">
+          <div class="hero-inner">
+            <span class="status-pill">ADAPTER CONTRACTS</span>
+            <h1>What an MCP-AQL adapter needs to describe and implement</h1>
+            <p class="lede">
+              The spec does not stop at request envelopes. It also defines the declarative shape of adapters,
+              the responsibilities of plugin layers, and the output constraints for generators and reference implementations.
+            </p>
+            <div class="hero-actions">
+              <a class="btn btn-primary" href="https://github.com/MCPAQL/spec/blob/main/docs/plugin-contracts.md">Plugin Contracts</a>
+              <a class="btn btn-secondary" href="https://github.com/MCPAQL/spec/blob/main/docs/adapter/element-type.md">Element Type Spec</a>
+            </div>
+          </div>
+        </section>
+
+        <section>
+          <h2 class="section-title">Contract layers</h2>
+          <div class="card table-card">
+            <table class="data-table">
+              <thead>
+                <tr>
+                  <th>Layer</th>
+                  <th>Primary source</th>
+                  <th>What it governs</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Adapter element schema</td>
+                  <td><a href="https://github.com/MCPAQL/spec/blob/main/docs/adapter/element-type.md">Element Type Specification</a></td>
+                  <td>How operations, parameters, auth, and pagination are declared</td>
+                </tr>
+                <tr>
+                  <td>Plugin interfaces</td>
+                  <td><a href="https://github.com/MCPAQL/spec/blob/main/docs/plugin-contracts.md">Plugin Interface Contracts</a></td>
+                  <td>What runtime plugins must provide to implement the declared adapter surface</td>
+                </tr>
+                <tr>
+                  <td>Generator outputs</td>
+                  <td><a href="https://github.com/MCPAQL/spec/blob/main/docs/adapter/generator.md">Generator specification</a></td>
+                  <td>How generated adapters preserve provenance, policy, and output constraints</td>
+                </tr>
+                <tr>
+                  <td>Reference runtime</td>
+                  <td><a href="https://github.com/MCPAQL/mcpaql-adapter">mcpaql-adapter repo</a></td>
+                  <td>Architecture, runtime pipeline, and dispatch behavior in practice</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <section>
+          <h2 class="section-title">Public takeaways</h2>
+          <div class="grid cols-2">
+            <article class="card">
+              <h3>Why this matters</h3>
+              <ul>
+                <li>Adapters need a declared contract, not just ad hoc handler code.</li>
+                <li>Tooling and generators only work if schemas and runtime plugins line up.</li>
+                <li>The website can point public readers to the right source-of-truth document for each layer.</li>
+              </ul>
+            </article>
+            <article class="card">
+              <h3>What is still open</h3>
+              <ul>
+                <li><a href="https://github.com/MCPAQL/spec/issues/211">#211 deferred plugin types</a></li>
+                <li><a href="https://github.com/MCPAQL/spec/issues/196">#196 adapter output requirements</a></li>
+                <li><a href="https://github.com/MCPAQL/spec/issues/204">#204 conformance validation framework</a></li>
+              </ul>
+            </article>
+          </div>
+        </section>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div class="container">
+      <p>&copy; 2026 DollhouseMCP Inc. d/b/a Dollhouse Research. MCP-AQL public draft documentation portal.</p>
+      <div class="footer-links">
+        <a href="index.html">Docs Library</a>
+        <a href="../index.html">Portal Home</a>
+        <a href="https://github.com/MCPAQL">MCPAQL Organization</a>
+        <a href="https://dollhouseresearch.com">Dollhouse Research</a>
+        <a href="https://github.com/DollhouseMCP/mcp-server">DollhouseMCP Production Profile</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../js/search.js"></script>
+</body>
+</html>

--- a/public/docs/adapter-contracts.html
+++ b/public/docs/adapter-contracts.html
@@ -58,8 +58,8 @@
               the responsibilities of plugin layers, and the output constraints for generators and reference implementations.
             </p>
             <div class="hero-actions">
-              <a class="btn btn-primary" href="https://github.com/MCPAQL/spec/blob/main/docs/plugin-contracts.md">Plugin Contracts</a>
-              <a class="btn btn-secondary" href="https://github.com/MCPAQL/spec/blob/main/docs/adapter/element-type.md">Element Type Spec</a>
+              <a class="btn btn-primary" href="../spec/plugin-contracts.html">Plugin Contracts</a>
+              <a class="btn btn-secondary" href="../spec/adapter/element-type.html">Element Type Spec</a>
             </div>
           </div>
         </section>
@@ -78,17 +78,17 @@
               <tbody>
                 <tr>
                   <td>Adapter element schema</td>
-                  <td><a href="https://github.com/MCPAQL/spec/blob/main/docs/adapter/element-type.md">Element Type Specification</a></td>
+                  <td><a href="../spec/adapter/element-type.html">Element Type Specification</a></td>
                   <td>How operations, parameters, auth, and pagination are declared</td>
                 </tr>
                 <tr>
                   <td>Plugin interfaces</td>
-                  <td><a href="https://github.com/MCPAQL/spec/blob/main/docs/plugin-contracts.md">Plugin Interface Contracts</a></td>
+                  <td><a href="../spec/plugin-contracts.html">Plugin Interface Contracts</a></td>
                   <td>What runtime plugins must provide to implement the declared adapter surface</td>
                 </tr>
                 <tr>
                   <td>Generator outputs</td>
-                  <td><a href="https://github.com/MCPAQL/spec/blob/main/docs/adapter/generator.md">Generator specification</a></td>
+                  <td><a href="../spec/adapter/generator.html">Generator specification</a></td>
                   <td>How generated adapters preserve provenance, policy, and output constraints</td>
                 </tr>
                 <tr>

--- a/public/docs/conformance.html
+++ b/public/docs/conformance.html
@@ -40,7 +40,7 @@
           <li><a href="protocol-core.html">Protocol Core</a></li>
           <li><a href="error-model.html">Error Model</a></li>
           <li><a href="security-model.html">Security Model</a></li>
-          <li><a href="conformance.html">Conformance</a></li>
+          <li><a class="current" href="conformance.html">Conformance</a></li>
           <li><a href="adapter-contracts.html">Adapter Contracts</a></li>
           <li><a href="implementation-profiles.html">Implementation Profiles</a></li>
           <li><a href="roadmap.html">Roadmap</a></li>
@@ -49,6 +49,13 @@
       </aside>
 
       <article class="docs-main">
+        <nav class="breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../index.html">Home</a></li>
+            <li><a href="index.html">Docs</a></li>
+            <li><span class="current">Conformance</span></li>
+          </ol>
+        </nav>
         <section class="hero docs-hero">
           <div class="hero-inner">
             <span class="status-pill">CONFORMANCE</span>
@@ -61,6 +68,31 @@
               <a class="btn btn-primary" href="../spec/conformance-testing.html">Conformance Doc</a>
               <a class="btn btn-secondary" href="https://github.com/MCPAQL/tools">Validator Tooling Repo</a>
             </div>
+          </div>
+        </section>
+
+        <section class="topic-bridge">
+          <div class="grid cols-2">
+            <article class="card">
+              <h3>Go Deeper In The Full Spec</h3>
+              <p>The detail behind compatibility claims and test scope lives in the longer conformance-oriented spec pages.</p>
+              <ul>
+                <li><a href="../spec/conformance-testing.html">Conformance Testing Specification</a></li>
+                <li><a href="../spec/versions/v1.0.0-draft.html">Normative Draft</a></li>
+                <li><a href="../spec/index.html">Browse the full spec reference</a></li>
+                <li><a href="https://github.com/MCPAQL/tools">Validator tooling repo</a></li>
+              </ul>
+            </article>
+            <article class="card">
+              <h3>Related Summary Pages</h3>
+              <p>Conformance lands best when read alongside the protocol rules, error surface, and launch scope.</p>
+              <ul>
+                <li><a href="protocol-core.html">Protocol Core</a></li>
+                <li><a href="error-model.html">Error Model</a></li>
+                <li><a href="../launch-checklist.html">Launch Checklist</a></li>
+                <li><a href="index.html">Back to the docs library</a></li>
+              </ul>
+            </article>
           </div>
         </section>
 

--- a/public/docs/conformance.html
+++ b/public/docs/conformance.html
@@ -23,7 +23,7 @@
         </ul>
         <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
-          <input id="site-search-input" data-search-input type="search" placeholder="Search conformance topics...">
+          <input id="site-search-input" data-search-input type="search" placeholder="Search MCP-AQL docs, spec pages, and adapter patterns...">
           <span class="search-count" data-search-count></span>
           <ul class="search-results" data-search-results hidden></ul>
         </form>
@@ -72,6 +72,7 @@
         </section>
 
         <section class="topic-bridge">
+          <h2 class="sr-only">Related reading</h2>
           <div class="grid cols-2">
             <article class="card">
               <h3>Go Deeper In The Full Spec</h3>
@@ -171,6 +172,16 @@
             </ul>
           </div>
         </section>
+        <nav class="page-nav" aria-label="Page navigation">
+          <a class="page-nav-link prev" href="security-model.html">
+            <span class="page-nav-eyebrow">Previous page</span>
+            <strong class="page-nav-label">Security Model</strong>
+          </a>
+          <a class="page-nav-link next" href="adapter-contracts.html">
+            <span class="page-nav-eyebrow">Next page</span>
+            <strong class="page-nav-label">Adapter Contracts</strong>
+          </a>
+        </nav>
       </article>
     </div>
   </main>

--- a/public/docs/conformance.html
+++ b/public/docs/conformance.html
@@ -58,7 +58,7 @@
               This page clarifies what can be asserted today versus what is still being built.
             </p>
             <div class="hero-actions">
-              <a class="btn btn-primary" href="https://github.com/MCPAQL/spec/blob/main/docs/conformance-testing.md">Conformance Doc</a>
+              <a class="btn btn-primary" href="../spec/conformance-testing.html">Conformance Doc</a>
               <a class="btn btn-secondary" href="https://github.com/MCPAQL/tools">Validator Tooling Repo</a>
             </div>
           </div>

--- a/public/docs/conformance.html
+++ b/public/docs/conformance.html
@@ -36,11 +36,15 @@
       <aside class="docs-side">
         <h2>In This Library</h2>
         <ul>
+          <li><a href="getting-started.html">Getting Started</a></li>
           <li><a href="protocol-core.html">Protocol Core</a></li>
+          <li><a href="error-model.html">Error Model</a></li>
           <li><a href="security-model.html">Security Model</a></li>
           <li><a href="conformance.html">Conformance</a></li>
+          <li><a href="adapter-contracts.html">Adapter Contracts</a></li>
           <li><a href="implementation-profiles.html">Implementation Profiles</a></li>
           <li><a href="roadmap.html">Roadmap</a></li>
+          <li><a href="release-notes.html">Release Notes</a></li>
         </ul>
       </aside>
 
@@ -121,6 +125,18 @@
             <p class="callout">
               Public messaging should avoid implying final certification until validator and conformance tracks are complete.
             </p>
+          </div>
+        </section>
+
+        <section>
+          <h2 class="section-title">Live conformance-related issues</h2>
+          <div class="card">
+            <ul>
+              <li><a href="https://github.com/MCPAQL/spec/issues/204">#204 conformance validation framework</a></li>
+              <li><a href="https://github.com/MCPAQL/spec/issues/199">#199 structured error surface alignment</a></li>
+              <li><a href="https://github.com/MCPAQL/spec/issues/57">#57 introspection must document handler-supported parameters</a></li>
+              <li><a href="https://github.com/MCPAQL/spec/issues/10">#10 conformance test suite</a></li>
+            </ul>
           </div>
         </section>
       </article>

--- a/public/docs/error-model.html
+++ b/public/docs/error-model.html
@@ -23,7 +23,7 @@
         </ul>
         <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
-          <input id="site-search-input" data-search-input type="search" placeholder="Search error-model topics...">
+          <input id="site-search-input" data-search-input type="search" placeholder="Search MCP-AQL docs, spec pages, and adapter patterns...">
           <span class="search-count" data-search-count></span>
           <ul class="search-results" data-search-results hidden></ul>
         </form>
@@ -72,6 +72,7 @@
         </section>
 
         <section class="topic-bridge">
+          <h2 class="sr-only">Related reading</h2>
           <div class="grid cols-2">
             <article class="card">
               <h3>Go Deeper In The Full Spec</h3>
@@ -156,6 +157,16 @@
             response envelope requirements, and implementation-facing schemas.
           </p>
         </section>
+        <nav class="page-nav" aria-label="Page navigation">
+          <a class="page-nav-link prev" href="protocol-core.html">
+            <span class="page-nav-eyebrow">Previous page</span>
+            <strong class="page-nav-label">Protocol Core</strong>
+          </a>
+          <a class="page-nav-link next" href="security-model.html">
+            <span class="page-nav-eyebrow">Next page</span>
+            <strong class="page-nav-label">Security Model</strong>
+          </a>
+        </nav>
       </article>
     </div>
   </main>

--- a/public/docs/error-model.html
+++ b/public/docs/error-model.html
@@ -1,0 +1,146 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="MCP-AQL error model: structured error envelopes, machine-readable codes, and draft alignment work.">
+  <title>MCP-AQL Docs | Error Model</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../css/style.css">
+</head>
+<body>
+  <header>
+    <div class="container">
+      <nav>
+        <a class="logo" href="../index.html"><span class="logo-mark"></span>MCP-AQL</a>
+        <ul class="nav-links">
+          <li><a href="../index.html">Home</a></li>
+          <li><a href="index.html">Docs</a></li>
+          <li><a href="../launch-checklist.html">Launch Checklist</a></li>
+          <li><a href="../apis/mcp-server.html">Adapter Patterns</a></li>
+        </ul>
+        <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
+          <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
+          <input id="site-search-input" data-search-input type="search" placeholder="Search error-model topics...">
+          <span class="search-count" data-search-count></span>
+          <ul class="search-results" data-search-results hidden></ul>
+        </form>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <div class="container docs-shell">
+      <aside class="docs-side">
+        <h2>In This Library</h2>
+        <ul>
+          <li><a href="getting-started.html">Getting Started</a></li>
+          <li><a href="protocol-core.html">Protocol Core</a></li>
+          <li><a href="error-model.html">Error Model</a></li>
+          <li><a href="security-model.html">Security Model</a></li>
+          <li><a href="conformance.html">Conformance</a></li>
+          <li><a href="adapter-contracts.html">Adapter Contracts</a></li>
+          <li><a href="implementation-profiles.html">Implementation Profiles</a></li>
+          <li><a href="roadmap.html">Roadmap</a></li>
+          <li><a href="release-notes.html">Release Notes</a></li>
+        </ul>
+      </aside>
+
+      <article class="docs-main">
+        <section class="hero docs-hero">
+          <div class="hero-inner">
+            <span class="status-pill">ERROR MODEL</span>
+            <h1>Machine-readable failures are part of the public contract</h1>
+            <p class="lede">
+              MCP-AQL uses a discriminated success/error envelope and a structured error object so clients can distinguish validation problems,
+              missing resources, permissions, and server failures without parsing free-form text.
+            </p>
+            <div class="hero-actions">
+              <a class="btn btn-primary" href="https://github.com/MCPAQL/spec/blob/main/docs/error-codes.md">Error Codes Spec</a>
+              <a class="btn btn-secondary" href="https://github.com/MCPAQL/spec/issues/199">Issue #199</a>
+            </div>
+          </div>
+        </section>
+
+        <section>
+          <h2 class="section-title">Canonical response envelope</h2>
+          <div class="grid cols-2">
+            <article class="card">
+              <h3>Success</h3>
+              <pre class="code-box">{
+  "success": true,
+  "data": { ... }
+}</pre>
+            </article>
+            <article class="card">
+              <h3>Failure</h3>
+              <pre class="code-box">{
+  "success": false,
+  "error": {
+    "code": "VALIDATION_MISSING_PARAM",
+    "message": "Missing required parameter 'owner'"
+  }
+}</pre>
+            </article>
+          </div>
+        </section>
+
+        <section>
+          <h2 class="section-title">Why the code field matters</h2>
+          <div class="card">
+            <ul>
+              <li>LLMs and client code can tell "fix your request" failures from "server-side problem" failures.</li>
+              <li>Adapters can map target-system failures into a predictable registry.</li>
+              <li>Monitoring and analytics can group failures by category instead of message text.</li>
+              <li>Localized or rewritten human messages do not break programmatic recovery.</li>
+            </ul>
+          </div>
+        </section>
+
+        <section>
+          <h2 class="section-title">Current draft focus</h2>
+          <div class="grid cols-2">
+            <article class="card">
+              <h3>Defined today</h3>
+              <ul>
+                <li>Structured <code>error.code</code> and <code>error.message</code> fields</li>
+                <li>MVP registry with validation, not-found, permission, and internal categories</li>
+                <li>Optional <code>details</code> object for additional context</li>
+              </ul>
+            </article>
+            <article class="card">
+              <h3>Still being aligned</h3>
+              <ul>
+                <li>Implementation surfaces that still emit string-only failures</li>
+                <li>Exact schema and prose alignment across all response definitions</li>
+                <li>Conformance checks that validate machine-readable error surfacing</li>
+              </ul>
+            </article>
+          </div>
+          <p class="callout">
+            Live spec issue <a href="https://github.com/MCPAQL/spec/issues/199">#199</a> tracks the remaining alignment work between the error-code registry,
+            response envelope requirements, and implementation-facing schemas.
+          </p>
+        </section>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div class="container">
+      <p>&copy; 2026 DollhouseMCP Inc. d/b/a Dollhouse Research. MCP-AQL public draft documentation portal.</p>
+      <div class="footer-links">
+        <a href="index.html">Docs Library</a>
+        <a href="../index.html">Portal Home</a>
+        <a href="https://github.com/MCPAQL">MCPAQL Organization</a>
+        <a href="https://dollhouseresearch.com">Dollhouse Research</a>
+        <a href="https://github.com/DollhouseMCP/mcp-server">DollhouseMCP Production Profile</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../js/search.js"></script>
+</body>
+</html>

--- a/public/docs/error-model.html
+++ b/public/docs/error-model.html
@@ -38,7 +38,7 @@
         <ul>
           <li><a href="getting-started.html">Getting Started</a></li>
           <li><a href="protocol-core.html">Protocol Core</a></li>
-          <li><a href="error-model.html">Error Model</a></li>
+          <li><a class="current" href="error-model.html">Error Model</a></li>
           <li><a href="security-model.html">Security Model</a></li>
           <li><a href="conformance.html">Conformance</a></li>
           <li><a href="adapter-contracts.html">Adapter Contracts</a></li>
@@ -49,6 +49,13 @@
       </aside>
 
       <article class="docs-main">
+        <nav class="breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../index.html">Home</a></li>
+            <li><a href="index.html">Docs</a></li>
+            <li><span class="current">Error Model</span></li>
+          </ol>
+        </nav>
         <section class="hero docs-hero">
           <div class="hero-inner">
             <span class="status-pill">ERROR MODEL</span>
@@ -61,6 +68,31 @@
               <a class="btn btn-primary" href="../spec/error-codes.html">Error Codes Spec</a>
               <a class="btn btn-secondary" href="https://github.com/MCPAQL/spec/issues/199">Issue #199</a>
             </div>
+          </div>
+        </section>
+
+        <section class="topic-bridge">
+          <div class="grid cols-2">
+            <article class="card">
+              <h3>Go Deeper In The Full Spec</h3>
+              <p>The structured error behavior lives in the spec itself, with the issue tracker only used for the remaining alignment work.</p>
+              <ul>
+                <li><a href="../spec/error-codes.html">Structured Error Codes Specification</a></li>
+                <li><a href="../spec/versions/v1.0.0-draft.html">Normative Draft</a></li>
+                <li><a href="../spec/index.html">Browse the full spec reference</a></li>
+                <li><a href="https://github.com/MCPAQL/spec/issues/199">Issue #199</a></li>
+              </ul>
+            </article>
+            <article class="card">
+              <h3>Related Summary Pages</h3>
+              <p>Error handling is easiest to understand alongside routing, safety, and conformance expectations.</p>
+              <ul>
+                <li><a href="protocol-core.html">Protocol Core</a></li>
+                <li><a href="security-model.html">Security Model</a></li>
+                <li><a href="conformance.html">Conformance</a></li>
+                <li><a href="index.html">Back to the docs library</a></li>
+              </ul>
+            </article>
           </div>
         </section>
 

--- a/public/docs/error-model.html
+++ b/public/docs/error-model.html
@@ -58,7 +58,7 @@
               missing resources, permissions, and server failures without parsing free-form text.
             </p>
             <div class="hero-actions">
-              <a class="btn btn-primary" href="https://github.com/MCPAQL/spec/blob/main/docs/error-codes.md">Error Codes Spec</a>
+              <a class="btn btn-primary" href="../spec/error-codes.html">Error Codes Spec</a>
               <a class="btn btn-secondary" href="https://github.com/MCPAQL/spec/issues/199">Issue #199</a>
             </div>
           </div>

--- a/public/docs/getting-started.html
+++ b/public/docs/getting-started.html
@@ -23,7 +23,7 @@
         </ul>
         <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
-          <input id="site-search-input" data-search-input type="search" placeholder="Search getting-started topics...">
+          <input id="site-search-input" data-search-input type="search" placeholder="Search MCP-AQL docs, spec pages, and adapter patterns...">
           <span class="search-count" data-search-count></span>
           <ul class="search-results" data-search-results hidden></ul>
         </form>
@@ -72,6 +72,7 @@
         </section>
 
         <section class="topic-bridge">
+          <h2 class="sr-only">Related reading</h2>
           <div class="grid cols-2">
             <article class="card">
               <h3>Go Deeper In The Full Spec</h3>
@@ -162,6 +163,16 @@
             </ol>
           </div>
         </section>
+        <nav class="page-nav" aria-label="Page navigation">
+          <a class="page-nav-link prev" href="index.html">
+            <span class="page-nav-eyebrow">Previous page</span>
+            <strong class="page-nav-label">Docs Library</strong>
+          </a>
+          <a class="page-nav-link next" href="protocol-core.html">
+            <span class="page-nav-eyebrow">Next page</span>
+            <strong class="page-nav-label">Protocol Core</strong>
+          </a>
+        </nav>
       </article>
     </div>
   </main>

--- a/public/docs/getting-started.html
+++ b/public/docs/getting-started.html
@@ -36,7 +36,7 @@
       <aside class="docs-side">
         <h2>In This Library</h2>
         <ul>
-          <li><a href="getting-started.html">Getting Started</a></li>
+          <li><a class="current" href="getting-started.html">Getting Started</a></li>
           <li><a href="protocol-core.html">Protocol Core</a></li>
           <li><a href="error-model.html">Error Model</a></li>
           <li><a href="security-model.html">Security Model</a></li>
@@ -49,6 +49,13 @@
       </aside>
 
       <article class="docs-main">
+        <nav class="breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../index.html">Home</a></li>
+            <li><a href="index.html">Docs</a></li>
+            <li><span class="current">Getting Started</span></li>
+          </ol>
+        </nav>
         <section class="hero docs-hero">
           <div class="hero-inner">
             <span class="status-pill">GETTING STARTED</span>
@@ -61,6 +68,31 @@
               <a class="btn btn-primary" href="../spec/repo/README.html">Spec README</a>
               <a class="btn btn-secondary" href="../spec/versions/v1.0.0-draft.html">Normative Draft</a>
             </div>
+          </div>
+        </section>
+
+        <section class="topic-bridge">
+          <div class="grid cols-2">
+            <article class="card">
+              <h3>Go Deeper In The Full Spec</h3>
+              <p>Use the website-hosted source pages when you want the actual protocol text instead of the onboarding summary.</p>
+              <ul>
+                <li><a href="../spec/repo/README.html">Spec README</a></li>
+                <li><a href="../spec/overview.html">Protocol Overview</a></li>
+                <li><a href="../spec/versions/v1.0.0-draft.html">Normative Draft</a></li>
+                <li><a href="../spec/index.html">Browse the full spec reference</a></li>
+              </ul>
+            </article>
+            <article class="card">
+              <h3>Keep Moving Through The Library</h3>
+              <p>Once the framing is clear, the next useful stops are the rules pages and the launch-readiness views.</p>
+              <ul>
+                <li><a href="protocol-core.html">Protocol Core</a></li>
+                <li><a href="error-model.html">Error Model</a></li>
+                <li><a href="security-model.html">Security Model</a></li>
+                <li><a href="index.html">Back to the docs library</a></li>
+              </ul>
+            </article>
           </div>
         </section>
 

--- a/public/docs/getting-started.html
+++ b/public/docs/getting-started.html
@@ -1,0 +1,152 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Quick-start guide to MCP-AQL: what it is, why it exists, and what to read first.">
+  <title>MCP-AQL Docs | Getting Started</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../css/style.css">
+</head>
+<body>
+  <header>
+    <div class="container">
+      <nav>
+        <a class="logo" href="../index.html"><span class="logo-mark"></span>MCP-AQL</a>
+        <ul class="nav-links">
+          <li><a href="../index.html">Home</a></li>
+          <li><a href="index.html">Docs</a></li>
+          <li><a href="../launch-checklist.html">Launch Checklist</a></li>
+          <li><a href="../apis/mcp-server.html">Adapter Patterns</a></li>
+        </ul>
+        <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
+          <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
+          <input id="site-search-input" data-search-input type="search" placeholder="Search getting-started topics...">
+          <span class="search-count" data-search-count></span>
+          <ul class="search-results" data-search-results hidden></ul>
+        </form>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <div class="container docs-shell">
+      <aside class="docs-side">
+        <h2>In This Library</h2>
+        <ul>
+          <li><a href="getting-started.html">Getting Started</a></li>
+          <li><a href="protocol-core.html">Protocol Core</a></li>
+          <li><a href="error-model.html">Error Model</a></li>
+          <li><a href="security-model.html">Security Model</a></li>
+          <li><a href="conformance.html">Conformance</a></li>
+          <li><a href="adapter-contracts.html">Adapter Contracts</a></li>
+          <li><a href="implementation-profiles.html">Implementation Profiles</a></li>
+          <li><a href="roadmap.html">Roadmap</a></li>
+          <li><a href="release-notes.html">Release Notes</a></li>
+        </ul>
+      </aside>
+
+      <article class="docs-main">
+        <section class="hero docs-hero">
+          <div class="hero-inner">
+            <span class="status-pill">GETTING STARTED</span>
+            <h1>What MCP-AQL is, why it exists, and what to read first</h1>
+            <p class="lede">
+              MCP-AQL consolidates many discrete MCP tools into a small semantic endpoint surface while preserving runtime discovery.
+              The result is less registration overhead, clearer routing, and a more scalable contract for agent-driven systems.
+            </p>
+            <div class="hero-actions">
+              <a class="btn btn-primary" href="https://github.com/MCPAQL/spec/blob/main/README.md">Spec README</a>
+              <a class="btn btn-secondary" href="https://github.com/MCPAQL/spec/blob/main/docs/versions/v1.0.0-draft.md">Normative Draft</a>
+            </div>
+          </div>
+        </section>
+
+        <section>
+          <h2 class="section-title">The one-paragraph version</h2>
+          <div class="card">
+            <p>
+              MCP-AQL is a protocol specification and implementation toolkit for exposing adapter operations through either five CRUDE endpoints
+              or a single routed endpoint. It keeps <code>introspect</code> mandatory, treats the versioned spec as canonical, and positions
+              production profiles like DollhouseMCP as practical references rather than the definition of the protocol.
+            </p>
+          </div>
+        </section>
+
+        <section>
+          <h2 class="section-title">Why teams look at it</h2>
+          <div class="grid cols-3">
+            <article class="card">
+              <h3>Lower token overhead</h3>
+              <p>Instead of loading dozens of tool definitions, clients can register five semantic endpoints or one unified endpoint.</p>
+            </article>
+            <article class="card">
+              <h3>Runtime discovery</h3>
+              <p>Clients discover operations, parameters, and types on demand with <code>introspect</code>.</p>
+            </article>
+            <article class="card">
+              <h3>Better public contracts</h3>
+              <p>CRUDE classification, structured responses, and spec-linked docs make compatibility claims easier to inspect.</p>
+            </article>
+          </div>
+        </section>
+
+        <section>
+          <h2 class="section-title">Quick-start request shape</h2>
+          <div class="grid cols-2">
+            <article class="card">
+              <h3>Discover operations</h3>
+              <pre class="code-box">{
+  "operation": "introspect",
+  "params": { "query": "operations" }
+}</pre>
+            </article>
+            <article class="card">
+              <h3>Call a discovered operation</h3>
+              <pre class="code-box">{
+  "operation": "create_user",
+  "params": {
+    "email": "alice@example.com",
+    "name": "Alice"
+  }
+}</pre>
+            </article>
+          </div>
+          <p class="callout">
+            The second example is schematic. Real operation names and parameters are adapter-defined and should be discovered first.
+          </p>
+        </section>
+
+        <section>
+          <h2 class="section-title">Suggested reading order</h2>
+          <div class="card">
+            <ol>
+              <li>Read the <a href="https://github.com/MCPAQL/spec/blob/main/docs/versions/v1.0.0-draft.md">versioned draft</a> for the canonical rules.</li>
+              <li>Use <a href="protocol-core.html">Protocol Core</a> for routing, request shape, and endpoint semantics.</li>
+              <li>Use <a href="error-model.html">Error Model</a> and <a href="security-model.html">Security Model</a> for operational expectations.</li>
+              <li>Use <a href="conformance.html">Conformance</a> and <a href="../launch-checklist.html">Launch Checklist</a> to understand current draft maturity.</li>
+            </ol>
+          </div>
+        </section>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div class="container">
+      <p>&copy; 2026 DollhouseMCP Inc. d/b/a Dollhouse Research. MCP-AQL public draft documentation portal.</p>
+      <div class="footer-links">
+        <a href="index.html">Docs Library</a>
+        <a href="../index.html">Portal Home</a>
+        <a href="https://github.com/MCPAQL">MCPAQL Organization</a>
+        <a href="https://dollhouseresearch.com">Dollhouse Research</a>
+        <a href="https://github.com/DollhouseMCP/mcp-server">DollhouseMCP Production Profile</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../js/search.js"></script>
+</body>
+</html>

--- a/public/docs/getting-started.html
+++ b/public/docs/getting-started.html
@@ -58,8 +58,8 @@
               The result is less registration overhead, clearer routing, and a more scalable contract for agent-driven systems.
             </p>
             <div class="hero-actions">
-              <a class="btn btn-primary" href="https://github.com/MCPAQL/spec/blob/main/README.md">Spec README</a>
-              <a class="btn btn-secondary" href="https://github.com/MCPAQL/spec/blob/main/docs/versions/v1.0.0-draft.md">Normative Draft</a>
+              <a class="btn btn-primary" href="../spec/repo/README.html">Spec README</a>
+              <a class="btn btn-secondary" href="../spec/versions/v1.0.0-draft.html">Normative Draft</a>
             </div>
           </div>
         </section>
@@ -123,7 +123,7 @@
           <h2 class="section-title">Suggested reading order</h2>
           <div class="card">
             <ol>
-              <li>Read the <a href="https://github.com/MCPAQL/spec/blob/main/docs/versions/v1.0.0-draft.md">versioned draft</a> for the canonical rules.</li>
+              <li>Read the <a href="../spec/versions/v1.0.0-draft.html">versioned draft</a> for the canonical rules.</li>
               <li>Use <a href="protocol-core.html">Protocol Core</a> for routing, request shape, and endpoint semantics.</li>
               <li>Use <a href="error-model.html">Error Model</a> and <a href="security-model.html">Security Model</a> for operational expectations.</li>
               <li>Use <a href="conformance.html">Conformance</a> and <a href="../launch-checklist.html">Launch Checklist</a> to understand current draft maturity.</li>

--- a/public/docs/implementation-profiles.html
+++ b/public/docs/implementation-profiles.html
@@ -36,11 +36,15 @@
       <aside class="docs-side">
         <h2>In This Library</h2>
         <ul>
+          <li><a href="getting-started.html">Getting Started</a></li>
           <li><a href="protocol-core.html">Protocol Core</a></li>
+          <li><a href="error-model.html">Error Model</a></li>
           <li><a href="security-model.html">Security Model</a></li>
           <li><a href="conformance.html">Conformance</a></li>
+          <li><a href="adapter-contracts.html">Adapter Contracts</a></li>
           <li><a href="implementation-profiles.html">Implementation Profiles</a></li>
           <li><a href="roadmap.html">Roadmap</a></li>
+          <li><a href="release-notes.html">Release Notes</a></li>
         </ul>
       </aside>
 
@@ -130,6 +134,26 @@
               <li>Call out known-open areas as launch-draft scope, not hidden debt.</li>
               <li>Publish examples as they become available and keep status explicit (draft vs production).</li>
             </ul>
+          </div>
+        </section>
+
+        <section>
+          <h2 class="section-title">Where to look next</h2>
+          <div class="grid cols-2">
+            <article class="card">
+              <h3>Contract details</h3>
+              <ul>
+                <li><a href="adapter-contracts.html">Adapter Contracts</a></li>
+                <li><a href="https://github.com/MCPAQL/spec/blob/main/docs/adapter/generator.md">Generator specification</a></li>
+              </ul>
+            </article>
+            <article class="card">
+              <h3>Launch and release context</h3>
+              <ul>
+                <li><a href="../launch-checklist.html">Launch Checklist</a></li>
+                <li><a href="release-notes.html">Release Notes</a></li>
+              </ul>
+            </article>
           </div>
         </section>
       </article>

--- a/public/docs/implementation-profiles.html
+++ b/public/docs/implementation-profiles.html
@@ -23,7 +23,7 @@
         </ul>
         <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
-          <input id="site-search-input" data-search-input type="search" placeholder="Search implementation topics...">
+          <input id="site-search-input" data-search-input type="search" placeholder="Search MCP-AQL docs, spec pages, and adapter patterns...">
           <span class="search-count" data-search-count></span>
           <ul class="search-results" data-search-results hidden></ul>
         </form>
@@ -72,6 +72,7 @@
         </section>
 
         <section class="topic-bridge">
+          <h2 class="sr-only">Related reading</h2>
           <div class="grid cols-2">
             <article class="card">
               <h3>Go Deeper In The Full Spec</h3>
@@ -188,6 +189,16 @@
             </article>
           </div>
         </section>
+        <nav class="page-nav" aria-label="Page navigation">
+          <a class="page-nav-link prev" href="adapter-contracts.html">
+            <span class="page-nav-eyebrow">Previous page</span>
+            <strong class="page-nav-label">Adapter Contracts</strong>
+          </a>
+          <a class="page-nav-link next" href="roadmap.html">
+            <span class="page-nav-eyebrow">Next page</span>
+            <strong class="page-nav-label">Roadmap</strong>
+          </a>
+        </nav>
       </article>
     </div>
   </main>

--- a/public/docs/implementation-profiles.html
+++ b/public/docs/implementation-profiles.html
@@ -58,7 +58,7 @@
               This boundary prevents implementation details from being mistaken as protocol law.
             </p>
             <div class="hero-actions">
-              <a class="btn btn-primary" href="https://github.com/MCPAQL/spec">Canonical Spec Source</a>
+              <a class="btn btn-primary" href="../spec/repo/README.html">Canonical Spec Source</a>
               <a class="btn btn-secondary" href="https://github.com/DollhouseMCP/mcp-server">Dollhouse Practical Profile</a>
             </div>
           </div>
@@ -144,7 +144,7 @@
               <h3>Contract details</h3>
               <ul>
                 <li><a href="adapter-contracts.html">Adapter Contracts</a></li>
-                <li><a href="https://github.com/MCPAQL/spec/blob/main/docs/adapter/generator.md">Generator specification</a></li>
+                <li><a href="../spec/adapter/generator.html">Generator specification</a></li>
               </ul>
             </article>
             <article class="card">

--- a/public/docs/implementation-profiles.html
+++ b/public/docs/implementation-profiles.html
@@ -42,13 +42,20 @@
           <li><a href="security-model.html">Security Model</a></li>
           <li><a href="conformance.html">Conformance</a></li>
           <li><a href="adapter-contracts.html">Adapter Contracts</a></li>
-          <li><a href="implementation-profiles.html">Implementation Profiles</a></li>
+          <li><a class="current" href="implementation-profiles.html">Implementation Profiles</a></li>
           <li><a href="roadmap.html">Roadmap</a></li>
           <li><a href="release-notes.html">Release Notes</a></li>
         </ul>
       </aside>
 
       <article class="docs-main">
+        <nav class="breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../index.html">Home</a></li>
+            <li><a href="index.html">Docs</a></li>
+            <li><span class="current">Implementation Profiles</span></li>
+          </ol>
+        </nav>
         <section class="hero docs-hero">
           <div class="hero-inner">
             <span class="status-pill">IMPLEMENTATION PROFILES</span>
@@ -61,6 +68,31 @@
               <a class="btn btn-primary" href="../spec/repo/README.html">Canonical Spec Source</a>
               <a class="btn btn-secondary" href="https://github.com/DollhouseMCP/mcp-server">Dollhouse Practical Profile</a>
             </div>
+          </div>
+        </section>
+
+        <section class="topic-bridge">
+          <div class="grid cols-2">
+            <article class="card">
+              <h3>Go Deeper In The Full Spec</h3>
+              <p>The protocol authority remains on-site in the spec pages, while implementation repos stay as practical reference material.</p>
+              <ul>
+                <li><a href="../spec/repo/README.html">Spec README</a></li>
+                <li><a href="../spec/adapter/generator.html">Generator Specification</a></li>
+                <li><a href="../spec/versions/v1.0.0-draft.html">Normative Draft</a></li>
+                <li><a href="../spec/index.html">Browse the full spec reference</a></li>
+              </ul>
+            </article>
+            <article class="card">
+              <h3>Related Summary Pages</h3>
+              <p>These pages are the closest summary-layer companions to the profile and implementation story.</p>
+              <ul>
+                <li><a href="adapter-contracts.html">Adapter Contracts</a></li>
+                <li><a href="roadmap.html">Roadmap</a></li>
+                <li><a href="release-notes.html">Release Notes</a></li>
+                <li><a href="index.html">Back to the docs library</a></li>
+              </ul>
+            </article>
           </div>
         </section>
 

--- a/public/docs/index.html
+++ b/public/docs/index.html
@@ -33,6 +33,12 @@
 
   <main>
     <div class="container">
+      <nav class="breadcrumbs" aria-label="Breadcrumb">
+        <ol>
+          <li><a href="../index.html">Home</a></li>
+          <li><span class="current">Docs</span></li>
+        </ol>
+      </nav>
       <section class="hero">
         <div class="hero-inner">
           <span class="status-pill">DOCUMENTATION LIBRARY</span>
@@ -56,94 +62,134 @@
         <p class="section-subtitle">Each track is mapped to canonical source repositories and intended launch visibility.</p>
         <div class="grid cols-3">
           <article class="card">
-            <h3>Getting Started</h3>
+            <h3><a class="card-title-link" href="getting-started.html">Getting Started</a></h3>
             <span class="state-chip live">Recommended first read</span>
             <p>Overview, quick-start request shape, token efficiency, and reading order for the draft.</p>
             <ul>
               <li><a href="getting-started.html">Site summary page</a></li>
               <li><a href="../spec/repo/README.html">Canonical README</a></li>
             </ul>
+            <div class="card-actions">
+              <a href="getting-started.html">Open summary</a>
+              <a href="../spec/repo/README.html">Open source page</a>
+            </div>
           </article>
           <article class="card">
-            <h3>Protocol Core</h3>
+            <h3><a class="card-title-link" href="protocol-core.html">Protocol Core</a></h3>
             <span class="state-chip live">Required</span>
             <p>Normative request/response model, endpoint semantics, introspection contract, and operation model.</p>
             <ul>
               <li><a href="protocol-core.html">Site summary page</a></li>
               <li><a href="../spec/versions/v1.0.0-draft.html">Normative source</a></li>
             </ul>
+            <div class="card-actions">
+              <a href="protocol-core.html">Open summary</a>
+              <a href="../spec/versions/v1.0.0-draft.html">Open source page</a>
+            </div>
           </article>
           <article class="card">
-            <h3>Error Model</h3>
+            <h3><a class="card-title-link" href="error-model.html">Error Model</a></h3>
             <span class="state-chip live">Required</span>
             <p>Structured error envelope, machine-readable codes, and current alignment gaps between draft and implementations.</p>
             <ul>
               <li><a href="error-model.html">Site summary page</a></li>
               <li><a href="../spec/error-codes.html">Canonical error code doc</a></li>
             </ul>
+            <div class="card-actions">
+              <a href="error-model.html">Open summary</a>
+              <a href="../spec/error-codes.html">Open source page</a>
+            </div>
           </article>
           <article class="card">
-            <h3>Security Model</h3>
+            <h3><a class="card-title-link" href="security-model.html">Security Model</a></h3>
             <span class="state-chip live">Required</span>
             <p>Gatekeeper boundaries, confirmation tokens, danger handling, and safety-loop alignment.</p>
             <ul>
               <li><a href="security-model.html">Site summary page</a></li>
               <li><a href="../spec/security/gatekeeper.html">Canonical security docs</a></li>
             </ul>
+            <div class="card-actions">
+              <a href="security-model.html">Open summary</a>
+              <a href="../spec/security/gatekeeper.html">Open source page</a>
+            </div>
           </article>
           <article class="card">
-            <h3>Conformance</h3>
+            <h3><a class="card-title-link" href="conformance.html">Conformance</a></h3>
             <span class="state-chip pending">In progress</span>
             <p>Compatibility baseline, validation posture, and planned validator tooling.</p>
             <ul>
               <li><a href="conformance.html">Site summary page</a></li>
               <li><a href="../spec/conformance-testing.html">Canonical conformance doc</a></li>
             </ul>
+            <div class="card-actions">
+              <a href="conformance.html">Open summary</a>
+              <a href="../spec/conformance-testing.html">Open source page</a>
+            </div>
           </article>
           <article class="card">
-            <h3>Implementation Profiles</h3>
+            <h3><a class="card-title-link" href="implementation-profiles.html">Implementation Profiles</a></h3>
             <span class="state-chip live">Required</span>
             <p>Boundary between canonical specification and practical production profile behavior.</p>
             <ul>
               <li><a href="implementation-profiles.html">Site summary page</a></li>
               <li><a href="https://github.com/MCPAQL/mcpaql-adapter">Reference runtime repo</a></li>
             </ul>
+            <div class="card-actions">
+              <a href="implementation-profiles.html">Open summary</a>
+              <a href="https://github.com/MCPAQL/mcpaql-adapter">Open runtime repo</a>
+            </div>
           </article>
           <article class="card">
-            <h3>Adapter Contracts</h3>
+            <h3><a class="card-title-link" href="adapter-contracts.html">Adapter Contracts</a></h3>
             <span class="state-chip live">Required</span>
             <p>Adapter schema, plugin contract, generator-output, and example-surface expectations across the implementation toolchain.</p>
             <ul>
               <li><a href="adapter-contracts.html">Site summary page</a></li>
               <li><a href="../spec/plugin-contracts.html">Canonical contract docs</a></li>
             </ul>
+            <div class="card-actions">
+              <a href="adapter-contracts.html">Open summary</a>
+              <a href="../spec/plugin-contracts.html">Open source page</a>
+            </div>
           </article>
           <article class="card">
-            <h3>Roadmap</h3>
+            <h3><a class="card-title-link" href="roadmap.html">Roadmap</a></h3>
             <span class="state-chip live">Public planning</span>
             <p>Phase-based protocol and ecosystem trajectory with current focus areas.</p>
             <ul>
               <li><a href="roadmap.html">Site summary page</a></li>
               <li><a href="https://github.com/MCPAQL/spec">Spec issue tracker source</a></li>
             </ul>
+            <div class="card-actions">
+              <a href="roadmap.html">Open summary</a>
+              <a href="../spec/index.html">Open full spec</a>
+            </div>
           </article>
           <article class="card">
-            <h3>Release Notes</h3>
+            <h3><a class="card-title-link" href="release-notes.html">Release Notes</a></h3>
             <span class="state-chip live">Change context</span>
             <p>Recent draft changes that affect public messaging, launch framing, and docs coverage priorities.</p>
             <ul>
               <li><a href="release-notes.html">Site summary page</a></li>
               <li><a href="../spec/repo/CHANGELOG.html">Canonical changelog</a></li>
             </ul>
+            <div class="card-actions">
+              <a href="release-notes.html">Open summary</a>
+              <a href="../spec/repo/CHANGELOG.html">Open source page</a>
+            </div>
           </article>
           <article class="card">
-            <h3>Launch Checklist</h3>
+            <h3><a class="card-title-link" href="../launch-checklist.html">Launch Checklist</a></h3>
             <span class="state-chip live">Public control</span>
             <p>Public-facing readiness checklist and launch-scope guardrails.</p>
             <ul>
               <li><a href="../launch-checklist.html">Checklist page</a></li>
               <li><a href="../spec/process/preliminary-public-launch-checklist.html">Canonical checklist source</a></li>
             </ul>
+            <div class="card-actions">
+              <a href="../launch-checklist.html">Open summary</a>
+              <a href="../spec/process/preliminary-public-launch-checklist.html">Open source page</a>
+            </div>
           </article>
         </div>
       </section>
@@ -153,14 +199,18 @@
         <p class="section-subtitle">The docs library now has a deeper sibling section generated from the canonical spec repo, so the website itself carries the fuller protocol material.</p>
         <div class="grid cols-2">
           <article class="card">
-            <h3>Use summaries for orientation</h3>
+            <h3><a class="card-title-link" href="getting-started.html">Use summaries for orientation</a></h3>
             <p>These docs pages still provide fast, curated entry points for launch framing, implementation posture, and topic overviews.</p>
-            <a href="getting-started.html">Start with guided summaries</a>
+            <div class="card-actions">
+              <a href="getting-started.html">Start with guided summaries</a>
+            </div>
           </article>
           <article class="card">
-            <h3>Use the spec mirror for depth</h3>
+            <h3><a class="card-title-link" href="../spec/index.html">Use the spec mirror for depth</a></h3>
             <p>The generated reference mirrors the deeper content from <code>MCPAQL/spec/docs</code>, including versioned drafts and supporting material.</p>
-            <a href="../spec/index.html">Browse the full repo-synced reference</a>
+            <div class="card-actions">
+              <a href="../spec/index.html">Browse the full repo-synced reference</a>
+            </div>
           </article>
         </div>
       </section>

--- a/public/docs/index.html
+++ b/public/docs/index.html
@@ -61,7 +61,7 @@
             <p>Overview, quick-start request shape, token efficiency, and reading order for the draft.</p>
             <ul>
               <li><a href="getting-started.html">Site summary page</a></li>
-              <li><a href="https://github.com/MCPAQL/spec/blob/main/README.md">Canonical README</a></li>
+              <li><a href="../spec/repo/README.html">Canonical README</a></li>
             </ul>
           </article>
           <article class="card">
@@ -70,7 +70,7 @@
             <p>Normative request/response model, endpoint semantics, introspection contract, and operation model.</p>
             <ul>
               <li><a href="protocol-core.html">Site summary page</a></li>
-              <li><a href="https://github.com/MCPAQL/spec/blob/main/docs/versions/v1.0.0-draft.md">Normative source</a></li>
+              <li><a href="../spec/versions/v1.0.0-draft.html">Normative source</a></li>
             </ul>
           </article>
           <article class="card">
@@ -79,7 +79,7 @@
             <p>Structured error envelope, machine-readable codes, and current alignment gaps between draft and implementations.</p>
             <ul>
               <li><a href="error-model.html">Site summary page</a></li>
-              <li><a href="https://github.com/MCPAQL/spec/blob/main/docs/error-codes.md">Canonical error code doc</a></li>
+              <li><a href="../spec/error-codes.html">Canonical error code doc</a></li>
             </ul>
           </article>
           <article class="card">
@@ -88,7 +88,7 @@
             <p>Gatekeeper boundaries, confirmation tokens, danger handling, and safety-loop alignment.</p>
             <ul>
               <li><a href="security-model.html">Site summary page</a></li>
-              <li><a href="https://github.com/MCPAQL/spec/blob/main/docs/security/gatekeeper.md">Canonical security docs</a></li>
+              <li><a href="../spec/security/gatekeeper.html">Canonical security docs</a></li>
             </ul>
           </article>
           <article class="card">
@@ -97,7 +97,7 @@
             <p>Compatibility baseline, validation posture, and planned validator tooling.</p>
             <ul>
               <li><a href="conformance.html">Site summary page</a></li>
-              <li><a href="https://github.com/MCPAQL/spec/blob/main/docs/conformance-testing.md">Canonical conformance doc</a></li>
+              <li><a href="../spec/conformance-testing.html">Canonical conformance doc</a></li>
             </ul>
           </article>
           <article class="card">
@@ -115,7 +115,7 @@
             <p>Adapter schema, plugin contract, generator-output, and example-surface expectations across the implementation toolchain.</p>
             <ul>
               <li><a href="adapter-contracts.html">Site summary page</a></li>
-              <li><a href="https://github.com/MCPAQL/spec/blob/main/docs/plugin-contracts.md">Canonical contract docs</a></li>
+              <li><a href="../spec/plugin-contracts.html">Canonical contract docs</a></li>
             </ul>
           </article>
           <article class="card">
@@ -133,7 +133,7 @@
             <p>Recent draft changes that affect public messaging, launch framing, and docs coverage priorities.</p>
             <ul>
               <li><a href="release-notes.html">Site summary page</a></li>
-              <li><a href="https://github.com/MCPAQL/spec/blob/main/CHANGELOG.md">Canonical changelog</a></li>
+              <li><a href="../spec/repo/CHANGELOG.html">Canonical changelog</a></li>
             </ul>
           </article>
           <article class="card">
@@ -142,7 +142,7 @@
             <p>Public-facing readiness checklist and launch-scope guardrails.</p>
             <ul>
               <li><a href="../launch-checklist.html">Checklist page</a></li>
-              <li><a href="https://github.com/MCPAQL/spec/blob/main/docs/process/preliminary-public-launch-checklist.md">Canonical checklist source</a></li>
+              <li><a href="../spec/process/preliminary-public-launch-checklist.html">Canonical checklist source</a></li>
             </ul>
           </article>
         </div>
@@ -179,32 +179,32 @@
             </thead>
             <tbody>
               <tr>
-                <td><a href="https://github.com/MCPAQL/spec/blob/main/docs/overview.md">overview.md</a></td>
+                <td><a href="../spec/repo/README.html">README.md</a></td>
                 <td><a href="getting-started.html">Getting Started</a></td>
-                <td>Protocol summary, token efficiency, and quick-start framing</td>
+                <td>Repository-level protocol summary, token efficiency, and quick-start framing</td>
               </tr>
               <tr>
-                <td><a href="https://github.com/MCPAQL/spec/tree/main/docs">spec/docs</a></td>
+                <td><a href="../spec/index.html">spec mirror</a></td>
                 <td><a href="../spec/index.html">Repo-Synced Spec Reference</a></td>
                 <td>Website-hosted full mirror of versioned and topical specification documents</td>
               </tr>
               <tr>
-                <td><a href="https://github.com/MCPAQL/spec/blob/main/docs/operations.md">operations.md</a></td>
+                <td><a href="../spec/versions/v1.0.0-draft.html">versions/v1.0.0-draft.md</a></td>
                 <td><a href="protocol-core.html">Protocol Core</a></td>
-                <td>Request shape, endpoint rules, operation semantics, routing</td>
+                <td>Normative request shape, endpoint rules, operation semantics, and routing</td>
               </tr>
               <tr>
-                <td><a href="https://github.com/MCPAQL/spec/blob/main/docs/error-codes.md">error-codes.md</a></td>
+                <td><a href="../spec/error-codes.html">error-codes.md</a></td>
                 <td><a href="error-model.html">Error Model</a></td>
                 <td>Structured errors, machine-readable codes, current gaps</td>
               </tr>
               <tr>
-                <td><a href="https://github.com/MCPAQL/spec/blob/main/docs/plugin-contracts.md">plugin-contracts.md</a></td>
+                <td><a href="../spec/plugin-contracts.html">plugin-contracts.md</a></td>
                 <td><a href="adapter-contracts.html">Adapter Contracts</a></td>
                 <td>Plugin responsibilities, schema contracts, generator outputs</td>
               </tr>
               <tr>
-                <td><a href="https://github.com/MCPAQL/spec/blob/main/CHANGELOG.md">CHANGELOG.md</a></td>
+                <td><a href="../spec/repo/CHANGELOG.html">CHANGELOG.md</a></td>
                 <td><a href="release-notes.html">Release Notes</a></td>
                 <td>Recent draft changes and launch-relevant deltas</td>
               </tr>

--- a/public/docs/index.html
+++ b/public/docs/index.html
@@ -23,7 +23,7 @@
         </ul>
         <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
-          <input id="site-search-input" data-search-input type="search" placeholder="Search protocol topics...">
+          <input id="site-search-input" data-search-input type="search" placeholder="Search MCP-AQL docs, spec pages, and adapter patterns...">
           <span class="search-count" data-search-count></span>
           <ul class="search-results" data-search-results hidden></ul>
         </form>

--- a/public/docs/index.html
+++ b/public/docs/index.html
@@ -39,12 +39,13 @@
           <h1>Browse MCP-AQL By Domain</h1>
           <p class="lede">
             This library organizes source material from the MCPAQL repositories into a protocol-site shape: core specification,
-            security model, conformance expectations, implementation profiles, and ecosystem roadmap.
+            quick start, core semantics, structured errors, safety model, conformance, adapter contracts, implementation profiles,
+            and release-status context.
           </p>
           <div class="hero-actions">
-            <a class="btn btn-primary" href="protocol-core.html">Protocol Core</a>
-            <a class="btn btn-secondary" href="security-model.html">Security Model</a>
-            <a class="btn btn-secondary" href="conformance.html">Conformance</a>
+            <a class="btn btn-primary" href="getting-started.html">Getting Started</a>
+            <a class="btn btn-secondary" href="error-model.html">Error Model</a>
+            <a class="btn btn-secondary" href="adapter-contracts.html">Adapter Contracts</a>
           </div>
         </div>
       </section>
@@ -54,12 +55,30 @@
         <p class="section-subtitle">Each track is mapped to canonical source repositories and intended launch visibility.</p>
         <div class="grid cols-3">
           <article class="card">
+            <h3>Getting Started</h3>
+            <span class="state-chip live">Recommended first read</span>
+            <p>Overview, quick-start request shape, token efficiency, and reading order for the draft.</p>
+            <ul>
+              <li><a href="getting-started.html">Site summary page</a></li>
+              <li><a href="https://github.com/MCPAQL/spec/blob/main/README.md">Canonical README</a></li>
+            </ul>
+          </article>
+          <article class="card">
             <h3>Protocol Core</h3>
             <span class="state-chip live">Required</span>
             <p>Normative request/response model, endpoint semantics, introspection contract, and operation model.</p>
             <ul>
               <li><a href="protocol-core.html">Site summary page</a></li>
               <li><a href="https://github.com/MCPAQL/spec/blob/main/docs/versions/v1.0.0-draft.md">Normative source</a></li>
+            </ul>
+          </article>
+          <article class="card">
+            <h3>Error Model</h3>
+            <span class="state-chip live">Required</span>
+            <p>Structured error envelope, machine-readable codes, and current alignment gaps between draft and implementations.</p>
+            <ul>
+              <li><a href="error-model.html">Site summary page</a></li>
+              <li><a href="https://github.com/MCPAQL/spec/blob/main/docs/error-codes.md">Canonical error code doc</a></li>
             </ul>
           </article>
           <article class="card">
@@ -90,12 +109,30 @@
             </ul>
           </article>
           <article class="card">
+            <h3>Adapter Contracts</h3>
+            <span class="state-chip live">Required</span>
+            <p>Adapter schema, plugin contract, generator-output, and example-surface expectations across the implementation toolchain.</p>
+            <ul>
+              <li><a href="adapter-contracts.html">Site summary page</a></li>
+              <li><a href="https://github.com/MCPAQL/spec/blob/main/docs/plugin-contracts.md">Canonical contract docs</a></li>
+            </ul>
+          </article>
+          <article class="card">
             <h3>Roadmap</h3>
             <span class="state-chip live">Public planning</span>
             <p>Phase-based protocol and ecosystem trajectory with current focus areas.</p>
             <ul>
               <li><a href="roadmap.html">Site summary page</a></li>
               <li><a href="https://github.com/MCPAQL/spec">Spec issue tracker source</a></li>
+            </ul>
+          </article>
+          <article class="card">
+            <h3>Release Notes</h3>
+            <span class="state-chip live">Change context</span>
+            <p>Recent draft changes that affect public messaging, launch framing, and docs coverage priorities.</p>
+            <ul>
+              <li><a href="release-notes.html">Site summary page</a></li>
+              <li><a href="https://github.com/MCPAQL/spec/blob/main/CHANGELOG.md">Canonical changelog</a></li>
             </ul>
           </article>
           <article class="card">
@@ -107,6 +144,49 @@
               <li><a href="https://github.com/MCPAQL/spec/blob/main/docs/process/preliminary-public-launch-checklist.md">Canonical checklist source</a></li>
             </ul>
           </article>
+        </div>
+      </section>
+
+      <section>
+        <h2 class="section-title">Canonical Spec Map</h2>
+        <p class="section-subtitle">The website now mirrors the major categories from the spec docs index so public readers can see what exists without opening the repository first.</p>
+        <div class="card table-card">
+          <table class="data-table">
+            <thead>
+              <tr>
+                <th>Spec source</th>
+                <th>Website surface</th>
+                <th>What it covers</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><a href="https://github.com/MCPAQL/spec/blob/main/docs/overview.md">overview.md</a></td>
+                <td><a href="getting-started.html">Getting Started</a></td>
+                <td>Protocol summary, token efficiency, and quick-start framing</td>
+              </tr>
+              <tr>
+                <td><a href="https://github.com/MCPAQL/spec/blob/main/docs/operations.md">operations.md</a></td>
+                <td><a href="protocol-core.html">Protocol Core</a></td>
+                <td>Request shape, endpoint rules, operation semantics, routing</td>
+              </tr>
+              <tr>
+                <td><a href="https://github.com/MCPAQL/spec/blob/main/docs/error-codes.md">error-codes.md</a></td>
+                <td><a href="error-model.html">Error Model</a></td>
+                <td>Structured errors, machine-readable codes, current gaps</td>
+              </tr>
+              <tr>
+                <td><a href="https://github.com/MCPAQL/spec/blob/main/docs/plugin-contracts.md">plugin-contracts.md</a></td>
+                <td><a href="adapter-contracts.html">Adapter Contracts</a></td>
+                <td>Plugin responsibilities, schema contracts, generator outputs</td>
+              </tr>
+              <tr>
+                <td><a href="https://github.com/MCPAQL/spec/blob/main/CHANGELOG.md">CHANGELOG.md</a></td>
+                <td><a href="release-notes.html">Release Notes</a></td>
+                <td>Recent draft changes and launch-relevant deltas</td>
+              </tr>
+            </tbody>
+          </table>
         </div>
       </section>
 

--- a/public/docs/index.html
+++ b/public/docs/index.html
@@ -45,6 +45,7 @@
           <div class="hero-actions">
             <a class="btn btn-primary" href="getting-started.html">Getting Started</a>
             <a class="btn btn-secondary" href="error-model.html">Error Model</a>
+            <a class="btn btn-secondary" href="../spec/index.html">Full Spec Reference</a>
             <a class="btn btn-secondary" href="adapter-contracts.html">Adapter Contracts</a>
           </div>
         </div>
@@ -148,8 +149,25 @@
       </section>
 
       <section>
+        <h2 class="section-title">Repo-Synced Full Spec Reference</h2>
+        <p class="section-subtitle">The docs library now has a deeper sibling section generated from the canonical spec repo, so the website itself carries the fuller protocol material.</p>
+        <div class="grid cols-2">
+          <article class="card">
+            <h3>Use summaries for orientation</h3>
+            <p>These docs pages still provide fast, curated entry points for launch framing, implementation posture, and topic overviews.</p>
+            <a href="getting-started.html">Start with guided summaries</a>
+          </article>
+          <article class="card">
+            <h3>Use the spec mirror for depth</h3>
+            <p>The generated reference mirrors the deeper content from <code>MCPAQL/spec/docs</code>, including versioned drafts and supporting material.</p>
+            <a href="../spec/index.html">Browse the full repo-synced reference</a>
+          </article>
+        </div>
+      </section>
+
+      <section>
         <h2 class="section-title">Canonical Spec Map</h2>
-        <p class="section-subtitle">The website now mirrors the major categories from the spec docs index so public readers can see what exists without opening the repository first.</p>
+        <p class="section-subtitle">The website now mirrors the major categories from the spec docs index so public readers can browse both summaries and the fuller reference without opening the repository first.</p>
         <div class="card table-card">
           <table class="data-table">
             <thead>
@@ -164,6 +182,11 @@
                 <td><a href="https://github.com/MCPAQL/spec/blob/main/docs/overview.md">overview.md</a></td>
                 <td><a href="getting-started.html">Getting Started</a></td>
                 <td>Protocol summary, token efficiency, and quick-start framing</td>
+              </tr>
+              <tr>
+                <td><a href="https://github.com/MCPAQL/spec/tree/main/docs">spec/docs</a></td>
+                <td><a href="../spec/index.html">Repo-Synced Spec Reference</a></td>
+                <td>Website-hosted full mirror of versioned and topical specification documents</td>
               </tr>
               <tr>
                 <td><a href="https://github.com/MCPAQL/spec/blob/main/docs/operations.md">operations.md</a></td>

--- a/public/docs/protocol-core.html
+++ b/public/docs/protocol-core.html
@@ -23,7 +23,7 @@
         </ul>
         <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
-          <input id="site-search-input" data-search-input type="search" placeholder="Search protocol topics...">
+          <input id="site-search-input" data-search-input type="search" placeholder="Search MCP-AQL docs, spec pages, and adapter patterns...">
           <span class="search-count" data-search-count></span>
           <ul class="search-results" data-search-results hidden></ul>
         </form>
@@ -72,6 +72,7 @@
         </section>
 
         <section class="topic-bridge">
+          <h2 class="sr-only">Related reading</h2>
           <div class="grid cols-2">
             <article class="card">
               <h3>Go Deeper In The Full Spec</h3>
@@ -234,6 +235,16 @@ mcp_aql_execute</pre>
             </article>
           </div>
         </section>
+        <nav class="page-nav" aria-label="Page navigation">
+          <a class="page-nav-link prev" href="getting-started.html">
+            <span class="page-nav-eyebrow">Previous page</span>
+            <strong class="page-nav-label">Getting Started</strong>
+          </a>
+          <a class="page-nav-link next" href="error-model.html">
+            <span class="page-nav-eyebrow">Next page</span>
+            <strong class="page-nav-label">Error Model</strong>
+          </a>
+        </nav>
       </article>
     </div>
   </main>

--- a/public/docs/protocol-core.html
+++ b/public/docs/protocol-core.html
@@ -37,7 +37,7 @@
         <h2>In This Library</h2>
         <ul>
           <li><a href="getting-started.html">Getting Started</a></li>
-          <li><a href="protocol-core.html">Protocol Core</a></li>
+          <li><a class="current" href="protocol-core.html">Protocol Core</a></li>
           <li><a href="error-model.html">Error Model</a></li>
           <li><a href="security-model.html">Security Model</a></li>
           <li><a href="conformance.html">Conformance</a></li>
@@ -49,6 +49,13 @@
       </aside>
 
       <article class="docs-main">
+        <nav class="breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../index.html">Home</a></li>
+            <li><a href="index.html">Docs</a></li>
+            <li><span class="current">Protocol Core</span></li>
+          </ol>
+        </nav>
         <section class="hero docs-hero">
           <div class="hero-inner">
             <span class="status-pill">PROTOCOL CORE</span>
@@ -61,6 +68,31 @@
               <a class="btn btn-primary" href="../spec/versions/v1.0.0-draft.html">Normative Spec</a>
               <a class="btn btn-secondary" href="../spec/README.html">Spec Docs Index</a>
             </div>
+          </div>
+        </section>
+
+        <section class="topic-bridge">
+          <div class="grid cols-2">
+            <article class="card">
+              <h3>Go Deeper In The Full Spec</h3>
+              <p>This summary is the fast map. These pages carry the fuller protocol requirements and supporting detail.</p>
+              <ul>
+                <li><a href="../spec/versions/v1.0.0-draft.html">Normative Draft</a></li>
+                <li><a href="../spec/crude-pattern.html">CRUDE Pattern</a></li>
+                <li><a href="../spec/operations.html">Operations Specification</a></li>
+                <li><a href="../spec/introspection.html">Introspection Specification</a></li>
+              </ul>
+            </article>
+            <article class="card">
+              <h3>Related Summary Pages</h3>
+              <p>These summary pages help connect the core semantics to safety, errors, and launch posture.</p>
+              <ul>
+                <li><a href="getting-started.html">Getting Started</a></li>
+                <li><a href="error-model.html">Error Model</a></li>
+                <li><a href="security-model.html">Security Model</a></li>
+                <li><a href="index.html">Back to the docs library</a></li>
+              </ul>
+            </article>
           </div>
         </section>
 

--- a/public/docs/protocol-core.html
+++ b/public/docs/protocol-core.html
@@ -58,8 +58,8 @@
               versioned specification in <code>MCPAQL/spec</code>; this page is a readable map of the same core requirements.
             </p>
             <div class="hero-actions">
-              <a class="btn btn-primary" href="https://github.com/MCPAQL/spec/blob/main/docs/versions/v1.0.0-draft.md">Normative Spec</a>
-              <a class="btn btn-secondary" href="https://github.com/MCPAQL/spec/blob/main/docs/README.md">Spec Docs Index</a>
+              <a class="btn btn-primary" href="../spec/versions/v1.0.0-draft.html">Normative Spec</a>
+              <a class="btn btn-secondary" href="../spec/README.html">Spec Docs Index</a>
             </div>
           </div>
         </section>
@@ -174,9 +174,9 @@ mcp_aql_execute</pre>
               Clients query operations, parameters, and element types on demand instead of loading static schema sprawl into context.
             </p>
             <ul>
-              <li><a href="https://github.com/MCPAQL/spec/blob/main/docs/introspection.md">Introspection specification</a></li>
-              <li><a href="https://github.com/MCPAQL/spec/blob/main/docs/operations.md">Operation design guide</a></li>
-              <li><a href="https://github.com/MCPAQL/spec/blob/main/docs/error-codes.md">Structured error model</a></li>
+              <li><a href="../spec/introspection.html">Introspection specification</a></li>
+              <li><a href="../spec/operations.html">Operation design guide</a></li>
+              <li><a href="../spec/error-codes.html">Structured error model</a></li>
             </ul>
           </div>
         </section>

--- a/public/docs/protocol-core.html
+++ b/public/docs/protocol-core.html
@@ -36,11 +36,15 @@
       <aside class="docs-side">
         <h2>In This Library</h2>
         <ul>
+          <li><a href="getting-started.html">Getting Started</a></li>
           <li><a href="protocol-core.html">Protocol Core</a></li>
+          <li><a href="error-model.html">Error Model</a></li>
           <li><a href="security-model.html">Security Model</a></li>
           <li><a href="conformance.html">Conformance</a></li>
+          <li><a href="adapter-contracts.html">Adapter Contracts</a></li>
           <li><a href="implementation-profiles.html">Implementation Profiles</a></li>
           <li><a href="roadmap.html">Roadmap</a></li>
+          <li><a href="release-notes.html">Release Notes</a></li>
         </ul>
       </aside>
 
@@ -174,6 +178,28 @@ mcp_aql_execute</pre>
               <li><a href="https://github.com/MCPAQL/spec/blob/main/docs/operations.md">Operation design guide</a></li>
               <li><a href="https://github.com/MCPAQL/spec/blob/main/docs/error-codes.md">Structured error model</a></li>
             </ul>
+          </div>
+        </section>
+
+        <section>
+          <h2 class="section-title">Operational rules readers usually miss</h2>
+          <div class="grid cols-2">
+            <article class="card">
+              <h3>Naming and parameter rules</h3>
+              <ul>
+                <li>Operation names are case-sensitive snake_case identifiers.</li>
+                <li>Public parameter names are snake_case, even if implementations accept aliases internally.</li>
+                <li>Unknown parameters should be rejected instead of ignored so clients can correct requests.</li>
+              </ul>
+            </article>
+            <article class="card">
+              <h3>Batch and payload considerations</h3>
+              <ul>
+                <li>Batch operations are first-class, but launch messaging should still treat resource-limit requirements as in progress.</li>
+                <li>Payload size, encoding, and response shape constraints are part of interoperability, not optional polish.</li>
+                <li><a href="https://github.com/MCPAQL/spec/issues/197">Issue #197</a> tracks the remaining batch-limit hardening work.</li>
+              </ul>
+            </article>
           </div>
         </section>
       </article>

--- a/public/docs/release-notes.html
+++ b/public/docs/release-notes.html
@@ -58,7 +58,7 @@
               without requiring readers to scan the entire repository history.
             </p>
             <div class="hero-actions">
-              <a class="btn btn-primary" href="https://github.com/MCPAQL/spec/blob/main/CHANGELOG.md">Full Changelog</a>
+              <a class="btn btn-primary" href="../spec/repo/CHANGELOG.html">Full Changelog</a>
               <a class="btn btn-secondary" href="https://github.com/MCPAQL/spec/issues/194">Release plan issue</a>
             </div>
           </div>

--- a/public/docs/release-notes.html
+++ b/public/docs/release-notes.html
@@ -44,11 +44,18 @@
           <li><a href="adapter-contracts.html">Adapter Contracts</a></li>
           <li><a href="implementation-profiles.html">Implementation Profiles</a></li>
           <li><a href="roadmap.html">Roadmap</a></li>
-          <li><a href="release-notes.html">Release Notes</a></li>
+          <li><a class="current" href="release-notes.html">Release Notes</a></li>
         </ul>
       </aside>
 
       <article class="docs-main">
+        <nav class="breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../index.html">Home</a></li>
+            <li><a href="index.html">Docs</a></li>
+            <li><span class="current">Release Notes</span></li>
+          </ol>
+        </nav>
         <section class="hero docs-hero">
           <div class="hero-inner">
             <span class="status-pill">RELEASE NOTES</span>
@@ -61,6 +68,31 @@
               <a class="btn btn-primary" href="../spec/repo/CHANGELOG.html">Full Changelog</a>
               <a class="btn btn-secondary" href="https://github.com/MCPAQL/spec/issues/194">Release plan issue</a>
             </div>
+          </div>
+        </section>
+
+        <section class="topic-bridge">
+          <div class="grid cols-2">
+            <article class="card">
+              <h3>Go Deeper In The Full Spec</h3>
+              <p>The on-site changelog and process pages carry the detailed history behind the launch-facing notes on this page.</p>
+              <ul>
+                <li><a href="../spec/repo/CHANGELOG.html">Full Changelog</a></li>
+                <li><a href="../spec/process/versioning.html">Versioning Strategy</a></li>
+                <li><a href="../spec/process/preliminary-public-launch-checklist.html">Launch Checklist Source</a></li>
+                <li><a href="../spec/index.html">Browse the full spec reference</a></li>
+              </ul>
+            </article>
+            <article class="card">
+              <h3>Related Summary Pages</h3>
+              <p>Release context is easiest to read alongside the roadmap and public launch controls.</p>
+              <ul>
+                <li><a href="roadmap.html">Roadmap</a></li>
+                <li><a href="../launch-checklist.html">Launch Checklist</a></li>
+                <li><a href="implementation-profiles.html">Implementation Profiles</a></li>
+                <li><a href="index.html">Back to the docs library</a></li>
+              </ul>
+            </article>
           </div>
         </section>
 

--- a/public/docs/release-notes.html
+++ b/public/docs/release-notes.html
@@ -23,7 +23,7 @@
         </ul>
         <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
-          <input id="site-search-input" data-search-input type="search" placeholder="Search release notes...">
+          <input id="site-search-input" data-search-input type="search" placeholder="Search MCP-AQL docs, spec pages, and adapter patterns...">
           <span class="search-count" data-search-count></span>
           <ul class="search-results" data-search-results hidden></ul>
         </form>
@@ -72,6 +72,7 @@
         </section>
 
         <section class="topic-bridge">
+          <h2 class="sr-only">Related reading</h2>
           <div class="grid cols-2">
             <article class="card">
               <h3>Go Deeper In The Full Spec</h3>
@@ -133,6 +134,16 @@
             </article>
           </div>
         </section>
+        <nav class="page-nav" aria-label="Page navigation">
+          <a class="page-nav-link prev" href="roadmap.html">
+            <span class="page-nav-eyebrow">Previous page</span>
+            <strong class="page-nav-label">Roadmap</strong>
+          </a>
+          <a class="page-nav-link next" href="../spec/index.html">
+            <span class="page-nav-eyebrow">Next page</span>
+            <strong class="page-nav-label">Full Spec Reference</strong>
+          </a>
+        </nav>
       </article>
     </div>
   </main>

--- a/public/docs/release-notes.html
+++ b/public/docs/release-notes.html
@@ -1,0 +1,123 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Recent MCP-AQL draft changes and launch-relevant release notes pulled from the specification changelog.">
+  <title>MCP-AQL Docs | Release Notes</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../css/style.css">
+</head>
+<body>
+  <header>
+    <div class="container">
+      <nav>
+        <a class="logo" href="../index.html"><span class="logo-mark"></span>MCP-AQL</a>
+        <ul class="nav-links">
+          <li><a href="../index.html">Home</a></li>
+          <li><a href="index.html">Docs</a></li>
+          <li><a href="../launch-checklist.html">Launch Checklist</a></li>
+          <li><a href="../apis/mcp-server.html">Adapter Patterns</a></li>
+        </ul>
+        <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
+          <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
+          <input id="site-search-input" data-search-input type="search" placeholder="Search release notes...">
+          <span class="search-count" data-search-count></span>
+          <ul class="search-results" data-search-results hidden></ul>
+        </form>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <div class="container docs-shell">
+      <aside class="docs-side">
+        <h2>In This Library</h2>
+        <ul>
+          <li><a href="getting-started.html">Getting Started</a></li>
+          <li><a href="protocol-core.html">Protocol Core</a></li>
+          <li><a href="error-model.html">Error Model</a></li>
+          <li><a href="security-model.html">Security Model</a></li>
+          <li><a href="conformance.html">Conformance</a></li>
+          <li><a href="adapter-contracts.html">Adapter Contracts</a></li>
+          <li><a href="implementation-profiles.html">Implementation Profiles</a></li>
+          <li><a href="roadmap.html">Roadmap</a></li>
+          <li><a href="release-notes.html">Release Notes</a></li>
+        </ul>
+      </aside>
+
+      <article class="docs-main">
+        <section class="hero docs-hero">
+          <div class="hero-inner">
+            <span class="status-pill">RELEASE NOTES</span>
+            <h1>Recent draft changes that affect public understanding</h1>
+            <p class="lede">
+              These notes summarize the most launch-relevant items from the spec changelog so the public website can reflect what changed
+              without requiring readers to scan the entire repository history.
+            </p>
+            <div class="hero-actions">
+              <a class="btn btn-primary" href="https://github.com/MCPAQL/spec/blob/main/CHANGELOG.md">Full Changelog</a>
+              <a class="btn btn-secondary" href="https://github.com/MCPAQL/spec/issues/194">Release plan issue</a>
+            </div>
+          </div>
+        </section>
+
+        <section>
+          <h2 class="section-title">Recent highlights</h2>
+          <div class="grid cols-2">
+            <article class="card">
+              <h3>Launch framing clarified</h3>
+              <ul>
+                <li>README and draft status language now explicitly frame MCP-AQL as a preliminary public draft.</li>
+                <li>Normative versus informative document boundaries were tightened across the spec docs.</li>
+                <li>A coordinated preliminary launch checklist was added for spec and reference-profile messaging.</li>
+              </ul>
+            </article>
+            <article class="card">
+              <h3>Safety model expanded</h3>
+              <ul>
+                <li>Execution safety loop, safety-dongle model, autonomy evaluator, and out-of-band verification are now documented.</li>
+                <li>Section 9 compliance mappings were expanded to better align informative safety docs to normative requirements.</li>
+                <li><a href="https://github.com/MCPAQL/spec/issues/216">Issue #216</a> remains the audit record for that alignment work.</li>
+              </ul>
+            </article>
+            <article class="card">
+              <h3>Operational contracts hardened</h3>
+              <ul>
+                <li>Unknown parameter rejection and structured error examples were added to reduce LLM ambiguity.</li>
+                <li>Canonical operation verbs and session lifecycle guidance were made more explicit.</li>
+                <li>Batch confirmation behavior and payload-size constraints were documented.</li>
+              </ul>
+            </article>
+            <article class="card">
+              <h3>Still open for draft launch</h3>
+              <ul>
+                <li><a href="https://github.com/MCPAQL/spec/issues/193">#193 MCP capability audit</a></li>
+                <li><a href="https://github.com/MCPAQL/spec/issues/197">#197 batch size and resource protections</a></li>
+                <li><a href="https://github.com/MCPAQL/spec/issues/199">#199 structured error surface alignment</a></li>
+              </ul>
+            </article>
+          </div>
+        </section>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div class="container">
+      <p>&copy; 2026 DollhouseMCP Inc. d/b/a Dollhouse Research. MCP-AQL public draft documentation portal.</p>
+      <div class="footer-links">
+        <a href="index.html">Docs Library</a>
+        <a href="../index.html">Portal Home</a>
+        <a href="https://github.com/MCPAQL">MCPAQL Organization</a>
+        <a href="https://dollhouseresearch.com">Dollhouse Research</a>
+        <a href="https://github.com/DollhouseMCP/mcp-server">DollhouseMCP Production Profile</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../js/search.js"></script>
+</body>
+</html>

--- a/public/docs/roadmap.html
+++ b/public/docs/roadmap.html
@@ -43,12 +43,19 @@
           <li><a href="conformance.html">Conformance</a></li>
           <li><a href="adapter-contracts.html">Adapter Contracts</a></li>
           <li><a href="implementation-profiles.html">Implementation Profiles</a></li>
-          <li><a href="roadmap.html">Roadmap</a></li>
+          <li><a class="current" href="roadmap.html">Roadmap</a></li>
           <li><a href="release-notes.html">Release Notes</a></li>
         </ul>
       </aside>
 
       <article class="docs-main">
+        <nav class="breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../index.html">Home</a></li>
+            <li><a href="index.html">Docs</a></li>
+            <li><span class="current">Roadmap</span></li>
+          </ol>
+        </nav>
         <section class="hero docs-hero">
           <div class="hero-inner">
             <span class="status-pill">ROADMAP</span>
@@ -57,6 +64,36 @@
               MCP-AQL development is staged across protocol quality, adapter maturity, examples, validator tooling, and ecosystem adoption.
               This page translates those tracks into a public roadmap view.
             </p>
+            <div class="hero-actions">
+              <a class="btn btn-primary" href="../spec/index.html">Full Spec Reference</a>
+              <a class="btn btn-secondary" href="../launch-checklist.html">Launch Checklist</a>
+              <a class="btn btn-secondary" href="release-notes.html">Release Notes</a>
+            </div>
+          </div>
+        </section>
+
+        <section class="topic-bridge">
+          <div class="grid cols-2">
+            <article class="card">
+              <h3>Go Deeper In The Full Spec</h3>
+              <p>The roadmap connects directly to the process and release-management pages in the full reference.</p>
+              <ul>
+                <li><a href="../spec/index.html">Browse the full spec reference</a></li>
+                <li><a href="../spec/process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li>
+                <li><a href="../spec/process/versioning.html">Versioning Strategy</a></li>
+                <li><a href="../spec/repo/CHANGELOG.html">Changelog</a></li>
+              </ul>
+            </article>
+            <article class="card">
+              <h3>Related Summary Pages</h3>
+              <p>These pages give the clearest summary-layer view of release timing, testing, and implementation posture.</p>
+              <ul>
+                <li><a href="release-notes.html">Release Notes</a></li>
+                <li><a href="conformance.html">Conformance</a></li>
+                <li><a href="implementation-profiles.html">Implementation Profiles</a></li>
+                <li><a href="index.html">Back to the docs library</a></li>
+              </ul>
+            </article>
           </div>
         </section>
 

--- a/public/docs/roadmap.html
+++ b/public/docs/roadmap.html
@@ -23,7 +23,7 @@
         </ul>
         <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
-          <input id="site-search-input" data-search-input type="search" placeholder="Search roadmap topics...">
+          <input id="site-search-input" data-search-input type="search" placeholder="Search MCP-AQL docs, spec pages, and adapter patterns...">
           <span class="search-count" data-search-count></span>
           <ul class="search-results" data-search-results hidden></ul>
         </form>
@@ -73,6 +73,7 @@
         </section>
 
         <section class="topic-bridge">
+          <h2 class="sr-only">Related reading</h2>
           <div class="grid cols-2">
             <article class="card">
               <h3>Go Deeper In The Full Spec</h3>
@@ -203,6 +204,16 @@
             </p>
           </div>
         </section>
+        <nav class="page-nav" aria-label="Page navigation">
+          <a class="page-nav-link prev" href="implementation-profiles.html">
+            <span class="page-nav-eyebrow">Previous page</span>
+            <strong class="page-nav-label">Implementation Profiles</strong>
+          </a>
+          <a class="page-nav-link next" href="release-notes.html">
+            <span class="page-nav-eyebrow">Next page</span>
+            <strong class="page-nav-label">Release Notes</strong>
+          </a>
+        </nav>
       </article>
     </div>
   </main>

--- a/public/docs/roadmap.html
+++ b/public/docs/roadmap.html
@@ -36,11 +36,15 @@
       <aside class="docs-side">
         <h2>In This Library</h2>
         <ul>
+          <li><a href="getting-started.html">Getting Started</a></li>
           <li><a href="protocol-core.html">Protocol Core</a></li>
+          <li><a href="error-model.html">Error Model</a></li>
           <li><a href="security-model.html">Security Model</a></li>
           <li><a href="conformance.html">Conformance</a></li>
+          <li><a href="adapter-contracts.html">Adapter Contracts</a></li>
           <li><a href="implementation-profiles.html">Implementation Profiles</a></li>
           <li><a href="roadmap.html">Roadmap</a></li>
+          <li><a href="release-notes.html">Release Notes</a></li>
         </ul>
       </aside>
 
@@ -105,10 +109,10 @@
               <h3>Spec Readiness</h3>
               <span class="state-chip pending">Active</span>
               <ul>
-                <li>MCP capability alignment audit</li>
-                <li>Batch/resource safeguard clarity</li>
-                <li>Structured error alignment and consistency</li>
-                <li>Conformance framework formalization</li>
+                <li><a href="https://github.com/MCPAQL/spec/issues/193">#193 MCP capability alignment audit</a></li>
+                <li><a href="https://github.com/MCPAQL/spec/issues/197">#197 batch/resource safeguard clarity</a></li>
+                <li><a href="https://github.com/MCPAQL/spec/issues/199">#199 structured error alignment and consistency</a></li>
+                <li><a href="https://github.com/MCPAQL/spec/issues/204">#204 conformance framework formalization</a></li>
               </ul>
             </article>
             <article class="card">
@@ -150,6 +154,16 @@
               <li>Avoid hidden dependencies on private issue trackers for public comprehension.</li>
               <li>Provide direct, readable status language for what is available now vs still in progress.</li>
             </ul>
+          </div>
+        </section>
+
+        <section>
+          <h2 class="section-title">Release coordination</h2>
+          <div class="card">
+            <p>
+              The coordinating epic is <a href="https://github.com/MCPAQL/spec/issues/194">spec issue #194</a>.
+              It ties together spec publication, proof-of-concept adapters, website readiness, and launch messaging with the Dollhouse practical profile.
+            </p>
           </div>
         </section>
       </article>

--- a/public/docs/security-model.html
+++ b/public/docs/security-model.html
@@ -39,7 +39,7 @@
           <li><a href="getting-started.html">Getting Started</a></li>
           <li><a href="protocol-core.html">Protocol Core</a></li>
           <li><a href="error-model.html">Error Model</a></li>
-          <li><a href="security-model.html">Security Model</a></li>
+          <li><a class="current" href="security-model.html">Security Model</a></li>
           <li><a href="conformance.html">Conformance</a></li>
           <li><a href="adapter-contracts.html">Adapter Contracts</a></li>
           <li><a href="implementation-profiles.html">Implementation Profiles</a></li>
@@ -49,6 +49,13 @@
       </aside>
 
       <article class="docs-main">
+        <nav class="breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../index.html">Home</a></li>
+            <li><a href="index.html">Docs</a></li>
+            <li><span class="current">Security Model</span></li>
+          </ol>
+        </nav>
         <section class="hero docs-hero">
           <div class="hero-inner">
             <span class="status-pill">SECURITY MODEL</span>
@@ -62,6 +69,31 @@
               <a class="btn btn-secondary" href="../spec/security/confirmation-tokens.html">Confirmation Tokens</a>
               <a class="btn btn-secondary" href="../spec/security/execution-safety-loop.html">Execution Safety Loop</a>
             </div>
+          </div>
+        </section>
+
+        <section class="topic-bridge">
+          <div class="grid cols-2">
+            <article class="card">
+              <h3>Go Deeper In The Full Spec</h3>
+              <p>The full safety model is split across several dedicated spec documents hosted here on the website.</p>
+              <ul>
+                <li><a href="../spec/security/gatekeeper.html">Gatekeeper Specification</a></li>
+                <li><a href="../spec/security/confirmation-tokens.html">Confirmation Tokens</a></li>
+                <li><a href="../spec/security/execution-safety-loop.html">Execution Safety Loop</a></li>
+                <li><a href="../spec/index.html">Browse the full spec reference</a></li>
+              </ul>
+            </article>
+            <article class="card">
+              <h3>Related Summary Pages</h3>
+              <p>Security decisions sit next to routing, error handling, and launch-readiness claims.</p>
+              <ul>
+                <li><a href="protocol-core.html">Protocol Core</a></li>
+                <li><a href="error-model.html">Error Model</a></li>
+                <li><a href="conformance.html">Conformance</a></li>
+                <li><a href="index.html">Back to the docs library</a></li>
+              </ul>
+            </article>
           </div>
         </section>
 

--- a/public/docs/security-model.html
+++ b/public/docs/security-model.html
@@ -23,7 +23,7 @@
         </ul>
         <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
-          <input id="site-search-input" data-search-input type="search" placeholder="Search security topics...">
+          <input id="site-search-input" data-search-input type="search" placeholder="Search MCP-AQL docs, spec pages, and adapter patterns...">
           <span class="search-count" data-search-count></span>
           <ul class="search-results" data-search-results hidden></ul>
         </form>
@@ -73,6 +73,7 @@
         </section>
 
         <section class="topic-bridge">
+          <h2 class="sr-only">Related reading</h2>
           <div class="grid cols-2">
             <article class="card">
               <h3>Go Deeper In The Full Spec</h3>
@@ -169,6 +170,16 @@
             </ul>
           </div>
         </section>
+        <nav class="page-nav" aria-label="Page navigation">
+          <a class="page-nav-link prev" href="error-model.html">
+            <span class="page-nav-eyebrow">Previous page</span>
+            <strong class="page-nav-label">Error Model</strong>
+          </a>
+          <a class="page-nav-link next" href="conformance.html">
+            <span class="page-nav-eyebrow">Next page</span>
+            <strong class="page-nav-label">Conformance</strong>
+          </a>
+        </nav>
       </article>
     </div>
   </main>

--- a/public/docs/security-model.html
+++ b/public/docs/security-model.html
@@ -58,9 +58,9 @@
               This page maps the current security model used in draft protocol and practical profiles.
             </p>
             <div class="hero-actions">
-              <a class="btn btn-primary" href="https://github.com/MCPAQL/spec/blob/main/docs/security/gatekeeper.md">Gatekeeper Spec</a>
-              <a class="btn btn-secondary" href="https://github.com/MCPAQL/spec/blob/main/docs/security/confirmation-tokens.md">Confirmation Tokens</a>
-              <a class="btn btn-secondary" href="https://github.com/MCPAQL/spec/blob/main/docs/security/execution-safety-loop.md">Execution Safety Loop</a>
+              <a class="btn btn-primary" href="../spec/security/gatekeeper.html">Gatekeeper Spec</a>
+              <a class="btn btn-secondary" href="../spec/security/confirmation-tokens.html">Confirmation Tokens</a>
+              <a class="btn btn-secondary" href="../spec/security/execution-safety-loop.html">Execution Safety Loop</a>
             </div>
           </div>
         </section>
@@ -130,9 +130,9 @@
           <h2 class="section-title">Source documents behind this summary</h2>
           <div class="card">
             <ul>
-              <li><a href="https://github.com/MCPAQL/spec/blob/main/docs/security/gatekeeper.md">Gatekeeper</a></li>
-              <li><a href="https://github.com/MCPAQL/spec/blob/main/docs/security/confirmation-tokens.md">Confirmation Tokens</a></li>
-              <li><a href="https://github.com/MCPAQL/spec/blob/main/docs/security/execution-safety-loop.md">Execution Safety Loop</a></li>
+              <li><a href="../spec/security/gatekeeper.html">Gatekeeper</a></li>
+              <li><a href="../spec/security/confirmation-tokens.html">Confirmation Tokens</a></li>
+              <li><a href="../spec/security/execution-safety-loop.html">Execution Safety Loop</a></li>
               <li><a href="https://github.com/MCPAQL/spec/issues/216">Issue #216 safety checklist alignment audit</a></li>
             </ul>
           </div>

--- a/public/docs/security-model.html
+++ b/public/docs/security-model.html
@@ -36,11 +36,15 @@
       <aside class="docs-side">
         <h2>In This Library</h2>
         <ul>
+          <li><a href="getting-started.html">Getting Started</a></li>
           <li><a href="protocol-core.html">Protocol Core</a></li>
+          <li><a href="error-model.html">Error Model</a></li>
           <li><a href="security-model.html">Security Model</a></li>
           <li><a href="conformance.html">Conformance</a></li>
+          <li><a href="adapter-contracts.html">Adapter Contracts</a></li>
           <li><a href="implementation-profiles.html">Implementation Profiles</a></li>
           <li><a href="roadmap.html">Roadmap</a></li>
+          <li><a href="release-notes.html">Release Notes</a></li>
         </ul>
       </aside>
 
@@ -118,6 +122,18 @@
               <li>Batch/resource exhaustion protections</li>
               <li>Structured error surface consistency</li>
               <li>Conformance coverage for security and safety behaviors</li>
+            </ul>
+          </div>
+        </section>
+
+        <section>
+          <h2 class="section-title">Source documents behind this summary</h2>
+          <div class="card">
+            <ul>
+              <li><a href="https://github.com/MCPAQL/spec/blob/main/docs/security/gatekeeper.md">Gatekeeper</a></li>
+              <li><a href="https://github.com/MCPAQL/spec/blob/main/docs/security/confirmation-tokens.md">Confirmation Tokens</a></li>
+              <li><a href="https://github.com/MCPAQL/spec/blob/main/docs/security/execution-safety-loop.md">Execution Safety Loop</a></li>
+              <li><a href="https://github.com/MCPAQL/spec/issues/216">Issue #216 safety checklist alignment audit</a></li>
             </ul>
           </div>
         </section>

--- a/public/index.html
+++ b/public/index.html
@@ -23,7 +23,7 @@
         </ul>
         <form class="site-search" data-search-form data-index-url="data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
-          <input id="site-search-input" data-search-input type="search" placeholder="Search docs, features, and repos...">
+          <input id="site-search-input" data-search-input type="search" placeholder="Search MCP-AQL docs, spec pages, and adapter patterns...">
           <span class="search-count" data-search-count></span>
           <ul class="search-results" data-search-results hidden></ul>
         </form>

--- a/public/index.html
+++ b/public/index.html
@@ -44,6 +44,7 @@
           <div class="hero-actions">
             <a class="btn btn-primary" href="docs/getting-started.html">Start With The Quick Path</a>
             <a class="btn btn-secondary" href="docs/index.html">Open Documentation Library</a>
+            <a class="btn btn-secondary" href="spec/index.html">Browse Full Spec Reference</a>
             <a class="btn btn-secondary" href="launch-checklist.html">Public Launch Checklist</a>
           </div>
         </div>
@@ -136,6 +137,29 @@
               <li>Generator/output-policy and provenance requirements</li>
             </ul>
             <a href="docs/adapter-contracts.html">Open Adapter Contracts</a>
+          </article>
+        </div>
+      </section>
+
+      <section>
+        <h2 class="section-title">Full Website-Hosted Spec Reference</h2>
+        <p class="section-subtitle">The public site now has a repo-synced spec layer generated from the canonical docs, so readers can stay on the website for the deeper protocol material too.</p>
+        <div class="grid cols-2">
+          <article class="card">
+            <h3>What changed</h3>
+            <ul>
+              <li>The full reference is generated directly from <code>MCPAQL/spec/docs</code>.</li>
+              <li>Versioned drafts, support docs, and topic pages are hosted under the website's own navigation and search.</li>
+              <li>Summary pages still help people orient quickly, but the detailed material is no longer repo-only.</li>
+            </ul>
+          </article>
+          <article class="card">
+            <h3>Where to go next</h3>
+            <ul>
+              <li><a href="spec/index.html">Open the full repo-synced spec reference</a></li>
+              <li><a href="spec/versions/v1.0.0-draft.html">Read the normative draft on-site</a></li>
+              <li><a href="docs/index.html">Use the docs library for guided entry points and summaries</a></li>
+            </ul>
           </article>
         </div>
       </section>

--- a/public/index.html
+++ b/public/index.html
@@ -36,14 +36,14 @@
       <section class="hero">
         <div class="hero-inner">
           <span class="status-pill">PRELIMINARY PUBLIC DRAFT</span>
-          <h1>MCP-AQL Protocol Website</h1>
+          <h1>MCP-AQL documentation that tracks the draft spec as it exists today</h1>
           <p class="lede">
-            This site is the browse-first documentation surface for MCP-AQL. It tracks canonical protocol definitions,
-            implementation profiles, conformance expectations, and launch readiness in one readable structure.
+            This site is the browse-first public surface for MCP-AQL: what the protocol is, how it routes operations,
+            how it handles safety and errors, what counts as draft-compatible today, and what remains open in the live spec backlog.
           </p>
           <div class="hero-actions">
-            <a class="btn btn-primary" href="docs/index.html">Open Documentation Library</a>
-            <a class="btn btn-secondary" href="https://github.com/MCPAQL/spec">Canonical Spec Repository</a>
+            <a class="btn btn-primary" href="docs/getting-started.html">Start With The Quick Path</a>
+            <a class="btn btn-secondary" href="docs/index.html">Open Documentation Library</a>
             <a class="btn btn-secondary" href="launch-checklist.html">Public Launch Checklist</a>
           </div>
         </div>
@@ -52,30 +52,31 @@
       <section>
         <h2 class="section-title">Start Here</h2>
         <p class="section-subtitle">
-          If you are new to MCP-AQL, this sequence gives you the protocol baseline and the implementation context without repo spelunking.
+          If you are new to MCP-AQL, this sequence gets you from protocol overview to launch reality without repo spelunking.
         </p>
         <div class="grid cols-3">
           <article class="card">
-            <h3>1. Read The Normative Draft</h3>
-            <p>The protocol authority starts with the versioned specification and core endpoint semantics.</p>
+            <h3>1. Understand The Model</h3>
+            <p>Start with the short overview, token-efficiency story, and quick-start request shape before dropping into the full draft.</p>
             <ul>
+              <li><a href="docs/getting-started.html">Getting Started</a></li>
               <li><a href="https://github.com/MCPAQL/spec/blob/main/docs/versions/v1.0.0-draft.md">Specification v1.0.0-draft</a></li>
               <li><a href="https://github.com/MCPAQL/spec/blob/main/docs/crude-pattern.md">CRUDE Pattern</a></li>
               <li><a href="https://github.com/MCPAQL/spec/blob/main/docs/introspection.md">Introspection</a></li>
             </ul>
           </article>
           <article class="card">
-            <h3>2. Understand Profiles</h3>
-            <p>MCP-AQL separates canonical protocol requirements from practical implementation profiles.</p>
+            <h3>2. Learn The Operational Rules</h3>
+            <p>Read the public summaries for routing, structured errors, safety controls, and conformance boundaries.</p>
             <ul>
-              <li><a href="docs/implementation-profiles.html">Canonical vs Practical Profiles</a></li>
-              <li><a href="https://github.com/DollhouseMCP/mcp-server">DollhouseMCP Production Profile</a></li>
-              <li><a href="https://dollhouseresearch.com">Dollhouse Research Context</a></li>
+              <li><a href="docs/protocol-core.html">Protocol Core</a></li>
+              <li><a href="docs/error-model.html">Error Model</a></li>
+              <li><a href="docs/security-model.html">Security Model</a></li>
             </ul>
           </article>
           <article class="card">
-            <h3>3. Validate Readiness</h3>
-            <p>Use the conformance and launch pages to track what is publish-ready versus explicitly in-progress.</p>
+            <h3>3. Track Draft Readiness</h3>
+            <p>Use the launch and roadmap pages to see what is publish-ready versus what is still explicitly open in the spec.</p>
             <ul>
               <li><a href="docs/conformance.html">Conformance and Validator Status</a></li>
               <li><a href="docs/roadmap.html">Protocol Roadmap</a></li>
@@ -95,9 +96,18 @@
               <li>Request and response contract model</li>
               <li>CRUDE and single-endpoint operation routing</li>
               <li>Runtime introspection for discoverability</li>
-              <li>Type, warning, and structured-error framing</li>
+              <li>Canonical verbs, parameter rules, and unknown-param handling</li>
             </ul>
             <a href="docs/protocol-core.html">Open Protocol Core</a>
+          </article>
+          <article class="card">
+            <h3>Error And Response Surface</h3>
+            <ul>
+              <li>Structured error envelope with code and message</li>
+              <li>MVP registry plus phase-1 robustness concerns</li>
+              <li>Current spec alignment work for error surfacing</li>
+            </ul>
+            <a href="docs/error-model.html">Open Error Model</a>
           </article>
           <article class="card">
             <h3>Security And Safety Surface</h3>
@@ -122,10 +132,34 @@
             <h3>Implementation And Ecosystem Surface</h3>
             <ul>
               <li>Reference runtime and plugin architecture docs</li>
-              <li>Example adapter strategy and launch candidates</li>
+              <li>Adapter schema and plugin contract requirements</li>
               <li>Generator/output-policy and provenance requirements</li>
             </ul>
-            <a href="docs/implementation-profiles.html">Open Implementation Profiles</a>
+            <a href="docs/adapter-contracts.html">Open Adapter Contracts</a>
+          </article>
+        </div>
+      </section>
+
+      <section>
+        <h2 class="section-title">Current Draft Blockers</h2>
+        <p class="section-subtitle">The website is explicit about the live spec issues that still shape launch messaging.</p>
+        <div class="grid cols-2">
+          <article class="card">
+            <h3>Phase-1 launch gate issues</h3>
+            <ul>
+              <li><a href="https://github.com/MCPAQL/spec/issues/193">#193 MCP 0.20 capability audit</a></li>
+              <li><a href="https://github.com/MCPAQL/spec/issues/197">#197 batch and resource exhaustion protections</a></li>
+              <li><a href="https://github.com/MCPAQL/spec/issues/199">#199 structured error surface alignment</a></li>
+              <li><a href="https://github.com/MCPAQL/spec/issues/194">#194 draft publication release plan</a></li>
+            </ul>
+          </article>
+          <article class="card">
+            <h3>Why they matter publicly</h3>
+            <ul>
+              <li>They define what the site can honestly call compatible today.</li>
+              <li>They affect batch safety, machine-readable errors, and MCP parity messaging.</li>
+              <li>They keep the draft positioned as real, useful, and still in progress.</li>
+            </ul>
           </article>
         </div>
       </section>

--- a/public/js/search.js
+++ b/public/js/search.js
@@ -49,25 +49,35 @@
 
     if (!input || !resultBox || !indexUrl) return;
 
-    fetch(indexUrl)
-      .then(function (resp) {
-        if (!resp.ok) throw new Error("Search index fetch failed");
-        return resp.json();
-      })
-      .then(function (index) {
-        function closeResults() {
-          resultBox.hidden = true;
-          resultBox.innerHTML = "";
-          if (count) count.textContent = "";
-        }
+    let indexPromise;
 
-        function updateResults() {
-          const query = input.value.trim();
-          if (!query) {
-            closeResults();
-            return;
-          }
+    function closeResults() {
+      resultBox.hidden = true;
+      resultBox.innerHTML = "";
+      if (count) count.textContent = "";
+    }
 
+    function loadIndex() {
+      if (!indexPromise) {
+        indexPromise = fetch(indexUrl)
+          .then(function (resp) {
+            if (!resp.ok) throw new Error("Search index fetch failed");
+            return resp.json();
+          });
+      }
+
+      return indexPromise;
+    }
+
+    function updateResults() {
+      const query = input.value.trim();
+      if (!query) {
+        closeResults();
+        return;
+      }
+
+      loadIndex()
+        .then(function (index) {
           const ranked = index
             .map(function (item) {
               return { item: item, score: scoreItem(item, query) };
@@ -101,27 +111,32 @@
 
           resultBox.hidden = false;
           if (count) count.textContent = ranked.length + " result" + (ranked.length === 1 ? "" : "s");
-        }
-
-        input.addEventListener("input", updateResults);
-        input.addEventListener("focus", updateResults);
-
-        document.addEventListener("click", function (event) {
-          if (!form.contains(event.target)) {
-            closeResults();
-          }
+        })
+        .catch(function () {
+          if (count) count.textContent = "Search unavailable";
         });
+    }
 
-        document.addEventListener("keydown", function (event) {
-          if (event.key === "Escape") {
-            closeResults();
-            input.blur();
-          }
-        });
-      })
-      .catch(function () {
+    input.addEventListener("input", updateResults);
+    input.addEventListener("focus", function () {
+      loadIndex().catch(function () {
         if (count) count.textContent = "Search unavailable";
       });
+    }, { once: true });
+    input.addEventListener("focus", updateResults);
+
+    document.addEventListener("click", function (event) {
+      if (!form.contains(event.target)) {
+        closeResults();
+      }
+    });
+
+    document.addEventListener("keydown", function (event) {
+      if (event.key === "Escape") {
+        closeResults();
+        input.blur();
+      }
+    });
   }
 
   document.addEventListener("DOMContentLoaded", function () {

--- a/public/js/search.js
+++ b/public/js/search.js
@@ -1,4 +1,6 @@
 (function () {
+  const GLOBAL_SEARCH_PLACEHOLDER = "Search MCP-AQL docs, spec pages, and adapter patterns...";
+
   function normalize(value) {
     return (value || "").toLowerCase().trim();
   }
@@ -101,6 +103,9 @@
     const indexUrl = form.getAttribute("data-index-url");
 
     if (!input || !resultBox || !indexUrl) return;
+
+    input.placeholder = GLOBAL_SEARCH_PLACEHOLDER;
+    input.setAttribute("enterkeyhint", "search");
 
     let indexPromise;
 
@@ -205,6 +210,7 @@
 
     if (formInput) {
       formInput.value = query;
+      formInput.placeholder = GLOBAL_SEARCH_PLACEHOLDER;
     }
 
     if (queryLabel) {

--- a/public/js/search.js
+++ b/public/js/search.js
@@ -3,6 +3,36 @@
     return (value || "").toLowerCase().trim();
   }
 
+  function rankItems(index, query, limit) {
+    return index
+      .map(function (item) {
+        return { item: item, score: scoreItem(item, query) };
+      })
+      .filter(function (entry) {
+        return entry.score > 0;
+      })
+      .sort(function (a, b) {
+        return b.score - a.score;
+      })
+      .slice(0, typeof limit === "number" ? limit : index.length)
+      .map(function (entry) {
+        return entry.item;
+      });
+  }
+
+  function escapeHtml(value) {
+    return (value || "")
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;");
+  }
+
+  function buildSearchPageUrl(indexUrl, query) {
+    const target = (indexUrl || "data/search-index.json").replace(/data\/search-index\.json$/, "search.html");
+    return target + "?q=" + encodeURIComponent(query || "");
+  }
+
   function scoreItem(item, query) {
     const q = normalize(query);
     if (!q) return 0;
@@ -38,6 +68,29 @@
     link.appendChild(excerpt);
 
     li.appendChild(link);
+    return li;
+  }
+
+  function renderPageResultItem(item, query) {
+    const li = document.createElement("li");
+    li.className = "search-page-item card";
+
+    const title = document.createElement("h3");
+    const link = document.createElement("a");
+    link.href = item.url;
+    link.textContent = item.title;
+    title.appendChild(link);
+
+    const excerpt = document.createElement("p");
+    excerpt.textContent = item.excerpt;
+
+    const meta = document.createElement("p");
+    meta.className = "search-page-meta";
+    meta.innerHTML = "Match for <code>" + escapeHtml(query) + "</code> in " + escapeHtml(item.url);
+
+    li.appendChild(title);
+    li.appendChild(excerpt);
+    li.appendChild(meta);
     return li;
   }
 
@@ -78,20 +131,7 @@
 
       loadIndex()
         .then(function (index) {
-          const ranked = index
-            .map(function (item) {
-              return { item: item, score: scoreItem(item, query) };
-            })
-            .filter(function (entry) {
-              return entry.score > 0;
-            })
-            .sort(function (a, b) {
-              return b.score - a.score;
-            })
-            .slice(0, 8)
-            .map(function (entry) {
-              return entry.item;
-            });
+          const ranked = rankItems(index, query, 8);
 
           resultBox.innerHTML = "";
 
@@ -124,6 +164,17 @@
       });
     }, { once: true });
     input.addEventListener("focus", updateResults);
+    form.addEventListener("submit", function (event) {
+      const query = input.value.trim();
+      if (!query) {
+        event.preventDefault();
+        closeResults();
+        return;
+      }
+
+      event.preventDefault();
+      window.location.href = buildSearchPageUrl(indexUrl, query);
+    });
 
     document.addEventListener("click", function (event) {
       if (!form.contains(event.target)) {
@@ -139,7 +190,66 @@
     });
   }
 
+  function mountSearchPage() {
+    const page = document.querySelector("[data-search-page]");
+    if (!page) return;
+
+    const params = new URLSearchParams(window.location.search);
+    const query = (params.get("q") || "").trim();
+    const indexUrl = page.getAttribute("data-index-url") || "data/search-index.json";
+    const queryLabel = page.querySelector("[data-search-query]");
+    const count = page.querySelector("[data-search-page-count]");
+    const resultsList = page.querySelector("[data-search-page-results]");
+    const empty = page.querySelector("[data-search-page-empty]");
+    const formInput = document.querySelector("[data-search-input]");
+
+    if (formInput) {
+      formInput.value = query;
+    }
+
+    if (queryLabel) {
+      queryLabel.textContent = query || "all docs";
+    }
+
+    if (!query) {
+      if (count) count.textContent = "Enter a protocol term to search the documentation.";
+      if (empty) empty.hidden = false;
+      if (resultsList) resultsList.innerHTML = "";
+      return;
+    }
+
+    fetch(indexUrl)
+      .then(function (resp) {
+        if (!resp.ok) throw new Error("Search index fetch failed");
+        return resp.json();
+      })
+      .then(function (index) {
+        const ranked = rankItems(index, query);
+
+        if (count) {
+          count.textContent = ranked.length + " result" + (ranked.length === 1 ? "" : "s") + " for \"" + query + "\"";
+        }
+
+        if (!resultsList) return;
+        resultsList.innerHTML = "";
+
+        if (!ranked.length) {
+          if (empty) empty.hidden = false;
+          return;
+        }
+
+        if (empty) empty.hidden = true;
+        ranked.forEach(function (item) {
+          resultsList.appendChild(renderPageResultItem(item, query));
+        });
+      })
+      .catch(function () {
+        if (count) count.textContent = "Search unavailable right now.";
+      });
+  }
+
   document.addEventListener("DOMContentLoaded", function () {
     document.querySelectorAll("[data-search-form]").forEach(mountSearch);
+    mountSearchPage();
   });
 })();

--- a/public/launch-checklist.html
+++ b/public/launch-checklist.html
@@ -23,7 +23,7 @@
         </ul>
         <form class="site-search" data-search-form data-index-url="data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
-          <input id="site-search-input" data-search-input type="search" placeholder="Search launch topics...">
+          <input id="site-search-input" data-search-input type="search" placeholder="Search MCP-AQL docs, spec pages, and adapter patterns...">
           <span class="search-count" data-search-count></span>
           <ul class="search-results" data-search-results hidden></ul>
         </form>

--- a/public/launch-checklist.html
+++ b/public/launch-checklist.html
@@ -51,10 +51,10 @@
             <h3>Track A: Spec Core</h3>
             <span class="state-chip pending">In progress</span>
             <ul>
-              <li>MCP capability alignment audit</li>
-              <li>Batch/resource safeguard clarity</li>
-              <li>Structured error alignment</li>
-              <li>Conformance framework formalization</li>
+              <li><a href="https://github.com/MCPAQL/spec/issues/193">#193 MCP capability alignment audit</a></li>
+              <li><a href="https://github.com/MCPAQL/spec/issues/197">#197 batch/resource safeguard clarity</a></li>
+              <li><a href="https://github.com/MCPAQL/spec/issues/199">#199 structured error alignment</a></li>
+              <li><a href="https://github.com/MCPAQL/spec/issues/194">#194 release-plan coordination</a></li>
             </ul>
           </article>
           <article class="card">
@@ -77,6 +77,18 @@
               <li>Draft adapter pattern guidance pages</li>
             </ul>
           </article>
+        </div>
+      </section>
+
+      <section>
+        <h2 class="section-title">Public docs minimum bar</h2>
+        <div class="card">
+          <ul>
+            <li>Home page must explain the draft clearly and point readers to the versioned spec.</li>
+            <li>Docs library must cover protocol core, errors, safety, conformance, contracts, profiles, and roadmap status.</li>
+            <li>Launch pages must link the real open issues instead of implying hidden readiness criteria.</li>
+            <li>Public wording must keep canonical spec authority distinct from the Dollhouse practical profile.</li>
+          </ul>
         </div>
       </section>
 

--- a/public/search.html
+++ b/public/search.html
@@ -23,7 +23,7 @@
         </ul>
         <form class="site-search" data-search-form data-index-url="data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
-          <input id="site-search-input" data-search-input type="search" placeholder="Search docs, spec pages, and adapter guidance...">
+          <input id="site-search-input" data-search-input type="search" placeholder="Search MCP-AQL docs, spec pages, and adapter patterns...">
           <span class="search-count" data-search-count></span>
           <ul class="search-results" data-search-results hidden></ul>
         </form>

--- a/public/search.html
+++ b/public/search.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Search MCP-AQL website content across protocol docs, repo-synced spec pages, adapters, and launch guidance.">
+  <title>MCP-AQL Search</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+  <header>
+    <div class="container">
+      <nav>
+        <a class="logo" href="index.html"><span class="logo-mark"></span>MCP-AQL</a>
+        <ul class="nav-links">
+          <li><a href="index.html">Home</a></li>
+          <li><a href="docs/index.html">Docs</a></li>
+          <li><a href="spec/index.html">Full Spec</a></li>
+          <li><a href="launch-checklist.html">Launch Checklist</a></li>
+        </ul>
+        <form class="site-search" data-search-form data-index-url="data/search-index.json" role="search">
+          <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
+          <input id="site-search-input" data-search-input type="search" placeholder="Search docs, spec pages, and adapter guidance...">
+          <span class="search-count" data-search-count></span>
+          <ul class="search-results" data-search-results hidden></ul>
+        </form>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <div class="container" data-search-page data-index-url="data/search-index.json">
+      <section class="hero">
+        <div class="hero-inner">
+          <span class="status-pill">SEARCH RESULTS</span>
+          <h1>Results for <span data-search-query>all docs</span></h1>
+          <p class="lede">Search spans the summary docs, the repo-synced full spec reference, launch pages, adapter patterns, and key repository surfaces.</p>
+          <p class="search-page-count" data-search-page-count>Loading results...</p>
+        </div>
+      </section>
+
+      <section>
+        <div class="search-page-layout">
+          <div class="card search-page-help">
+            <h2>Search Tips</h2>
+            <ul>
+              <li>Try protocol terms like <code>crude</code>, <code>introspect</code>, <code>gatekeeper</code>, or <code>conformance</code>.</li>
+              <li>Search also covers the full website-hosted spec mirror under <a href="spec/index.html">Full Spec</a>.</li>
+              <li>If you are looking for the normative draft, try <code>v1.0.0</code> or <code>versions</code>.</li>
+            </ul>
+          </div>
+
+          <div>
+            <div class="card search-page-empty" data-search-page-empty hidden>
+              <h2>No results yet</h2>
+              <p>Try a broader term or use protocol vocabulary from the docs and spec.</p>
+            </div>
+            <ul class="search-page-results" data-search-page-results></ul>
+          </div>
+        </div>
+      </section>
+    </div>
+  </main>
+
+  <footer>
+    <div class="container">
+      <p>&copy; 2026 DollhouseMCP Inc. d/b/a Dollhouse Research. MCP-AQL public draft documentation portal.</p>
+      <div class="footer-links">
+        <a href="docs/index.html">Documentation Library</a>
+        <a href="spec/index.html">Repo-Synced Spec</a>
+        <a href="https://github.com/MCPAQL">MCPAQL Organization</a>
+        <a href="https://dollhouseresearch.com">Dollhouse Research</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="js/search.js"></script>
+</body>
+</html>

--- a/public/spec/README.html
+++ b/public/spec/README.html
@@ -73,6 +73,13 @@
       </aside>
 
       <article class="docs-main">
+        <nav class="breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../index.html">Home</a></li>
+            <li><a href="index.html">Full Spec</a></li>
+            <li><span class="current">MCP-AQL Specification Documentation</span></li>
+          </ol>
+        </nav>
         <section class="hero docs-hero">
           <div class="hero-inner">
             <span class="status-pill">REPO-SYNCED SPEC DOC</span>

--- a/public/spec/README.html
+++ b/public/spec/README.html
@@ -23,7 +23,7 @@
         </ul>
         <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
-          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <input id="site-search-input" data-search-input type="search" placeholder="Search MCP-AQL docs, spec pages, and adapter patterns...">
           <span class="search-count" data-search-count></span>
           <ul class="search-results" data-search-results hidden></ul>
         </form>
@@ -38,7 +38,7 @@
         <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
         <div class="docs-side-group">
   <h3>Core</h3>
-  <ul><li><a href="conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="error-codes.html">Structured Error Codes Specification</a></li><li><a href="introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="mcp-integration.html">MCP Integration Specification</a></li><li><a href="operations.html">MCP-AQL Operations Specification</a></li><li><a href="overview.html">MCP-AQL Protocol Overview</a></li><li><a href="plugin-contracts.html">Plugin Interface Contracts</a></li><li><a class="current" href="README.html">MCP-AQL Specification Documentation</a></li><li><a href="repo/README.html">MCP-AQL Specification</a></li></ul>
+  <ul><li><a href="conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="error-codes.html">Structured Error Codes Specification</a></li><li><a href="introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="mcp-integration.html">MCP Integration Specification</a></li><li><a href="operations.html">MCP-AQL Operations Specification</a></li><li><a href="overview.html">MCP-AQL Protocol Overview</a></li><li><a href="plugin-contracts.html">Plugin Interface Contracts</a></li><li><a class="current" aria-current="page" href="README.html">MCP-AQL Specification Documentation</a></li><li><a href="repo/README.html">MCP-AQL Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Versions</h3>
   <ul><li><a href="versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
@@ -346,6 +346,16 @@
 
           </div>
         </section>
+        <nav class="page-nav" aria-label="Page navigation">
+  <a class="page-nav-link prev" href="plugin-contracts.html">
+    <span class="page-nav-eyebrow">Previous spec page</span>
+    <strong class="page-nav-label">Plugin Interface Contracts</strong>
+  </a>
+  <a class="page-nav-link next" href="repo/README.html">
+    <span class="page-nav-eyebrow">Next spec page</span>
+    <strong class="page-nav-label">MCP-AQL Specification</strong>
+  </a>
+</nav>
       </article>
     </div>
   </main>

--- a/public/spec/README.html
+++ b/public/spec/README.html
@@ -1,0 +1,360 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="This directory contains the MCP-AQL specification set:">
+  <title>MCP-AQL Spec | MCP-AQL Specification Documentation</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../css/style.css">
+</head>
+<body>
+  <header>
+    <div class="container">
+      <nav>
+        <a class="logo" href="../index.html"><span class="logo-mark"></span>MCP-AQL</a>
+        <ul class="nav-links">
+          <li><a href="../index.html">Home</a></li>
+          <li><a href="../docs/index.html">Docs</a></li>
+          <li><a href="../launch-checklist.html">Launch Checklist</a></li>
+          <li><a href="../apis/mcp-server.html">Adapter Patterns</a></li>
+        </ul>
+        <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
+          <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
+          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <span class="search-count" data-search-count></span>
+          <ul class="search-results" data-search-results hidden></ul>
+        </form>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <div class="container docs-shell">
+      <aside class="docs-side">
+        <h2>Repo-Synced Spec</h2>
+        <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
+        <div class="docs-side-group">
+  <h3>Core</h3>
+  <ul><li><a href="conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="error-codes.html">Structured Error Codes Specification</a></li><li><a href="introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="mcp-integration.html">MCP Integration Specification</a></li><li><a href="operations.html">MCP-AQL Operations Specification</a></li><li><a href="overview.html">MCP-AQL Protocol Overview</a></li><li><a href="plugin-contracts.html">Plugin Interface Contracts</a></li><li><a class="current" href="README.html">MCP-AQL Specification Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Versions</h3>
+  <ul><li><a href="versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Adapter</h3>
+  <ul><li><a href="adapter/danger-levels.html">Dangerous Operation Classification Specification</a></li><li><a href="adapter/discovery-bundle.html">MCP Server Discovery Bundle</a></li><li><a href="adapter/element-type.html">Adapter Element Type Specification</a></li><li><a href="adapter/generator.html">Adapter Generator Specification</a></li><li><a href="adapter/rate-limiting.html">Rate Limiting and Quota Management Specification</a></li><li><a href="adapter/trust-levels.html">Trust Levels Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Security</h3>
+  <ul><li><a href="security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Features</h3>
+  <ul><li><a href="features/field-selection.html">Field Selection Specification</a></li><li><a href="features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="features/warnings.html">Warnings Array Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Guides</h3>
+  <ul><li><a href="guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="guides/README.html">Developer Guides</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Process</h3>
+  <ul><li><a href="process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="process/versioning.html">Versioning Strategy</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Architecture</h3>
+  <ul><li><a href="architecture/README.html">Architecture Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Research</h3>
+  <ul><li><a href="research/mcp-vs-mcpaql-vs-a2a.html">Protocol Landscape: MCP vs MCP-AQL vs A2A</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Reference</h3>
+  <ul><li><a href="reference/README.html">Reference Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>ADRs</h3>
+  <ul><li><a href="adr/ADR-001-crude-pattern.html">ADR-001: CRUDE Pattern (Extending CRUD with Execute)</a></li><li><a href="adr/ADR-002-graphql-style-input.html">ADR-002: GraphQL-Style Input Objects for Updates</a></li><li><a href="adr/ADR-003-snake-case-parameters.html">ADR-003: snake_case Parameter Convention</a></li><li><a href="adr/ADR-004-schema-driven-operations.html">ADR-004: Schema-Driven Operation Definitions</a></li><li><a href="adr/ADR-005-introspection-system.html">ADR-005: GraphQL-Style Introspection System</a></li><li><a href="adr/ADR-006-discriminated-responses.html">ADR-006: Discriminated Response Format</a></li><li><a href="adr/index.html">Architecture Decision Records</a></li><li><a href="adr/README.html">Architecture Decision Records</a></li></ul>
+</div>
+      </aside>
+
+      <article class="docs-main">
+        <section class="hero docs-hero">
+          <div class="hero-inner">
+            <span class="status-pill">REPO-SYNCED SPEC DOC</span>
+            <h1>MCP-AQL Specification Documentation</h1>
+            <p class="lede">This directory contains the MCP-AQL specification set:</p>
+            <div class="spec-meta"><span class="state-chip live">Support document</span></div>
+            <p class="spec-source">Source: <a href="https://github.com/MCPAQL/spec/blob/main/docs/README.md">spec/docs/README.md</a></p>
+            <div class="hero-actions">
+              <a class="btn btn-primary" href="https://github.com/MCPAQL/spec/blob/main/docs/README.md">Open Source Markdown</a>
+              <a class="btn btn-secondary" href="index.html">Browse Full Spec Reference</a>
+            </div>
+          </div>
+        </section>
+
+        <section>
+          <div class="card spec-prose">
+            <p>This directory contains the MCP-AQL specification set:</p>
+<ul>
+<li><strong>Normative source:</strong> <a href="versions/v1.0.0-draft.html">versions/v1.0.0-draft.md</a></li>
+<li><strong>Informative support documents:</strong> all other files under <code>docs/</code></li>
+</ul>
+<p>In case of conflict, the versioned normative document takes precedence.</p>
+<p>Implementation architecture documentation is maintained in the <a href="https://github.com/MCPAQL/mcpaql-adapter">mcpaql-adapter</a> repository. Example adapters are in the <a href="https://github.com/MCPAQL/examples">examples</a> repository.</p>
+<h2 id="document-organization">Document Organization</h2>
+<h3 id="core-specification">Core Specification</h3>
+<table>
+<thead>
+<tr>
+<th>Document</th>
+<th>Description</th>
+<th>Status</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a href="versions/v1.0.0-draft.html">v1.0.0-draft</a></td>
+<td>Current specification version</td>
+<td>Draft</td>
+</tr>
+<tr>
+<td><a href="crude-pattern.html">CRUDE Pattern</a></td>
+<td>Endpoint semantics and routing</td>
+<td>Draft</td>
+</tr>
+<tr>
+<td><a href="endpoint-modes.html">Endpoint Modes</a></td>
+<td>CRUDE vs Single mode configuration</td>
+<td>Draft</td>
+</tr>
+<tr>
+<td><a href="introspection.html">Introspection</a></td>
+<td>Runtime discovery system</td>
+<td>Draft</td>
+</tr>
+<tr>
+<td><a href="operations.html">Operations</a></td>
+<td>Operation design guide</td>
+<td>Draft</td>
+</tr>
+<tr>
+<td><a href="error-codes.html">Error Codes</a></td>
+<td>Structured error code system</td>
+<td>Draft (MVP)</td>
+</tr>
+<tr>
+<td><a href="conformance-testing.html">Conformance Testing</a></td>
+<td>Test requirements and evaluation methodology</td>
+<td>Draft</td>
+</tr>
+</tbody>
+</table>
+<h3 id="plugin--adapter-contracts">Plugin &amp; Adapter Contracts</h3>
+<table>
+<thead>
+<tr>
+<th>Document</th>
+<th>Description</th>
+<th>Status</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a href="plugin-contracts.html">Plugin Interface Contracts</a></td>
+<td>What each plugin type MUST provide</td>
+<td>Draft (MVP)</td>
+</tr>
+<tr>
+<td><a href="adapter/element-type.html">Element Type Specification</a></td>
+<td>Declarative adapter schema format</td>
+<td>Draft (MVP)</td>
+</tr>
+<tr>
+<td><a href="adapter/discovery-bundle.html">MCP Server Discovery Bundle</a></td>
+<td>Raw capture + normalized bundle contract for generator pipelines</td>
+<td>Draft</td>
+</tr>
+</tbody>
+</table>
+<h3 id="features">Features</h3>
+<table>
+<thead>
+<tr>
+<th>Document</th>
+<th>Description</th>
+<th>Impl Status</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a href="features/field-selection.html">Field Selection</a></td>
+<td>GraphQL-style response filtering</td>
+<td>Implemented</td>
+</tr>
+</tbody>
+</table>
+<h3 id="security">Security</h3>
+<table>
+<thead>
+<tr>
+<th>Document</th>
+<th>Description</th>
+<th>Impl Status</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a href="security/gatekeeper.html">Gatekeeper</a></td>
+<td>Multi-layer access control</td>
+<td>Implemented</td>
+</tr>
+</tbody>
+</table>
+<h3 id="process">Process</h3>
+<table>
+<thead>
+<tr>
+<th>Document</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a href="process/rfc-process.html">RFC Process</a></td>
+<td>How to propose specification changes</td>
+</tr>
+<tr>
+<td><a href="process/breaking-changes.html">Breaking Changes</a></td>
+<td>Policy for handling breaking changes</td>
+</tr>
+<tr>
+<td><a href="process/versioning.html">Versioning</a></td>
+<td>Version numbering and release process</td>
+</tr>
+<tr>
+<td><a href="process/preliminary-public-launch-checklist.html">Preliminary Launch Checklist</a></td>
+<td>Coordinated draft-launch criteria</td>
+</tr>
+</tbody>
+</table>
+<h3 id="guides">Guides</h3>
+<table>
+<thead>
+<tr>
+<th>Document</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a href="guides/protocol-comparison.html">Protocol Comparison</a></td>
+<td>MCP-AQL vs other protocols</td>
+</tr>
+</tbody>
+</table>
+<h3 id="roadmap">Roadmap</h3>
+<p>Future features are tracked as GitHub issues. Key upcoming features:</p>
+<p><strong>Phase 0 - MVP Core:</strong></p>
+<ul>
+<li>Adapter Element Type (#61)</li>
+<li>Plugin Interface (#62)</li>
+<li>Universal Adapter Runtime (#63)</li>
+<li>Structured error codes (#35)</li>
+</ul>
+<p><strong>Phase 1 - Robustness:</strong></p>
+<ul>
+<li>Trust levels (#59)</li>
+<li>Dangerous operation classification (#49)</li>
+<li>Rate limiting (#60)</li>
+<li>Cursor-based pagination (#37)</li>
+</ul>
+<p><strong>Phase 2+ - Advanced:</strong></p>
+<ul>
+<li>Computed fields (#42)</li>
+<li>Streaming responses (#43)</li>
+<li>Relationship queries (#44)</li>
+<li>Schema versioning (#48)</li>
+</ul>
+<h2 id="reading-order">Reading Order</h2>
+<p>For newcomers to MCP-AQL:</p>
+<ol type="1">
+<li><strong><a href="versions/v1.0.0-draft.html">v1.0.0-draft</a></strong> - Start with the main specification</li>
+<li><strong><a href="crude-pattern.html">CRUDE Pattern</a></strong> - Understand the endpoint semantics</li>
+<li><strong><a href="operations.html">Operations</a></strong> - Learn operation design patterns</li>
+<li><strong><a href="introspection.html">Introspection</a></strong> - Learn the discovery system</li>
+<li><strong><a href="conformance-testing.html">Conformance Testing</a></strong> - Understand conformance requirements</li>
+</ol>
+<p>For adapter developers:</p>
+<ol type="1">
+<li><strong><a href="adapter/element-type.html">Element Type Specification</a></strong> - Declarative schema format</li>
+<li><strong><a href="plugin-contracts.html">Plugin Interface Contracts</a></strong> - Plugin system contracts</li>
+<li><strong><a href="https://github.com/MCPAQL/mcpaql-adapter/blob/develop/docs/architecture/overview.md">Architecture Overview</a></strong> - Understand adapter structure (in mcpaql-adapter repo)</li>
+<li><strong><a href="https://github.com/MCPAQL/mcpaql-adapter/blob/develop/docs/guides/development.md">Development Guide</a></strong> - Implementation walkthrough (in mcpaql-adapter repo)</li>
+<li><strong><a href="security/gatekeeper.html">Gatekeeper</a></strong> - Security implementation</li>
+</ol>
+<h2 id="cross-repository-content">Cross-Repository Content</h2>
+<p>MCP-AQL follows a four-level protocol model:</p>
+<table>
+<thead>
+<tr>
+<th>Level</th>
+<th>What</th>
+<th>Normative?</th>
+<th>Repository</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>1. Wire format</td>
+<td>Request/response JSON, error codes, introspection</td>
+<td>MUST</td>
+<td><strong>this repo</strong></td>
+</tr>
+<tr>
+<td>2. Schema semantics</td>
+<td>Operation declarations, params, auth, target</td>
+<td>MUST/SHOULD</td>
+<td><strong>this repo</strong></td>
+</tr>
+<tr>
+<td>3. Canonical format</td>
+<td>Markdown + YAML front matter interchange format</td>
+<td>SHOULD</td>
+<td><strong>this repo</strong></td>
+</tr>
+<tr>
+<td>4. Implementation guidance</td>
+<td>Runtime architecture, plugin pipeline, dispatch</td>
+<td>Non-normative</td>
+<td><a href="https://github.com/MCPAQL/mcpaql-adapter">mcpaql-adapter</a></td>
+</tr>
+</tbody>
+</table>
+<p>Example adapters: <a href="https://github.com/MCPAQL/examples">examples</a></p>
+<h2 id="reference-profile">Reference Profile</h2>
+<p><a href="https://github.com/DollhouseMCP/mcp-server">DollhouseMCP</a> is treated as a practical reference profile for MCP-AQL. It validates feasibility at scale, but protocol authority remains with the normative specification in this repository.</p>
+<h2 id="contributing">Contributing</h2>
+<p>See <a href="https://github.com/MCPAQL/spec/blob/main/CONTRIBUTING.md">CONTRIBUTING.md</a> for guidelines on contributing to the specification.</p>
+<h2 id="license">License</h2>
+<ul>
+<li><strong>Specification text</strong>: CC BY 4.0</li>
+<li><strong>Code/schemas/tests</strong>: AGPL-3.0</li>
+</ul>
+<p>See <a href="https://github.com/MCPAQL/spec/blob/main/LICENSING.md">LICENSING.md</a> for details.</p>
+
+          </div>
+        </section>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div class="container">
+      <p>&copy; 2026 DollhouseMCP Inc. d/b/a Dollhouse Research. MCP-AQL public draft documentation portal.</p>
+      <div class="footer-links">
+        <a href="../docs/index.html">Docs Library</a>
+        <a href="index.html">Repo-Synced Spec</a>
+        <a href="https://github.com/MCPAQL">MCPAQL Organization</a>
+        <a href="https://dollhouseresearch.com">Dollhouse Research</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../js/search.js"></script>
+</body>
+</html>

--- a/public/spec/README.html
+++ b/public/spec/README.html
@@ -38,7 +38,7 @@
         <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
         <div class="docs-side-group">
   <h3>Core</h3>
-  <ul><li><a href="conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="error-codes.html">Structured Error Codes Specification</a></li><li><a href="introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="mcp-integration.html">MCP Integration Specification</a></li><li><a href="operations.html">MCP-AQL Operations Specification</a></li><li><a href="overview.html">MCP-AQL Protocol Overview</a></li><li><a href="plugin-contracts.html">Plugin Interface Contracts</a></li><li><a class="current" href="README.html">MCP-AQL Specification Documentation</a></li></ul>
+  <ul><li><a href="conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="error-codes.html">Structured Error Codes Specification</a></li><li><a href="introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="mcp-integration.html">MCP Integration Specification</a></li><li><a href="operations.html">MCP-AQL Operations Specification</a></li><li><a href="overview.html">MCP-AQL Protocol Overview</a></li><li><a href="plugin-contracts.html">Plugin Interface Contracts</a></li><li><a class="current" href="README.html">MCP-AQL Specification Documentation</a></li><li><a href="repo/README.html">MCP-AQL Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Versions</h3>
   <ul><li><a href="versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
@@ -56,7 +56,7 @@
   <ul><li><a href="guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
-  <ul><li><a href="process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="process/versioning.html">Versioning Strategy</a></li></ul>
+  <ul><li><a href="process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="process/versioning.html">Versioning Strategy</a></li><li><a href="repo/CHANGELOG.html">Changelog</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Architecture</h3>
   <ul><li><a href="architecture/README.html">Architecture Documentation</a></li></ul>

--- a/public/spec/adapter/danger-levels.html
+++ b/public/spec/adapter/danger-levels.html
@@ -73,6 +73,13 @@
       </aside>
 
       <article class="docs-main">
+        <nav class="breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../../index.html">Home</a></li>
+            <li><a href="../index.html">Full Spec</a></li>
+            <li><span class="current">Dangerous Operation Classification Specification</span></li>
+          </ol>
+        </nav>
         <section class="hero docs-hero">
           <div class="hero-inner">
             <span class="status-pill">REPO-SYNCED SPEC DOC</span>

--- a/public/spec/adapter/danger-levels.html
+++ b/public/spec/adapter/danger-levels.html
@@ -38,7 +38,7 @@
         <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
         <div class="docs-side-group">
   <h3>Core</h3>
-  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li></ul>
+  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li><li><a href="../repo/README.html">MCP-AQL Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Versions</h3>
   <ul><li><a href="../versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
@@ -56,7 +56,7 @@
   <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
-  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li></ul>
+  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li><li><a href="../repo/CHANGELOG.html">Changelog</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Architecture</h3>
   <ul><li><a href="../architecture/README.html">Architecture Documentation</a></li></ul>

--- a/public/spec/adapter/danger-levels.html
+++ b/public/spec/adapter/danger-levels.html
@@ -1,0 +1,913 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="This document defines a standard classification system for dangerous operations in MCP-AQL adapters. Danger levels enable automatic lockdown of high-risk actions, consistent confirmation requirements, and trust-based per">
+  <title>MCP-AQL Spec | Dangerous Operation Classification Specification</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../../css/style.css">
+</head>
+<body>
+  <header>
+    <div class="container">
+      <nav>
+        <a class="logo" href="../../index.html"><span class="logo-mark"></span>MCP-AQL</a>
+        <ul class="nav-links">
+          <li><a href="../../index.html">Home</a></li>
+          <li><a href="../../docs/index.html">Docs</a></li>
+          <li><a href="../../launch-checklist.html">Launch Checklist</a></li>
+          <li><a href="../../apis/mcp-server.html">Adapter Patterns</a></li>
+        </ul>
+        <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
+          <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
+          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <span class="search-count" data-search-count></span>
+          <ul class="search-results" data-search-results hidden></ul>
+        </form>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <div class="container docs-shell">
+      <aside class="docs-side">
+        <h2>Repo-Synced Spec</h2>
+        <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
+        <div class="docs-side-group">
+  <h3>Core</h3>
+  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Versions</h3>
+  <ul><li><a href="../versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Adapter</h3>
+  <ul><li><a class="current" href="danger-levels.html">Dangerous Operation Classification Specification</a></li><li><a href="discovery-bundle.html">MCP Server Discovery Bundle</a></li><li><a href="element-type.html">Adapter Element Type Specification</a></li><li><a href="generator.html">Adapter Generator Specification</a></li><li><a href="rate-limiting.html">Rate Limiting and Quota Management Specification</a></li><li><a href="trust-levels.html">Trust Levels Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Security</h3>
+  <ul><li><a href="../security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="../security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="../security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Features</h3>
+  <ul><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Guides</h3>
+  <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Process</h3>
+  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Architecture</h3>
+  <ul><li><a href="../architecture/README.html">Architecture Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Research</h3>
+  <ul><li><a href="../research/mcp-vs-mcpaql-vs-a2a.html">Protocol Landscape: MCP vs MCP-AQL vs A2A</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Reference</h3>
+  <ul><li><a href="../reference/README.html">Reference Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>ADRs</h3>
+  <ul><li><a href="../adr/ADR-001-crude-pattern.html">ADR-001: CRUDE Pattern (Extending CRUD with Execute)</a></li><li><a href="../adr/ADR-002-graphql-style-input.html">ADR-002: GraphQL-Style Input Objects for Updates</a></li><li><a href="../adr/ADR-003-snake-case-parameters.html">ADR-003: snake_case Parameter Convention</a></li><li><a href="../adr/ADR-004-schema-driven-operations.html">ADR-004: Schema-Driven Operation Definitions</a></li><li><a href="../adr/ADR-005-introspection-system.html">ADR-005: GraphQL-Style Introspection System</a></li><li><a href="../adr/ADR-006-discriminated-responses.html">ADR-006: Discriminated Response Format</a></li><li><a href="../adr/index.html">Architecture Decision Records</a></li><li><a href="../adr/README.html">Architecture Decision Records</a></li></ul>
+</div>
+      </aside>
+
+      <article class="docs-main">
+        <section class="hero docs-hero">
+          <div class="hero-inner">
+            <span class="status-pill">REPO-SYNCED SPEC DOC</span>
+            <h1>Dangerous Operation Classification Specification</h1>
+            <p class="lede">This document defines a standard classification system for dangerous operations in MCP-AQL adapters. Danger levels enable automatic lockdown of high-risk actions, consistent confirmation requirements, and trust-based per</p>
+            <div class="spec-meta"><span class="state-chip live">Support document</span><span class="state-chip pending">Draft</span><span class="state-chip">1.0.0-draft</span><span class="state-chip">2026-01-28</span></div>
+            <p class="spec-source">Source: <a href="https://github.com/MCPAQL/spec/blob/main/docs/adapter/danger-levels.md">spec/docs/adapter/danger-levels.md</a></p>
+            <div class="hero-actions">
+              <a class="btn btn-primary" href="https://github.com/MCPAQL/spec/blob/main/docs/adapter/danger-levels.md">Open Source Markdown</a>
+              <a class="btn btn-secondary" href="../index.html">Browse Full Spec Reference</a>
+            </div>
+          </div>
+        </section>
+
+        <section>
+          <div class="card spec-prose">
+            <p><strong>Version:</strong> 1.0.0-draft <strong>Status:</strong> Draft <strong>Last Updated:</strong> 2026-01-28</p>
+<h2 id="abstract">Abstract</h2>
+<p>This document defines a standard classification system for dangerous operations in MCP-AQL adapters. Danger levels enable automatic lockdown of high-risk actions, consistent confirmation requirements, and trust-based permission gating.</p>
+<hr />
+<h2 id="table-of-contents">Table of Contents</h2>
+<ol type="1">
+<li><a href="#1-overview">Overview</a></li>
+<li><a href="#2-danger-level-enum">Danger Level Enum</a></li>
+<li><a href="#3-operation-schema">Operation Schema</a></li>
+<li><a href="#4-trust-to-danger-gating">Trust-to-Danger Gating</a></li>
+<li><a href="#5-automatic-lockdown">Automatic Lockdown</a></li>
+<li><a href="#6-standard-dangerous-patterns">Standard Dangerous Patterns</a></li>
+<li><a href="#7-implementation-requirements">Implementation Requirements</a></li>
+<li><a href="#8-danger-zone-enforcement-during-execution">Danger Zone Enforcement During Execution</a></li>
+<li><a href="#9-future-extensions">Future Extensions</a></li>
+</ol>
+<hr />
+<h2 id="1-overview">1. Overview</h2>
+<h3 id="11-purpose">1.1 Purpose</h3>
+<p>MCP-AQL adapters expose operations that can have significant consequences:</p>
+<ul>
+<li><strong>Data modification</strong> - Creating, updating, or deleting resources</li>
+<li><strong>Irreversible actions</strong> - Operations that cannot be undone</li>
+<li><strong>Bulk operations</strong> - Actions affecting multiple resources</li>
+<li><strong>System-level changes</strong> - Configuration or access modifications</li>
+</ul>
+<p>Danger levels provide a standardized framework for:</p>
+<ul>
+<li><strong>Risk classification</strong> - Categorize operations by potential harm</li>
+<li><strong>Confirmation requirements</strong> - Require acknowledgment for risky actions</li>
+<li><strong>Trust-based gating</strong> - Restrict operations based on adapter trust level</li>
+<li><strong>Consistent UX</strong> - Uniform handling across different adapters</li>
+</ul>
+<h3 id="12-design-principles">1.2 Design Principles</h3>
+<ol type="1">
+<li><strong>Safe by default</strong> - Operations without classification treated as potentially dangerous</li>
+<li><strong>Explicit classification</strong> - Adapter authors declare danger levels</li>
+<li><strong>Progressive escalation</strong> - Higher danger requires stronger safeguards</li>
+<li><strong>Auditable decisions</strong> - All dangerous operation attempts logged</li>
+</ol>
+<h3 id="13-inspiration">1.3 Inspiration</h3>
+<p>This specification is inspired by:</p>
+<ul>
+<li>Claude Code's dangerous git operation handling (force push, hard reset)</li>
+<li>Database permission systems (SELECT vs DELETE vs DROP)</li>
+<li>Unix file permissions (read, write, execute escalation)</li>
+</ul>
+<h3 id="14-relationship-to-trust-levels">1.4 Relationship to Trust Levels</h3>
+<p>Danger levels work in conjunction with trust levels (see <a href="trust-levels.html">Trust Levels</a>):</p>
+<ul>
+<li><strong>Trust levels</strong> describe adapter reliability (who vouches for it)</li>
+<li><strong>Danger levels</strong> describe operation risk (what harm could occur)</li>
+<li><strong>Gating matrix</strong> combines both to determine if operation is permitted</li>
+</ul>
+<hr />
+<h2 id="2-danger-level-enum">2. Danger Level Enum</h2>
+<h3 id="21-danger-level-values">2.1 Danger Level Values</h3>
+<table>
+<thead>
+<tr>
+<th>Level</th>
+<th>Value</th>
+<th>Name</th>
+<th>Behavior</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>0</td>
+<td><code>safe</code></td>
+<td>Safe</td>
+<td>No restrictions</td>
+</tr>
+<tr>
+<td>1</td>
+<td><code>reversible</code></td>
+<td>Reversible</td>
+<td>Standard confirmation</td>
+</tr>
+<tr>
+<td>2</td>
+<td><code>destructive</code></td>
+<td>Destructive</td>
+<td>Enhanced confirmation</td>
+</tr>
+<tr>
+<td>3</td>
+<td><code>dangerous</code></td>
+<td>Dangerous</td>
+<td>Explicit unlock required</td>
+</tr>
+<tr>
+<td>4</td>
+<td><code>forbidden</code></td>
+<td>Forbidden</td>
+<td>Blocked unless admin override</td>
+</tr>
+</tbody>
+</table>
+<h3 id="22-level-descriptions">2.2 Level Descriptions</h3>
+<h4 id="221-safe-level-0">2.2.1 safe (Level 0)</h4>
+<p>Operations that cannot cause harm and are always permitted.</p>
+<p><strong>Characteristics:</strong></p>
+<ul>
+<li>Read-only operations</li>
+<li>No state modification</li>
+<li>No external effects</li>
+<li>Fully reversible (N/A - no changes made)</li>
+</ul>
+<p><strong>Examples:</strong></p>
+<ul>
+<li>List resources</li>
+<li>Get resource details</li>
+<li>Search operations</li>
+<li>Introspection queries</li>
+</ul>
+<h4 id="222-reversible-level-1">2.2.2 reversible (Level 1)</h4>
+<p>Operations that modify state but whose effects can typically be undone.</p>
+<p><strong>Characteristics:</strong></p>
+<ul>
+<li>Creates new resources</li>
+<li>Modifies existing data</li>
+<li>Changes are typically reversible</li>
+<li>Affects single resources</li>
+</ul>
+<p><strong>Examples:</strong></p>
+<ul>
+<li>Create a new record</li>
+<li>Update existing fields</li>
+<li>Add permissions</li>
+<li>Enable features</li>
+</ul>
+<h4 id="223-destructive-level-2">2.2.3 destructive (Level 2)</h4>
+<p>Operations that remove or significantly alter data, requiring enhanced confirmation.</p>
+<p><strong>Characteristics:</strong></p>
+<ul>
+<li>Deletes resources</li>
+<li>Overwrites data</li>
+<li>May affect dependent resources</li>
+<li>Partially reversible (with effort)</li>
+</ul>
+<p><strong>Examples:</strong></p>
+<ul>
+<li>Delete a single resource</li>
+<li>Overwrite file contents</li>
+<li>Remove permissions</li>
+<li>Archive/disable resources</li>
+</ul>
+<h4 id="224-dangerous-level-3">2.2.4 dangerous (Level 3)</h4>
+<p>Operations that can cause significant harm and require explicit unlock.</p>
+<p><strong>Characteristics:</strong></p>
+<ul>
+<li>Bulk modifications</li>
+<li>Bypasses safety checks</li>
+<li>Affects multiple resources</li>
+<li>Difficult or impossible to reverse</li>
+</ul>
+<p><strong>Examples:</strong></p>
+<ul>
+<li>Force push (overwrites history)</li>
+<li>Bulk delete operations</li>
+<li>Override safety validations</li>
+<li>Clear audit logs</li>
+</ul>
+<h4 id="225-forbidden-level-4">2.2.5 forbidden (Level 4)</h4>
+<p>Operations that should never be performed without administrator override.</p>
+<p><strong>Characteristics:</strong></p>
+<ul>
+<li>Catastrophic potential</li>
+<li>System-wide impact</li>
+<li>Cannot be undone</li>
+<li>Production environment risks</li>
+</ul>
+<p><strong>Examples:</strong></p>
+<ul>
+<li>Drop database/table</li>
+<li>Delete all records</li>
+<li>Reset to factory state</li>
+<li>Production data mutations</li>
+<li>Truncate operations</li>
+</ul>
+<hr />
+<h2 id="3-operation-schema">3. Operation Schema</h2>
+<h3 id="31-danger-metadata-in-operations">3.1 Danger Metadata in Operations</h3>
+<p>Operations declare danger level in their schema:</p>
+<div class="sourceCode" id="cb1"><pre class="sourceCode yaml"><code class="sourceCode yaml"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a><span class="fu">operations</span><span class="kw">:</span></span>
+<span id="cb1-2"><a href="#cb1-2" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">delete</span><span class="kw">:</span></span>
+<span id="cb1-3"><a href="#cb1-3" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="kw">-</span><span class="at"> </span><span class="fu">name</span><span class="kw">:</span><span class="at"> delete_repo</span></span>
+<span id="cb1-4"><a href="#cb1-4" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">maps_to</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;DELETE /repos/{owner}/{repo}&quot;</span></span>
+<span id="cb1-5"><a href="#cb1-5" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">description</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;Permanently delete a repository&quot;</span></span>
+<span id="cb1-6"><a href="#cb1-6" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">danger</span><span class="kw">:</span></span>
+<span id="cb1-7"><a href="#cb1-7" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">level</span><span class="kw">:</span><span class="at"> destructive</span></span>
+<span id="cb1-8"><a href="#cb1-8" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">reasons</span><span class="kw">:</span></span>
+<span id="cb1-9"><a href="#cb1-9" aria-hidden="true" tabindex="-1"></a><span class="at">          </span><span class="kw">-</span><span class="at"> </span><span class="st">&quot;Permanently removes repository and all contents&quot;</span></span>
+<span id="cb1-10"><a href="#cb1-10" aria-hidden="true" tabindex="-1"></a><span class="at">          </span><span class="kw">-</span><span class="at"> </span><span class="st">&quot;Cannot be recovered after grace period&quot;</span></span>
+<span id="cb1-11"><a href="#cb1-11" aria-hidden="true" tabindex="-1"></a><span class="at">          </span><span class="kw">-</span><span class="at"> </span><span class="st">&quot;Affects forks and dependent projects&quot;</span></span>
+<span id="cb1-12"><a href="#cb1-12" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">confirmation_message</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;Delete repository &#39;{owner}/{repo}&#39;? This cannot be undone.&quot;</span></span>
+<span id="cb1-13"><a href="#cb1-13" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">cooldown_seconds</span><span class="kw">:</span><span class="at"> </span><span class="dv">5</span></span></code></pre></div>
+<h3 id="32-danger-block-schema">3.2 Danger Block Schema</h3>
+<div class="sourceCode" id="cb2"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="kw">interface</span> DangerMetadata {</span>
+<span id="cb2-2"><a href="#cb2-2" aria-hidden="true" tabindex="-1"></a>  <span class="co">/**</span></span>
+<span id="cb2-3"><a href="#cb2-3" aria-hidden="true" tabindex="-1"></a><span class="co">   * Danger level (0-4)</span></span>
+<span id="cb2-4"><a href="#cb2-4" aria-hidden="true" tabindex="-1"></a><span class="co">   * Default: inferred from CRUDE category</span></span>
+<span id="cb2-5"><a href="#cb2-5" aria-hidden="true" tabindex="-1"></a><span class="co">   */</span></span>
+<span id="cb2-6"><a href="#cb2-6" aria-hidden="true" tabindex="-1"></a>  level<span class="op">:</span> <span class="st">&#39;safe&#39;</span> <span class="op">|</span> <span class="st">&#39;reversible&#39;</span> <span class="op">|</span> <span class="st">&#39;destructive&#39;</span> <span class="op">|</span> <span class="st">&#39;dangerous&#39;</span> <span class="op">|</span> <span class="st">&#39;forbidden&#39;</span><span class="op">;</span></span>
+<span id="cb2-7"><a href="#cb2-7" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb2-8"><a href="#cb2-8" aria-hidden="true" tabindex="-1"></a>  <span class="co">/**</span></span>
+<span id="cb2-9"><a href="#cb2-9" aria-hidden="true" tabindex="-1"></a><span class="co">   * Human-readable explanations of why this is dangerous</span></span>
+<span id="cb2-10"><a href="#cb2-10" aria-hidden="true" tabindex="-1"></a><span class="co">   */</span></span>
+<span id="cb2-11"><a href="#cb2-11" aria-hidden="true" tabindex="-1"></a>  reasons<span class="op">?:</span> <span class="dt">string</span>[]<span class="op">;</span></span>
+<span id="cb2-12"><a href="#cb2-12" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb2-13"><a href="#cb2-13" aria-hidden="true" tabindex="-1"></a>  <span class="co">/**</span></span>
+<span id="cb2-14"><a href="#cb2-14" aria-hidden="true" tabindex="-1"></a><span class="co">   * Custom confirmation message template</span></span>
+<span id="cb2-15"><a href="#cb2-15" aria-hidden="true" tabindex="-1"></a><span class="co">   * Supports {param} interpolation</span></span>
+<span id="cb2-16"><a href="#cb2-16" aria-hidden="true" tabindex="-1"></a><span class="co">   */</span></span>
+<span id="cb2-17"><a href="#cb2-17" aria-hidden="true" tabindex="-1"></a>  confirmation_message<span class="op">?:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb2-18"><a href="#cb2-18" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb2-19"><a href="#cb2-19" aria-hidden="true" tabindex="-1"></a>  <span class="co">/**</span></span>
+<span id="cb2-20"><a href="#cb2-20" aria-hidden="true" tabindex="-1"></a><span class="co">   * Minimum seconds between confirmation and execution</span></span>
+<span id="cb2-21"><a href="#cb2-21" aria-hidden="true" tabindex="-1"></a><span class="co">   * Gives user time to reconsider</span></span>
+<span id="cb2-22"><a href="#cb2-22" aria-hidden="true" tabindex="-1"></a><span class="co">   */</span></span>
+<span id="cb2-23"><a href="#cb2-23" aria-hidden="true" tabindex="-1"></a>  cooldown_seconds<span class="op">?:</span> <span class="dt">number</span><span class="op">;</span></span>
+<span id="cb2-24"><a href="#cb2-24" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb2-25"><a href="#cb2-25" aria-hidden="true" tabindex="-1"></a>  <span class="co">/**</span></span>
+<span id="cb2-26"><a href="#cb2-26" aria-hidden="true" tabindex="-1"></a><span class="co">   * Requires re-authentication before execution</span></span>
+<span id="cb2-27"><a href="#cb2-27" aria-hidden="true" tabindex="-1"></a><span class="co">   */</span></span>
+<span id="cb2-28"><a href="#cb2-28" aria-hidden="true" tabindex="-1"></a>  requires_reauth<span class="op">?:</span> <span class="dt">boolean</span><span class="op">;</span></span>
+<span id="cb2-29"><a href="#cb2-29" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb2-30"><a href="#cb2-30" aria-hidden="true" tabindex="-1"></a>  <span class="co">/**</span></span>
+<span id="cb2-31"><a href="#cb2-31" aria-hidden="true" tabindex="-1"></a><span class="co">   * Additional context for audit logging</span></span>
+<span id="cb2-32"><a href="#cb2-32" aria-hidden="true" tabindex="-1"></a><span class="co">   */</span></span>
+<span id="cb2-33"><a href="#cb2-33" aria-hidden="true" tabindex="-1"></a>  audit_context<span class="op">?:</span> <span class="dt">string</span>[]<span class="op">;</span></span>
+<span id="cb2-34"><a href="#cb2-34" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<h3 id="33-default-danger-levels-by-crude-category">3.3 Default Danger Levels by CRUDE Category</h3>
+<p>When <code>danger.level</code> is not specified, defaults are inferred:</p>
+<table>
+<thead>
+<tr>
+<th>CRUDE Category</th>
+<th>Default Danger Level</th>
+<th>Rationale</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Read</td>
+<td><code>safe</code> (0)</td>
+<td>No state modification</td>
+</tr>
+<tr>
+<td>Create</td>
+<td><code>reversible</code> (1)</td>
+<td>Adds data, reversible by delete</td>
+</tr>
+<tr>
+<td>Update</td>
+<td><code>reversible</code> (1)</td>
+<td>Modifies data, often reversible</td>
+</tr>
+<tr>
+<td>Delete</td>
+<td><code>destructive</code> (2)</td>
+<td>Removes data</td>
+</tr>
+<tr>
+<td>Execute</td>
+<td><code>reversible</code> (1)</td>
+<td>Depends on operation</td>
+</tr>
+</tbody>
+</table>
+<p>Adapter authors SHOULD override defaults when operations are more dangerous than the category default suggests.</p>
+<h3 id="34-introspection-response">3.4 Introspection Response</h3>
+<p>Danger metadata is available via introspection:</p>
+<div class="sourceCode" id="cb3"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb3-1"><a href="#cb3-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb3-2"><a href="#cb3-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;introspect&quot;</span><span class="op">,</span></span>
+<span id="cb3-3"><a href="#cb3-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> { <span class="dt">query</span><span class="op">:</span> <span class="st">&quot;operations&quot;</span><span class="op">,</span> <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;force_delete&quot;</span> }</span>
+<span id="cb3-4"><a href="#cb3-4" aria-hidden="true" tabindex="-1"></a>}</span>
+<span id="cb3-5"><a href="#cb3-5" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb3-6"><a href="#cb3-6" aria-hidden="true" tabindex="-1"></a><span class="co">// Response</span></span>
+<span id="cb3-7"><a href="#cb3-7" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb3-8"><a href="#cb3-8" aria-hidden="true" tabindex="-1"></a>  <span class="dt">success</span><span class="op">:</span> <span class="kw">true</span><span class="op">,</span></span>
+<span id="cb3-9"><a href="#cb3-9" aria-hidden="true" tabindex="-1"></a>  <span class="dt">data</span><span class="op">:</span> {</span>
+<span id="cb3-10"><a href="#cb3-10" aria-hidden="true" tabindex="-1"></a>    <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;force_delete&quot;</span><span class="op">,</span></span>
+<span id="cb3-11"><a href="#cb3-11" aria-hidden="true" tabindex="-1"></a>    <span class="dt">endpoint</span><span class="op">:</span> <span class="st">&quot;DELETE&quot;</span><span class="op">,</span></span>
+<span id="cb3-12"><a href="#cb3-12" aria-hidden="true" tabindex="-1"></a>    <span class="dt">danger</span><span class="op">:</span> {</span>
+<span id="cb3-13"><a href="#cb3-13" aria-hidden="true" tabindex="-1"></a>      <span class="dt">level</span><span class="op">:</span> <span class="st">&quot;dangerous&quot;</span><span class="op">,</span></span>
+<span id="cb3-14"><a href="#cb3-14" aria-hidden="true" tabindex="-1"></a>      <span class="dt">reasons</span><span class="op">:</span> [</span>
+<span id="cb3-15"><a href="#cb3-15" aria-hidden="true" tabindex="-1"></a>        <span class="st">&quot;Bypasses soft-delete protection&quot;</span><span class="op">,</span></span>
+<span id="cb3-16"><a href="#cb3-16" aria-hidden="true" tabindex="-1"></a>        <span class="st">&quot;Cannot be undone&quot;</span><span class="op">,</span></span>
+<span id="cb3-17"><a href="#cb3-17" aria-hidden="true" tabindex="-1"></a>        <span class="st">&quot;Affects dependent resources&quot;</span></span>
+<span id="cb3-18"><a href="#cb3-18" aria-hidden="true" tabindex="-1"></a>      ]<span class="op">,</span></span>
+<span id="cb3-19"><a href="#cb3-19" aria-hidden="true" tabindex="-1"></a>      <span class="dt">confirmation_message</span><span class="op">:</span> <span class="st">&quot;This will permanently delete {resource} and all dependent data.&quot;</span></span>
+<span id="cb3-20"><a href="#cb3-20" aria-hidden="true" tabindex="-1"></a>    }</span>
+<span id="cb3-21"><a href="#cb3-21" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb3-22"><a href="#cb3-22" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<hr />
+<h2 id="4-trust-to-danger-gating">4. Trust-to-Danger Gating</h2>
+<p>This section defines the canonical gating matrix that combines adapter trust levels with operation danger levels. For trust level definitions and promotion rules, see <a href="trust-levels.html">Trust Levels Specification</a>.</p>
+<h3 id="41-gating-matrix">4.1 Gating Matrix</h3>
+<p>The combination of adapter trust level and operation danger level determines behavior:</p>
+<table>
+<thead>
+<tr>
+<th>Danger Level</th>
+<th>untested</th>
+<th>generated</th>
+<th>validated</th>
+<th>community_reviewed</th>
+<th>certified</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>safe (0)</td>
+<td>introspect_only</td>
+<td>allow</td>
+<td>allow</td>
+<td>allow</td>
+<td>allow</td>
+</tr>
+<tr>
+<td>reversible (1)</td>
+<td>deny</td>
+<td>deny</td>
+<td>allow</td>
+<td>allow</td>
+<td>allow</td>
+</tr>
+<tr>
+<td>destructive (2)</td>
+<td>deny</td>
+<td>deny</td>
+<td>confirm</td>
+<td>allow</td>
+<td>allow</td>
+</tr>
+<tr>
+<td>dangerous (3)</td>
+<td>deny</td>
+<td>deny</td>
+<td>deny</td>
+<td>confirm</td>
+<td>allow</td>
+</tr>
+<tr>
+<td>forbidden (4)</td>
+<td>deny</td>
+<td>deny</td>
+<td>deny</td>
+<td>deny</td>
+<td>confirm</td>
+</tr>
+</tbody>
+</table>
+<h3 id="42-behavior-definitions">4.2 Behavior Definitions</h3>
+<table>
+<thead>
+<tr>
+<th>Behavior</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>allow</code></td>
+<td>Operation executes without additional gates</td>
+</tr>
+<tr>
+<td><code>confirm</code></td>
+<td>Operation requires explicit user confirmation</td>
+</tr>
+<tr>
+<td><code>deny</code></td>
+<td>Operation blocked with error response</td>
+</tr>
+<tr>
+<td><code>introspect_only</code></td>
+<td>Only introspection operations permitted; all other operations (including safe ones) are blocked</td>
+</tr>
+</tbody>
+</table>
+<h3 id="43-confirmation-flow">4.3 Confirmation Flow</h3>
+<p>When confirmation is required, the adapter issues a confirmation token that the client must include in a retry request. See <a href="../security/confirmation-tokens.html">Confirmation Token Specification</a> for token generation, validation, and lifecycle requirements.</p>
+<p><strong>Step 1: Initial Request</strong></p>
+<div class="sourceCode" id="cb4"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb4-1"><a href="#cb4-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb4-2"><a href="#cb4-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;delete_repo&quot;</span><span class="op">,</span></span>
+<span id="cb4-3"><a href="#cb4-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> { <span class="dt">owner</span><span class="op">:</span> <span class="st">&quot;acme&quot;</span><span class="op">,</span> <span class="dt">repo</span><span class="op">:</span> <span class="st">&quot;widgets&quot;</span> }</span>
+<span id="cb4-4"><a href="#cb4-4" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<p><strong>Step 2: Confirmation Required Response</strong></p>
+<div class="sourceCode" id="cb5"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb5-1"><a href="#cb5-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb5-2"><a href="#cb5-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb5-3"><a href="#cb5-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;error&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb5-4"><a href="#cb5-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;code&quot;</span><span class="fu">:</span> <span class="st">&quot;CONFIRMATION_REQUIRED&quot;</span><span class="fu">,</span></span>
+<span id="cb5-5"><a href="#cb5-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;This operation requires confirmation&quot;</span><span class="fu">,</span></span>
+<span id="cb5-6"><a href="#cb5-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;details&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb5-7"><a href="#cb5-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;delete_repo&quot;</span><span class="fu">,</span></span>
+<span id="cb5-8"><a href="#cb5-8" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;danger_level&quot;</span><span class="fu">:</span> <span class="st">&quot;destructive&quot;</span><span class="fu">,</span></span>
+<span id="cb5-9"><a href="#cb5-9" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;reasons&quot;</span><span class="fu">:</span> <span class="ot">[</span></span>
+<span id="cb5-10"><a href="#cb5-10" aria-hidden="true" tabindex="-1"></a>        <span class="st">&quot;Permanently removes repository and all contents&quot;</span><span class="ot">,</span></span>
+<span id="cb5-11"><a href="#cb5-11" aria-hidden="true" tabindex="-1"></a>        <span class="st">&quot;Cannot be recovered after grace period&quot;</span></span>
+<span id="cb5-12"><a href="#cb5-12" aria-hidden="true" tabindex="-1"></a>      <span class="ot">]</span><span class="fu">,</span></span>
+<span id="cb5-13"><a href="#cb5-13" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;confirmation_message&quot;</span><span class="fu">:</span> <span class="st">&quot;Delete repository &#39;acme/widgets&#39;? This cannot be undone.&quot;</span><span class="fu">,</span></span>
+<span id="cb5-14"><a href="#cb5-14" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;confirmation_token&quot;</span><span class="fu">:</span> <span class="st">&quot;conf_abc123xyz&quot;</span><span class="fu">,</span></span>
+<span id="cb5-15"><a href="#cb5-15" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;expires_at&quot;</span><span class="fu">:</span> <span class="st">&quot;2026-01-28T12:05:00Z&quot;</span></span>
+<span id="cb5-16"><a href="#cb5-16" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb5-17"><a href="#cb5-17" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb5-18"><a href="#cb5-18" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<p><strong>Step 3: Confirmed Request</strong></p>
+<div class="sourceCode" id="cb6"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb6-1"><a href="#cb6-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb6-2"><a href="#cb6-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;delete_repo&quot;</span><span class="op">,</span></span>
+<span id="cb6-3"><a href="#cb6-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> {</span>
+<span id="cb6-4"><a href="#cb6-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">owner</span><span class="op">:</span> <span class="st">&quot;acme&quot;</span><span class="op">,</span></span>
+<span id="cb6-5"><a href="#cb6-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">repo</span><span class="op">:</span> <span class="st">&quot;widgets&quot;</span><span class="op">,</span></span>
+<span id="cb6-6"><a href="#cb6-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">_confirmation</span><span class="op">:</span> <span class="st">&quot;conf_abc123xyz&quot;</span></span>
+<span id="cb6-7"><a href="#cb6-7" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb6-8"><a href="#cb6-8" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<h3 id="44-denial-response">4.4 Denial Response</h3>
+<p>When an operation is denied due to trust/danger mismatch:</p>
+<div class="sourceCode" id="cb7"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb7-1"><a href="#cb7-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb7-2"><a href="#cb7-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb7-3"><a href="#cb7-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;error&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb7-4"><a href="#cb7-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;code&quot;</span><span class="fu">:</span> <span class="st">&quot;PERMISSION_DANGER_LEVEL_DENIED&quot;</span><span class="fu">,</span></span>
+<span id="cb7-5"><a href="#cb7-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;Operation &#39;bulk_delete&#39; (danger: dangerous) denied for adapter trust level &#39;validated&#39;&quot;</span><span class="fu">,</span></span>
+<span id="cb7-6"><a href="#cb7-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;details&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb7-7"><a href="#cb7-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;bulk_delete&quot;</span><span class="fu">,</span></span>
+<span id="cb7-8"><a href="#cb7-8" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;danger_level&quot;</span><span class="fu">:</span> <span class="st">&quot;dangerous&quot;</span><span class="fu">,</span></span>
+<span id="cb7-9"><a href="#cb7-9" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;adapter_trust&quot;</span><span class="fu">:</span> <span class="st">&quot;validated&quot;</span><span class="fu">,</span></span>
+<span id="cb7-10"><a href="#cb7-10" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;minimum_trust_required&quot;</span><span class="fu">:</span> <span class="st">&quot;community_reviewed&quot;</span><span class="fu">,</span></span>
+<span id="cb7-11"><a href="#cb7-11" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;reasons&quot;</span><span class="fu">:</span> <span class="ot">[</span></span>
+<span id="cb7-12"><a href="#cb7-12" aria-hidden="true" tabindex="-1"></a>        <span class="st">&quot;Affects multiple resources&quot;</span><span class="ot">,</span></span>
+<span id="cb7-13"><a href="#cb7-13" aria-hidden="true" tabindex="-1"></a>        <span class="st">&quot;Cannot be undone&quot;</span></span>
+<span id="cb7-14"><a href="#cb7-14" aria-hidden="true" tabindex="-1"></a>      <span class="ot">]</span></span>
+<span id="cb7-15"><a href="#cb7-15" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb7-16"><a href="#cb7-16" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb7-17"><a href="#cb7-17" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<blockquote>
+<p><strong>Note:</strong> The <code>PERMISSION_DANGER_LEVEL_DENIED</code> error code is introduced by this specification and should be added to the <a href="../error-codes.html">Error Codes Specification</a> as a future extension under the <code>PERMISSION_</code> category.</p>
+</blockquote>
+<hr />
+<h2 id="5-automatic-lockdown">5. Automatic Lockdown</h2>
+<h3 id="51-pattern-based-classification">5.1 Pattern-Based Classification</h3>
+<p>Systems SHOULD automatically classify operations based on naming patterns:</p>
+<div class="sourceCode" id="cb8"><pre class="sourceCode yaml"><code class="sourceCode yaml"><span id="cb8-1"><a href="#cb8-1" aria-hidden="true" tabindex="-1"></a><span class="co"># Gatekeeper configuration</span></span>
+<span id="cb8-2"><a href="#cb8-2" aria-hidden="true" tabindex="-1"></a><span class="fu">danger_patterns</span><span class="kw">:</span></span>
+<span id="cb8-3"><a href="#cb8-3" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">dangerous</span><span class="kw">:</span></span>
+<span id="cb8-4"><a href="#cb8-4" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="kw">-</span><span class="at"> </span><span class="st">&quot;force_*&quot;</span><span class="co">           # Force operations</span></span>
+<span id="cb8-5"><a href="#cb8-5" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="kw">-</span><span class="at"> </span><span class="st">&quot;*_permanently&quot;</span><span class="co">     # Permanent actions</span></span>
+<span id="cb8-6"><a href="#cb8-6" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="kw">-</span><span class="at"> </span><span class="st">&quot;bulk_delete*&quot;</span><span class="co">      # Bulk deletion</span></span>
+<span id="cb8-7"><a href="#cb8-7" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="kw">-</span><span class="at"> </span><span class="st">&quot;override_*&quot;</span><span class="co">        # Safety overrides</span></span>
+<span id="cb8-8"><a href="#cb8-8" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="kw">-</span><span class="at"> </span><span class="st">&quot;bypass_*&quot;</span><span class="co">          # Validation bypass</span></span>
+<span id="cb8-9"><a href="#cb8-9" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb8-10"><a href="#cb8-10" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">forbidden</span><span class="kw">:</span></span>
+<span id="cb8-11"><a href="#cb8-11" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="kw">-</span><span class="at"> </span><span class="st">&quot;drop_*&quot;</span><span class="co">            # Drop database/table</span></span>
+<span id="cb8-12"><a href="#cb8-12" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="kw">-</span><span class="at"> </span><span class="st">&quot;delete_all*&quot;</span><span class="co">       # Delete all records</span></span>
+<span id="cb8-13"><a href="#cb8-13" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="kw">-</span><span class="at"> </span><span class="st">&quot;truncate_*&quot;</span><span class="co">        # Truncate operations</span></span>
+<span id="cb8-14"><a href="#cb8-14" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="kw">-</span><span class="at"> </span><span class="st">&quot;reset_*&quot;</span><span class="co">           # Reset to factory</span></span>
+<span id="cb8-15"><a href="#cb8-15" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="kw">-</span><span class="at"> </span><span class="st">&quot;destroy_*&quot;</span><span class="co">         # Destroy operations</span></span></code></pre></div>
+<p><strong>Pattern precedence:</strong> When an operation matches multiple patterns at different danger levels, the <strong>highest</strong> danger level applies. For example, <code>force_delete_all</code> matches both <code>force_*</code> (dangerous, level 3) and <code>delete_all*</code> (forbidden, level 4), so it defaults to <code>forbidden</code>.</p>
+<h3 id="52-lockdown-behavior">5.2 Lockdown Behavior</h3>
+<p>When an operation matches a dangerous pattern:</p>
+<ol type="1">
+<li><strong>Classification</strong> - Operation tagged with inferred danger level</li>
+<li><strong>Warning</strong> - LLM/user warned of danger classification</li>
+<li><strong>Confirmation</strong> - Appropriate confirmation level applied</li>
+<li><strong>Audit</strong> - Operation attempt logged regardless of outcome</li>
+</ol>
+<h3 id="53-override-mechanism">5.3 Override Mechanism</h3>
+<p>Explicit danger declarations in the adapter schema override pattern matching:</p>
+<div class="sourceCode" id="cb9"><pre class="sourceCode yaml"><code class="sourceCode yaml"><span id="cb9-1"><a href="#cb9-1" aria-hidden="true" tabindex="-1"></a><span class="fu">operations</span><span class="kw">:</span></span>
+<span id="cb9-2"><a href="#cb9-2" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">execute</span><span class="kw">:</span></span>
+<span id="cb9-3"><a href="#cb9-3" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="kw">-</span><span class="at"> </span><span class="fu">name</span><span class="kw">:</span><span class="at"> force_sync</span></span>
+<span id="cb9-4"><a href="#cb9-4" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">maps_to</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;POST /sync?force=true&quot;</span></span>
+<span id="cb9-5"><a href="#cb9-5" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">description</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;Force synchronization (safe, just skips cache)&quot;</span></span>
+<span id="cb9-6"><a href="#cb9-6" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">danger</span><span class="kw">:</span></span>
+<span id="cb9-7"><a href="#cb9-7" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">level</span><span class="kw">:</span><span class="at"> safe</span><span class="co">  # Overrides pattern match for &quot;force_*&quot;</span></span>
+<span id="cb9-8"><a href="#cb9-8" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">reasons</span><span class="kw">:</span></span>
+<span id="cb9-9"><a href="#cb9-9" aria-hidden="true" tabindex="-1"></a><span class="at">          </span><span class="kw">-</span><span class="at"> </span><span class="st">&quot;Force flag only bypasses cache, no data risk&quot;</span></span></code></pre></div>
+<hr />
+<h2 id="6-standard-dangerous-patterns">6. Standard Dangerous Patterns</h2>
+<h3 id="61-level-3-dangerous-patterns">6.1 Level 3 (Dangerous) Patterns</h3>
+<p>Operations matching these patterns SHOULD default to <code>dangerous</code>:</p>
+<table>
+<thead>
+<tr>
+<th>Pattern</th>
+<th>Description</th>
+<th>Examples</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>force_*</code></td>
+<td>Force operations bypassing safety</td>
+<td><code>force_push</code>, <code>force_delete</code></td>
+</tr>
+<tr>
+<td><code>*_permanently</code></td>
+<td>Permanent/irreversible actions</td>
+<td><code>remove_permanently</code></td>
+</tr>
+<tr>
+<td><code>bulk_delete*</code></td>
+<td>Mass deletion operations</td>
+<td><code>bulk_delete_users</code></td>
+</tr>
+<tr>
+<td><code>override_*</code></td>
+<td>Safety override operations</td>
+<td><code>override_validation</code></td>
+</tr>
+<tr>
+<td><code>bypass_*</code></td>
+<td>Validation bypass</td>
+<td><code>bypass_approval</code></td>
+</tr>
+<tr>
+<td><code>*_without_backup</code></td>
+<td>Operations skipping backup</td>
+<td><code>delete_without_backup</code></td>
+</tr>
+<tr>
+<td><code>purge_*</code></td>
+<td>Purge/clean operations</td>
+<td><code>purge_logs</code>, <code>purge_cache</code></td>
+</tr>
+</tbody>
+</table>
+<h3 id="62-level-4-forbidden-patterns">6.2 Level 4 (Forbidden) Patterns</h3>
+<p>Operations matching these patterns SHOULD default to <code>forbidden</code>:</p>
+<table>
+<thead>
+<tr>
+<th>Pattern</th>
+<th>Description</th>
+<th>Examples</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>drop_*</code></td>
+<td>Drop database/table/collection</td>
+<td><code>drop_table</code>, <code>drop_database</code></td>
+</tr>
+<tr>
+<td><code>delete_all*</code></td>
+<td>Delete all records</td>
+<td><code>delete_all_users</code></td>
+</tr>
+<tr>
+<td><code>truncate_*</code></td>
+<td>Truncate operations</td>
+<td><code>truncate_table</code></td>
+</tr>
+<tr>
+<td><code>reset_*</code></td>
+<td>Reset to empty/factory state</td>
+<td><code>reset_database</code></td>
+</tr>
+<tr>
+<td><code>destroy_*</code></td>
+<td>Complete destruction</td>
+<td><code>destroy_environment</code></td>
+</tr>
+<tr>
+<td><code>wipe_*</code></td>
+<td>Wipe operations</td>
+<td><code>wipe_data</code></td>
+</tr>
+<tr>
+<td><code>*_production</code></td>
+<td>Production mutations</td>
+<td><code>deploy_production</code></td>
+</tr>
+</tbody>
+</table>
+<h3 id="63-safe-patterns">6.3 Safe Patterns</h3>
+<p>Operations matching these patterns are confirmed <code>safe</code>:</p>
+<table>
+<thead>
+<tr>
+<th>Pattern</th>
+<th>Description</th>
+<th>Examples</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>get_*</code></td>
+<td>Retrieve single resource</td>
+<td><code>get_user</code>, <code>get_repo</code></td>
+</tr>
+<tr>
+<td><code>list_*</code></td>
+<td>List resources</td>
+<td><code>list_repos</code>, <code>list_users</code></td>
+</tr>
+<tr>
+<td><code>search_*</code></td>
+<td>Search operations</td>
+<td><code>search_issues</code></td>
+</tr>
+<tr>
+<td><code>count_*</code></td>
+<td>Count operations</td>
+<td><code>count_records</code></td>
+</tr>
+<tr>
+<td><code>check_*</code></td>
+<td>Validation checks</td>
+<td><code>check_status</code></td>
+</tr>
+<tr>
+<td><code>introspect*</code></td>
+<td>Introspection</td>
+<td><code>introspect</code></td>
+</tr>
+</tbody>
+</table>
+<hr />
+<h2 id="7-implementation-requirements">7. Implementation Requirements</h2>
+<h3 id="71-must-requirements">7.1 MUST Requirements</h3>
+<p>Implementations supporting danger levels MUST:</p>
+<ol type="1">
+<li>Default unlabeled operations to at least <code>reversible</code> (not <code>safe</code>)</li>
+<li>Enforce confirmation for <code>destructive</code> and higher operations</li>
+<li>Log all dangerous operation attempts (level 2+)</li>
+<li>Return appropriate error codes for denied operations</li>
+<li>Include danger information in introspection responses</li>
+</ol>
+<h3 id="72-should-requirements">7.2 SHOULD Requirements</h3>
+<p>Implementations supporting danger levels SHOULD:</p>
+<ol type="1">
+<li>Implement pattern-based automatic classification</li>
+<li>Support configurable gating policies</li>
+<li>Provide confirmation token mechanism</li>
+<li>Allow adapter-level danger overrides</li>
+<li>Display danger reasons to users before confirmation</li>
+</ol>
+<h3 id="73-may-requirements">7.3 MAY Requirements</h3>
+<p>Implementations supporting danger levels MAY:</p>
+<ol type="1">
+<li>Implement cooldown periods between confirmation and execution</li>
+<li>Require re-authentication for <code>dangerous</code> and <code>forbidden</code> operations</li>
+<li>Support custom confirmation UX per danger level</li>
+<li>Integrate with external approval workflows</li>
+</ol>
+<h3 id="74-audit-requirements">7.4 Audit Requirements</h3>
+<p>All operations at danger level 2 (destructive) or higher MUST be logged:</p>
+<div class="sourceCode" id="cb10"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb10-1"><a href="#cb10-1" aria-hidden="true" tabindex="-1"></a><span class="kw">interface</span> DangerAuditEntry {</span>
+<span id="cb10-2"><a href="#cb10-2" aria-hidden="true" tabindex="-1"></a>  timestamp<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb10-3"><a href="#cb10-3" aria-hidden="true" tabindex="-1"></a>  adapter_name<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb10-4"><a href="#cb10-4" aria-hidden="true" tabindex="-1"></a>  operation<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb10-5"><a href="#cb10-5" aria-hidden="true" tabindex="-1"></a>  danger_level<span class="op">:</span> <span class="dt">number</span><span class="op">;</span></span>
+<span id="cb10-6"><a href="#cb10-6" aria-hidden="true" tabindex="-1"></a>  adapter_trust<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb10-7"><a href="#cb10-7" aria-hidden="true" tabindex="-1"></a>  outcome<span class="op">:</span> <span class="st">&#39;allowed&#39;</span> <span class="op">|</span> <span class="st">&#39;confirmed&#39;</span> <span class="op">|</span> <span class="st">&#39;denied&#39;</span><span class="op">;</span></span>
+<span id="cb10-8"><a href="#cb10-8" aria-hidden="true" tabindex="-1"></a>  confirmation_token<span class="op">?:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb10-9"><a href="#cb10-9" aria-hidden="true" tabindex="-1"></a>  user_id<span class="op">?:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb10-10"><a href="#cb10-10" aria-hidden="true" tabindex="-1"></a>  parameters<span class="op">?:</span> <span class="bu">Record</span><span class="op">&lt;</span><span class="dt">string</span><span class="op">,</span> <span class="dt">unknown</span><span class="op">&gt;;</span>  <span class="co">// Redacted as appropriate</span></span>
+<span id="cb10-11"><a href="#cb10-11" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<hr />
+<h2 id="8-danger-zone-enforcement-during-execution">8. Danger Zone Enforcement During Execution</h2>
+<p>When the <a href="../security/execution-safety-loop.html">Execution Safety Loop</a> is active, danger levels integrate with the <a href="../versions/v1.0.0-draft.html#87-autonomy-evaluation">Autonomy Evaluator</a> to provide continuous risk assessment during agent execution.</p>
+<h3 id="81-safety-tier-mapping">8.1 Safety Tier Mapping</h3>
+<p>The Autonomy Evaluator maps danger levels to safety tiers using a numeric risk score (0-100):</p>
+<table>
+<thead>
+<tr>
+<th>Danger Level</th>
+<th>Risk Score Range</th>
+<th>Safety Tier</th>
+<th>Enforcement</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>safe (0)</td>
+<td>0-15</td>
+<td><code>advisory</code></td>
+<td>No intervention</td>
+</tr>
+<tr>
+<td>reversible (1)</td>
+<td>16-40</td>
+<td><code>advisory</code> or <code>confirm</code></td>
+<td>Depends on risk tolerance</td>
+</tr>
+<tr>
+<td>destructive (2)</td>
+<td>41-60</td>
+<td><code>confirm</code></td>
+<td>Requires approval</td>
+</tr>
+<tr>
+<td>dangerous (3)</td>
+<td>61-85</td>
+<td><code>verify</code></td>
+<td>Mandatory pause + approval</td>
+</tr>
+<tr>
+<td>forbidden (4)</td>
+<td>86-100</td>
+<td><code>danger_zone</code></td>
+<td>Hard stop + out-of-band verification</td>
+</tr>
+</tbody>
+</table>
+<blockquote>
+<p><strong>Note:</strong> The exact risk score assigned depends on additional factors evaluated by the Autonomy Evaluator pipeline (step history, action patterns, risk tolerance configuration). The danger level provides the baseline, not the final score.</p>
+</blockquote>
+<h3 id="82-out-of-band-verification-by-danger-level">8.2 Out-of-Band Verification by Danger Level</h3>
+<p>Operations at danger level <code>dangerous</code> (level 3) and <code>forbidden</code> (level 4) both trigger out-of-band verification during execution, but with different enforcement severity:</p>
+<p><strong>Forbidden (level 4) — Hard block (<code>danger_zone</code> tier):</strong></p>
+<ol type="1">
+<li>The Autonomy Evaluator assigns <code>danger_zone</code> safety tier</li>
+<li>The <code>AutonomyDirective</code> returns <code>stopped: true</code></li>
+<li>A <code>danger_zone</code> notification is broadcast to all executing agents</li>
+<li>The agent is blocked at the agent level (not just the current execution)</li>
+<li>A verification challenge is generated with a code displayed through an AI-inaccessible channel</li>
+<li>Only successful out-of-band verification or admin override can unblock the agent</li>
+<li>The block persists across server restarts</li>
+</ol>
+<p><strong>Dangerous (level 3) — Pause (<code>verify</code> tier):</strong></p>
+<ol type="1">
+<li>The Autonomy Evaluator assigns <code>verify</code> safety tier</li>
+<li>The <code>AutonomyDirective</code> returns <code>continue: false</code> (without <code>stopped: true</code>)</li>
+<li>An <code>autonomy_pause</code> notification is sent to the executing agent (not broadcast)</li>
+<li>A verification challenge is generated and displayed through an AI-inaccessible channel</li>
+<li>The agent is paused until verification succeeds or the challenge expires</li>
+<li>The pause does not persist across server restarts and does not prevent new executions</li>
+</ol>
+<p>See <a href="../versions/v1.0.0-draft.html#88-out-of-band-verification">Section 8.8 (Out-of-Band Verification)</a> of the core specification for the full challenge-response protocol.</p>
+<h3 id="83-danger-escalation-during-execution">8.3 Danger Escalation During Execution</h3>
+<p>An operation's effective danger level MAY increase during execution based on context:</p>
+<ul>
+<li><strong>Repetition escalation:</strong> The same operation performed repeatedly within an execution session MAY escalate (e.g., a single <code>delete_record</code> is <code>destructive</code>, but 50 sequential deletions MAY escalate to <code>dangerous</code>)</li>
+<li><strong>Pattern escalation:</strong> The Autonomy Evaluator's pattern matching (Section 8.7.2, Stage 3) MAY assign a higher safety tier than the operation's declared danger level warrants</li>
+<li><strong>Cumulative risk:</strong> Adapters MAY track cumulative risk within an execution and escalate when a threshold is exceeded</li>
+</ul>
+<p>Danger level escalation during execution does not modify the operation's declared danger level — it affects only the safety tier assigned by the Autonomy Evaluator for that specific evaluation.</p>
+<hr />
+<h2 id="9-future-extensions">9. Future Extensions</h2>
+<h3 id="91-conditional-danger-levels">9.1 Conditional Danger Levels</h3>
+<p>Danger level based on parameter values:</p>
+<div class="sourceCode" id="cb11"><pre class="sourceCode yaml"><code class="sourceCode yaml"><span id="cb11-1"><a href="#cb11-1" aria-hidden="true" tabindex="-1"></a><span class="fu">operations</span><span class="kw">:</span></span>
+<span id="cb11-2"><a href="#cb11-2" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">delete</span><span class="kw">:</span></span>
+<span id="cb11-3"><a href="#cb11-3" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="kw">-</span><span class="at"> </span><span class="fu">name</span><span class="kw">:</span><span class="at"> delete_records</span></span>
+<span id="cb11-4"><a href="#cb11-4" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">maps_to</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;DELETE /records&quot;</span></span>
+<span id="cb11-5"><a href="#cb11-5" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">danger</span><span class="kw">:</span></span>
+<span id="cb11-6"><a href="#cb11-6" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">default_level</span><span class="kw">:</span><span class="at"> reversible</span></span>
+<span id="cb11-7"><a href="#cb11-7" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">conditions</span><span class="kw">:</span></span>
+<span id="cb11-8"><a href="#cb11-8" aria-hidden="true" tabindex="-1"></a><span class="at">          </span><span class="kw">-</span><span class="at"> </span><span class="fu">when</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;params.count &gt; 100&quot;</span></span>
+<span id="cb11-9"><a href="#cb11-9" aria-hidden="true" tabindex="-1"></a><span class="at">            </span><span class="fu">level</span><span class="kw">:</span><span class="at"> dangerous</span></span>
+<span id="cb11-10"><a href="#cb11-10" aria-hidden="true" tabindex="-1"></a><span class="at">            </span><span class="fu">reason</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;Bulk delete of more than 100 records&quot;</span></span>
+<span id="cb11-11"><a href="#cb11-11" aria-hidden="true" tabindex="-1"></a><span class="at">          </span><span class="kw">-</span><span class="at"> </span><span class="fu">when</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;params.permanent == true&quot;</span></span>
+<span id="cb11-12"><a href="#cb11-12" aria-hidden="true" tabindex="-1"></a><span class="at">            </span><span class="fu">level</span><span class="kw">:</span><span class="at"> destructive</span></span>
+<span id="cb11-13"><a href="#cb11-13" aria-hidden="true" tabindex="-1"></a><span class="at">            </span><span class="fu">reason</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;Permanent deletion requested&quot;</span></span></code></pre></div>
+<h3 id="92-approval-workflows">9.2 Approval Workflows</h3>
+<p>Integration with external approval systems:</p>
+<div class="sourceCode" id="cb12"><pre class="sourceCode yaml"><code class="sourceCode yaml"><span id="cb12-1"><a href="#cb12-1" aria-hidden="true" tabindex="-1"></a><span class="fu">danger</span><span class="kw">:</span></span>
+<span id="cb12-2"><a href="#cb12-2" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">level</span><span class="kw">:</span><span class="at"> dangerous</span></span>
+<span id="cb12-3"><a href="#cb12-3" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">approval</span><span class="kw">:</span></span>
+<span id="cb12-4"><a href="#cb12-4" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">required</span><span class="kw">:</span><span class="at"> </span><span class="ch">true</span></span>
+<span id="cb12-5"><a href="#cb12-5" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">approvers</span><span class="kw">:</span></span>
+<span id="cb12-6"><a href="#cb12-6" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="kw">-</span><span class="at"> </span><span class="fu">role</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;admin&quot;</span></span>
+<span id="cb12-7"><a href="#cb12-7" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="kw">-</span><span class="at"> </span><span class="fu">team</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;security&quot;</span></span>
+<span id="cb12-8"><a href="#cb12-8" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">timeout_hours</span><span class="kw">:</span><span class="at"> </span><span class="dv">24</span></span></code></pre></div>
+<h3 id="93-danger-escalation">9.3 Danger Escalation</h3>
+<p>Operations that become more dangerous over time:</p>
+<div class="sourceCode" id="cb13"><pre class="sourceCode yaml"><code class="sourceCode yaml"><span id="cb13-1"><a href="#cb13-1" aria-hidden="true" tabindex="-1"></a><span class="fu">danger</span><span class="kw">:</span></span>
+<span id="cb13-2"><a href="#cb13-2" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">level</span><span class="kw">:</span><span class="at"> reversible</span></span>
+<span id="cb13-3"><a href="#cb13-3" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">escalation</span><span class="kw">:</span></span>
+<span id="cb13-4"><a href="#cb13-4" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="kw">-</span><span class="at"> </span><span class="fu">after_count</span><span class="kw">:</span><span class="at"> </span><span class="dv">10</span></span>
+<span id="cb13-5"><a href="#cb13-5" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">level</span><span class="kw">:</span><span class="at"> destructive</span></span>
+<span id="cb13-6"><a href="#cb13-6" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">message</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;You&#39;ve performed this operation 10 times this hour&quot;</span></span>
+<span id="cb13-7"><a href="#cb13-7" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="kw">-</span><span class="at"> </span><span class="fu">after_count</span><span class="kw">:</span><span class="at"> </span><span class="dv">50</span></span>
+<span id="cb13-8"><a href="#cb13-8" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">level</span><span class="kw">:</span><span class="at"> dangerous</span></span>
+<span id="cb13-9"><a href="#cb13-9" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">message</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;Unusual activity detected&quot;</span></span></code></pre></div>
+<h3 id="94-danger-score-aggregation">9.4 Danger Score Aggregation</h3>
+<p>Combining multiple risk factors into a composite score:</p>
+<div class="sourceCode" id="cb14"><pre class="sourceCode yaml"><code class="sourceCode yaml"><span id="cb14-1"><a href="#cb14-1" aria-hidden="true" tabindex="-1"></a><span class="fu">danger</span><span class="kw">:</span></span>
+<span id="cb14-2"><a href="#cb14-2" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">score_factors</span><span class="kw">:</span></span>
+<span id="cb14-3"><a href="#cb14-3" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="kw">-</span><span class="at"> </span><span class="fu">base_level</span><span class="kw">:</span><span class="at"> reversible</span></span>
+<span id="cb14-4"><a href="#cb14-4" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="kw">-</span><span class="at"> </span><span class="fu">production_env</span><span class="kw">:</span><span class="at"> </span><span class="dv">+1</span></span>
+<span id="cb14-5"><a href="#cb14-5" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="kw">-</span><span class="at"> </span><span class="fu">bulk_operation</span><span class="kw">:</span><span class="at"> </span><span class="dv">+1</span></span>
+<span id="cb14-6"><a href="#cb14-6" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="kw">-</span><span class="at"> </span><span class="fu">no_backup</span><span class="kw">:</span><span class="at"> </span><span class="dv">+1</span></span>
+<span id="cb14-7"><a href="#cb14-7" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">computed_level</span><span class="kw">:</span><span class="at"> dangerous</span><span class="co">  # Sum exceeds threshold</span></span></code></pre></div>
+<hr />
+<h2 id="references">References</h2>
+<ul>
+<li><a href="element-type.html">Adapter Element Type Specification</a></li>
+<li><a href="trust-levels.html">Trust Levels Specification</a></li>
+<li><a href="rate-limiting.html">Rate Limiting Specification</a></li>
+<li><a href="../security/confirmation-tokens.html">Confirmation Token Specification</a></li>
+<li><a href="../security/gatekeeper.html">Security Model: Gatekeeper</a></li>
+<li><a href="../security/execution-safety-loop.html">Execution Safety Loop Specification</a></li>
+<li><a href="../error-codes.html">Error Codes Specification</a></li>
+<li>Claude Code dangerous git operation handling</li>
+<li>GitHub Issue: <a href="https://github.com/MCPAQL/spec/issues/49">#49</a></li>
+</ul>
+
+          </div>
+        </section>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div class="container">
+      <p>&copy; 2026 DollhouseMCP Inc. d/b/a Dollhouse Research. MCP-AQL public draft documentation portal.</p>
+      <div class="footer-links">
+        <a href="../../docs/index.html">Docs Library</a>
+        <a href="../index.html">Repo-Synced Spec</a>
+        <a href="https://github.com/MCPAQL">MCPAQL Organization</a>
+        <a href="https://dollhouseresearch.com">Dollhouse Research</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../../js/search.js"></script>
+</body>
+</html>

--- a/public/spec/adapter/danger-levels.html
+++ b/public/spec/adapter/danger-levels.html
@@ -23,7 +23,7 @@
         </ul>
         <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
-          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <input id="site-search-input" data-search-input type="search" placeholder="Search MCP-AQL docs, spec pages, and adapter patterns...">
           <span class="search-count" data-search-count></span>
           <ul class="search-results" data-search-results hidden></ul>
         </form>
@@ -44,7 +44,7 @@
   <ul><li><a href="../versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Adapter</h3>
-  <ul><li><a class="current" href="danger-levels.html">Dangerous Operation Classification Specification</a></li><li><a href="discovery-bundle.html">MCP Server Discovery Bundle</a></li><li><a href="element-type.html">Adapter Element Type Specification</a></li><li><a href="generator.html">Adapter Generator Specification</a></li><li><a href="rate-limiting.html">Rate Limiting and Quota Management Specification</a></li><li><a href="trust-levels.html">Trust Levels Specification</a></li></ul>
+  <ul><li><a class="current" aria-current="page" href="danger-levels.html">Dangerous Operation Classification Specification</a></li><li><a href="discovery-bundle.html">MCP Server Discovery Bundle</a></li><li><a href="element-type.html">Adapter Element Type Specification</a></li><li><a href="generator.html">Adapter Generator Specification</a></li><li><a href="rate-limiting.html">Rate Limiting and Quota Management Specification</a></li><li><a href="trust-levels.html">Trust Levels Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Security</h3>
   <ul><li><a href="../security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="../security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="../security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
@@ -899,6 +899,16 @@
 
           </div>
         </section>
+        <nav class="page-nav" aria-label="Page navigation">
+  <a class="page-nav-link prev" href="../versions/v1.0.0-draft.html">
+    <span class="page-nav-eyebrow">Previous spec page</span>
+    <strong class="page-nav-label">MCP-AQL Specification</strong>
+  </a>
+  <a class="page-nav-link next" href="discovery-bundle.html">
+    <span class="page-nav-eyebrow">Next spec page</span>
+    <strong class="page-nav-label">MCP Server Discovery Bundle</strong>
+  </a>
+</nav>
       </article>
     </div>
   </main>

--- a/public/spec/adapter/discovery-bundle.html
+++ b/public/spec/adapter/discovery-bundle.html
@@ -23,7 +23,7 @@
         </ul>
         <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
-          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <input id="site-search-input" data-search-input type="search" placeholder="Search MCP-AQL docs, spec pages, and adapter patterns...">
           <span class="search-count" data-search-count></span>
           <ul class="search-results" data-search-results hidden></ul>
         </form>
@@ -44,7 +44,7 @@
   <ul><li><a href="../versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Adapter</h3>
-  <ul><li><a href="danger-levels.html">Dangerous Operation Classification Specification</a></li><li><a class="current" href="discovery-bundle.html">MCP Server Discovery Bundle</a></li><li><a href="element-type.html">Adapter Element Type Specification</a></li><li><a href="generator.html">Adapter Generator Specification</a></li><li><a href="rate-limiting.html">Rate Limiting and Quota Management Specification</a></li><li><a href="trust-levels.html">Trust Levels Specification</a></li></ul>
+  <ul><li><a href="danger-levels.html">Dangerous Operation Classification Specification</a></li><li><a class="current" aria-current="page" href="discovery-bundle.html">MCP Server Discovery Bundle</a></li><li><a href="element-type.html">Adapter Element Type Specification</a></li><li><a href="generator.html">Adapter Generator Specification</a></li><li><a href="rate-limiting.html">Rate Limiting and Quota Management Specification</a></li><li><a href="trust-levels.html">Trust Levels Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Security</h3>
   <ul><li><a href="../security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="../security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="../security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
@@ -217,6 +217,16 @@
 
           </div>
         </section>
+        <nav class="page-nav" aria-label="Page navigation">
+  <a class="page-nav-link prev" href="danger-levels.html">
+    <span class="page-nav-eyebrow">Previous spec page</span>
+    <strong class="page-nav-label">Dangerous Operation Classification Specification</strong>
+  </a>
+  <a class="page-nav-link next" href="element-type.html">
+    <span class="page-nav-eyebrow">Next spec page</span>
+    <strong class="page-nav-label">Adapter Element Type Specification</strong>
+  </a>
+</nav>
       </article>
     </div>
   </main>

--- a/public/spec/adapter/discovery-bundle.html
+++ b/public/spec/adapter/discovery-bundle.html
@@ -73,6 +73,13 @@
       </aside>
 
       <article class="docs-main">
+        <nav class="breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../../index.html">Home</a></li>
+            <li><a href="../index.html">Full Spec</a></li>
+            <li><span class="current">MCP Server Discovery Bundle</span></li>
+          </ol>
+        </nav>
         <section class="hero docs-hero">
           <div class="hero-inner">
             <span class="status-pill">REPO-SYNCED SPEC DOC</span>

--- a/public/spec/adapter/discovery-bundle.html
+++ b/public/spec/adapter/discovery-bundle.html
@@ -38,7 +38,7 @@
         <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
         <div class="docs-side-group">
   <h3>Core</h3>
-  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li></ul>
+  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li><li><a href="../repo/README.html">MCP-AQL Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Versions</h3>
   <ul><li><a href="../versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
@@ -56,7 +56,7 @@
   <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
-  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li></ul>
+  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li><li><a href="../repo/CHANGELOG.html">Changelog</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Architecture</h3>
   <ul><li><a href="../architecture/README.html">Architecture Documentation</a></li></ul>

--- a/public/spec/adapter/discovery-bundle.html
+++ b/public/spec/adapter/discovery-bundle.html
@@ -1,0 +1,231 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Document Status: This document is informative support text for the current MCP-AQL draft. The normative source of truth remains Specification v1.0.0-draft plus the published schemas in spec/schemas/.">
+  <title>MCP-AQL Spec | MCP Server Discovery Bundle</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../../css/style.css">
+</head>
+<body>
+  <header>
+    <div class="container">
+      <nav>
+        <a class="logo" href="../../index.html"><span class="logo-mark"></span>MCP-AQL</a>
+        <ul class="nav-links">
+          <li><a href="../../index.html">Home</a></li>
+          <li><a href="../../docs/index.html">Docs</a></li>
+          <li><a href="../../launch-checklist.html">Launch Checklist</a></li>
+          <li><a href="../../apis/mcp-server.html">Adapter Patterns</a></li>
+        </ul>
+        <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
+          <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
+          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <span class="search-count" data-search-count></span>
+          <ul class="search-results" data-search-results hidden></ul>
+        </form>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <div class="container docs-shell">
+      <aside class="docs-side">
+        <h2>Repo-Synced Spec</h2>
+        <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
+        <div class="docs-side-group">
+  <h3>Core</h3>
+  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Versions</h3>
+  <ul><li><a href="../versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Adapter</h3>
+  <ul><li><a href="danger-levels.html">Dangerous Operation Classification Specification</a></li><li><a class="current" href="discovery-bundle.html">MCP Server Discovery Bundle</a></li><li><a href="element-type.html">Adapter Element Type Specification</a></li><li><a href="generator.html">Adapter Generator Specification</a></li><li><a href="rate-limiting.html">Rate Limiting and Quota Management Specification</a></li><li><a href="trust-levels.html">Trust Levels Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Security</h3>
+  <ul><li><a href="../security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="../security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="../security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Features</h3>
+  <ul><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Guides</h3>
+  <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Process</h3>
+  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Architecture</h3>
+  <ul><li><a href="../architecture/README.html">Architecture Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Research</h3>
+  <ul><li><a href="../research/mcp-vs-mcpaql-vs-a2a.html">Protocol Landscape: MCP vs MCP-AQL vs A2A</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Reference</h3>
+  <ul><li><a href="../reference/README.html">Reference Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>ADRs</h3>
+  <ul><li><a href="../adr/ADR-001-crude-pattern.html">ADR-001: CRUDE Pattern (Extending CRUD with Execute)</a></li><li><a href="../adr/ADR-002-graphql-style-input.html">ADR-002: GraphQL-Style Input Objects for Updates</a></li><li><a href="../adr/ADR-003-snake-case-parameters.html">ADR-003: snake_case Parameter Convention</a></li><li><a href="../adr/ADR-004-schema-driven-operations.html">ADR-004: Schema-Driven Operation Definitions</a></li><li><a href="../adr/ADR-005-introspection-system.html">ADR-005: GraphQL-Style Introspection System</a></li><li><a href="../adr/ADR-006-discriminated-responses.html">ADR-006: Discriminated Response Format</a></li><li><a href="../adr/index.html">Architecture Decision Records</a></li><li><a href="../adr/README.html">Architecture Decision Records</a></li></ul>
+</div>
+      </aside>
+
+      <article class="docs-main">
+        <section class="hero docs-hero">
+          <div class="hero-inner">
+            <span class="status-pill">REPO-SYNCED SPEC DOC</span>
+            <h1>MCP Server Discovery Bundle</h1>
+            <p class="lede">Document Status: This document is informative support text for the current MCP-AQL draft. The normative source of truth remains Specification v1.0.0-draft plus the published schemas in spec/schemas/.</p>
+            <div class="spec-meta"><span class="state-chip live">Support document</span><span class="state-chip pending">Draft</span><span class="state-chip">1.0.0-draft</span><span class="state-chip">2026-03-19</span></div>
+            <p class="spec-source">Source: <a href="https://github.com/MCPAQL/spec/blob/main/docs/adapter/discovery-bundle.md">spec/docs/adapter/discovery-bundle.md</a></p>
+            <div class="hero-actions">
+              <a class="btn btn-primary" href="https://github.com/MCPAQL/spec/blob/main/docs/adapter/discovery-bundle.md">Open Source Markdown</a>
+              <a class="btn btn-secondary" href="../index.html">Browse Full Spec Reference</a>
+            </div>
+          </div>
+        </section>
+
+        <section>
+          <div class="card spec-prose">
+            <p><strong>Version:</strong> 1.0.0-draft <strong>Status:</strong> Draft <strong>Last Updated:</strong> 2026-03-19</p>
+<blockquote>
+<p><strong>Document Status:</strong> This document is <strong>informative support text</strong> for the current MCP-AQL draft. The normative source of truth remains <a href="../versions/v1.0.0-draft.html">Specification v1.0.0-draft</a> plus the published schemas in <code>spec/schemas/</code>.</p>
+</blockquote>
+<h2 id="abstract">Abstract</h2>
+<p>This document defines the minimal discovery bundle contract used when interrogating an MCP server and synthesizing a spec-aligned MCP-AQL adapter schema. The bundle is an intermediate artifact in the MCP server -&gt; MCP-AQL adapter pipeline. It is not a separate protocol layer and does not supersede the main MCP-AQL specification.</p>
+<h2 id="purpose">Purpose</h2>
+<p>The discovery bundle exists to make generator pipelines reproducible and auditable:</p>
+<ul>
+<li><code>raw_capture</code> preserves what the source MCP server actually reported</li>
+<li><code>normalized_bundle</code> records the generator-facing interpretation of that capture</li>
+<li>provenance fields make it possible to trace every inferred value back to source metadata or an explicit heuristic</li>
+</ul>
+<p>This split is especially important when adapting third-party MCP servers whose tool descriptions may be incomplete, ambiguous, or biased toward a specific host application.</p>
+<h2 id="two-layer-structure">Two-Layer Structure</h2>
+<h3 id="raw_capture"><code>raw_capture</code></h3>
+<p><code>raw_capture</code> contains source facts captured directly from the MCP server, without semantic rewriting.</p>
+<p>Current minimal required contents:</p>
+<ul>
+<li>exact <code>tools/list</code> payload</li>
+</ul>
+<p><code>raw_capture</code> SHOULD preserve source field names exactly as received.</p>
+<p>When an interrogator captures additional source response metadata such as pagination cursors, opaque <code>_meta</code> fields, or other transport-specific response facts, those MAY also be preserved in <code>raw_capture</code>.</p>
+<p>The following capture context belongs in <code>source</code>, not <code>raw_capture</code>:</p>
+<ul>
+<li>server identity/version information when available</li>
+<li>capture timestamp</li>
+<li>connection metadata needed to understand the source context</li>
+<li>redacted capture configuration</li>
+</ul>
+<h3 id="normalized_bundle"><code>normalized_bundle</code></h3>
+<p><code>normalized_bundle</code> contains derived records that downstream schema builders and validators consume.</p>
+<p>Minimum contents:</p>
+<ul>
+<li>normalized operation records</li>
+<li>endpoint classification suggestions</li>
+<li>parameter normalization records</li>
+<li>danger-level defaults</li>
+<li>confidence markers</li>
+<li>warnings for ambiguity or unsupported shapes</li>
+</ul>
+<p>Every inferred field in <code>normalized_bundle</code> SHOULD carry enough provenance to explain whether it came from:</p>
+<ol type="1">
+<li><code>direct_source_metadata</code></li>
+<li><code>deterministic_normalization</code></li>
+<li><code>heuristic_classification</code></li>
+<li><code>manual_override</code></li>
+</ol>
+<p>Generators SHOULD populate <code>provenance.inference_sources</code> whenever a normalized field was derived rather than copied directly from source metadata.</p>
+<h2 id="minimal-record-shape">Minimal Record Shape</h2>
+<p>The current minimal discovery bundle contract is captured in <a href="https://github.com/MCPAQL/spec/blob/main/schemas/discovery-bundle.schema.json"><code>schemas/discovery-bundle.schema.json</code></a>.</p>
+<p>Important required concepts:</p>
+<ul>
+<li><code>source</code>
+<ul>
+<li>source server identity</li>
+<li>transport information</li>
+<li>auth metadata with secrets redacted from persisted config</li>
+</ul></li>
+<li><code>raw_capture.tools</code>
+<ul>
+<li>raw upstream tool definitions</li>
+</ul></li>
+<li><code>normalized_bundle.operations</code>
+<ul>
+<li><code>source_tool_name</code></li>
+<li><code>operation_name</code></li>
+<li><code>endpoint</code></li>
+<li><code>endpoint_confidence</code></li>
+<li><code>danger_level</code></li>
+<li><code>needs_review</code></li>
+<li>normalized parameter list</li>
+<li><code>maps_to</code></li>
+</ul></li>
+<li><code>normalized_bundle.warnings</code>
+<ul>
+<li>machine-readable warnings emitted during capture/normalization</li>
+<li><code>review_reasons</code> remain human-readable operation-local explanations, while <code>warnings</code> remain the cross-operation machine-readable signal channel</li>
+</ul></li>
+</ul>
+<h2 id="mapping-expectations">Mapping Expectations</h2>
+<p>The discovery bundle is intentionally narrow. It does not define MCP-AQL itself. Instead, it exists to preserve enough information for a later schema builder to produce an MCP-AQL adapter schema that validates against the current MCP-AQL spec.</p>
+<p>The schema builder is expected to:</p>
+<ul>
+<li>preserve source semantics before style normalization</li>
+<li>classify CRUDE endpoints conservatively</li>
+<li>surface ambiguous operations for review rather than silently “guessing”</li>
+<li>transform <code>normalized_bundle.operations[].params</code> from an ordered array of parameter records into the keyed <code>params</code> object used by the adapter schema</li>
+<li>treat <code>params[].source_path</code> as a dot-path into the raw upstream tool object unless a future version defines a different encoding</li>
+<li>understand that <code>maps_to</code> and <code>danger_level</code> may be generator suggestions or manual-review outcomes rather than source-declared facts</li>
+<li>carry or intentionally discard fields such as parameter <code>format</code> when the downstream adapter schema cannot represent them directly</li>
+<li>preserve the normalized <code>returns</code> wrapper contract even when the upstream MCP tool returns a non-object domain payload</li>
+<li>keep sidecar provenance/warning data outside the adapter schema when the adapter schema cannot represent it directly</li>
+</ul>
+<h2 id="current-scope-notes">Current Scope Notes</h2>
+<p>The current minimal schema reflects the first transport and auth milestone for the GitHub golden path:</p>
+<ul>
+<li><code>source.transport</code> currently enumerates <code>streamable_http</code> only</li>
+<li><code>source.auth.type</code> currently enumerates <code>bearer</code> and <code>none</code> only</li>
+<li><code>source.server</code> is optional because not every interrogated MCP server exposes stable server identity metadata during initialization</li>
+</ul>
+<p>These constraints describe the current capture contract, not the full design space for future interrogators.</p>
+<h2 id="non-goals">Non-Goals</h2>
+<p>The discovery bundle does <strong>not</strong>:</p>
+<ul>
+<li>replace the MCP-AQL adapter schema</li>
+<li>replace the canonical Markdown + YAML adapter format</li>
+<li>make existing implementations normative</li>
+<li>require speculative probing of side-effecting tools</li>
+</ul>
+<h2 id="safety-guidance">Safety Guidance</h2>
+<p>Interrogators SHOULD default to non-side-effecting capture:</p>
+<ul>
+<li>call <code>tools/list</code></li>
+<li>capture initialization metadata</li>
+<li>avoid tool execution unless the operator explicitly opts into safe probes</li>
+</ul>
+<p>If probes are used, probe results SHOULD be stored separately from pure <code>tools/list</code> facts and clearly labeled as observations rather than declarations.</p>
+
+          </div>
+        </section>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div class="container">
+      <p>&copy; 2026 DollhouseMCP Inc. d/b/a Dollhouse Research. MCP-AQL public draft documentation portal.</p>
+      <div class="footer-links">
+        <a href="../../docs/index.html">Docs Library</a>
+        <a href="../index.html">Repo-Synced Spec</a>
+        <a href="https://github.com/MCPAQL">MCPAQL Organization</a>
+        <a href="https://dollhouseresearch.com">Dollhouse Research</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../../js/search.js"></script>
+</body>
+</html>

--- a/public/spec/adapter/element-type.html
+++ b/public/spec/adapter/element-type.html
@@ -1,0 +1,582 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="This document defines the Adapter Element Type, a declarative schema format for describing how MCP-AQL CRUDE operations map to target API calls. Adapters are Markdown files with YAML front matter that a universal runtime">
+  <title>MCP-AQL Spec | Adapter Element Type Specification</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../../css/style.css">
+</head>
+<body>
+  <header>
+    <div class="container">
+      <nav>
+        <a class="logo" href="../../index.html"><span class="logo-mark"></span>MCP-AQL</a>
+        <ul class="nav-links">
+          <li><a href="../../index.html">Home</a></li>
+          <li><a href="../../docs/index.html">Docs</a></li>
+          <li><a href="../../launch-checklist.html">Launch Checklist</a></li>
+          <li><a href="../../apis/mcp-server.html">Adapter Patterns</a></li>
+        </ul>
+        <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
+          <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
+          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <span class="search-count" data-search-count></span>
+          <ul class="search-results" data-search-results hidden></ul>
+        </form>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <div class="container docs-shell">
+      <aside class="docs-side">
+        <h2>Repo-Synced Spec</h2>
+        <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
+        <div class="docs-side-group">
+  <h3>Core</h3>
+  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Versions</h3>
+  <ul><li><a href="../versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Adapter</h3>
+  <ul><li><a href="danger-levels.html">Dangerous Operation Classification Specification</a></li><li><a href="discovery-bundle.html">MCP Server Discovery Bundle</a></li><li><a class="current" href="element-type.html">Adapter Element Type Specification</a></li><li><a href="generator.html">Adapter Generator Specification</a></li><li><a href="rate-limiting.html">Rate Limiting and Quota Management Specification</a></li><li><a href="trust-levels.html">Trust Levels Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Security</h3>
+  <ul><li><a href="../security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="../security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="../security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Features</h3>
+  <ul><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Guides</h3>
+  <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Process</h3>
+  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Architecture</h3>
+  <ul><li><a href="../architecture/README.html">Architecture Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Research</h3>
+  <ul><li><a href="../research/mcp-vs-mcpaql-vs-a2a.html">Protocol Landscape: MCP vs MCP-AQL vs A2A</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Reference</h3>
+  <ul><li><a href="../reference/README.html">Reference Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>ADRs</h3>
+  <ul><li><a href="../adr/ADR-001-crude-pattern.html">ADR-001: CRUDE Pattern (Extending CRUD with Execute)</a></li><li><a href="../adr/ADR-002-graphql-style-input.html">ADR-002: GraphQL-Style Input Objects for Updates</a></li><li><a href="../adr/ADR-003-snake-case-parameters.html">ADR-003: snake_case Parameter Convention</a></li><li><a href="../adr/ADR-004-schema-driven-operations.html">ADR-004: Schema-Driven Operation Definitions</a></li><li><a href="../adr/ADR-005-introspection-system.html">ADR-005: GraphQL-Style Introspection System</a></li><li><a href="../adr/ADR-006-discriminated-responses.html">ADR-006: Discriminated Response Format</a></li><li><a href="../adr/index.html">Architecture Decision Records</a></li><li><a href="../adr/README.html">Architecture Decision Records</a></li></ul>
+</div>
+      </aside>
+
+      <article class="docs-main">
+        <section class="hero docs-hero">
+          <div class="hero-inner">
+            <span class="status-pill">REPO-SYNCED SPEC DOC</span>
+            <h1>Adapter Element Type Specification</h1>
+            <p class="lede">This document defines the Adapter Element Type, a declarative schema format for describing how MCP-AQL CRUDE operations map to target API calls. Adapters are Markdown files with YAML front matter that a universal runtime</p>
+            <div class="spec-meta"><span class="state-chip live">Support document</span><span class="state-chip pending">Draft (MVP)</span><span class="state-chip">1.0.0-draft</span><span class="state-chip">2026-01-26</span></div>
+            <p class="spec-source">Source: <a href="https://github.com/MCPAQL/spec/blob/main/docs/adapter/element-type.md">spec/docs/adapter/element-type.md</a></p>
+            <div class="hero-actions">
+              <a class="btn btn-primary" href="https://github.com/MCPAQL/spec/blob/main/docs/adapter/element-type.md">Open Source Markdown</a>
+              <a class="btn btn-secondary" href="../index.html">Browse Full Spec Reference</a>
+            </div>
+          </div>
+        </section>
+
+        <section>
+          <div class="card spec-prose">
+            <p><strong>Version:</strong> 1.0.0-draft <strong>Status:</strong> Draft (MVP) <strong>Last Updated:</strong> 2026-01-26</p>
+<h2 id="abstract">Abstract</h2>
+<p>This document defines the Adapter Element Type, a declarative schema format for describing how MCP-AQL CRUDE operations map to target API calls. Adapters are Markdown files with YAML front matter that a universal runtime interprets at call time.</p>
+<hr />
+<h2 id="table-of-contents">Table of Contents</h2>
+<ol type="1">
+<li><a href="#1-overview">Overview</a></li>
+<li><a href="#2-schema-structure">Schema Structure</a></li>
+<li><a href="#3-canonical-format-rationale">Canonical Format Rationale</a></li>
+<li><a href="#4-required-fields">Required Fields</a></li>
+<li><a href="#5-target-configuration">Target Configuration</a></li>
+<li><a href="#6-authentication">Authentication</a></li>
+<li><a href="#7-operations">Operations</a></li>
+<li><a href="#8-parameter-types">Parameter Types</a></li>
+<li><a href="#9-example-adapter">Example Adapter</a></li>
+<li><a href="#10-future-extensions">Future Extensions</a></li>
+</ol>
+<hr />
+<h2 id="1-overview">1. Overview</h2>
+<h3 id="11-purpose">1.1 Purpose</h3>
+<p>Adapters enable LLMs to interact with any HTTP API using the MCP-AQL CRUDE interface. Rather than generating code for each API, adapters use a declarative schema that the runtime interprets dynamically.</p>
+<h3 id="12-design-principles">1.2 Design Principles</h3>
+<ol type="1">
+<li><strong>Schema IS the adapter</strong> - No separate code, no compilation</li>
+<li><strong>Declarative over imperative</strong> - Runtime interprets, does not execute custom code</li>
+<li><strong>Introspection for free</strong> - Generated directly from schema</li>
+<li><strong>Hot reloadable</strong> - Change schema, behavior changes immediately</li>
+<li><strong>Human-readable</strong> - Markdown body provides documentation</li>
+</ol>
+<h3 id="13-file-format">1.3 File Format</h3>
+<p>Adapters follow the established element pattern:</p>
+<ul>
+<li><strong>Filename:</strong> <code>{name}-adapter.md</code> (e.g., <code>github-api-adapter.md</code>)</li>
+<li><strong>YAML front matter</strong> containing all configuration and operation mappings</li>
+<li><strong>Markdown body</strong> for human-readable documentation</li>
+</ul>
+<h3 id="14-mvp-scope">1.4 MVP Scope</h3>
+<p>This specification covers the Minimum Viable Product (MVP) for adapters:</p>
+<p><strong>Included:</strong></p>
+<ul>
+<li>HTTP transport only</li>
+<li>REST protocol only</li>
+<li>JSON serialization only</li>
+<li>Bearer token, API key, and no-auth authentication</li>
+<li>Basic operation definitions with parameters</li>
+</ul>
+<p><strong>Deferred to future specifications:</strong></p>
+<ul>
+<li>Trust levels (see #59)</li>
+<li>Rate limiting (see #60)</li>
+<li>Danger level classification (see #49)</li>
+<li>Pagination plugins (see #37)</li>
+<li>Field selection support</li>
+<li>Response transformation</li>
+<li>Alternative transports (WebSocket, serial, native)</li>
+<li>Alternative protocols (GraphQL, gRPC)</li>
+<li>Alternative serialization (XML, Protobuf)</li>
+<li>Advanced authentication (OAuth, mTLS)</li>
+</ul>
+<hr />
+<h2 id="2-schema-structure">2. Schema Structure</h2>
+<h3 id="21-complete-structure">2.1 Complete Structure</h3>
+<div class="sourceCode" id="cb1"><pre class="sourceCode yaml"><code class="sourceCode yaml"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a><span class="pp">---</span></span>
+<span id="cb1-2"><a href="#cb1-2" aria-hidden="true" tabindex="-1"></a><span class="co"># Required fields</span></span>
+<span id="cb1-3"><a href="#cb1-3" aria-hidden="true" tabindex="-1"></a><span class="fu">name</span><span class="kw">:</span><span class="at"> string</span><span class="co">                    # Unique identifier</span></span>
+<span id="cb1-4"><a href="#cb1-4" aria-hidden="true" tabindex="-1"></a><span class="fu">type</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;adapter&quot;</span><span class="co">                 # MUST be &quot;adapter&quot;</span></span>
+<span id="cb1-5"><a href="#cb1-5" aria-hidden="true" tabindex="-1"></a><span class="fu">version</span><span class="kw">:</span><span class="at"> string</span><span class="co">                 # Semver version</span></span>
+<span id="cb1-6"><a href="#cb1-6" aria-hidden="true" tabindex="-1"></a><span class="fu">description</span><span class="kw">:</span><span class="at"> string</span><span class="co">             # Human-readable description</span></span>
+<span id="cb1-7"><a href="#cb1-7" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb1-8"><a href="#cb1-8" aria-hidden="true" tabindex="-1"></a><span class="co"># Target configuration</span></span>
+<span id="cb1-9"><a href="#cb1-9" aria-hidden="true" tabindex="-1"></a><span class="fu">target</span><span class="kw">:</span></span>
+<span id="cb1-10"><a href="#cb1-10" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">base_url</span><span class="kw">:</span><span class="at"> string</span><span class="co">              # API base URL</span></span>
+<span id="cb1-11"><a href="#cb1-11" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">transport</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;http&quot;</span><span class="co">             # MVP: only &quot;http&quot;</span></span>
+<span id="cb1-12"><a href="#cb1-12" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">protocol</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;rest&quot;</span><span class="co">              # MVP: only &quot;rest&quot;</span></span>
+<span id="cb1-13"><a href="#cb1-13" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">serialization</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;json&quot;</span><span class="co">         # MVP: only &quot;json&quot;</span></span>
+<span id="cb1-14"><a href="#cb1-14" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb1-15"><a href="#cb1-15" aria-hidden="true" tabindex="-1"></a><span class="co"># Authentication (optional)</span></span>
+<span id="cb1-16"><a href="#cb1-16" aria-hidden="true" tabindex="-1"></a><span class="fu">auth</span><span class="kw">:</span></span>
+<span id="cb1-17"><a href="#cb1-17" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">type</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;bearer&quot;</span><span class="at"> </span><span class="er">|</span><span class="at"> </span><span class="er">&quot;api_key&quot;</span><span class="at"> </span><span class="er">|</span><span class="at"> </span><span class="er">&quot;none&quot;</span></span>
+<span id="cb1-18"><a href="#cb1-18" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">token_env</span><span class="kw">:</span><span class="at"> string</span><span class="co">             # For bearer: env var containing token</span></span>
+<span id="cb1-19"><a href="#cb1-19" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">header_name</span><span class="kw">:</span><span class="at"> string</span><span class="co">           # For api_key: header name</span></span>
+<span id="cb1-20"><a href="#cb1-20" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">key_env</span><span class="kw">:</span><span class="at"> string</span><span class="co">               # For api_key: env var containing key</span></span>
+<span id="cb1-21"><a href="#cb1-21" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb1-22"><a href="#cb1-22" aria-hidden="true" tabindex="-1"></a><span class="co"># Operation mappings</span></span>
+<span id="cb1-23"><a href="#cb1-23" aria-hidden="true" tabindex="-1"></a><span class="fu">operations</span><span class="kw">:</span></span>
+<span id="cb1-24"><a href="#cb1-24" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">create</span><span class="kw">:</span><span class="at"> OperationDefinition[]</span></span>
+<span id="cb1-25"><a href="#cb1-25" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">read</span><span class="kw">:</span><span class="at"> OperationDefinition[]</span></span>
+<span id="cb1-26"><a href="#cb1-26" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">update</span><span class="kw">:</span><span class="at"> OperationDefinition[]</span></span>
+<span id="cb1-27"><a href="#cb1-27" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">delete</span><span class="kw">:</span><span class="at"> OperationDefinition[]</span></span>
+<span id="cb1-28"><a href="#cb1-28" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">execute</span><span class="kw">:</span><span class="at"> OperationDefinition[]</span></span>
+<span id="cb1-29"><a href="#cb1-29" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb1-30"><a href="#cb1-30" aria-hidden="true" tabindex="-1"></a><span class="co"># Optional metadata</span></span>
+<span id="cb1-31"><a href="#cb1-31" aria-hidden="true" tabindex="-1"></a><span class="fu">author</span><span class="kw">:</span><span class="at"> string</span></span>
+<span id="cb1-32"><a href="#cb1-32" aria-hidden="true" tabindex="-1"></a><span class="fu">tags</span><span class="kw">:</span><span class="at"> string[]</span></span>
+<span id="cb1-33"><a href="#cb1-33" aria-hidden="true" tabindex="-1"></a><span class="fu">triggers</span><span class="kw">:</span><span class="at"> string[]</span></span>
+<span id="cb1-34"><a href="#cb1-34" aria-hidden="true" tabindex="-1"></a><span class="fu">created</span><span class="kw">:</span><span class="at"> string</span><span class="co">                 # ISO 8601 timestamp</span></span>
+<span id="cb1-35"><a href="#cb1-35" aria-hidden="true" tabindex="-1"></a><span class="fu">modified</span><span class="kw">:</span><span class="at"> string</span><span class="co">                # ISO 8601 timestamp</span></span>
+<span id="cb1-36"><a href="#cb1-36" aria-hidden="true" tabindex="-1"></a><span class="pp">---</span></span>
+<span id="cb1-37"><a href="#cb1-37" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb1-38"><a href="#cb1-38" aria-hidden="true" tabindex="-1"></a><span class="co"># Markdown documentation body</span></span></code></pre></div>
+<hr />
+<h2 id="3-canonical-format-rationale">3. Canonical Format Rationale</h2>
+<h3 id="31-why-markdown--yaml-front-matter">3.1 Why Markdown + YAML Front Matter</h3>
+<p>The Markdown + YAML front matter format is the SHOULD (recommended) interchange format for adapter schemas. This choice is deliberate:</p>
+<ol type="1">
+<li><p><strong>Human-readable for security auditing</strong> - Adapter schemas define what API calls an LLM can make. Plain text makes it straightforward for security reviewers to inspect exactly which endpoints are exposed, what parameters are accepted, and what authentication is used.</p></li>
+<li><p><strong>LLM-readable for automated review</strong> - Language models can directly read and reason about adapter schemas without specialized parsers, enabling automated security review and schema validation workflows.</p></li>
+<li><p><strong>Grep-friendly for searching operations</strong> - Teams can use standard text search tools to find operations across adapter collections (e.g., <code>grep -r "maps_to.*DELETE" adapters/</code>).</p></li>
+<li><p><strong>Discourages obfuscation</strong> - A text-based format makes it difficult to hide malicious configurations. Binary or compiled adapter formats would make security review harder.</p></li>
+<li><p><strong>Version control friendly</strong> - Diffs are meaningful, merge conflicts are resolvable, and change history is transparent.</p></li>
+</ol>
+<h3 id="32-alternative-representations">3.2 Alternative Representations</h3>
+<p>Adapter schemas MAY be stored in alternative representations (JSON, database records, programmatic builders) for implementation convenience. However:</p>
+<ul>
+<li>Alternative representations SHOULD be translatable to the canonical Markdown + YAML format for review purposes</li>
+<li>Tooling SHOULD support exporting to canonical format</li>
+<li>The canonical format is the normative reference when discrepancies exist between representations</li>
+</ul>
+<hr />
+<h2 id="4-required-fields">4. Required Fields</h2>
+<h3 id="41-name">4.1 name</h3>
+<p><strong>Type:</strong> string <strong>Required:</strong> Yes</p>
+<p>A unique identifier for the adapter. MUST be lowercase with hyphens for word separation.</p>
+<div class="sourceCode" id="cb2"><pre class="sourceCode yaml"><code class="sourceCode yaml"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="fu">name</span><span class="kw">:</span><span class="at"> github-api</span></span></code></pre></div>
+<p><strong>Constraints:</strong></p>
+<ul>
+<li>MUST match pattern <code>^[a-z][a-z0-9-]*[a-z0-9]$</code></li>
+<li>MUST be 2-64 characters</li>
+<li>SHOULD be descriptive of the target API</li>
+</ul>
+<h3 id="42-type">4.2 type</h3>
+<p><strong>Type:</strong> string (literal) <strong>Required:</strong> Yes</p>
+<p>MUST be the literal string <code>"adapter"</code>. This enables tooling to identify element types without path inspection.</p>
+<div class="sourceCode" id="cb3"><pre class="sourceCode yaml"><code class="sourceCode yaml"><span id="cb3-1"><a href="#cb3-1" aria-hidden="true" tabindex="-1"></a><span class="fu">type</span><span class="kw">:</span><span class="at"> adapter</span></span></code></pre></div>
+<h3 id="43-version">4.3 version</h3>
+<p><strong>Type:</strong> string (semver) <strong>Required:</strong> Yes</p>
+<p>Semantic version of the adapter schema.</p>
+<div class="sourceCode" id="cb4"><pre class="sourceCode yaml"><code class="sourceCode yaml"><span id="cb4-1"><a href="#cb4-1" aria-hidden="true" tabindex="-1"></a><span class="fu">version</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;1.0.0&quot;</span></span></code></pre></div>
+<p><strong>Constraints:</strong></p>
+<ul>
+<li>MUST follow <a href="https://semver.org/">Semantic Versioning 2.0.0</a></li>
+<li>SHOULD be quoted to prevent YAML number parsing issues</li>
+</ul>
+<h3 id="44-description">4.4 description</h3>
+<p><strong>Type:</strong> string <strong>Required:</strong> Yes</p>
+<p>Human-readable description of the adapter's purpose.</p>
+<div class="sourceCode" id="cb5"><pre class="sourceCode yaml"><code class="sourceCode yaml"><span id="cb5-1"><a href="#cb5-1" aria-hidden="true" tabindex="-1"></a><span class="fu">description</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;Adapter for GitHub REST API v3, enabling repository and issue management&quot;</span></span></code></pre></div>
+<p><strong>Constraints:</strong></p>
+<ul>
+<li>SHOULD be 10-200 characters</li>
+<li>SHOULD describe the target API and main capabilities</li>
+</ul>
+<hr />
+<h2 id="5-target-configuration">5. Target Configuration</h2>
+<h3 id="51-target-block">5.1 target Block</h3>
+<p>The <code>target</code> block defines how to connect to the API.</p>
+<div class="sourceCode" id="cb6"><pre class="sourceCode yaml"><code class="sourceCode yaml"><span id="cb6-1"><a href="#cb6-1" aria-hidden="true" tabindex="-1"></a><span class="fu">target</span><span class="kw">:</span></span>
+<span id="cb6-2"><a href="#cb6-2" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">base_url</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;https://api.github.com&quot;</span></span>
+<span id="cb6-3"><a href="#cb6-3" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">transport</span><span class="kw">:</span><span class="at"> http</span></span>
+<span id="cb6-4"><a href="#cb6-4" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">protocol</span><span class="kw">:</span><span class="at"> rest</span></span>
+<span id="cb6-5"><a href="#cb6-5" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">serialization</span><span class="kw">:</span><span class="at"> json</span></span></code></pre></div>
+<h3 id="52-base_url">5.2 base_url</h3>
+<p><strong>Type:</strong> string (URL) <strong>Required:</strong> Yes</p>
+<p>The base URL for all API requests. Operation <code>maps_to</code> paths are appended to this URL.</p>
+<div class="sourceCode" id="cb7"><pre class="sourceCode yaml"><code class="sourceCode yaml"><span id="cb7-1"><a href="#cb7-1" aria-hidden="true" tabindex="-1"></a><span class="fu">base_url</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;https://api.github.com&quot;</span></span></code></pre></div>
+<p><strong>Constraints:</strong></p>
+<ul>
+<li>MUST be a valid HTTPS URL (HTTP allowed only for localhost/development)</li>
+<li>MUST NOT include trailing slash</li>
+<li>MAY include path prefix (e.g., <code>https://api.example.com/v1</code>)</li>
+</ul>
+<h3 id="53-transport">5.3 transport</h3>
+<p><strong>Type:</strong> string (enum) <strong>Required:</strong> Yes</p>
+<p>The transport layer for API communication.</p>
+<p><strong>MVP Values:</strong></p>
+<ul>
+<li><code>http</code> - HTTP/HTTPS transport</li>
+</ul>
+<p><strong>Future Values (deferred):</strong></p>
+<ul>
+<li><code>websocket</code> - WebSocket transport</li>
+<li><code>serial</code> - Serial port transport</li>
+<li><code>native</code> - Native library bindings</li>
+</ul>
+<div class="sourceCode" id="cb8"><pre class="sourceCode yaml"><code class="sourceCode yaml"><span id="cb8-1"><a href="#cb8-1" aria-hidden="true" tabindex="-1"></a><span class="fu">transport</span><span class="kw">:</span><span class="at"> http</span></span></code></pre></div>
+<h3 id="54-protocol">5.4 protocol</h3>
+<p><strong>Type:</strong> string (enum) <strong>Required:</strong> Yes</p>
+<p>The API protocol used by the target.</p>
+<p><strong>MVP Values:</strong></p>
+<ul>
+<li><code>rest</code> - RESTful API</li>
+</ul>
+<p><strong>Future Values (deferred):</strong></p>
+<ul>
+<li><code>graphql</code> - GraphQL API</li>
+<li><code>grpc</code> - gRPC API</li>
+<li><code>custom</code> - Custom protocol with plugin</li>
+</ul>
+<div class="sourceCode" id="cb9"><pre class="sourceCode yaml"><code class="sourceCode yaml"><span id="cb9-1"><a href="#cb9-1" aria-hidden="true" tabindex="-1"></a><span class="fu">protocol</span><span class="kw">:</span><span class="at"> rest</span></span></code></pre></div>
+<h3 id="55-serialization">5.5 serialization</h3>
+<p><strong>Type:</strong> string (enum) <strong>Required:</strong> Yes</p>
+<p>The serialization format for request/response bodies.</p>
+<p><strong>MVP Values:</strong></p>
+<ul>
+<li><code>json</code> - JSON serialization</li>
+</ul>
+<p><strong>Future Values (deferred):</strong></p>
+<ul>
+<li><code>xml</code> - XML serialization</li>
+<li><code>protobuf</code> - Protocol Buffers</li>
+<li><code>msgpack</code> - MessagePack</li>
+</ul>
+<div class="sourceCode" id="cb10"><pre class="sourceCode yaml"><code class="sourceCode yaml"><span id="cb10-1"><a href="#cb10-1" aria-hidden="true" tabindex="-1"></a><span class="fu">serialization</span><span class="kw">:</span><span class="at"> json</span></span></code></pre></div>
+<hr />
+<h2 id="6-authentication">6. Authentication</h2>
+<h3 id="61-auth-block">6.1 auth Block</h3>
+<p>The <code>auth</code> block configures API authentication. If omitted, the adapter uses no authentication.</p>
+<h3 id="62-type-none">6.2 type: none</h3>
+<p>No authentication required.</p>
+<div class="sourceCode" id="cb11"><pre class="sourceCode yaml"><code class="sourceCode yaml"><span id="cb11-1"><a href="#cb11-1" aria-hidden="true" tabindex="-1"></a><span class="fu">auth</span><span class="kw">:</span></span>
+<span id="cb11-2"><a href="#cb11-2" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">type</span><span class="kw">:</span><span class="at"> none</span></span></code></pre></div>
+<h3 id="63-type-bearer">6.3 type: bearer</h3>
+<p>Bearer token authentication sent in the <code>Authorization</code> header.</p>
+<div class="sourceCode" id="cb12"><pre class="sourceCode yaml"><code class="sourceCode yaml"><span id="cb12-1"><a href="#cb12-1" aria-hidden="true" tabindex="-1"></a><span class="fu">auth</span><span class="kw">:</span></span>
+<span id="cb12-2"><a href="#cb12-2" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">type</span><span class="kw">:</span><span class="at"> bearer</span></span>
+<span id="cb12-3"><a href="#cb12-3" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">token_env</span><span class="kw">:</span><span class="at"> GITHUB_TOKEN</span></span></code></pre></div>
+<p><strong>Fields:</strong></p>
+<ul>
+<li><code>token_env</code> (required): Environment variable name containing the bearer token</li>
+</ul>
+<p><strong>Runtime behavior:</strong></p>
+<pre><code>Authorization: Bearer ${GITHUB_TOKEN}</code></pre>
+<h3 id="64-type-api_key">6.4 type: api_key</h3>
+<p>API key authentication sent in a custom header.</p>
+<div class="sourceCode" id="cb14"><pre class="sourceCode yaml"><code class="sourceCode yaml"><span id="cb14-1"><a href="#cb14-1" aria-hidden="true" tabindex="-1"></a><span class="fu">auth</span><span class="kw">:</span></span>
+<span id="cb14-2"><a href="#cb14-2" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">type</span><span class="kw">:</span><span class="at"> api_key</span></span>
+<span id="cb14-3"><a href="#cb14-3" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">header_name</span><span class="kw">:</span><span class="at"> X-API-Key</span></span>
+<span id="cb14-4"><a href="#cb14-4" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">key_env</span><span class="kw">:</span><span class="at"> OPENAI_API_KEY</span></span></code></pre></div>
+<p><strong>Fields:</strong></p>
+<ul>
+<li><code>header_name</code> (required): HTTP header name for the API key</li>
+<li><code>key_env</code> (required): Environment variable name containing the key</li>
+</ul>
+<p><strong>Runtime behavior:</strong></p>
+<pre><code>X-API-Key: ${OPENAI_API_KEY}</code></pre>
+<h3 id="65-security-considerations">6.5 Security Considerations</h3>
+<ul>
+<li>Adapter schemas MUST NOT contain actual credentials</li>
+<li>Credentials MUST be loaded from environment variables at runtime</li>
+<li>Runtime implementations SHOULD warn if credentials are embedded in schemas</li>
+</ul>
+<hr />
+<h2 id="7-operations">7. Operations</h2>
+<h3 id="71-operations-block">7.1 operations Block</h3>
+<p>The <code>operations</code> block maps MCP-AQL CRUDE operations to target API calls.</p>
+<div class="sourceCode" id="cb16"><pre class="sourceCode yaml"><code class="sourceCode yaml"><span id="cb16-1"><a href="#cb16-1" aria-hidden="true" tabindex="-1"></a><span class="fu">operations</span><span class="kw">:</span></span>
+<span id="cb16-2"><a href="#cb16-2" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">create</span><span class="kw">:</span></span>
+<span id="cb16-3"><a href="#cb16-3" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="kw">-</span><span class="at"> </span><span class="fu">name</span><span class="kw">:</span><span class="at"> create_repo</span></span>
+<span id="cb16-4"><a href="#cb16-4" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">maps_to</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;POST /user/repos&quot;</span></span>
+<span id="cb16-5"><a href="#cb16-5" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">description</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;Create a new repository&quot;</span></span>
+<span id="cb16-6"><a href="#cb16-6" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">params</span><span class="kw">:</span></span>
+<span id="cb16-7"><a href="#cb16-7" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">name</span><span class="kw">:</span><span class="at"> </span><span class="kw">{</span><span class="at"> </span><span class="fu">type</span><span class="kw">:</span><span class="at"> string</span><span class="kw">,</span><span class="at"> </span><span class="fu">required</span><span class="kw">:</span><span class="at"> </span><span class="ch">true</span><span class="at"> </span><span class="kw">}</span></span>
+<span id="cb16-8"><a href="#cb16-8" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">private</span><span class="kw">:</span><span class="at"> </span><span class="kw">{</span><span class="at"> </span><span class="fu">type</span><span class="kw">:</span><span class="at"> boolean</span><span class="kw">,</span><span class="at"> </span><span class="fu">default</span><span class="kw">:</span><span class="at"> </span><span class="ch">false</span><span class="at"> </span><span class="kw">}</span></span>
+<span id="cb16-9"><a href="#cb16-9" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb16-10"><a href="#cb16-10" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">read</span><span class="kw">:</span></span>
+<span id="cb16-11"><a href="#cb16-11" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="kw">-</span><span class="at"> </span><span class="fu">name</span><span class="kw">:</span><span class="at"> list_repos</span></span>
+<span id="cb16-12"><a href="#cb16-12" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">maps_to</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;GET /users/{username}/repos&quot;</span></span>
+<span id="cb16-13"><a href="#cb16-13" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">description</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;List repositories for a user&quot;</span></span>
+<span id="cb16-14"><a href="#cb16-14" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">params</span><span class="kw">:</span></span>
+<span id="cb16-15"><a href="#cb16-15" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">username</span><span class="kw">:</span><span class="at"> </span><span class="kw">{</span><span class="at"> </span><span class="fu">type</span><span class="kw">:</span><span class="at"> string</span><span class="kw">,</span><span class="at"> </span><span class="fu">required</span><span class="kw">:</span><span class="at"> </span><span class="ch">true</span><span class="at"> </span><span class="kw">}</span></span></code></pre></div>
+<h3 id="72-operationdefinition">7.2 OperationDefinition</h3>
+<p>Each operation in a CRUDE category is an OperationDefinition object:</p>
+<div class="sourceCode" id="cb17"><pre class="sourceCode yaml"><code class="sourceCode yaml"><span id="cb17-1"><a href="#cb17-1" aria-hidden="true" tabindex="-1"></a><span class="fu">name</span><span class="kw">:</span><span class="at"> string</span><span class="co">                    # Operation name (required)</span></span>
+<span id="cb17-2"><a href="#cb17-2" aria-hidden="true" tabindex="-1"></a><span class="fu">maps_to</span><span class="kw">:</span><span class="at"> string</span><span class="co">                 # HTTP method and path (required)</span></span>
+<span id="cb17-3"><a href="#cb17-3" aria-hidden="true" tabindex="-1"></a><span class="fu">description</span><span class="kw">:</span><span class="at"> string</span><span class="co">             # Human-readable description</span></span>
+<span id="cb17-4"><a href="#cb17-4" aria-hidden="true" tabindex="-1"></a><span class="fu">params</span><span class="kw">:</span><span class="at"> ParamDefinition{}</span><span class="co">       # Parameter definitions</span></span></code></pre></div>
+<h3 id="73-name">7.3 name</h3>
+<p><strong>Type:</strong> string <strong>Required:</strong> Yes</p>
+<p>The operation identifier used in MCP-AQL requests.</p>
+<div class="sourceCode" id="cb18"><pre class="sourceCode yaml"><code class="sourceCode yaml"><span id="cb18-1"><a href="#cb18-1" aria-hidden="true" tabindex="-1"></a><span class="fu">name</span><span class="kw">:</span><span class="at"> get_repo</span></span></code></pre></div>
+<p><strong>Constraints:</strong></p>
+<ul>
+<li>MUST be unique across all CRUDE categories</li>
+<li>MUST match pattern <code>^[a-z][a-z0-9_]*$</code></li>
+<li>SHOULD use snake_case</li>
+</ul>
+<h3 id="74-maps_to">7.4 maps_to</h3>
+<p><strong>Type:</strong> string <strong>Required:</strong> Yes</p>
+<p>The HTTP method and path template for the target API.</p>
+<div class="sourceCode" id="cb19"><pre class="sourceCode yaml"><code class="sourceCode yaml"><span id="cb19-1"><a href="#cb19-1" aria-hidden="true" tabindex="-1"></a><span class="fu">maps_to</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;GET /repos/{owner}/{repo}&quot;</span></span></code></pre></div>
+<p><strong>Format:</strong> <code>METHOD /path/with/{placeholders}</code></p>
+<p><strong>Supported methods:</strong> GET, POST, PUT, PATCH, DELETE</p>
+<p><strong>Path placeholders:</strong></p>
+<ul>
+<li>Wrapped in curly braces: <code>{param_name}</code></li>
+<li>MUST correspond to a parameter definition</li>
+<li>Replaced at runtime with parameter values</li>
+</ul>
+<h3 id="75-description">7.5 description</h3>
+<p><strong>Type:</strong> string <strong>Required:</strong> No (recommended)</p>
+<p>Human-readable description of what the operation does.</p>
+<div class="sourceCode" id="cb20"><pre class="sourceCode yaml"><code class="sourceCode yaml"><span id="cb20-1"><a href="#cb20-1" aria-hidden="true" tabindex="-1"></a><span class="fu">description</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;Get detailed information about a specific repository&quot;</span></span></code></pre></div>
+<h3 id="76-params">7.6 params</h3>
+<p><strong>Type:</strong> object mapping param names to ParamDefinition <strong>Required:</strong> No</p>
+<p>Parameter definitions for the operation.</p>
+<div class="sourceCode" id="cb21"><pre class="sourceCode yaml"><code class="sourceCode yaml"><span id="cb21-1"><a href="#cb21-1" aria-hidden="true" tabindex="-1"></a><span class="fu">params</span><span class="kw">:</span></span>
+<span id="cb21-2"><a href="#cb21-2" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">owner</span><span class="kw">:</span></span>
+<span id="cb21-3"><a href="#cb21-3" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">type</span><span class="kw">:</span><span class="at"> string</span></span>
+<span id="cb21-4"><a href="#cb21-4" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">required</span><span class="kw">:</span><span class="at"> </span><span class="ch">true</span></span>
+<span id="cb21-5"><a href="#cb21-5" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">description</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;Repository owner username&quot;</span></span>
+<span id="cb21-6"><a href="#cb21-6" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">repo</span><span class="kw">:</span></span>
+<span id="cb21-7"><a href="#cb21-7" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">type</span><span class="kw">:</span><span class="at"> string</span></span>
+<span id="cb21-8"><a href="#cb21-8" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">required</span><span class="kw">:</span><span class="at"> </span><span class="ch">true</span></span>
+<span id="cb21-9"><a href="#cb21-9" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">description</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;Repository name&quot;</span></span>
+<span id="cb21-10"><a href="#cb21-10" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">include_stats</span><span class="kw">:</span></span>
+<span id="cb21-11"><a href="#cb21-11" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">type</span><span class="kw">:</span><span class="at"> boolean</span></span>
+<span id="cb21-12"><a href="#cb21-12" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">default</span><span class="kw">:</span><span class="at"> </span><span class="ch">false</span></span>
+<span id="cb21-13"><a href="#cb21-13" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">description</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;Include repository statistics&quot;</span></span></code></pre></div>
+<hr />
+<h2 id="8-parameter-types">8. Parameter Types</h2>
+<h3 id="81-paramdefinition">8.1 ParamDefinition</h3>
+<div class="sourceCode" id="cb22"><pre class="sourceCode yaml"><code class="sourceCode yaml"><span id="cb22-1"><a href="#cb22-1" aria-hidden="true" tabindex="-1"></a><span class="fu">type</span><span class="kw">:</span><span class="at"> string</span><span class="co">                    # Data type (required)</span></span>
+<span id="cb22-2"><a href="#cb22-2" aria-hidden="true" tabindex="-1"></a><span class="fu">required</span><span class="kw">:</span><span class="at"> boolean</span><span class="co">               # Is parameter required (default: false)</span></span>
+<span id="cb22-3"><a href="#cb22-3" aria-hidden="true" tabindex="-1"></a><span class="fu">description</span><span class="kw">:</span><span class="at"> string</span><span class="co">             # Human-readable description</span></span>
+<span id="cb22-4"><a href="#cb22-4" aria-hidden="true" tabindex="-1"></a><span class="fu">default</span><span class="kw">:</span><span class="at"> any</span><span class="co">                    # Default value if not provided</span></span>
+<span id="cb22-5"><a href="#cb22-5" aria-hidden="true" tabindex="-1"></a><span class="fu">enum</span><span class="kw">:</span><span class="at"> any[]</span><span class="co">                     # Allowed values</span></span></code></pre></div>
+<h3 id="82-type-field">8.2 type Field</h3>
+<p><strong>Supported types:</strong></p>
+<table>
+<thead>
+<tr>
+<th>Type</th>
+<th>Description</th>
+<th>Example</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>string</code></td>
+<td>Text value</td>
+<td><code>"hello"</code></td>
+</tr>
+<tr>
+<td><code>integer</code></td>
+<td>Whole number</td>
+<td><code>42</code></td>
+</tr>
+<tr>
+<td><code>number</code></td>
+<td>Decimal number</td>
+<td><code>3.14</code></td>
+</tr>
+<tr>
+<td><code>boolean</code></td>
+<td>True/false</td>
+<td><code>true</code></td>
+</tr>
+<tr>
+<td><code>array</code></td>
+<td>List of values</td>
+<td><code>[1, 2, 3]</code></td>
+</tr>
+<tr>
+<td><code>object</code></td>
+<td>Key-value map</td>
+<td><code>{"key": "value"}</code></td>
+</tr>
+</tbody>
+</table>
+<h3 id="83-required-field">8.3 required Field</h3>
+<p><strong>Type:</strong> boolean <strong>Default:</strong> false</p>
+<p>When true, the runtime MUST reject requests missing this parameter.</p>
+<div class="sourceCode" id="cb23"><pre class="sourceCode yaml"><code class="sourceCode yaml"><span id="cb23-1"><a href="#cb23-1" aria-hidden="true" tabindex="-1"></a><span class="fu">name</span><span class="kw">:</span><span class="at"> </span><span class="kw">{</span><span class="at"> </span><span class="fu">type</span><span class="kw">:</span><span class="at"> string</span><span class="kw">,</span><span class="at"> </span><span class="fu">required</span><span class="kw">:</span><span class="at"> </span><span class="ch">true</span><span class="at"> </span><span class="kw">}</span></span></code></pre></div>
+<h3 id="84-description-field">8.4 description Field</h3>
+<p><strong>Type:</strong> string</p>
+<p>Human-readable description shown in introspection.</p>
+<div class="sourceCode" id="cb24"><pre class="sourceCode yaml"><code class="sourceCode yaml"><span id="cb24-1"><a href="#cb24-1" aria-hidden="true" tabindex="-1"></a><span class="fu">owner</span><span class="kw">:</span></span>
+<span id="cb24-2"><a href="#cb24-2" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">type</span><span class="kw">:</span><span class="at"> string</span></span>
+<span id="cb24-3"><a href="#cb24-3" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">required</span><span class="kw">:</span><span class="at"> </span><span class="ch">true</span></span>
+<span id="cb24-4"><a href="#cb24-4" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">description</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;The account owner of the repository&quot;</span></span></code></pre></div>
+<h3 id="85-default-field">8.5 default Field</h3>
+<p><strong>Type:</strong> any (matching the param type)</p>
+<p>Default value used when parameter is not provided.</p>
+<div class="sourceCode" id="cb25"><pre class="sourceCode yaml"><code class="sourceCode yaml"><span id="cb25-1"><a href="#cb25-1" aria-hidden="true" tabindex="-1"></a><span class="fu">per_page</span><span class="kw">:</span></span>
+<span id="cb25-2"><a href="#cb25-2" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">type</span><span class="kw">:</span><span class="at"> integer</span></span>
+<span id="cb25-3"><a href="#cb25-3" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">default</span><span class="kw">:</span><span class="at"> </span><span class="dv">30</span></span>
+<span id="cb25-4"><a href="#cb25-4" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">description</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;Results per page (max 100)&quot;</span></span></code></pre></div>
+<h3 id="86-enum-field">8.6 enum Field</h3>
+<p><strong>Type:</strong> array</p>
+<p>Restricts parameter to specific values.</p>
+<div class="sourceCode" id="cb26"><pre class="sourceCode yaml"><code class="sourceCode yaml"><span id="cb26-1"><a href="#cb26-1" aria-hidden="true" tabindex="-1"></a><span class="fu">state</span><span class="kw">:</span></span>
+<span id="cb26-2"><a href="#cb26-2" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">type</span><span class="kw">:</span><span class="at"> string</span></span>
+<span id="cb26-3"><a href="#cb26-3" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">enum</span><span class="kw">:</span><span class="at"> </span><span class="kw">[</span><span class="at">open</span><span class="kw">,</span><span class="at"> closed</span><span class="kw">,</span><span class="at"> all</span><span class="kw">]</span></span>
+<span id="cb26-4"><a href="#cb26-4" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">default</span><span class="kw">:</span><span class="at"> open</span></span>
+<span id="cb26-5"><a href="#cb26-5" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">description</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;Filter by issue state&quot;</span></span></code></pre></div>
+<hr />
+<h2 id="9-example-adapter">9. Example Adapter</h2>
+<p>See the <a href="https://github.com/MCPAQL/examples/blob/develop/adapters/github-api-adapter.md">GitHub API Adapter</a> in the examples repository for a complete example.</p>
+<h3 id="91-minimal-example">9.1 Minimal Example</h3>
+<div class="sourceCode" id="cb27"><pre class="sourceCode yaml"><code class="sourceCode yaml"><span id="cb27-1"><a href="#cb27-1" aria-hidden="true" tabindex="-1"></a><span class="pp">---</span></span>
+<span id="cb27-2"><a href="#cb27-2" aria-hidden="true" tabindex="-1"></a><span class="fu">name</span><span class="kw">:</span><span class="at"> minimal-api</span></span>
+<span id="cb27-3"><a href="#cb27-3" aria-hidden="true" tabindex="-1"></a><span class="fu">type</span><span class="kw">:</span><span class="at"> adapter</span></span>
+<span id="cb27-4"><a href="#cb27-4" aria-hidden="true" tabindex="-1"></a><span class="fu">version</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;1.0.0&quot;</span></span>
+<span id="cb27-5"><a href="#cb27-5" aria-hidden="true" tabindex="-1"></a><span class="fu">description</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;Minimal example adapter&quot;</span></span>
+<span id="cb27-6"><a href="#cb27-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb27-7"><a href="#cb27-7" aria-hidden="true" tabindex="-1"></a><span class="fu">target</span><span class="kw">:</span></span>
+<span id="cb27-8"><a href="#cb27-8" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">base_url</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;https://api.example.com&quot;</span></span>
+<span id="cb27-9"><a href="#cb27-9" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">transport</span><span class="kw">:</span><span class="at"> http</span></span>
+<span id="cb27-10"><a href="#cb27-10" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">protocol</span><span class="kw">:</span><span class="at"> rest</span></span>
+<span id="cb27-11"><a href="#cb27-11" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">serialization</span><span class="kw">:</span><span class="at"> json</span></span>
+<span id="cb27-12"><a href="#cb27-12" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb27-13"><a href="#cb27-13" aria-hidden="true" tabindex="-1"></a><span class="fu">operations</span><span class="kw">:</span></span>
+<span id="cb27-14"><a href="#cb27-14" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">read</span><span class="kw">:</span></span>
+<span id="cb27-15"><a href="#cb27-15" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="kw">-</span><span class="at"> </span><span class="fu">name</span><span class="kw">:</span><span class="at"> get_status</span></span>
+<span id="cb27-16"><a href="#cb27-16" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">maps_to</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;GET /status&quot;</span></span>
+<span id="cb27-17"><a href="#cb27-17" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">description</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;Get API status&quot;</span></span>
+<span id="cb27-18"><a href="#cb27-18" aria-hidden="true" tabindex="-1"></a><span class="pp">---</span></span>
+<span id="cb27-19"><a href="#cb27-19" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb27-20"><a href="#cb27-20" aria-hidden="true" tabindex="-1"></a><span class="co"># Minimal API Adapter</span></span>
+<span id="cb27-21"><a href="#cb27-21" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb27-22"><a href="#cb27-22" aria-hidden="true" tabindex="-1"></a><span class="at">This adapter demonstrates the minimum required fields.</span></span></code></pre></div>
+<hr />
+<h2 id="10-future-extensions">10. Future Extensions</h2>
+<p>The following features are deferred from the MVP and will be specified in future issues:</p>
+<h3 id="101-trust-levels-59">10.1 Trust Levels (#59)</h3>
+<div class="sourceCode" id="cb28"><pre class="sourceCode yaml"><code class="sourceCode yaml"><span id="cb28-1"><a href="#cb28-1" aria-hidden="true" tabindex="-1"></a><span class="fu">trust</span><span class="kw">:</span></span>
+<span id="cb28-2"><a href="#cb28-2" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">level</span><span class="kw">:</span><span class="at"> generated | community | verified | official</span></span>
+<span id="cb28-3"><a href="#cb28-3" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">verified_by</span><span class="kw">:</span><span class="at"> string</span></span>
+<span id="cb28-4"><a href="#cb28-4" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">verified_at</span><span class="kw">:</span><span class="at"> string</span></span></code></pre></div>
+<h3 id="102-rate-limiting-60">10.2 Rate Limiting (#60)</h3>
+<div class="sourceCode" id="cb29"><pre class="sourceCode yaml"><code class="sourceCode yaml"><span id="cb29-1"><a href="#cb29-1" aria-hidden="true" tabindex="-1"></a><span class="fu">rate_limits</span><span class="kw">:</span></span>
+<span id="cb29-2"><a href="#cb29-2" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">requests_per_minute</span><span class="kw">:</span><span class="at"> </span><span class="dv">60</span></span>
+<span id="cb29-3"><a href="#cb29-3" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">requests_per_hour</span><span class="kw">:</span><span class="at"> </span><span class="dv">1000</span></span>
+<span id="cb29-4"><a href="#cb29-4" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">concurrent_requests</span><span class="kw">:</span><span class="at"> </span><span class="dv">5</span></span></code></pre></div>
+<h3 id="103-danger-levels-49">10.3 Danger Levels (#49)</h3>
+<div class="sourceCode" id="cb30"><pre class="sourceCode yaml"><code class="sourceCode yaml"><span id="cb30-1"><a href="#cb30-1" aria-hidden="true" tabindex="-1"></a><span class="fu">operations</span><span class="kw">:</span></span>
+<span id="cb30-2"><a href="#cb30-2" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">delete</span><span class="kw">:</span></span>
+<span id="cb30-3"><a href="#cb30-3" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="kw">-</span><span class="at"> </span><span class="fu">name</span><span class="kw">:</span><span class="at"> delete_repo</span></span>
+<span id="cb30-4"><a href="#cb30-4" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">maps_to</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;DELETE /repos/{owner}/{repo}&quot;</span></span>
+<span id="cb30-5"><a href="#cb30-5" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">danger_level</span><span class="kw">:</span><span class="at"> destructive</span></span>
+<span id="cb30-6"><a href="#cb30-6" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">requires_confirmation</span><span class="kw">:</span><span class="at"> </span><span class="ch">true</span></span></code></pre></div>
+<h3 id="104-pagination-37">10.4 Pagination (#37)</h3>
+<div class="sourceCode" id="cb31"><pre class="sourceCode yaml"><code class="sourceCode yaml"><span id="cb31-1"><a href="#cb31-1" aria-hidden="true" tabindex="-1"></a><span class="fu">operations</span><span class="kw">:</span></span>
+<span id="cb31-2"><a href="#cb31-2" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">read</span><span class="kw">:</span></span>
+<span id="cb31-3"><a href="#cb31-3" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="kw">-</span><span class="at"> </span><span class="fu">name</span><span class="kw">:</span><span class="at"> list_repos</span></span>
+<span id="cb31-4"><a href="#cb31-4" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">maps_to</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;GET /users/{username}/repos&quot;</span></span>
+<span id="cb31-5"><a href="#cb31-5" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">pagination</span><span class="kw">:</span></span>
+<span id="cb31-6"><a href="#cb31-6" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">style</span><span class="kw">:</span><span class="at"> cursor | offset | page | link_header</span></span>
+<span id="cb31-7"><a href="#cb31-7" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">param_name</span><span class="kw">:</span><span class="at"> page</span></span>
+<span id="cb31-8"><a href="#cb31-8" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">per_page_param</span><span class="kw">:</span><span class="at"> per_page</span></span></code></pre></div>
+<h3 id="105-field-selection">10.5 Field Selection</h3>
+<div class="sourceCode" id="cb32"><pre class="sourceCode yaml"><code class="sourceCode yaml"><span id="cb32-1"><a href="#cb32-1" aria-hidden="true" tabindex="-1"></a><span class="fu">operations</span><span class="kw">:</span></span>
+<span id="cb32-2"><a href="#cb32-2" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">read</span><span class="kw">:</span></span>
+<span id="cb32-3"><a href="#cb32-3" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="kw">-</span><span class="at"> </span><span class="fu">name</span><span class="kw">:</span><span class="at"> get_repo</span></span>
+<span id="cb32-4"><a href="#cb32-4" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">maps_to</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;GET /repos/{owner}/{repo}&quot;</span></span>
+<span id="cb32-5"><a href="#cb32-5" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">supports_fields</span><span class="kw">:</span><span class="at"> </span><span class="ch">true</span></span>
+<span id="cb32-6"><a href="#cb32-6" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">default_fields</span><span class="kw">:</span><span class="at"> </span><span class="kw">[</span><span class="at">id</span><span class="kw">,</span><span class="at"> name</span><span class="kw">,</span><span class="at"> full_name</span><span class="kw">,</span><span class="at"> description</span><span class="kw">]</span></span></code></pre></div>
+<hr />
+<h2 id="references">References</h2>
+<ul>
+<li><a href="../versions/v1.0.0-draft.html">MCP-AQL Specification</a></li>
+<li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li>
+<li><a href="trust-levels.html">Trust Levels Specification</a></li>
+<li><a href="danger-levels.html">Dangerous Operation Classification</a></li>
+<li><a href="rate-limiting.html">Rate Limiting Specification</a></li>
+<li><a href="https://github.com/MCPAQL/mcpaql-adapter/blob/develop/docs/guides/development.md">Adapter Development Guide</a> (in mcpaql-adapter repo)</li>
+<li><a href="https://github.com/MCPAQL/mcpaql-adapter/blob/develop/docs/architecture/runtime.md">Universal Adapter Runtime</a> (in mcpaql-adapter repo)</li>
+<li>GitHub Issue: <a href="https://github.com/MCPAQL/spec/issues/61">#61</a></li>
+</ul>
+
+          </div>
+        </section>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div class="container">
+      <p>&copy; 2026 DollhouseMCP Inc. d/b/a Dollhouse Research. MCP-AQL public draft documentation portal.</p>
+      <div class="footer-links">
+        <a href="../../docs/index.html">Docs Library</a>
+        <a href="../index.html">Repo-Synced Spec</a>
+        <a href="https://github.com/MCPAQL">MCPAQL Organization</a>
+        <a href="https://dollhouseresearch.com">Dollhouse Research</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../../js/search.js"></script>
+</body>
+</html>

--- a/public/spec/adapter/element-type.html
+++ b/public/spec/adapter/element-type.html
@@ -23,7 +23,7 @@
         </ul>
         <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
-          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <input id="site-search-input" data-search-input type="search" placeholder="Search MCP-AQL docs, spec pages, and adapter patterns...">
           <span class="search-count" data-search-count></span>
           <ul class="search-results" data-search-results hidden></ul>
         </form>
@@ -44,7 +44,7 @@
   <ul><li><a href="../versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Adapter</h3>
-  <ul><li><a href="danger-levels.html">Dangerous Operation Classification Specification</a></li><li><a href="discovery-bundle.html">MCP Server Discovery Bundle</a></li><li><a class="current" href="element-type.html">Adapter Element Type Specification</a></li><li><a href="generator.html">Adapter Generator Specification</a></li><li><a href="rate-limiting.html">Rate Limiting and Quota Management Specification</a></li><li><a href="trust-levels.html">Trust Levels Specification</a></li></ul>
+  <ul><li><a href="danger-levels.html">Dangerous Operation Classification Specification</a></li><li><a href="discovery-bundle.html">MCP Server Discovery Bundle</a></li><li><a class="current" aria-current="page" href="element-type.html">Adapter Element Type Specification</a></li><li><a href="generator.html">Adapter Generator Specification</a></li><li><a href="rate-limiting.html">Rate Limiting and Quota Management Specification</a></li><li><a href="trust-levels.html">Trust Levels Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Security</h3>
   <ul><li><a href="../security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="../security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="../security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
@@ -568,6 +568,16 @@
 
           </div>
         </section>
+        <nav class="page-nav" aria-label="Page navigation">
+  <a class="page-nav-link prev" href="discovery-bundle.html">
+    <span class="page-nav-eyebrow">Previous spec page</span>
+    <strong class="page-nav-label">MCP Server Discovery Bundle</strong>
+  </a>
+  <a class="page-nav-link next" href="generator.html">
+    <span class="page-nav-eyebrow">Next spec page</span>
+    <strong class="page-nav-label">Adapter Generator Specification</strong>
+  </a>
+</nav>
       </article>
     </div>
   </main>

--- a/public/spec/adapter/element-type.html
+++ b/public/spec/adapter/element-type.html
@@ -38,7 +38,7 @@
         <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
         <div class="docs-side-group">
   <h3>Core</h3>
-  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li></ul>
+  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li><li><a href="../repo/README.html">MCP-AQL Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Versions</h3>
   <ul><li><a href="../versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
@@ -56,7 +56,7 @@
   <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
-  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li></ul>
+  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li><li><a href="../repo/CHANGELOG.html">Changelog</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Architecture</h3>
   <ul><li><a href="../architecture/README.html">Architecture Documentation</a></li></ul>

--- a/public/spec/adapter/element-type.html
+++ b/public/spec/adapter/element-type.html
@@ -73,6 +73,13 @@
       </aside>
 
       <article class="docs-main">
+        <nav class="breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../../index.html">Home</a></li>
+            <li><a href="../index.html">Full Spec</a></li>
+            <li><span class="current">Adapter Element Type Specification</span></li>
+          </ol>
+        </nav>
         <section class="hero docs-hero">
           <div class="hero-inner">
             <span class="status-pill">REPO-SYNCED SPEC DOC</span>

--- a/public/spec/adapter/generator.html
+++ b/public/spec/adapter/generator.html
@@ -23,7 +23,7 @@
         </ul>
         <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
-          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <input id="site-search-input" data-search-input type="search" placeholder="Search MCP-AQL docs, spec pages, and adapter patterns...">
           <span class="search-count" data-search-count></span>
           <ul class="search-results" data-search-results hidden></ul>
         </form>
@@ -44,7 +44,7 @@
   <ul><li><a href="../versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Adapter</h3>
-  <ul><li><a href="danger-levels.html">Dangerous Operation Classification Specification</a></li><li><a href="discovery-bundle.html">MCP Server Discovery Bundle</a></li><li><a href="element-type.html">Adapter Element Type Specification</a></li><li><a class="current" href="generator.html">Adapter Generator Specification</a></li><li><a href="rate-limiting.html">Rate Limiting and Quota Management Specification</a></li><li><a href="trust-levels.html">Trust Levels Specification</a></li></ul>
+  <ul><li><a href="danger-levels.html">Dangerous Operation Classification Specification</a></li><li><a href="discovery-bundle.html">MCP Server Discovery Bundle</a></li><li><a href="element-type.html">Adapter Element Type Specification</a></li><li><a class="current" aria-current="page" href="generator.html">Adapter Generator Specification</a></li><li><a href="rate-limiting.html">Rate Limiting and Quota Management Specification</a></li><li><a href="trust-levels.html">Trust Levels Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Security</h3>
   <ul><li><a href="../security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="../security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="../security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
@@ -1136,6 +1136,16 @@
 
           </div>
         </section>
+        <nav class="page-nav" aria-label="Page navigation">
+  <a class="page-nav-link prev" href="element-type.html">
+    <span class="page-nav-eyebrow">Previous spec page</span>
+    <strong class="page-nav-label">Adapter Element Type Specification</strong>
+  </a>
+  <a class="page-nav-link next" href="rate-limiting.html">
+    <span class="page-nav-eyebrow">Next spec page</span>
+    <strong class="page-nav-label">Rate Limiting and Quota Management Specification</strong>
+  </a>
+</nav>
       </article>
     </div>
   </main>

--- a/public/spec/adapter/generator.html
+++ b/public/spec/adapter/generator.html
@@ -73,6 +73,13 @@
       </aside>
 
       <article class="docs-main">
+        <nav class="breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../../index.html">Home</a></li>
+            <li><a href="../index.html">Full Spec</a></li>
+            <li><span class="current">Adapter Generator Specification</span></li>
+          </ol>
+        </nav>
         <section class="hero docs-hero">
           <div class="hero-inner">
             <span class="status-pill">REPO-SYNCED SPEC DOC</span>

--- a/public/spec/adapter/generator.html
+++ b/public/spec/adapter/generator.html
@@ -1,0 +1,1150 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="This document specifies the requirements and behavior of MCP-AQL adapter generators. An adapter generator takes a schema definition as input and produces compliant adapter code with required licensing artifacts and prove">
+  <title>MCP-AQL Spec | Adapter Generator Specification</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../../css/style.css">
+</head>
+<body>
+  <header>
+    <div class="container">
+      <nav>
+        <a class="logo" href="../../index.html"><span class="logo-mark"></span>MCP-AQL</a>
+        <ul class="nav-links">
+          <li><a href="../../index.html">Home</a></li>
+          <li><a href="../../docs/index.html">Docs</a></li>
+          <li><a href="../../launch-checklist.html">Launch Checklist</a></li>
+          <li><a href="../../apis/mcp-server.html">Adapter Patterns</a></li>
+        </ul>
+        <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
+          <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
+          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <span class="search-count" data-search-count></span>
+          <ul class="search-results" data-search-results hidden></ul>
+        </form>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <div class="container docs-shell">
+      <aside class="docs-side">
+        <h2>Repo-Synced Spec</h2>
+        <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
+        <div class="docs-side-group">
+  <h3>Core</h3>
+  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Versions</h3>
+  <ul><li><a href="../versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Adapter</h3>
+  <ul><li><a href="danger-levels.html">Dangerous Operation Classification Specification</a></li><li><a href="discovery-bundle.html">MCP Server Discovery Bundle</a></li><li><a href="element-type.html">Adapter Element Type Specification</a></li><li><a class="current" href="generator.html">Adapter Generator Specification</a></li><li><a href="rate-limiting.html">Rate Limiting and Quota Management Specification</a></li><li><a href="trust-levels.html">Trust Levels Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Security</h3>
+  <ul><li><a href="../security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="../security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="../security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Features</h3>
+  <ul><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Guides</h3>
+  <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Process</h3>
+  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Architecture</h3>
+  <ul><li><a href="../architecture/README.html">Architecture Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Research</h3>
+  <ul><li><a href="../research/mcp-vs-mcpaql-vs-a2a.html">Protocol Landscape: MCP vs MCP-AQL vs A2A</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Reference</h3>
+  <ul><li><a href="../reference/README.html">Reference Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>ADRs</h3>
+  <ul><li><a href="../adr/ADR-001-crude-pattern.html">ADR-001: CRUDE Pattern (Extending CRUD with Execute)</a></li><li><a href="../adr/ADR-002-graphql-style-input.html">ADR-002: GraphQL-Style Input Objects for Updates</a></li><li><a href="../adr/ADR-003-snake-case-parameters.html">ADR-003: snake_case Parameter Convention</a></li><li><a href="../adr/ADR-004-schema-driven-operations.html">ADR-004: Schema-Driven Operation Definitions</a></li><li><a href="../adr/ADR-005-introspection-system.html">ADR-005: GraphQL-Style Introspection System</a></li><li><a href="../adr/ADR-006-discriminated-responses.html">ADR-006: Discriminated Response Format</a></li><li><a href="../adr/index.html">Architecture Decision Records</a></li><li><a href="../adr/README.html">Architecture Decision Records</a></li></ul>
+</div>
+      </aside>
+
+      <article class="docs-main">
+        <section class="hero docs-hero">
+          <div class="hero-inner">
+            <span class="status-pill">REPO-SYNCED SPEC DOC</span>
+            <h1>Adapter Generator Specification</h1>
+            <p class="lede">This document specifies the requirements and behavior of MCP-AQL adapter generators. An adapter generator takes a schema definition as input and produces compliant adapter code with required licensing artifacts and prove</p>
+            <div class="spec-meta"><span class="state-chip live">Support document</span><span class="state-chip pending">Draft</span><span class="state-chip">1.0.0-draft</span><span class="state-chip">2026-01-29</span></div>
+            <p class="spec-source">Source: <a href="https://github.com/MCPAQL/spec/blob/main/docs/adapter/generator.md">spec/docs/adapter/generator.md</a></p>
+            <div class="hero-actions">
+              <a class="btn btn-primary" href="https://github.com/MCPAQL/spec/blob/main/docs/adapter/generator.md">Open Source Markdown</a>
+              <a class="btn btn-secondary" href="../index.html">Browse Full Spec Reference</a>
+            </div>
+          </div>
+        </section>
+
+        <section>
+          <div class="card spec-prose">
+            <p><strong>Version:</strong> 1.0.0-draft <strong>Status:</strong> Draft <strong>Last Updated:</strong> 2026-01-29</p>
+<h2 id="abstract">Abstract</h2>
+<p>This document specifies the requirements and behavior of MCP-AQL adapter generators. An adapter generator takes a schema definition as input and produces compliant adapter code with required licensing artifacts and provenance information.</p>
+<hr />
+<h2 id="table-of-contents">Table of Contents</h2>
+<ol type="1">
+<li><a href="#1-overview">Overview</a></li>
+<li><a href="#2-schema-input-format">Schema Input Format</a></li>
+<li><a href="#3-generated-output-structure">Generated Output Structure</a></li>
+<li><a href="#4-licensing-artifacts">Licensing Artifacts</a></li>
+<li><a href="#5-provenance-information">Provenance Information</a></li>
+<li><a href="#6-language-templates">Language Templates</a></li>
+<li><a href="#7-command-line-interface">Command-Line Interface</a></li>
+<li><a href="#8-conformance-requirements">Conformance Requirements</a></li>
+</ol>
+<hr />
+<h2 id="1-overview">1. Overview</h2>
+<h3 id="11-purpose">1.1 Purpose</h3>
+<p>Adapter generators automate the creation of MCP-AQL adapters from schema definitions. This ensures:</p>
+<ul>
+<li><strong>Consistency</strong> - All generated adapters follow the same patterns</li>
+<li><strong>Compliance</strong> - Licensing and attribution requirements are met</li>
+<li><strong>Traceability</strong> - Provenance information enables debugging and auditing</li>
+<li><strong>Productivity</strong> - Developers focus on business logic, not boilerplate</li>
+</ul>
+<h3 id="12-generator-types">1.2 Generator Types</h3>
+<table>
+<thead>
+<tr>
+<th>Type</th>
+<th>Description</th>
+<th>Use Case</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>Schema-to-Code</strong></td>
+<td>Generates adapter source code from schema</td>
+<td>Development workflow</td>
+</tr>
+<tr>
+<td><strong>Schema-to-Runtime</strong></td>
+<td>Generates runtime configuration</td>
+<td>Dynamic adapter loading</td>
+</tr>
+<tr>
+<td><strong>Code-to-Schema</strong></td>
+<td>Extracts schema from existing adapter</td>
+<td>Migration, documentation</td>
+</tr>
+</tbody>
+</table>
+<p>This specification primarily covers Schema-to-Code generators.</p>
+<h3 id="13-scope">1.3 Scope</h3>
+<p><strong>In scope:</strong></p>
+<ul>
+<li>Schema input format and validation</li>
+<li>Generated code structure and artifacts</li>
+<li>Licensing and provenance requirements</li>
+<li>Language-specific template guidance</li>
+</ul>
+<p><strong>Out of scope:</strong></p>
+<ul>
+<li>Runtime behavior (see <a href="../versions/v1.0.0-draft.html">MCP-AQL Specification</a>)</li>
+<li>Adapter testing (see <a href="../conformance-testing.html">Conformance Testing</a>)</li>
+<li>Deployment and distribution</li>
+</ul>
+<hr />
+<h2 id="2-schema-input-format">2. Schema Input Format</h2>
+<h3 id="21-schema-structure">2.1 Schema Structure</h3>
+<p>Generators MUST accept schemas in the following format:</p>
+<div class="sourceCode" id="cb1"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a><span class="kw">interface</span> AdapterSchema {</span>
+<span id="cb1-2"><a href="#cb1-2" aria-hidden="true" tabindex="-1"></a>  <span class="co">/**</span></span>
+<span id="cb1-3"><a href="#cb1-3" aria-hidden="true" tabindex="-1"></a><span class="co">   * Schema format version</span></span>
+<span id="cb1-4"><a href="#cb1-4" aria-hidden="true" tabindex="-1"></a><span class="co">   */</span></span>
+<span id="cb1-5"><a href="#cb1-5" aria-hidden="true" tabindex="-1"></a>  schema_version<span class="op">:</span> <span class="st">&#39;1.0&#39;</span><span class="op">;</span></span>
+<span id="cb1-6"><a href="#cb1-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb1-7"><a href="#cb1-7" aria-hidden="true" tabindex="-1"></a>  <span class="co">/**</span></span>
+<span id="cb1-8"><a href="#cb1-8" aria-hidden="true" tabindex="-1"></a><span class="co">   * Adapter metadata</span></span>
+<span id="cb1-9"><a href="#cb1-9" aria-hidden="true" tabindex="-1"></a><span class="co">   */</span></span>
+<span id="cb1-10"><a href="#cb1-10" aria-hidden="true" tabindex="-1"></a>  adapter<span class="op">:</span> {</span>
+<span id="cb1-11"><a href="#cb1-11" aria-hidden="true" tabindex="-1"></a>    <span class="co">/** Unique adapter identifier */</span></span>
+<span id="cb1-12"><a href="#cb1-12" aria-hidden="true" tabindex="-1"></a>    name<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb1-13"><a href="#cb1-13" aria-hidden="true" tabindex="-1"></a>    <span class="co">/** Human-readable display name */</span></span>
+<span id="cb1-14"><a href="#cb1-14" aria-hidden="true" tabindex="-1"></a>    display_name<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb1-15"><a href="#cb1-15" aria-hidden="true" tabindex="-1"></a>    <span class="co">/** Adapter version (semver) */</span></span>
+<span id="cb1-16"><a href="#cb1-16" aria-hidden="true" tabindex="-1"></a>    version<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb1-17"><a href="#cb1-17" aria-hidden="true" tabindex="-1"></a>    <span class="co">/** Brief description */</span></span>
+<span id="cb1-18"><a href="#cb1-18" aria-hidden="true" tabindex="-1"></a>    description<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb1-19"><a href="#cb1-19" aria-hidden="true" tabindex="-1"></a>    <span class="co">/** Target API being adapted */</span></span>
+<span id="cb1-20"><a href="#cb1-20" aria-hidden="true" tabindex="-1"></a>    target_api<span class="op">:</span> {</span>
+<span id="cb1-21"><a href="#cb1-21" aria-hidden="true" tabindex="-1"></a>      name<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb1-22"><a href="#cb1-22" aria-hidden="true" tabindex="-1"></a>      base_url<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb1-23"><a href="#cb1-23" aria-hidden="true" tabindex="-1"></a>      version<span class="op">?:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb1-24"><a href="#cb1-24" aria-hidden="true" tabindex="-1"></a>    }<span class="op">;</span></span>
+<span id="cb1-25"><a href="#cb1-25" aria-hidden="true" tabindex="-1"></a>  }<span class="op">;</span></span>
+<span id="cb1-26"><a href="#cb1-26" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb1-27"><a href="#cb1-27" aria-hidden="true" tabindex="-1"></a>  <span class="co">/**</span></span>
+<span id="cb1-28"><a href="#cb1-28" aria-hidden="true" tabindex="-1"></a><span class="co">   * Authentication configuration</span></span>
+<span id="cb1-29"><a href="#cb1-29" aria-hidden="true" tabindex="-1"></a><span class="co">   */</span></span>
+<span id="cb1-30"><a href="#cb1-30" aria-hidden="true" tabindex="-1"></a>  auth<span class="op">?:</span> {</span>
+<span id="cb1-31"><a href="#cb1-31" aria-hidden="true" tabindex="-1"></a>    type<span class="op">:</span> <span class="st">&#39;api_key&#39;</span> <span class="op">|</span> <span class="st">&#39;oauth2&#39;</span> <span class="op">|</span> <span class="st">&#39;bearer&#39;</span> <span class="op">|</span> <span class="st">&#39;basic&#39;</span> <span class="op">|</span> <span class="st">&#39;none&#39;</span><span class="op">;</span></span>
+<span id="cb1-32"><a href="#cb1-32" aria-hidden="true" tabindex="-1"></a>    config<span class="op">?:</span> <span class="bu">Record</span><span class="op">&lt;</span><span class="dt">string</span><span class="op">,</span> <span class="dt">unknown</span><span class="op">&gt;;</span></span>
+<span id="cb1-33"><a href="#cb1-33" aria-hidden="true" tabindex="-1"></a>  }<span class="op">;</span></span>
+<span id="cb1-34"><a href="#cb1-34" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb1-35"><a href="#cb1-35" aria-hidden="true" tabindex="-1"></a>  <span class="co">/**</span></span>
+<span id="cb1-36"><a href="#cb1-36" aria-hidden="true" tabindex="-1"></a><span class="co">   * Operation definitions by endpoint</span></span>
+<span id="cb1-37"><a href="#cb1-37" aria-hidden="true" tabindex="-1"></a><span class="co">   */</span></span>
+<span id="cb1-38"><a href="#cb1-38" aria-hidden="true" tabindex="-1"></a>  endpoints<span class="op">:</span> {</span>
+<span id="cb1-39"><a href="#cb1-39" aria-hidden="true" tabindex="-1"></a>    create<span class="op">?:</span> OperationDefinition[]<span class="op">;</span></span>
+<span id="cb1-40"><a href="#cb1-40" aria-hidden="true" tabindex="-1"></a>    read<span class="op">?:</span> OperationDefinition[]<span class="op">;</span></span>
+<span id="cb1-41"><a href="#cb1-41" aria-hidden="true" tabindex="-1"></a>    update<span class="op">?:</span> OperationDefinition[]<span class="op">;</span></span>
+<span id="cb1-42"><a href="#cb1-42" aria-hidden="true" tabindex="-1"></a>    <span class="kw">delete</span><span class="op">?:</span> OperationDefinition[]<span class="op">;</span></span>
+<span id="cb1-43"><a href="#cb1-43" aria-hidden="true" tabindex="-1"></a>    execute<span class="op">?:</span> OperationDefinition[]<span class="op">;</span></span>
+<span id="cb1-44"><a href="#cb1-44" aria-hidden="true" tabindex="-1"></a>  }<span class="op">;</span></span>
+<span id="cb1-45"><a href="#cb1-45" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb1-46"><a href="#cb1-46" aria-hidden="true" tabindex="-1"></a>  <span class="co">/**</span></span>
+<span id="cb1-47"><a href="#cb1-47" aria-hidden="true" tabindex="-1"></a><span class="co">   * Custom type definitions</span></span>
+<span id="cb1-48"><a href="#cb1-48" aria-hidden="true" tabindex="-1"></a><span class="co">   */</span></span>
+<span id="cb1-49"><a href="#cb1-49" aria-hidden="true" tabindex="-1"></a>  types<span class="op">?:</span> TypeDefinition[]<span class="op">;</span></span>
+<span id="cb1-50"><a href="#cb1-50" aria-hidden="true" tabindex="-1"></a>}</span>
+<span id="cb1-51"><a href="#cb1-51" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb1-52"><a href="#cb1-52" aria-hidden="true" tabindex="-1"></a><span class="kw">interface</span> OperationDefinition {</span>
+<span id="cb1-53"><a href="#cb1-53" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** Operation name (snake_case) */</span></span>
+<span id="cb1-54"><a href="#cb1-54" aria-hidden="true" tabindex="-1"></a>  name<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb1-55"><a href="#cb1-55" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** Human-readable description */</span></span>
+<span id="cb1-56"><a href="#cb1-56" aria-hidden="true" tabindex="-1"></a>  description<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb1-57"><a href="#cb1-57" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** Input parameters */</span></span>
+<span id="cb1-58"><a href="#cb1-58" aria-hidden="true" tabindex="-1"></a>  params<span class="op">:</span> ParameterDefinition[]<span class="op">;</span></span>
+<span id="cb1-59"><a href="#cb1-59" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** Output schema */</span></span>
+<span id="cb1-60"><a href="#cb1-60" aria-hidden="true" tabindex="-1"></a>  returns<span class="op">:</span> TypeReference<span class="op">;</span></span>
+<span id="cb1-61"><a href="#cb1-61" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** Danger level for security classification */</span></span>
+<span id="cb1-62"><a href="#cb1-62" aria-hidden="true" tabindex="-1"></a>  danger_level<span class="op">?:</span> <span class="st">&#39;safe&#39;</span> <span class="op">|</span> <span class="st">&#39;reversible&#39;</span> <span class="op">|</span> <span class="st">&#39;destructive&#39;</span> <span class="op">|</span> <span class="st">&#39;dangerous&#39;</span> <span class="op">|</span> <span class="st">&#39;forbidden&#39;</span><span class="op">;</span></span>
+<span id="cb1-63"><a href="#cb1-63" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** HTTP method and path for target API */</span></span>
+<span id="cb1-64"><a href="#cb1-64" aria-hidden="true" tabindex="-1"></a>  http<span class="op">?:</span> {</span>
+<span id="cb1-65"><a href="#cb1-65" aria-hidden="true" tabindex="-1"></a>    method<span class="op">:</span> <span class="st">&#39;GET&#39;</span> <span class="op">|</span> <span class="st">&#39;POST&#39;</span> <span class="op">|</span> <span class="st">&#39;PUT&#39;</span> <span class="op">|</span> <span class="st">&#39;PATCH&#39;</span> <span class="op">|</span> <span class="st">&#39;DELETE&#39;</span><span class="op">;</span></span>
+<span id="cb1-66"><a href="#cb1-66" aria-hidden="true" tabindex="-1"></a>    path<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb1-67"><a href="#cb1-67" aria-hidden="true" tabindex="-1"></a>  }<span class="op">;</span></span>
+<span id="cb1-68"><a href="#cb1-68" aria-hidden="true" tabindex="-1"></a>}</span>
+<span id="cb1-69"><a href="#cb1-69" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb1-70"><a href="#cb1-70" aria-hidden="true" tabindex="-1"></a><span class="kw">interface</span> ParameterDefinition {</span>
+<span id="cb1-71"><a href="#cb1-71" aria-hidden="true" tabindex="-1"></a>  name<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb1-72"><a href="#cb1-72" aria-hidden="true" tabindex="-1"></a>  type<span class="op">:</span> TypeReference<span class="op">;</span></span>
+<span id="cb1-73"><a href="#cb1-73" aria-hidden="true" tabindex="-1"></a>  required<span class="op">:</span> <span class="dt">boolean</span><span class="op">;</span></span>
+<span id="cb1-74"><a href="#cb1-74" aria-hidden="true" tabindex="-1"></a>  description<span class="op">?:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb1-75"><a href="#cb1-75" aria-hidden="true" tabindex="-1"></a>  <span class="cf">default</span><span class="op">?:</span> <span class="dt">unknown</span><span class="op">;</span></span>
+<span id="cb1-76"><a href="#cb1-76" aria-hidden="true" tabindex="-1"></a>}</span>
+<span id="cb1-77"><a href="#cb1-77" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb1-78"><a href="#cb1-78" aria-hidden="true" tabindex="-1"></a><span class="kw">type</span> TypeReference <span class="op">=</span></span>
+<span id="cb1-79"><a href="#cb1-79" aria-hidden="true" tabindex="-1"></a>  <span class="op">|</span> <span class="st">&#39;string&#39;</span> <span class="op">|</span> <span class="st">&#39;integer&#39;</span> <span class="op">|</span> <span class="st">&#39;number&#39;</span> <span class="op">|</span> <span class="st">&#39;boolean&#39;</span> <span class="op">|</span> <span class="st">&#39;object&#39;</span> <span class="op">|</span> <span class="st">&#39;array&#39;</span></span>
+<span id="cb1-80"><a href="#cb1-80" aria-hidden="true" tabindex="-1"></a>  <span class="op">|</span> { array<span class="op">:</span> TypeReference }</span>
+<span id="cb1-81"><a href="#cb1-81" aria-hidden="true" tabindex="-1"></a>  <span class="op">|</span> { object<span class="op">:</span> <span class="bu">Record</span><span class="op">&lt;</span><span class="dt">string</span><span class="op">,</span> TypeReference<span class="op">&gt;</span> }</span>
+<span id="cb1-82"><a href="#cb1-82" aria-hidden="true" tabindex="-1"></a>  <span class="op">|</span> { ref<span class="op">:</span> <span class="dt">string</span> }<span class="op">;</span></span>
+<span id="cb1-83"><a href="#cb1-83" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb1-84"><a href="#cb1-84" aria-hidden="true" tabindex="-1"></a><span class="kw">interface</span> TypeDefinition {</span>
+<span id="cb1-85"><a href="#cb1-85" aria-hidden="true" tabindex="-1"></a>  name<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb1-86"><a href="#cb1-86" aria-hidden="true" tabindex="-1"></a>  fields<span class="op">:</span> ParameterDefinition[]<span class="op">;</span></span>
+<span id="cb1-87"><a href="#cb1-87" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<h3 id="22-schema-validation">2.2 Schema Validation</h3>
+<p>Generators MUST validate input schemas:</p>
+<ol type="1">
+<li><strong>Required fields</strong> - All required fields MUST be present</li>
+<li><strong>Type correctness</strong> - Field values MUST match expected types</li>
+<li><strong>Reference resolution</strong> - Type references MUST resolve</li>
+<li><strong>Name uniqueness</strong> - Operation and type names MUST be unique</li>
+<li><strong>Naming conventions</strong> - Names MUST follow snake_case convention</li>
+</ol>
+<p><strong>Validation error codes:</strong></p>
+<table>
+<thead>
+<tr>
+<th>Validation</th>
+<th>Error Code</th>
+<th>Example Message</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Missing required field</td>
+<td><code>SCHEMA_MISSING_FIELD</code></td>
+<td>"Required field 'adapter.name' is missing"</td>
+</tr>
+<tr>
+<td>Type mismatch</td>
+<td><code>SCHEMA_INVALID_TYPE</code></td>
+<td>"Field 'params[0].required' expected boolean, got string"</td>
+</tr>
+<tr>
+<td>Unresolved reference</td>
+<td><code>SCHEMA_UNRESOLVED_REF</code></td>
+<td>"Type reference 'Repository' not found in types"</td>
+</tr>
+<tr>
+<td>Duplicate name</td>
+<td><code>SCHEMA_DUPLICATE_NAME</code></td>
+<td>"Operation 'get_user' defined multiple times in read endpoint"</td>
+</tr>
+<tr>
+<td>Invalid naming</td>
+<td><code>SCHEMA_INVALID_NAME</code></td>
+<td>"Parameter name 'userName' must be snake_case (try 'user_name')"</td>
+</tr>
+</tbody>
+</table>
+<p><strong>Example validation error response:</strong></p>
+<div class="sourceCode" id="cb2"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb2-2"><a href="#cb2-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb2-3"><a href="#cb2-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;error&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb2-4"><a href="#cb2-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;code&quot;</span><span class="fu">:</span> <span class="st">&quot;SCHEMA_INVALID_TYPE&quot;</span><span class="fu">,</span></span>
+<span id="cb2-5"><a href="#cb2-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;Field &#39;endpoints.read[0].params[0].required&#39; expected boolean, got string&quot;</span><span class="fu">,</span></span>
+<span id="cb2-6"><a href="#cb2-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;details&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb2-7"><a href="#cb2-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;field_path&quot;</span><span class="fu">:</span> <span class="st">&quot;endpoints.read[0].params[0].required&quot;</span><span class="fu">,</span></span>
+<span id="cb2-8"><a href="#cb2-8" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;expected_type&quot;</span><span class="fu">:</span> <span class="st">&quot;boolean&quot;</span><span class="fu">,</span></span>
+<span id="cb2-9"><a href="#cb2-9" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;actual_type&quot;</span><span class="fu">:</span> <span class="st">&quot;string&quot;</span><span class="fu">,</span></span>
+<span id="cb2-10"><a href="#cb2-10" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;actual_value&quot;</span><span class="fu">:</span> <span class="st">&quot;true&quot;</span><span class="fu">,</span></span>
+<span id="cb2-11"><a href="#cb2-11" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;suggestion&quot;</span><span class="fu">:</span> <span class="st">&quot;Use `required: true` instead of `required: </span><span class="ch">\&quot;</span><span class="st">true</span><span class="ch">\&quot;</span><span class="st">`&quot;</span></span>
+<span id="cb2-12"><a href="#cb2-12" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb2-13"><a href="#cb2-13" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb2-14"><a href="#cb2-14" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<p>Validation errors MUST include:</p>
+<ul>
+<li>Field path (e.g., <code>endpoints.read[0].params[2].name</code>)</li>
+<li>Expected value/type</li>
+<li>Actual value/type</li>
+<li>Suggested fix when possible</li>
+</ul>
+<h3 id="23-schema-examples">2.3 Schema Examples</h3>
+<p><strong>Minimal schema:</strong></p>
+<div class="sourceCode" id="cb3"><pre class="sourceCode yaml"><code class="sourceCode yaml"><span id="cb3-1"><a href="#cb3-1" aria-hidden="true" tabindex="-1"></a><span class="fu">schema_version</span><span class="kw">:</span><span class="at"> </span><span class="st">&#39;1.0&#39;</span></span>
+<span id="cb3-2"><a href="#cb3-2" aria-hidden="true" tabindex="-1"></a><span class="fu">adapter</span><span class="kw">:</span></span>
+<span id="cb3-3"><a href="#cb3-3" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">name</span><span class="kw">:</span><span class="at"> example_api</span></span>
+<span id="cb3-4"><a href="#cb3-4" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">display_name</span><span class="kw">:</span><span class="at"> Example API</span></span>
+<span id="cb3-5"><a href="#cb3-5" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">version</span><span class="kw">:</span><span class="at"> </span><span class="fl">1.0.0</span></span>
+<span id="cb3-6"><a href="#cb3-6" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">description</span><span class="kw">:</span><span class="at"> Example adapter for demonstration</span></span>
+<span id="cb3-7"><a href="#cb3-7" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">target_api</span><span class="kw">:</span></span>
+<span id="cb3-8"><a href="#cb3-8" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">name</span><span class="kw">:</span><span class="at"> Example Service</span></span>
+<span id="cb3-9"><a href="#cb3-9" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">base_url</span><span class="kw">:</span><span class="at"> https://api.example.com/v1</span></span>
+<span id="cb3-10"><a href="#cb3-10" aria-hidden="true" tabindex="-1"></a><span class="fu">endpoints</span><span class="kw">:</span></span>
+<span id="cb3-11"><a href="#cb3-11" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">read</span><span class="kw">:</span></span>
+<span id="cb3-12"><a href="#cb3-12" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="kw">-</span><span class="at"> </span><span class="fu">name</span><span class="kw">:</span><span class="at"> get_item</span></span>
+<span id="cb3-13"><a href="#cb3-13" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">description</span><span class="kw">:</span><span class="at"> Retrieve an item by ID</span></span>
+<span id="cb3-14"><a href="#cb3-14" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">params</span><span class="kw">:</span></span>
+<span id="cb3-15"><a href="#cb3-15" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="kw">-</span><span class="at"> </span><span class="fu">name</span><span class="kw">:</span><span class="at"> id</span></span>
+<span id="cb3-16"><a href="#cb3-16" aria-hidden="true" tabindex="-1"></a><span class="at">          </span><span class="fu">type</span><span class="kw">:</span><span class="at"> string</span></span>
+<span id="cb3-17"><a href="#cb3-17" aria-hidden="true" tabindex="-1"></a><span class="at">          </span><span class="fu">required</span><span class="kw">:</span><span class="at"> </span><span class="ch">true</span></span>
+<span id="cb3-18"><a href="#cb3-18" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">returns</span><span class="kw">:</span><span class="at"> object</span></span>
+<span id="cb3-19"><a href="#cb3-19" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">http</span><span class="kw">:</span></span>
+<span id="cb3-20"><a href="#cb3-20" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">method</span><span class="kw">:</span><span class="at"> GET</span></span>
+<span id="cb3-21"><a href="#cb3-21" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">path</span><span class="kw">:</span><span class="at"> /items/{id}</span></span></code></pre></div>
+<p><strong>Schema with authentication and types:</strong></p>
+<div class="sourceCode" id="cb4"><pre class="sourceCode yaml"><code class="sourceCode yaml"><span id="cb4-1"><a href="#cb4-1" aria-hidden="true" tabindex="-1"></a><span class="fu">schema_version</span><span class="kw">:</span><span class="at"> </span><span class="st">&#39;1.0&#39;</span></span>
+<span id="cb4-2"><a href="#cb4-2" aria-hidden="true" tabindex="-1"></a><span class="fu">adapter</span><span class="kw">:</span></span>
+<span id="cb4-3"><a href="#cb4-3" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">name</span><span class="kw">:</span><span class="at"> github_api</span></span>
+<span id="cb4-4"><a href="#cb4-4" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">display_name</span><span class="kw">:</span><span class="at"> GitHub API</span></span>
+<span id="cb4-5"><a href="#cb4-5" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">version</span><span class="kw">:</span><span class="at"> </span><span class="fl">1.0.0</span></span>
+<span id="cb4-6"><a href="#cb4-6" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">description</span><span class="kw">:</span><span class="at"> MCP-AQL adapter for GitHub REST API</span></span>
+<span id="cb4-7"><a href="#cb4-7" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">target_api</span><span class="kw">:</span></span>
+<span id="cb4-8"><a href="#cb4-8" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">name</span><span class="kw">:</span><span class="at"> GitHub REST API</span></span>
+<span id="cb4-9"><a href="#cb4-9" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">base_url</span><span class="kw">:</span><span class="at"> https://api.github.com</span></span>
+<span id="cb4-10"><a href="#cb4-10" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">version</span><span class="kw">:</span><span class="at"> </span><span class="st">&#39;2022-11-28&#39;</span></span>
+<span id="cb4-11"><a href="#cb4-11" aria-hidden="true" tabindex="-1"></a><span class="fu">auth</span><span class="kw">:</span></span>
+<span id="cb4-12"><a href="#cb4-12" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">type</span><span class="kw">:</span><span class="at"> bearer</span></span>
+<span id="cb4-13"><a href="#cb4-13" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">config</span><span class="kw">:</span></span>
+<span id="cb4-14"><a href="#cb4-14" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">header_name</span><span class="kw">:</span><span class="at"> Authorization</span></span>
+<span id="cb4-15"><a href="#cb4-15" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">prefix</span><span class="kw">:</span><span class="at"> </span><span class="st">&#39;Bearer &#39;</span></span>
+<span id="cb4-16"><a href="#cb4-16" aria-hidden="true" tabindex="-1"></a><span class="fu">types</span><span class="kw">:</span></span>
+<span id="cb4-17"><a href="#cb4-17" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="kw">-</span><span class="at"> </span><span class="fu">name</span><span class="kw">:</span><span class="at"> Repository</span></span>
+<span id="cb4-18"><a href="#cb4-18" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">fields</span><span class="kw">:</span></span>
+<span id="cb4-19"><a href="#cb4-19" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="kw">-</span><span class="at"> </span><span class="fu">name</span><span class="kw">:</span><span class="at"> id</span></span>
+<span id="cb4-20"><a href="#cb4-20" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">type</span><span class="kw">:</span><span class="at"> integer</span></span>
+<span id="cb4-21"><a href="#cb4-21" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">required</span><span class="kw">:</span><span class="at"> </span><span class="ch">true</span></span>
+<span id="cb4-22"><a href="#cb4-22" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="kw">-</span><span class="at"> </span><span class="fu">name</span><span class="kw">:</span><span class="at"> name</span></span>
+<span id="cb4-23"><a href="#cb4-23" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">type</span><span class="kw">:</span><span class="at"> string</span></span>
+<span id="cb4-24"><a href="#cb4-24" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">required</span><span class="kw">:</span><span class="at"> </span><span class="ch">true</span></span>
+<span id="cb4-25"><a href="#cb4-25" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="kw">-</span><span class="at"> </span><span class="fu">name</span><span class="kw">:</span><span class="at"> full_name</span></span>
+<span id="cb4-26"><a href="#cb4-26" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">type</span><span class="kw">:</span><span class="at"> string</span></span>
+<span id="cb4-27"><a href="#cb4-27" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">required</span><span class="kw">:</span><span class="at"> </span><span class="ch">true</span></span>
+<span id="cb4-28"><a href="#cb4-28" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="kw">-</span><span class="at"> </span><span class="fu">name</span><span class="kw">:</span><span class="at"> private</span></span>
+<span id="cb4-29"><a href="#cb4-29" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">type</span><span class="kw">:</span><span class="at"> boolean</span></span>
+<span id="cb4-30"><a href="#cb4-30" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">required</span><span class="kw">:</span><span class="at"> </span><span class="ch">true</span></span>
+<span id="cb4-31"><a href="#cb4-31" aria-hidden="true" tabindex="-1"></a><span class="fu">endpoints</span><span class="kw">:</span></span>
+<span id="cb4-32"><a href="#cb4-32" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">read</span><span class="kw">:</span></span>
+<span id="cb4-33"><a href="#cb4-33" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="kw">-</span><span class="at"> </span><span class="fu">name</span><span class="kw">:</span><span class="at"> get_repo</span></span>
+<span id="cb4-34"><a href="#cb4-34" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">description</span><span class="kw">:</span><span class="at"> Get a repository by owner and name</span></span>
+<span id="cb4-35"><a href="#cb4-35" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">params</span><span class="kw">:</span></span>
+<span id="cb4-36"><a href="#cb4-36" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="kw">-</span><span class="at"> </span><span class="fu">name</span><span class="kw">:</span><span class="at"> owner</span></span>
+<span id="cb4-37"><a href="#cb4-37" aria-hidden="true" tabindex="-1"></a><span class="at">          </span><span class="fu">type</span><span class="kw">:</span><span class="at"> string</span></span>
+<span id="cb4-38"><a href="#cb4-38" aria-hidden="true" tabindex="-1"></a><span class="at">          </span><span class="fu">required</span><span class="kw">:</span><span class="at"> </span><span class="ch">true</span></span>
+<span id="cb4-39"><a href="#cb4-39" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="kw">-</span><span class="at"> </span><span class="fu">name</span><span class="kw">:</span><span class="at"> repo</span></span>
+<span id="cb4-40"><a href="#cb4-40" aria-hidden="true" tabindex="-1"></a><span class="at">          </span><span class="fu">type</span><span class="kw">:</span><span class="at"> string</span></span>
+<span id="cb4-41"><a href="#cb4-41" aria-hidden="true" tabindex="-1"></a><span class="at">          </span><span class="fu">required</span><span class="kw">:</span><span class="at"> </span><span class="ch">true</span></span>
+<span id="cb4-42"><a href="#cb4-42" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">returns</span><span class="kw">:</span></span>
+<span id="cb4-43"><a href="#cb4-43" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">ref</span><span class="kw">:</span><span class="at"> Repository</span></span>
+<span id="cb4-44"><a href="#cb4-44" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">http</span><span class="kw">:</span></span>
+<span id="cb4-45"><a href="#cb4-45" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">method</span><span class="kw">:</span><span class="at"> GET</span></span>
+<span id="cb4-46"><a href="#cb4-46" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">path</span><span class="kw">:</span><span class="at"> /repos/{owner}/{repo}</span></span>
+<span id="cb4-47"><a href="#cb4-47" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">delete</span><span class="kw">:</span></span>
+<span id="cb4-48"><a href="#cb4-48" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="kw">-</span><span class="at"> </span><span class="fu">name</span><span class="kw">:</span><span class="at"> delete_repo</span></span>
+<span id="cb4-49"><a href="#cb4-49" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">description</span><span class="kw">:</span><span class="at"> Delete a repository</span></span>
+<span id="cb4-50"><a href="#cb4-50" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">params</span><span class="kw">:</span></span>
+<span id="cb4-51"><a href="#cb4-51" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="kw">-</span><span class="at"> </span><span class="fu">name</span><span class="kw">:</span><span class="at"> owner</span></span>
+<span id="cb4-52"><a href="#cb4-52" aria-hidden="true" tabindex="-1"></a><span class="at">          </span><span class="fu">type</span><span class="kw">:</span><span class="at"> string</span></span>
+<span id="cb4-53"><a href="#cb4-53" aria-hidden="true" tabindex="-1"></a><span class="at">          </span><span class="fu">required</span><span class="kw">:</span><span class="at"> </span><span class="ch">true</span></span>
+<span id="cb4-54"><a href="#cb4-54" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="kw">-</span><span class="at"> </span><span class="fu">name</span><span class="kw">:</span><span class="at"> repo</span></span>
+<span id="cb4-55"><a href="#cb4-55" aria-hidden="true" tabindex="-1"></a><span class="at">          </span><span class="fu">type</span><span class="kw">:</span><span class="at"> string</span></span>
+<span id="cb4-56"><a href="#cb4-56" aria-hidden="true" tabindex="-1"></a><span class="at">          </span><span class="fu">required</span><span class="kw">:</span><span class="at"> </span><span class="ch">true</span></span>
+<span id="cb4-57"><a href="#cb4-57" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">returns</span><span class="kw">:</span><span class="at"> object</span></span>
+<span id="cb4-58"><a href="#cb4-58" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">danger_level</span><span class="kw">:</span><span class="at"> destructive</span></span>
+<span id="cb4-59"><a href="#cb4-59" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">http</span><span class="kw">:</span></span>
+<span id="cb4-60"><a href="#cb4-60" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">method</span><span class="kw">:</span><span class="at"> DELETE</span></span>
+<span id="cb4-61"><a href="#cb4-61" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">path</span><span class="kw">:</span><span class="at"> /repos/{owner}/{repo}</span></span></code></pre></div>
+<h3 id="24-schema-version-evolution">2.4 Schema Version Evolution</h3>
+<p><strong>Version format rationale:</strong></p>
+<p>The <code>schema_version</code> field uses a simplified <code>major.minor</code> format (e.g., <code>'1.0'</code>) rather than full semver:</p>
+<ul>
+<li><strong>Schema version</strong> (<code>schema_version: '1.0'</code>): Defines the input format the generator expects</li>
+<li><strong>Adapter version</strong> (<code>adapter.version: '1.0.0'</code>): Follows semver for the generated adapter's release lifecycle</li>
+</ul>
+<p>This distinction separates concerns: schema format stability vs. adapter functionality evolution.</p>
+<p><strong>Evolution strategy:</strong></p>
+<table>
+<thead>
+<tr>
+<th>Change Type</th>
+<th>Version Increment</th>
+<th>Example</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Breaking schema changes</td>
+<td>Major (<code>1.0</code> → <code>2.0</code>)</td>
+<td>Removing required fields, restructuring <code>endpoints</code></td>
+</tr>
+<tr>
+<td>New optional features</td>
+<td>Minor (<code>1.0</code> → <code>1.1</code>)</td>
+<td>Adding <code>auth.config.scopes</code> field</td>
+</tr>
+<tr>
+<td>Clarifications, fixes</td>
+<td>No change</td>
+<td>Documentation updates, validation improvements</td>
+</tr>
+</tbody>
+</table>
+<p><strong>Backward compatibility requirements:</strong></p>
+<p>Generators SHOULD support multiple schema versions:</p>
+<ol type="1">
+<li><strong>Current version</strong> - Full support (REQUIRED)</li>
+<li><strong>Previous major version</strong> - Conversion/migration support (RECOMMENDED)</li>
+<li><strong>Older versions</strong> - Reject with clear upgrade guidance (OPTIONAL)</li>
+</ol>
+<p><strong>Version handling in generators:</strong></p>
+<div class="sourceCode" id="cb5"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb5-1"><a href="#cb5-1" aria-hidden="true" tabindex="-1"></a><span class="kw">function</span> <span class="fu">validateSchemaVersion</span>(schema) {</span>
+<span id="cb5-2"><a href="#cb5-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">const</span> supportedVersions <span class="op">=</span> [<span class="st">&#39;1.0&#39;</span><span class="op">,</span> <span class="st">&#39;1.1&#39;</span>]<span class="op">;</span></span>
+<span id="cb5-3"><a href="#cb5-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">const</span> deprecatedVersions <span class="op">=</span> [<span class="st">&#39;0.9&#39;</span>]<span class="op">;</span></span>
+<span id="cb5-4"><a href="#cb5-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb5-5"><a href="#cb5-5" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> (supportedVersions<span class="op">.</span><span class="fu">includes</span>(schema<span class="op">.</span><span class="at">schema_version</span>)) {</span>
+<span id="cb5-6"><a href="#cb5-6" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> { <span class="dt">valid</span><span class="op">:</span> <span class="kw">true</span> }<span class="op">;</span></span>
+<span id="cb5-7"><a href="#cb5-7" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb5-8"><a href="#cb5-8" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb5-9"><a href="#cb5-9" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> (deprecatedVersions<span class="op">.</span><span class="fu">includes</span>(schema<span class="op">.</span><span class="at">schema_version</span>)) {</span>
+<span id="cb5-10"><a href="#cb5-10" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> {</span>
+<span id="cb5-11"><a href="#cb5-11" aria-hidden="true" tabindex="-1"></a>      <span class="dt">valid</span><span class="op">:</span> <span class="kw">false</span><span class="op">,</span></span>
+<span id="cb5-12"><a href="#cb5-12" aria-hidden="true" tabindex="-1"></a>      <span class="dt">code</span><span class="op">:</span> <span class="st">&#39;SCHEMA_VERSION_DEPRECATED&#39;</span><span class="op">,</span></span>
+<span id="cb5-13"><a href="#cb5-13" aria-hidden="true" tabindex="-1"></a>      <span class="dt">message</span><span class="op">:</span> <span class="vs">`Schema version &#39;</span><span class="sc">${</span>schema<span class="op">.</span><span class="at">schema_version</span><span class="sc">}</span><span class="vs">&#39; is deprecated`</span><span class="op">,</span></span>
+<span id="cb5-14"><a href="#cb5-14" aria-hidden="true" tabindex="-1"></a>      <span class="dt">migration_guide</span><span class="op">:</span> <span class="st">&#39;https://mcpaql.org/docs/schema-migration&#39;</span></span>
+<span id="cb5-15"><a href="#cb5-15" aria-hidden="true" tabindex="-1"></a>    }<span class="op">;</span></span>
+<span id="cb5-16"><a href="#cb5-16" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb5-17"><a href="#cb5-17" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb5-18"><a href="#cb5-18" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> {</span>
+<span id="cb5-19"><a href="#cb5-19" aria-hidden="true" tabindex="-1"></a>    <span class="dt">valid</span><span class="op">:</span> <span class="kw">false</span><span class="op">,</span></span>
+<span id="cb5-20"><a href="#cb5-20" aria-hidden="true" tabindex="-1"></a>    <span class="dt">code</span><span class="op">:</span> <span class="st">&#39;SCHEMA_VERSION_UNSUPPORTED&#39;</span><span class="op">,</span></span>
+<span id="cb5-21"><a href="#cb5-21" aria-hidden="true" tabindex="-1"></a>    <span class="dt">message</span><span class="op">:</span> <span class="vs">`Unknown schema version &#39;</span><span class="sc">${</span>schema<span class="op">.</span><span class="at">schema_version</span><span class="sc">}</span><span class="vs">&#39;`</span><span class="op">,</span></span>
+<span id="cb5-22"><a href="#cb5-22" aria-hidden="true" tabindex="-1"></a>    <span class="dt">supported_versions</span><span class="op">:</span> supportedVersions</span>
+<span id="cb5-23"><a href="#cb5-23" aria-hidden="true" tabindex="-1"></a>  }<span class="op">;</span></span>
+<span id="cb5-24"><a href="#cb5-24" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<p><strong>Migration guidance:</strong></p>
+<p>When schema versions change, the MCP-AQL project SHOULD provide:</p>
+<ol type="1">
+<li><strong>Migration guide</strong> documenting required schema changes</li>
+<li><strong>Automated migration tool</strong> (when feasible)</li>
+<li><strong>Deprecation period</strong> of at least 6 months for major versions</li>
+</ol>
+<hr />
+<h2 id="3-generated-output-structure">3. Generated Output Structure</h2>
+<h3 id="31-directory-layout">3.1 Directory Layout</h3>
+<p>Generators MUST produce the following directory structure.</p>
+<blockquote>
+<p><strong>Note:</strong> <code>{ext}</code> in the structure below represents language-specific file extensions:</p>
+<ul>
+<li>TypeScript: <code>.ts</code></li>
+<li>JavaScript: <code>.js</code></li>
+<li>Python: <code>.py</code></li>
+<li>Go: <code>.go</code></li>
+<li>Rust: <code>.rs</code></li>
+<li>Java: <code>.java</code></li>
+</ul>
+</blockquote>
+<pre><code>generated-adapter/
+├── LICENSE                    # AGPL-3.0 license text
+├── NOTICE.md                  # Attribution notice
+├── COMMERCIAL-LICENSE.md      # Commercial licensing info
+├── MCPAQL-PROVENANCE.json     # Generation metadata
+├── README.md                  # Generated documentation
+├── src/                       # Source code (language-specific)
+│   ├── index.{ext}            # Main entry point
+│   ├── operations/            # Operation implementations
+│   │   ├── create.{ext}
+│   │   ├── read.{ext}
+│   │   ├── update.{ext}
+│   │   ├── delete.{ext}
+│   │   └── execute.{ext}
+│   ├── types/                 # Type definitions
+│   └── utils/                 # Helper utilities
+├── schema/                    # Source schema (for reference)
+│   └── adapter.yaml
+└── tests/                     # Generated test stubs
+    └── conformance/           # Conformance test cases</code></pre>
+<h3 id="32-generated-code-requirements">3.2 Generated Code Requirements</h3>
+<p>Generated code MUST:</p>
+<ol type="1">
+<li><strong>Implement CRUDE endpoints</strong> - All five endpoints with operation dispatch</li>
+<li><strong>Include introspection</strong> - Support for <code>introspect</code> operation</li>
+<li><strong>Handle errors correctly</strong> - Use structured error codes</li>
+<li><strong>Validate inputs</strong> - Parameter validation before API calls</li>
+<li><strong>Transform responses</strong> - Map target API responses to MCP-AQL format</li>
+</ol>
+<p>Generated code SHOULD:</p>
+<ol type="1">
+<li>Include inline documentation/comments</li>
+<li>Provide type definitions/interfaces</li>
+<li>Include example usage in README</li>
+<li>Generate test stubs for each operation</li>
+</ol>
+<h3 id="33-readme-generation">3.3 README Generation</h3>
+<p>Generated README.md MUST include:</p>
+<div class="sourceCode" id="cb7"><pre class="sourceCode markdown"><code class="sourceCode markdown"><span id="cb7-1"><a href="#cb7-1" aria-hidden="true" tabindex="-1"></a><span class="fu"># {Adapter Display Name}</span></span>
+<span id="cb7-2"><a href="#cb7-2" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb7-3"><a href="#cb7-3" aria-hidden="true" tabindex="-1"></a><span class="at">&gt; Generated by MCP-AQL Adapter Generator v{version}</span></span>
+<span id="cb7-4"><a href="#cb7-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb7-5"><a href="#cb7-5" aria-hidden="true" tabindex="-1"></a><span class="fu">## Overview</span></span>
+<span id="cb7-6"><a href="#cb7-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb7-7"><a href="#cb7-7" aria-hidden="true" tabindex="-1"></a>{Description from schema}</span>
+<span id="cb7-8"><a href="#cb7-8" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb7-9"><a href="#cb7-9" aria-hidden="true" tabindex="-1"></a><span class="fu">## Installation</span></span>
+<span id="cb7-10"><a href="#cb7-10" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb7-11"><a href="#cb7-11" aria-hidden="true" tabindex="-1"></a>{Language-specific installation instructions}</span>
+<span id="cb7-12"><a href="#cb7-12" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb7-13"><a href="#cb7-13" aria-hidden="true" tabindex="-1"></a><span class="fu">## Usage</span></span>
+<span id="cb7-14"><a href="#cb7-14" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb7-15"><a href="#cb7-15" aria-hidden="true" tabindex="-1"></a>{Basic usage example}</span>
+<span id="cb7-16"><a href="#cb7-16" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb7-17"><a href="#cb7-17" aria-hidden="true" tabindex="-1"></a><span class="fu">## Operations</span></span>
+<span id="cb7-18"><a href="#cb7-18" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb7-19"><a href="#cb7-19" aria-hidden="true" tabindex="-1"></a><span class="fu">### Create Operations</span></span>
+<span id="cb7-20"><a href="#cb7-20" aria-hidden="true" tabindex="-1"></a>{List with descriptions}</span>
+<span id="cb7-21"><a href="#cb7-21" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb7-22"><a href="#cb7-22" aria-hidden="true" tabindex="-1"></a><span class="fu">### Read Operations</span></span>
+<span id="cb7-23"><a href="#cb7-23" aria-hidden="true" tabindex="-1"></a>{List with descriptions}</span>
+<span id="cb7-24"><a href="#cb7-24" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb7-25"><a href="#cb7-25" aria-hidden="true" tabindex="-1"></a><span class="fu">### Update Operations</span></span>
+<span id="cb7-26"><a href="#cb7-26" aria-hidden="true" tabindex="-1"></a>{List with descriptions}</span>
+<span id="cb7-27"><a href="#cb7-27" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb7-28"><a href="#cb7-28" aria-hidden="true" tabindex="-1"></a><span class="fu">### Delete Operations</span></span>
+<span id="cb7-29"><a href="#cb7-29" aria-hidden="true" tabindex="-1"></a>{List with descriptions}</span>
+<span id="cb7-30"><a href="#cb7-30" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb7-31"><a href="#cb7-31" aria-hidden="true" tabindex="-1"></a><span class="fu">### Execute Operations</span></span>
+<span id="cb7-32"><a href="#cb7-32" aria-hidden="true" tabindex="-1"></a>{List with descriptions}</span>
+<span id="cb7-33"><a href="#cb7-33" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb7-34"><a href="#cb7-34" aria-hidden="true" tabindex="-1"></a><span class="fu">## Provenance</span></span>
+<span id="cb7-35"><a href="#cb7-35" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb7-36"><a href="#cb7-36" aria-hidden="true" tabindex="-1"></a>This adapter was generated from schema <span class="in">`{schema_fingerprint}`</span>.</span>
+<span id="cb7-37"><a href="#cb7-37" aria-hidden="true" tabindex="-1"></a>See MCPAQL-PROVENANCE.json for full generation metadata.</span>
+<span id="cb7-38"><a href="#cb7-38" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb7-39"><a href="#cb7-39" aria-hidden="true" tabindex="-1"></a><span class="fu">## License</span></span>
+<span id="cb7-40"><a href="#cb7-40" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb7-41"><a href="#cb7-41" aria-hidden="true" tabindex="-1"></a>This adapter is dual-licensed:</span>
+<span id="cb7-42"><a href="#cb7-42" aria-hidden="true" tabindex="-1"></a><span class="ss">- </span>AGPL-3.0 for open source use (see LICENSE)</span>
+<span id="cb7-43"><a href="#cb7-43" aria-hidden="true" tabindex="-1"></a><span class="ss">- </span>Commercial license available (see COMMERCIAL-LICENSE.md)</span></code></pre></div>
+<hr />
+<h2 id="4-licensing-artifacts">4. Licensing Artifacts</h2>
+<h3 id="41-required-files">4.1 Required Files</h3>
+<p>Generators MUST include the following licensing files:</p>
+<table>
+<thead>
+<tr>
+<th>File</th>
+<th>Content</th>
+<th>Notes</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>LICENSE</code></td>
+<td>AGPL-3.0 full text</td>
+<td>Standard AGPL-3.0 license</td>
+</tr>
+<tr>
+<td><code>NOTICE.md</code></td>
+<td>Attribution notice</td>
+<td>Credits MCP-AQL project</td>
+</tr>
+<tr>
+<td><code>COMMERCIAL-LICENSE.md</code></td>
+<td>Commercial options</td>
+<td>Contact information</td>
+</tr>
+</tbody>
+</table>
+<h3 id="42-license-file">4.2 LICENSE File</h3>
+<p>The LICENSE file MUST contain the complete AGPL-3.0 license text, unmodified.</p>
+<h3 id="43-noticemd-template">4.3 NOTICE.md Template</h3>
+<div class="sourceCode" id="cb8"><pre class="sourceCode markdown"><code class="sourceCode markdown"><span id="cb8-1"><a href="#cb8-1" aria-hidden="true" tabindex="-1"></a><span class="fu"># Attribution Notice</span></span>
+<span id="cb8-2"><a href="#cb8-2" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb8-3"><a href="#cb8-3" aria-hidden="true" tabindex="-1"></a>This software was generated using the MCP-AQL Adapter Generator.</span>
+<span id="cb8-4"><a href="#cb8-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb8-5"><a href="#cb8-5" aria-hidden="true" tabindex="-1"></a><span class="fu">## MCP-AQL Project</span></span>
+<span id="cb8-6"><a href="#cb8-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb8-7"><a href="#cb8-7" aria-hidden="true" tabindex="-1"></a><span class="ss">- </span>Website: https://mcpaql.org</span>
+<span id="cb8-8"><a href="#cb8-8" aria-hidden="true" tabindex="-1"></a><span class="ss">- </span>Specification: https://github.com/MCPAQL/spec</span>
+<span id="cb8-9"><a href="#cb8-9" aria-hidden="true" tabindex="-1"></a><span class="ss">- </span>Generator: https://github.com/MCPAQL/adapter-generator</span>
+<span id="cb8-10"><a href="#cb8-10" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb8-11"><a href="#cb8-11" aria-hidden="true" tabindex="-1"></a><span class="fu">## License</span></span>
+<span id="cb8-12"><a href="#cb8-12" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb8-13"><a href="#cb8-13" aria-hidden="true" tabindex="-1"></a>This adapter is licensed under the GNU Affero General Public License v3.0 (AGPL-3.0).</span>
+<span id="cb8-14"><a href="#cb8-14" aria-hidden="true" tabindex="-1"></a>A commercial license is available for organizations that cannot comply with AGPL terms.</span>
+<span id="cb8-15"><a href="#cb8-15" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb8-16"><a href="#cb8-16" aria-hidden="true" tabindex="-1"></a><span class="fu">## Third-Party Components</span></span>
+<span id="cb8-17"><a href="#cb8-17" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb8-18"><a href="#cb8-18" aria-hidden="true" tabindex="-1"></a>{List any third-party libraries used in generated code}</span>
+<span id="cb8-19"><a href="#cb8-19" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb8-20"><a href="#cb8-20" aria-hidden="true" tabindex="-1"></a><span class="fu">## Generation Information</span></span>
+<span id="cb8-21"><a href="#cb8-21" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb8-22"><a href="#cb8-22" aria-hidden="true" tabindex="-1"></a><span class="ss">- </span>Generator Version: {generator_version}</span>
+<span id="cb8-23"><a href="#cb8-23" aria-hidden="true" tabindex="-1"></a><span class="ss">- </span>Generated: {timestamp}</span>
+<span id="cb8-24"><a href="#cb8-24" aria-hidden="true" tabindex="-1"></a><span class="ss">- </span>Schema: {schema_fingerprint}</span></code></pre></div>
+<h3 id="44-commercial-licensemd-template">4.4 COMMERCIAL-LICENSE.md Template</h3>
+<div class="sourceCode" id="cb9"><pre class="sourceCode markdown"><code class="sourceCode markdown"><span id="cb9-1"><a href="#cb9-1" aria-hidden="true" tabindex="-1"></a><span class="fu"># Commercial Licensing</span></span>
+<span id="cb9-2"><a href="#cb9-2" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb9-3"><a href="#cb9-3" aria-hidden="true" tabindex="-1"></a>This MCP-AQL adapter is dual-licensed:</span>
+<span id="cb9-4"><a href="#cb9-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb9-5"><a href="#cb9-5" aria-hidden="true" tabindex="-1"></a><span class="fu">## Open Source License (AGPL-3.0)</span></span>
+<span id="cb9-6"><a href="#cb9-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb9-7"><a href="#cb9-7" aria-hidden="true" tabindex="-1"></a>The default license for this adapter is the GNU Affero General Public License v3.0.</span>
+<span id="cb9-8"><a href="#cb9-8" aria-hidden="true" tabindex="-1"></a>This license requires that:</span>
+<span id="cb9-9"><a href="#cb9-9" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb9-10"><a href="#cb9-10" aria-hidden="true" tabindex="-1"></a><span class="ss">- </span>Source code modifications are shared under the same license</span>
+<span id="cb9-11"><a href="#cb9-11" aria-hidden="true" tabindex="-1"></a><span class="ss">- </span>Network use (e.g., SaaS) triggers distribution requirements</span>
+<span id="cb9-12"><a href="#cb9-12" aria-hidden="true" tabindex="-1"></a><span class="ss">- </span>Attribution is maintained</span>
+<span id="cb9-13"><a href="#cb9-13" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb9-14"><a href="#cb9-14" aria-hidden="true" tabindex="-1"></a>See the LICENSE file for full terms.</span>
+<span id="cb9-15"><a href="#cb9-15" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb9-16"><a href="#cb9-16" aria-hidden="true" tabindex="-1"></a><span class="fu">## Commercial License</span></span>
+<span id="cb9-17"><a href="#cb9-17" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb9-18"><a href="#cb9-18" aria-hidden="true" tabindex="-1"></a>Organizations that cannot comply with AGPL-3.0 requirements may obtain a commercial license.</span>
+<span id="cb9-19"><a href="#cb9-19" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb9-20"><a href="#cb9-20" aria-hidden="true" tabindex="-1"></a><span class="fu">### Commercial License Benefits</span></span>
+<span id="cb9-21"><a href="#cb9-21" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb9-22"><a href="#cb9-22" aria-hidden="true" tabindex="-1"></a><span class="ss">- </span>No copyleft obligations</span>
+<span id="cb9-23"><a href="#cb9-23" aria-hidden="true" tabindex="-1"></a><span class="ss">- </span>No source code disclosure requirements</span>
+<span id="cb9-24"><a href="#cb9-24" aria-hidden="true" tabindex="-1"></a><span class="ss">- </span>Priority support available</span>
+<span id="cb9-25"><a href="#cb9-25" aria-hidden="true" tabindex="-1"></a><span class="ss">- </span>Custom terms available</span>
+<span id="cb9-26"><a href="#cb9-26" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb9-27"><a href="#cb9-27" aria-hidden="true" tabindex="-1"></a><span class="fu">### Contact</span></span>
+<span id="cb9-28"><a href="#cb9-28" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb9-29"><a href="#cb9-29" aria-hidden="true" tabindex="-1"></a>For commercial licensing inquiries:</span>
+<span id="cb9-30"><a href="#cb9-30" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb9-31"><a href="#cb9-31" aria-hidden="true" tabindex="-1"></a><span class="ss">- </span>Email: licensing@mcpaql.org</span>
+<span id="cb9-32"><a href="#cb9-32" aria-hidden="true" tabindex="-1"></a><span class="ss">- </span>Website: https://mcpaql.org/licensing</span>
+<span id="cb9-33"><a href="#cb9-33" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb9-34"><a href="#cb9-34" aria-hidden="true" tabindex="-1"></a><span class="fu">## Contributor License Agreement</span></span>
+<span id="cb9-35"><a href="#cb9-35" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb9-36"><a href="#cb9-36" aria-hidden="true" tabindex="-1"></a>Contributors to this adapter may be asked to sign a CLA to enable dual licensing.</span></code></pre></div>
+<hr />
+<h2 id="5-provenance-information">5. Provenance Information</h2>
+<h3 id="51-mcpaql-provenancejson">5.1 MCPAQL-PROVENANCE.json</h3>
+<p>Generators MUST create a provenance file with the following structure:</p>
+<div class="sourceCode" id="cb10"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb10-1"><a href="#cb10-1" aria-hidden="true" tabindex="-1"></a><span class="kw">interface</span> ProvenanceInfo {</span>
+<span id="cb10-2"><a href="#cb10-2" aria-hidden="true" tabindex="-1"></a>  <span class="co">/**</span></span>
+<span id="cb10-3"><a href="#cb10-3" aria-hidden="true" tabindex="-1"></a><span class="co">   * MCP-AQL specification version the generator targets</span></span>
+<span id="cb10-4"><a href="#cb10-4" aria-hidden="true" tabindex="-1"></a><span class="co">   */</span></span>
+<span id="cb10-5"><a href="#cb10-5" aria-hidden="true" tabindex="-1"></a>  mcpaql_spec_version<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb10-6"><a href="#cb10-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb10-7"><a href="#cb10-7" aria-hidden="true" tabindex="-1"></a>  <span class="co">/**</span></span>
+<span id="cb10-8"><a href="#cb10-8" aria-hidden="true" tabindex="-1"></a><span class="co">   * Generator identification</span></span>
+<span id="cb10-9"><a href="#cb10-9" aria-hidden="true" tabindex="-1"></a><span class="co">   */</span></span>
+<span id="cb10-10"><a href="#cb10-10" aria-hidden="true" tabindex="-1"></a>  generator<span class="op">:</span> {</span>
+<span id="cb10-11"><a href="#cb10-11" aria-hidden="true" tabindex="-1"></a>    <span class="co">/** Generator name (e.g., &quot;mcpaql-adapter-generator&quot;) */</span></span>
+<span id="cb10-12"><a href="#cb10-12" aria-hidden="true" tabindex="-1"></a>    name<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb10-13"><a href="#cb10-13" aria-hidden="true" tabindex="-1"></a>    <span class="co">/** Generator version (semver) */</span></span>
+<span id="cb10-14"><a href="#cb10-14" aria-hidden="true" tabindex="-1"></a>    version<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb10-15"><a href="#cb10-15" aria-hidden="true" tabindex="-1"></a>    <span class="co">/** Git commit hash of generator (if available) */</span></span>
+<span id="cb10-16"><a href="#cb10-16" aria-hidden="true" tabindex="-1"></a>    commit<span class="op">?:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb10-17"><a href="#cb10-17" aria-hidden="true" tabindex="-1"></a>    <span class="co">/** Generator repository URL */</span></span>
+<span id="cb10-18"><a href="#cb10-18" aria-hidden="true" tabindex="-1"></a>    repository<span class="op">?:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb10-19"><a href="#cb10-19" aria-hidden="true" tabindex="-1"></a>  }<span class="op">;</span></span>
+<span id="cb10-20"><a href="#cb10-20" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb10-21"><a href="#cb10-21" aria-hidden="true" tabindex="-1"></a>  <span class="co">/**</span></span>
+<span id="cb10-22"><a href="#cb10-22" aria-hidden="true" tabindex="-1"></a><span class="co">   * Source schema information</span></span>
+<span id="cb10-23"><a href="#cb10-23" aria-hidden="true" tabindex="-1"></a><span class="co">   */</span></span>
+<span id="cb10-24"><a href="#cb10-24" aria-hidden="true" tabindex="-1"></a>  schema<span class="op">:</span> {</span>
+<span id="cb10-25"><a href="#cb10-25" aria-hidden="true" tabindex="-1"></a>    <span class="co">/** SHA-256 hash of the input schema */</span></span>
+<span id="cb10-26"><a href="#cb10-26" aria-hidden="true" tabindex="-1"></a>    fingerprint<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb10-27"><a href="#cb10-27" aria-hidden="true" tabindex="-1"></a>    <span class="co">/** Original schema filename */</span></span>
+<span id="cb10-28"><a href="#cb10-28" aria-hidden="true" tabindex="-1"></a>    filename<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb10-29"><a href="#cb10-29" aria-hidden="true" tabindex="-1"></a>    <span class="co">/** Schema version from adapter.version */</span></span>
+<span id="cb10-30"><a href="#cb10-30" aria-hidden="true" tabindex="-1"></a>    version<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb10-31"><a href="#cb10-31" aria-hidden="true" tabindex="-1"></a>  }<span class="op">;</span></span>
+<span id="cb10-32"><a href="#cb10-32" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb10-33"><a href="#cb10-33" aria-hidden="true" tabindex="-1"></a>  <span class="co">/**</span></span>
+<span id="cb10-34"><a href="#cb10-34" aria-hidden="true" tabindex="-1"></a><span class="co">   * Generation metadata</span></span>
+<span id="cb10-35"><a href="#cb10-35" aria-hidden="true" tabindex="-1"></a><span class="co">   */</span></span>
+<span id="cb10-36"><a href="#cb10-36" aria-hidden="true" tabindex="-1"></a>  generation<span class="op">:</span> {</span>
+<span id="cb10-37"><a href="#cb10-37" aria-hidden="true" tabindex="-1"></a>    <span class="co">/** ISO 8601 timestamp of generation */</span></span>
+<span id="cb10-38"><a href="#cb10-38" aria-hidden="true" tabindex="-1"></a>    timestamp<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb10-39"><a href="#cb10-39" aria-hidden="true" tabindex="-1"></a>    <span class="co">/** Target language/platform */</span></span>
+<span id="cb10-40"><a href="#cb10-40" aria-hidden="true" tabindex="-1"></a>    target<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb10-41"><a href="#cb10-41" aria-hidden="true" tabindex="-1"></a>    <span class="co">/** Generator options used */</span></span>
+<span id="cb10-42"><a href="#cb10-42" aria-hidden="true" tabindex="-1"></a>    options<span class="op">?:</span> <span class="bu">Record</span><span class="op">&lt;</span><span class="dt">string</span><span class="op">,</span> <span class="dt">unknown</span><span class="op">&gt;;</span></span>
+<span id="cb10-43"><a href="#cb10-43" aria-hidden="true" tabindex="-1"></a>  }<span class="op">;</span></span>
+<span id="cb10-44"><a href="#cb10-44" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb10-45"><a href="#cb10-45" aria-hidden="true" tabindex="-1"></a>  <span class="co">/**</span></span>
+<span id="cb10-46"><a href="#cb10-46" aria-hidden="true" tabindex="-1"></a><span class="co">   * Verification information</span></span>
+<span id="cb10-47"><a href="#cb10-47" aria-hidden="true" tabindex="-1"></a><span class="co">   */</span></span>
+<span id="cb10-48"><a href="#cb10-48" aria-hidden="true" tabindex="-1"></a>  verification<span class="op">?:</span> {</span>
+<span id="cb10-49"><a href="#cb10-49" aria-hidden="true" tabindex="-1"></a>    <span class="co">/** SHA-256 hash of generated code (excluding provenance file) */</span></span>
+<span id="cb10-50"><a href="#cb10-50" aria-hidden="true" tabindex="-1"></a>    code_hash<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb10-51"><a href="#cb10-51" aria-hidden="true" tabindex="-1"></a>    <span class="co">/** Conformance test results if run during generation */</span></span>
+<span id="cb10-52"><a href="#cb10-52" aria-hidden="true" tabindex="-1"></a>    conformance_result<span class="op">?:</span> <span class="st">&#39;passed&#39;</span> <span class="op">|</span> <span class="st">&#39;failed&#39;</span> <span class="op">|</span> <span class="st">&#39;skipped&#39;</span><span class="op">;</span></span>
+<span id="cb10-53"><a href="#cb10-53" aria-hidden="true" tabindex="-1"></a>  }<span class="op">;</span></span>
+<span id="cb10-54"><a href="#cb10-54" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<h3 id="52-example-provenance-file">5.2 Example Provenance File</h3>
+<div class="sourceCode" id="cb11"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb11-1"><a href="#cb11-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb11-2"><a href="#cb11-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;mcpaql_spec_version&quot;</span><span class="fu">:</span> <span class="st">&quot;1.0.0&quot;</span><span class="fu">,</span></span>
+<span id="cb11-3"><a href="#cb11-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;generator&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb11-4"><a href="#cb11-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;mcpaql-adapter-generator&quot;</span><span class="fu">,</span></span>
+<span id="cb11-5"><a href="#cb11-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;version&quot;</span><span class="fu">:</span> <span class="st">&quot;1.2.3&quot;</span><span class="fu">,</span></span>
+<span id="cb11-6"><a href="#cb11-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;commit&quot;</span><span class="fu">:</span> <span class="st">&quot;abc123def456&quot;</span><span class="fu">,</span></span>
+<span id="cb11-7"><a href="#cb11-7" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;repository&quot;</span><span class="fu">:</span> <span class="st">&quot;https://github.com/MCPAQL/adapter-generator&quot;</span></span>
+<span id="cb11-8"><a href="#cb11-8" aria-hidden="true" tabindex="-1"></a>  <span class="fu">},</span></span>
+<span id="cb11-9"><a href="#cb11-9" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;schema&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb11-10"><a href="#cb11-10" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;fingerprint&quot;</span><span class="fu">:</span> <span class="st">&quot;sha256:a1b2c3d4e5f6...&quot;</span><span class="fu">,</span></span>
+<span id="cb11-11"><a href="#cb11-11" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;filename&quot;</span><span class="fu">:</span> <span class="st">&quot;github-api.yaml&quot;</span><span class="fu">,</span></span>
+<span id="cb11-12"><a href="#cb11-12" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;version&quot;</span><span class="fu">:</span> <span class="st">&quot;1.0.0&quot;</span></span>
+<span id="cb11-13"><a href="#cb11-13" aria-hidden="true" tabindex="-1"></a>  <span class="fu">},</span></span>
+<span id="cb11-14"><a href="#cb11-14" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;generation&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb11-15"><a href="#cb11-15" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;timestamp&quot;</span><span class="fu">:</span> <span class="st">&quot;2026-01-29T10:30:00Z&quot;</span><span class="fu">,</span></span>
+<span id="cb11-16"><a href="#cb11-16" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;target&quot;</span><span class="fu">:</span> <span class="st">&quot;typescript&quot;</span><span class="fu">,</span></span>
+<span id="cb11-17"><a href="#cb11-17" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;options&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb11-18"><a href="#cb11-18" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;strict_mode&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb11-19"><a href="#cb11-19" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;include_tests&quot;</span><span class="fu">:</span> <span class="kw">true</span></span>
+<span id="cb11-20"><a href="#cb11-20" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb11-21"><a href="#cb11-21" aria-hidden="true" tabindex="-1"></a>  <span class="fu">},</span></span>
+<span id="cb11-22"><a href="#cb11-22" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;verification&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb11-23"><a href="#cb11-23" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;code_hash&quot;</span><span class="fu">:</span> <span class="st">&quot;sha256:f6e5d4c3b2a1...&quot;</span><span class="fu">,</span></span>
+<span id="cb11-24"><a href="#cb11-24" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;conformance_result&quot;</span><span class="fu">:</span> <span class="st">&quot;passed&quot;</span></span>
+<span id="cb11-25"><a href="#cb11-25" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb11-26"><a href="#cb11-26" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<h3 id="53-fingerprint-calculation">5.3 Fingerprint Calculation</h3>
+<p>Schema fingerprints MUST be calculated as follows:</p>
+<ol type="1">
+<li>Normalize the schema (remove comments, normalize whitespace)</li>
+<li>Serialize to canonical JSON (sorted keys, no extra whitespace)</li>
+<li>Calculate SHA-256 hash</li>
+<li>Format as <code>sha256:{hex_digest}</code></li>
+</ol>
+<div class="sourceCode" id="cb12"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb12-1"><a href="#cb12-1" aria-hidden="true" tabindex="-1"></a><span class="kw">function</span> <span class="fu">calculateFingerprint</span>(schema<span class="op">:</span> AdapterSchema)<span class="op">:</span> <span class="dt">string</span> {</span>
+<span id="cb12-2"><a href="#cb12-2" aria-hidden="true" tabindex="-1"></a>  <span class="co">// Recursively sort object keys for canonical JSON</span></span>
+<span id="cb12-3"><a href="#cb12-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">function</span> <span class="fu">sortKeys</span>(obj<span class="op">:</span> <span class="dt">unknown</span>)<span class="op">:</span> <span class="dt">unknown</span> {</span>
+<span id="cb12-4"><a href="#cb12-4" aria-hidden="true" tabindex="-1"></a>    <span class="cf">if</span> (<span class="bu">Array</span><span class="op">.</span><span class="fu">isArray</span>(obj)) {</span>
+<span id="cb12-5"><a href="#cb12-5" aria-hidden="true" tabindex="-1"></a>      <span class="cf">return</span> obj<span class="op">.</span><span class="fu">map</span>(sortKeys)<span class="op">;</span></span>
+<span id="cb12-6"><a href="#cb12-6" aria-hidden="true" tabindex="-1"></a>    }</span>
+<span id="cb12-7"><a href="#cb12-7" aria-hidden="true" tabindex="-1"></a>    <span class="cf">if</span> (obj <span class="op">!==</span> <span class="kw">null</span> <span class="op">&amp;&amp;</span> <span class="kw">typeof</span> obj <span class="op">===</span> <span class="st">&#39;object&#39;</span>) {</span>
+<span id="cb12-8"><a href="#cb12-8" aria-hidden="true" tabindex="-1"></a>      <span class="kw">const</span> sorted<span class="op">:</span> <span class="bu">Record</span><span class="op">&lt;</span><span class="dt">string</span><span class="op">,</span> <span class="dt">unknown</span><span class="op">&gt;</span> <span class="op">=</span> {}<span class="op">;</span></span>
+<span id="cb12-9"><a href="#cb12-9" aria-hidden="true" tabindex="-1"></a>      <span class="cf">for</span> (<span class="kw">const</span> key <span class="kw">of</span> <span class="bu">Object</span><span class="op">.</span><span class="fu">keys</span>(obj)<span class="op">.</span><span class="fu">sort</span>()) {</span>
+<span id="cb12-10"><a href="#cb12-10" aria-hidden="true" tabindex="-1"></a>        sorted[key] <span class="op">=</span> <span class="fu">sortKeys</span>((obj <span class="im">as</span> <span class="bu">Record</span><span class="op">&lt;</span><span class="dt">string</span><span class="op">,</span> <span class="dt">unknown</span><span class="op">&gt;</span>)[key])<span class="op">;</span></span>
+<span id="cb12-11"><a href="#cb12-11" aria-hidden="true" tabindex="-1"></a>      }</span>
+<span id="cb12-12"><a href="#cb12-12" aria-hidden="true" tabindex="-1"></a>      <span class="cf">return</span> sorted<span class="op">;</span></span>
+<span id="cb12-13"><a href="#cb12-13" aria-hidden="true" tabindex="-1"></a>    }</span>
+<span id="cb12-14"><a href="#cb12-14" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> obj<span class="op">;</span></span>
+<span id="cb12-15"><a href="#cb12-15" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb12-16"><a href="#cb12-16" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb12-17"><a href="#cb12-17" aria-hidden="true" tabindex="-1"></a>  <span class="kw">const</span> normalized <span class="op">=</span> <span class="bu">JSON</span><span class="op">.</span><span class="fu">stringify</span>(<span class="fu">sortKeys</span>(schema))<span class="op">;</span></span>
+<span id="cb12-18"><a href="#cb12-18" aria-hidden="true" tabindex="-1"></a>  <span class="kw">const</span> hash <span class="op">=</span> crypto<span class="op">.</span><span class="fu">createHash</span>(<span class="st">&#39;sha256&#39;</span>)<span class="op">.</span><span class="fu">update</span>(normalized)<span class="op">.</span><span class="fu">digest</span>(<span class="st">&#39;hex&#39;</span>)<span class="op">;</span></span>
+<span id="cb12-19"><a href="#cb12-19" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> <span class="vs">`sha256:</span><span class="sc">${</span>hash<span class="sc">}</span><span class="vs">`</span><span class="op">;</span></span>
+<span id="cb12-20"><a href="#cb12-20" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<hr />
+<h2 id="6-language-templates">6. Language Templates</h2>
+<h3 id="61-supported-languages">6.1 Supported Languages</h3>
+<p>Generators SHOULD support multiple target languages:</p>
+<table>
+<thead>
+<tr>
+<th>Language</th>
+<th>Status</th>
+<th>Template ID</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>TypeScript</td>
+<td>Required</td>
+<td><code>typescript</code></td>
+</tr>
+<tr>
+<td>JavaScript</td>
+<td>Required</td>
+<td><code>javascript</code></td>
+</tr>
+<tr>
+<td>Python</td>
+<td>Recommended</td>
+<td><code>python</code></td>
+</tr>
+<tr>
+<td>Go</td>
+<td>Optional</td>
+<td><code>go</code></td>
+</tr>
+<tr>
+<td>Rust</td>
+<td>Optional</td>
+<td><code>rust</code></td>
+</tr>
+<tr>
+<td>Java</td>
+<td>Optional</td>
+<td><code>java</code></td>
+</tr>
+</tbody>
+</table>
+<h3 id="62-template-structure">6.2 Template Structure</h3>
+<p>Each language template MUST provide:</p>
+<ol type="1">
+<li><strong>Entry point</strong> - Main adapter class/module</li>
+<li><strong>Endpoint handlers</strong> - CRUDE endpoint implementations</li>
+<li><strong>Type definitions</strong> - Schema types in target language</li>
+<li><strong>Error handling</strong> - Structured error code support</li>
+<li><strong>HTTP client</strong> - Target API communication</li>
+</ol>
+<h3 id="63-typescript-template-example">6.3 TypeScript Template Example</h3>
+<p><strong>Entry point (index.ts):</strong></p>
+<div class="sourceCode" id="cb13"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb13-1"><a href="#cb13-1" aria-hidden="true" tabindex="-1"></a><span class="im">import</span> { createEndpoints } <span class="im">from</span> <span class="st">&#39;./operations&#39;</span><span class="op">;</span></span>
+<span id="cb13-2"><a href="#cb13-2" aria-hidden="true" tabindex="-1"></a><span class="im">import</span> { AdapterConfig } <span class="im">from</span> <span class="st">&#39;./types&#39;</span><span class="op">;</span></span>
+<span id="cb13-3"><a href="#cb13-3" aria-hidden="true" tabindex="-1"></a><span class="im">import</span> { schema } <span class="im">from</span> <span class="st">&#39;../schema/adapter&#39;</span><span class="op">;</span></span>
+<span id="cb13-4"><a href="#cb13-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb13-5"><a href="#cb13-5" aria-hidden="true" tabindex="-1"></a><span class="im">export</span> <span class="kw">class</span> Adapter {</span>
+<span id="cb13-6"><a href="#cb13-6" aria-hidden="true" tabindex="-1"></a>  <span class="kw">private</span> config<span class="op">:</span> AdapterConfig<span class="op">;</span></span>
+<span id="cb13-7"><a href="#cb13-7" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb13-8"><a href="#cb13-8" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constructor</span>(config<span class="op">:</span> AdapterConfig) {</span>
+<span id="cb13-9"><a href="#cb13-9" aria-hidden="true" tabindex="-1"></a>    <span class="kw">this</span><span class="op">.</span><span class="at">config</span> <span class="op">=</span> config<span class="op">;</span></span>
+<span id="cb13-10"><a href="#cb13-10" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb13-11"><a href="#cb13-11" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb13-12"><a href="#cb13-12" aria-hidden="true" tabindex="-1"></a>  <span class="kw">async</span> <span class="fu">handleRequest</span>(endpoint<span class="op">:</span> <span class="dt">string</span><span class="op">,</span> request<span class="op">:</span> <span class="dt">unknown</span>) {</span>
+<span id="cb13-13"><a href="#cb13-13" aria-hidden="true" tabindex="-1"></a>    <span class="kw">const</span> endpoints <span class="op">=</span> <span class="fu">createEndpoints</span>(<span class="kw">this</span><span class="op">.</span><span class="at">config</span>)<span class="op">;</span></span>
+<span id="cb13-14"><a href="#cb13-14" aria-hidden="true" tabindex="-1"></a>    <span class="kw">const</span> handler <span class="op">=</span> endpoints[endpoint]<span class="op">;</span></span>
+<span id="cb13-15"><a href="#cb13-15" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb13-16"><a href="#cb13-16" aria-hidden="true" tabindex="-1"></a>    <span class="cf">if</span> (<span class="op">!</span>handler) {</span>
+<span id="cb13-17"><a href="#cb13-17" aria-hidden="true" tabindex="-1"></a>      <span class="cf">return</span> {</span>
+<span id="cb13-18"><a href="#cb13-18" aria-hidden="true" tabindex="-1"></a>        success<span class="op">:</span> <span class="kw">false</span><span class="op">,</span></span>
+<span id="cb13-19"><a href="#cb13-19" aria-hidden="true" tabindex="-1"></a>        error<span class="op">:</span> {</span>
+<span id="cb13-20"><a href="#cb13-20" aria-hidden="true" tabindex="-1"></a>          code<span class="op">:</span> <span class="st">&#39;NOT_FOUND_OPERATION&#39;</span><span class="op">,</span></span>
+<span id="cb13-21"><a href="#cb13-21" aria-hidden="true" tabindex="-1"></a>          message<span class="op">:</span> <span class="vs">`Unknown endpoint: &#39;</span><span class="sc">${</span>endpoint<span class="sc">}</span><span class="vs">&#39;`</span></span>
+<span id="cb13-22"><a href="#cb13-22" aria-hidden="true" tabindex="-1"></a>        }</span>
+<span id="cb13-23"><a href="#cb13-23" aria-hidden="true" tabindex="-1"></a>      }<span class="op">;</span></span>
+<span id="cb13-24"><a href="#cb13-24" aria-hidden="true" tabindex="-1"></a>    }</span>
+<span id="cb13-25"><a href="#cb13-25" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb13-26"><a href="#cb13-26" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> <span class="fu">handler</span>(request)<span class="op">;</span></span>
+<span id="cb13-27"><a href="#cb13-27" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb13-28"><a href="#cb13-28" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb13-29"><a href="#cb13-29" aria-hidden="true" tabindex="-1"></a>  <span class="fu">getSchema</span>() {</span>
+<span id="cb13-30"><a href="#cb13-30" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> schema<span class="op">;</span></span>
+<span id="cb13-31"><a href="#cb13-31" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb13-32"><a href="#cb13-32" aria-hidden="true" tabindex="-1"></a>}</span>
+<span id="cb13-33"><a href="#cb13-33" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb13-34"><a href="#cb13-34" aria-hidden="true" tabindex="-1"></a><span class="im">export</span> { schema }<span class="op">;</span></span></code></pre></div>
+<h3 id="64-template-customization">6.4 Template Customization</h3>
+<p>Generators MAY support template customization:</p>
+<table>
+<thead>
+<tr>
+<th>Option</th>
+<th>Description</th>
+<th>Default</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>strict_mode</code></td>
+<td>Enable strict type checking</td>
+<td><code>true</code></td>
+</tr>
+<tr>
+<td><code>include_tests</code></td>
+<td>Generate test stubs</td>
+<td><code>true</code></td>
+</tr>
+<tr>
+<td><code>inline_docs</code></td>
+<td>Include JSDoc/docstrings</td>
+<td><code>true</code></td>
+</tr>
+<tr>
+<td><code>error_handling</code></td>
+<td>Error handling style</td>
+<td><code>structured</code></td>
+</tr>
+<tr>
+<td><code>http_client</code></td>
+<td>HTTP client library</td>
+<td>Language default</td>
+</tr>
+</tbody>
+</table>
+<hr />
+<h2 id="7-command-line-interface">7. Command-Line Interface</h2>
+<h3 id="71-cli-invocation">7.1 CLI Invocation</h3>
+<p>Generators MUST provide a command-line interface with the following signature:</p>
+<div class="sourceCode" id="cb14"><pre class="sourceCode bash"><code class="sourceCode bash"><span id="cb14-1"><a href="#cb14-1" aria-hidden="true" tabindex="-1"></a><span class="ex">mcpaql-generate</span> <span class="at">--schema</span> <span class="op">&lt;</span>path<span class="op">&gt;</span> --target <span class="op">&lt;</span>language<span class="op">&gt;</span> <span class="pp">[</span><span class="ss">options</span><span class="pp">]</span></span></code></pre></div>
+<h3 id="72-required-arguments">7.2 Required Arguments</h3>
+<table>
+<thead>
+<tr>
+<th>Argument</th>
+<th>Description</th>
+<th>Example</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>--schema</code>, <code>-s</code></td>
+<td>Path to the input schema file (YAML or JSON)</td>
+<td><code>--schema adapter.yaml</code></td>
+</tr>
+<tr>
+<td><code>--target</code>, <code>-t</code></td>
+<td>Target language/platform</td>
+<td><code>--target typescript</code></td>
+</tr>
+</tbody>
+</table>
+<h3 id="73-optional-arguments">7.3 Optional Arguments</h3>
+<table>
+<thead>
+<tr>
+<th>Argument</th>
+<th>Description</th>
+<th>Default</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>--output</code>, <code>-o</code></td>
+<td>Output directory for generated code</td>
+<td><code>./generated</code></td>
+</tr>
+<tr>
+<td><code>--config</code>, <code>-c</code></td>
+<td>Path to generator configuration file</td>
+<td>None</td>
+</tr>
+<tr>
+<td><code>--output-format</code></td>
+<td>Output format (<code>human</code> or <code>json</code>)</td>
+<td><code>human</code></td>
+</tr>
+<tr>
+<td><code>--strict</code></td>
+<td>Enable strict validation mode (fail on warnings, enforce all optional constraints)</td>
+<td><code>false</code></td>
+</tr>
+<tr>
+<td><code>--dry-run</code></td>
+<td>Validate schema without generating output</td>
+<td><code>false</code></td>
+</tr>
+<tr>
+<td><code>--verbose</code>, <code>-v</code></td>
+<td>Enable verbose output</td>
+<td><code>false</code></td>
+</tr>
+<tr>
+<td><code>--quiet</code>, <code>-q</code></td>
+<td>Suppress non-error output</td>
+<td><code>false</code></td>
+</tr>
+<tr>
+<td><code>--version</code></td>
+<td>Print generator version and exit</td>
+<td>-</td>
+</tr>
+<tr>
+<td><code>--help</code>, <code>-h</code></td>
+<td>Print help message and exit</td>
+<td>-</td>
+</tr>
+</tbody>
+</table>
+<p><strong>Notes:</strong></p>
+<ul>
+<li><code>--verbose</code> and <code>--quiet</code> are mutually exclusive. If both are specified, generators MUST exit with code 3 (Configuration error).</li>
+<li>When both <code>--config</code> and individual CLI arguments are provided, CLI arguments MUST take precedence over configuration file settings.</li>
+</ul>
+<h3 id="74-exit-codes">7.4 Exit Codes</h3>
+<p>Generators MUST use consistent exit codes:</p>
+<table>
+<thead>
+<tr>
+<th>Code</th>
+<th>Meaning</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>0</code></td>
+<td>Success</td>
+<td>Generation completed successfully</td>
+</tr>
+<tr>
+<td><code>1</code></td>
+<td>Internal error</td>
+<td>Unexpected error (assertion failures, uncaught exceptions)</td>
+</tr>
+<tr>
+<td><code>2</code></td>
+<td>Schema validation error</td>
+<td>Input schema is invalid</td>
+</tr>
+<tr>
+<td><code>3</code></td>
+<td>Configuration error</td>
+<td>Invalid generator configuration</td>
+</tr>
+<tr>
+<td><code>4</code></td>
+<td>I/O error</td>
+<td>File read/write failure</td>
+</tr>
+<tr>
+<td><code>5</code></td>
+<td>Template error</td>
+<td>Language template processing failed</td>
+</tr>
+</tbody>
+</table>
+<h3 id="75-output-format">7.5 Output Format</h3>
+<p>Generators SHOULD support structured output for integration with other tools:</p>
+<div class="sourceCode" id="cb15"><pre class="sourceCode bash"><code class="sourceCode bash"><span id="cb15-1"><a href="#cb15-1" aria-hidden="true" tabindex="-1"></a><span class="co"># Human-readable output (default)</span></span>
+<span id="cb15-2"><a href="#cb15-2" aria-hidden="true" tabindex="-1"></a><span class="ex">mcpaql-generate</span> <span class="at">--schema</span> adapter.yaml <span class="at">--target</span> typescript</span>
+<span id="cb15-3"><a href="#cb15-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb15-4"><a href="#cb15-4" aria-hidden="true" tabindex="-1"></a><span class="co"># JSON output for programmatic consumption</span></span>
+<span id="cb15-5"><a href="#cb15-5" aria-hidden="true" tabindex="-1"></a><span class="ex">mcpaql-generate</span> <span class="at">--schema</span> adapter.yaml <span class="at">--target</span> typescript <span class="at">--output-format</span> json</span></code></pre></div>
+<p><strong>JSON success output:</strong></p>
+<div class="sourceCode" id="cb16"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb16-1"><a href="#cb16-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb16-2"><a href="#cb16-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb16-3"><a href="#cb16-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;output_directory&quot;</span><span class="fu">:</span> <span class="st">&quot;./generated&quot;</span><span class="fu">,</span></span>
+<span id="cb16-4"><a href="#cb16-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;files_generated&quot;</span><span class="fu">:</span> <span class="ot">[</span></span>
+<span id="cb16-5"><a href="#cb16-5" aria-hidden="true" tabindex="-1"></a>    <span class="st">&quot;src/index.ts&quot;</span><span class="ot">,</span></span>
+<span id="cb16-6"><a href="#cb16-6" aria-hidden="true" tabindex="-1"></a>    <span class="st">&quot;src/operations/read.ts&quot;</span><span class="ot">,</span></span>
+<span id="cb16-7"><a href="#cb16-7" aria-hidden="true" tabindex="-1"></a>    <span class="st">&quot;LICENSE&quot;</span><span class="ot">,</span></span>
+<span id="cb16-8"><a href="#cb16-8" aria-hidden="true" tabindex="-1"></a>    <span class="st">&quot;NOTICE.md&quot;</span></span>
+<span id="cb16-9"><a href="#cb16-9" aria-hidden="true" tabindex="-1"></a>  <span class="ot">]</span><span class="fu">,</span></span>
+<span id="cb16-10"><a href="#cb16-10" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;provenance&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb16-11"><a href="#cb16-11" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;schema_fingerprint&quot;</span><span class="fu">:</span> <span class="st">&quot;sha256:abc123...&quot;</span><span class="fu">,</span></span>
+<span id="cb16-12"><a href="#cb16-12" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;generator_version&quot;</span><span class="fu">:</span> <span class="st">&quot;1.2.3&quot;</span></span>
+<span id="cb16-13"><a href="#cb16-13" aria-hidden="true" tabindex="-1"></a>  <span class="fu">},</span></span>
+<span id="cb16-14"><a href="#cb16-14" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;warnings&quot;</span><span class="fu">:</span> <span class="ot">[]</span></span>
+<span id="cb16-15"><a href="#cb16-15" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<p><strong>JSON error output:</strong></p>
+<div class="sourceCode" id="cb17"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb17-1"><a href="#cb17-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb17-2"><a href="#cb17-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb17-3"><a href="#cb17-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;error&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb17-4"><a href="#cb17-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;code&quot;</span><span class="fu">:</span> <span class="dv">2</span><span class="fu">,</span></span>
+<span id="cb17-5"><a href="#cb17-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;SCHEMA_VALIDATION_ERROR&quot;</span><span class="fu">,</span></span>
+<span id="cb17-6"><a href="#cb17-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;Schema validation failed&quot;</span><span class="fu">,</span></span>
+<span id="cb17-7"><a href="#cb17-7" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;details&quot;</span><span class="fu">:</span> <span class="ot">[</span></span>
+<span id="cb17-8"><a href="#cb17-8" aria-hidden="true" tabindex="-1"></a>      <span class="fu">{</span></span>
+<span id="cb17-9"><a href="#cb17-9" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;path&quot;</span><span class="fu">:</span> <span class="st">&quot;endpoints.read[0].params[2].name&quot;</span><span class="fu">,</span></span>
+<span id="cb17-10"><a href="#cb17-10" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;code&quot;</span><span class="fu">:</span> <span class="st">&quot;SCHEMA_INVALID_NAME&quot;</span><span class="fu">,</span></span>
+<span id="cb17-11"><a href="#cb17-11" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;Parameter name &#39;userName&#39; must be snake_case&quot;</span><span class="fu">,</span></span>
+<span id="cb17-12"><a href="#cb17-12" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;suggestion&quot;</span><span class="fu">:</span> <span class="st">&quot;Use &#39;user_name&#39; instead&quot;</span></span>
+<span id="cb17-13"><a href="#cb17-13" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span></span>
+<span id="cb17-14"><a href="#cb17-14" aria-hidden="true" tabindex="-1"></a>    <span class="ot">]</span></span>
+<span id="cb17-15"><a href="#cb17-15" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb17-16"><a href="#cb17-16" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<h3 id="76-example-usage">7.6 Example Usage</h3>
+<p><strong>Basic generation:</strong></p>
+<div class="sourceCode" id="cb18"><pre class="sourceCode bash"><code class="sourceCode bash"><span id="cb18-1"><a href="#cb18-1" aria-hidden="true" tabindex="-1"></a><span class="ex">mcpaql-generate</span> <span class="at">--schema</span> github-api.yaml <span class="at">--target</span> typescript <span class="at">--output</span> ./adapters/github</span></code></pre></div>
+<p><strong>With configuration and verbose output:</strong></p>
+<div class="sourceCode" id="cb19"><pre class="sourceCode bash"><code class="sourceCode bash"><span id="cb19-1"><a href="#cb19-1" aria-hidden="true" tabindex="-1"></a><span class="ex">mcpaql-generate</span> <span class="dt">\</span></span>
+<span id="cb19-2"><a href="#cb19-2" aria-hidden="true" tabindex="-1"></a>  <span class="at">--schema</span> adapter.yaml <span class="dt">\</span></span>
+<span id="cb19-3"><a href="#cb19-3" aria-hidden="true" tabindex="-1"></a>  <span class="at">--target</span> typescript <span class="dt">\</span></span>
+<span id="cb19-4"><a href="#cb19-4" aria-hidden="true" tabindex="-1"></a>  <span class="at">--output</span> ./generated <span class="dt">\</span></span>
+<span id="cb19-5"><a href="#cb19-5" aria-hidden="true" tabindex="-1"></a>  <span class="at">--config</span> generator.config.json <span class="dt">\</span></span>
+<span id="cb19-6"><a href="#cb19-6" aria-hidden="true" tabindex="-1"></a>  <span class="at">--verbose</span></span></code></pre></div>
+<p><strong>Validation only (dry run):</strong></p>
+<div class="sourceCode" id="cb20"><pre class="sourceCode bash"><code class="sourceCode bash"><span id="cb20-1"><a href="#cb20-1" aria-hidden="true" tabindex="-1"></a><span class="ex">mcpaql-generate</span> <span class="at">--schema</span> adapter.yaml <span class="at">--target</span> typescript <span class="at">--dry-run</span></span></code></pre></div>
+<hr />
+<h2 id="8-conformance-requirements">8. Conformance Requirements</h2>
+<h3 id="81-generator-conformance">8.1 Generator Conformance</h3>
+<p>A conformant generator MUST:</p>
+<ol type="1">
+<li>Accept valid schemas without error</li>
+<li>Reject invalid schemas with descriptive errors</li>
+<li>Produce all required output files</li>
+<li>Include valid licensing artifacts</li>
+<li>Generate correct provenance information</li>
+<li>Produce code that passes basic syntax checks</li>
+</ol>
+<h3 id="82-generated-adapter-conformance">8.2 Generated Adapter Conformance</h3>
+<p>Generated adapters MUST:</p>
+<ol type="1">
+<li>Implement all five CRUDE endpoints</li>
+<li>Support the <code>introspect</code> operation</li>
+<li>Return discriminated responses (<code>success: true/false</code>)</li>
+<li>Use structured error codes from the specification</li>
+<li>Handle missing/invalid parameters correctly</li>
+</ol>
+<h3 id="83-conformance-testing">8.3 Conformance Testing</h3>
+<p>Generators SHOULD include conformance test generation:</p>
+<div class="sourceCode" id="cb21"><pre class="sourceCode bash"><code class="sourceCode bash"><span id="cb21-1"><a href="#cb21-1" aria-hidden="true" tabindex="-1"></a><span class="co"># Run conformance tests on generated adapter</span></span>
+<span id="cb21-2"><a href="#cb21-2" aria-hidden="true" tabindex="-1"></a><span class="ex">mcpaql-conformance</span> test ./generated-adapter</span></code></pre></div>
+<p>See <a href="../conformance-testing.html">Conformance Testing Specification</a> for test requirements.</p>
+<hr />
+<h2 id="references">References</h2>
+<ul>
+<li><a href="../versions/v1.0.0-draft.html">MCP-AQL Specification</a></li>
+<li><a href="../crude-pattern.html">CRUDE Pattern</a></li>
+<li><a href="../error-codes.html">Error Codes Specification</a></li>
+<li><a href="../conformance-testing.html">Conformance Testing Specification</a></li>
+<li><a href="trust-levels.html">Trust Levels Specification</a></li>
+<li><a href="danger-levels.html">Dangerous Operation Classification</a></li>
+<li>GitHub Issue: <a href="https://github.com/MCPAQL/spec/issues/21">#21</a></li>
+</ul>
+
+          </div>
+        </section>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div class="container">
+      <p>&copy; 2026 DollhouseMCP Inc. d/b/a Dollhouse Research. MCP-AQL public draft documentation portal.</p>
+      <div class="footer-links">
+        <a href="../../docs/index.html">Docs Library</a>
+        <a href="../index.html">Repo-Synced Spec</a>
+        <a href="https://github.com/MCPAQL">MCPAQL Organization</a>
+        <a href="https://dollhouseresearch.com">Dollhouse Research</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../../js/search.js"></script>
+</body>
+</html>

--- a/public/spec/adapter/generator.html
+++ b/public/spec/adapter/generator.html
@@ -38,7 +38,7 @@
         <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
         <div class="docs-side-group">
   <h3>Core</h3>
-  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li></ul>
+  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li><li><a href="../repo/README.html">MCP-AQL Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Versions</h3>
   <ul><li><a href="../versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
@@ -56,7 +56,7 @@
   <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
-  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li></ul>
+  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li><li><a href="../repo/CHANGELOG.html">Changelog</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Architecture</h3>
   <ul><li><a href="../architecture/README.html">Architecture Documentation</a></li></ul>

--- a/public/spec/adapter/rate-limiting.html
+++ b/public/spec/adapter/rate-limiting.html
@@ -1,0 +1,710 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="This document defines the rate limiting and quota management system for MCP-AQL adapters. Rate limits enable systems to respect API constraints, prevent runaway costs, and provide graceful degradation under load.">
+  <title>MCP-AQL Spec | Rate Limiting and Quota Management Specification</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../../css/style.css">
+</head>
+<body>
+  <header>
+    <div class="container">
+      <nav>
+        <a class="logo" href="../../index.html"><span class="logo-mark"></span>MCP-AQL</a>
+        <ul class="nav-links">
+          <li><a href="../../index.html">Home</a></li>
+          <li><a href="../../docs/index.html">Docs</a></li>
+          <li><a href="../../launch-checklist.html">Launch Checklist</a></li>
+          <li><a href="../../apis/mcp-server.html">Adapter Patterns</a></li>
+        </ul>
+        <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
+          <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
+          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <span class="search-count" data-search-count></span>
+          <ul class="search-results" data-search-results hidden></ul>
+        </form>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <div class="container docs-shell">
+      <aside class="docs-side">
+        <h2>Repo-Synced Spec</h2>
+        <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
+        <div class="docs-side-group">
+  <h3>Core</h3>
+  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Versions</h3>
+  <ul><li><a href="../versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Adapter</h3>
+  <ul><li><a href="danger-levels.html">Dangerous Operation Classification Specification</a></li><li><a href="discovery-bundle.html">MCP Server Discovery Bundle</a></li><li><a href="element-type.html">Adapter Element Type Specification</a></li><li><a href="generator.html">Adapter Generator Specification</a></li><li><a class="current" href="rate-limiting.html">Rate Limiting and Quota Management Specification</a></li><li><a href="trust-levels.html">Trust Levels Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Security</h3>
+  <ul><li><a href="../security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="../security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="../security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Features</h3>
+  <ul><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Guides</h3>
+  <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Process</h3>
+  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Architecture</h3>
+  <ul><li><a href="../architecture/README.html">Architecture Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Research</h3>
+  <ul><li><a href="../research/mcp-vs-mcpaql-vs-a2a.html">Protocol Landscape: MCP vs MCP-AQL vs A2A</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Reference</h3>
+  <ul><li><a href="../reference/README.html">Reference Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>ADRs</h3>
+  <ul><li><a href="../adr/ADR-001-crude-pattern.html">ADR-001: CRUDE Pattern (Extending CRUD with Execute)</a></li><li><a href="../adr/ADR-002-graphql-style-input.html">ADR-002: GraphQL-Style Input Objects for Updates</a></li><li><a href="../adr/ADR-003-snake-case-parameters.html">ADR-003: snake_case Parameter Convention</a></li><li><a href="../adr/ADR-004-schema-driven-operations.html">ADR-004: Schema-Driven Operation Definitions</a></li><li><a href="../adr/ADR-005-introspection-system.html">ADR-005: GraphQL-Style Introspection System</a></li><li><a href="../adr/ADR-006-discriminated-responses.html">ADR-006: Discriminated Response Format</a></li><li><a href="../adr/index.html">Architecture Decision Records</a></li><li><a href="../adr/README.html">Architecture Decision Records</a></li></ul>
+</div>
+      </aside>
+
+      <article class="docs-main">
+        <section class="hero docs-hero">
+          <div class="hero-inner">
+            <span class="status-pill">REPO-SYNCED SPEC DOC</span>
+            <h1>Rate Limiting and Quota Management Specification</h1>
+            <p class="lede">This document defines the rate limiting and quota management system for MCP-AQL adapters. Rate limits enable systems to respect API constraints, prevent runaway costs, and provide graceful degradation under load.</p>
+            <div class="spec-meta"><span class="state-chip live">Support document</span><span class="state-chip pending">Draft</span><span class="state-chip">1.0.0-draft</span><span class="state-chip">2026-01-28</span></div>
+            <p class="spec-source">Source: <a href="https://github.com/MCPAQL/spec/blob/main/docs/adapter/rate-limiting.md">spec/docs/adapter/rate-limiting.md</a></p>
+            <div class="hero-actions">
+              <a class="btn btn-primary" href="https://github.com/MCPAQL/spec/blob/main/docs/adapter/rate-limiting.md">Open Source Markdown</a>
+              <a class="btn btn-secondary" href="../index.html">Browse Full Spec Reference</a>
+            </div>
+          </div>
+        </section>
+
+        <section>
+          <div class="card spec-prose">
+            <p><strong>Version:</strong> 1.0.0-draft <strong>Status:</strong> Draft <strong>Last Updated:</strong> 2026-01-28</p>
+<h2 id="abstract">Abstract</h2>
+<p>This document defines the rate limiting and quota management system for MCP-AQL adapters. Rate limits enable systems to respect API constraints, prevent runaway costs, and provide graceful degradation under load.</p>
+<hr />
+<h2 id="table-of-contents">Table of Contents</h2>
+<ol type="1">
+<li><a href="#1-overview">Overview</a></li>
+<li><a href="#2-rate-limits-schema">Rate Limits Schema</a></li>
+<li><a href="#3-quota-management">Quota Management</a></li>
+<li><a href="#4-enforcement-behavior">Enforcement Behavior</a></li>
+<li><a href="#5-error-codes">Error Codes</a></li>
+<li><a href="#6-introspection">Introspection</a></li>
+<li><a href="#7-implementation-requirements">Implementation Requirements</a></li>
+<li><a href="#8-future-extensions">Future Extensions</a></li>
+</ol>
+<hr />
+<h2 id="1-overview">1. Overview</h2>
+<h3 id="11-purpose">1.1 Purpose</h3>
+<p>When adapters wrap external APIs:</p>
+<ul>
+<li><strong>APIs have rate limits</strong> that must be respected to avoid blocking</li>
+<li><strong>Users want budgets</strong> to control costs and usage</li>
+<li><strong>Systems need protection</strong> against runaway API calls (especially in autonomous agent loops)</li>
+<li><strong>Graceful degradation</strong> is preferable to hard failures</li>
+</ul>
+<p>Rate limiting in MCP-AQL provides:</p>
+<ul>
+<li><strong>API limit awareness</strong> - Extract and respect target API constraints</li>
+<li><strong>User-configurable quotas</strong> - Budget controls at multiple thresholds</li>
+<li><strong>Progressive enforcement</strong> - Warn, pause, and hard stop behaviors</li>
+<li><strong>Cost tracking</strong> - Monitor usage for paid APIs</li>
+</ul>
+<h3 id="12-design-principles">1.2 Design Principles</h3>
+<ol type="1">
+<li><strong>Respect upstream limits</strong> - Never exceed API provider constraints</li>
+<li><strong>User control</strong> - Configurable quotas override defaults</li>
+<li><strong>Progressive response</strong> - Warn before blocking</li>
+<li><strong>Transparent status</strong> - Quota state always queryable</li>
+</ol>
+<h3 id="13-scope">1.3 Scope</h3>
+<p><strong>Included:</strong></p>
+<ul>
+<li>Rate limit schema for adapters</li>
+<li>Quota configuration</li>
+<li>Enforcement behaviors</li>
+<li>Error codes for rate limiting</li>
+<li>Introspection of quota status</li>
+</ul>
+<p><strong>Deferred:</strong></p>
+<ul>
+<li>Cross-adapter quota aggregation</li>
+<li>Token-based rate limiting for LLM APIs</li>
+<li>Distributed rate limiting coordination</li>
+</ul>
+<hr />
+<h2 id="2-rate-limits-schema">2. Rate Limits Schema</h2>
+<h3 id="21-schema-structure">2.1 Schema Structure</h3>
+<p>The <code>rate_limits</code> block in adapter front matter:</p>
+<div class="sourceCode" id="cb1"><pre class="sourceCode yaml"><code class="sourceCode yaml"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a><span class="fu">rate_limits</span><span class="kw">:</span></span>
+<span id="cb1-2"><a href="#cb1-2" aria-hidden="true" tabindex="-1"></a><span class="co">  # API-defined limits (from target API documentation or headers)</span></span>
+<span id="cb1-3"><a href="#cb1-3" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">api_limits</span><span class="kw">:</span></span>
+<span id="cb1-4"><a href="#cb1-4" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="kw">-</span><span class="at"> </span><span class="fu">scope</span><span class="kw">:</span><span class="at"> global</span></span>
+<span id="cb1-5"><a href="#cb1-5" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">limit</span><span class="kw">:</span><span class="at"> </span><span class="dv">5000</span></span>
+<span id="cb1-6"><a href="#cb1-6" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">window</span><span class="kw">:</span><span class="at"> hour</span></span>
+<span id="cb1-7"><a href="#cb1-7" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="kw">-</span><span class="at"> </span><span class="fu">scope</span><span class="kw">:</span><span class="at"> endpoint</span></span>
+<span id="cb1-8"><a href="#cb1-8" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">endpoint</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;POST /search&quot;</span></span>
+<span id="cb1-9"><a href="#cb1-9" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">limit</span><span class="kw">:</span><span class="at"> </span><span class="dv">30</span></span>
+<span id="cb1-10"><a href="#cb1-10" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">window</span><span class="kw">:</span><span class="at"> minute</span></span>
+<span id="cb1-11"><a href="#cb1-11" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb1-12"><a href="#cb1-12" aria-hidden="true" tabindex="-1"></a><span class="co">  # User-configurable quotas</span></span>
+<span id="cb1-13"><a href="#cb1-13" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">quotas</span><span class="kw">:</span></span>
+<span id="cb1-14"><a href="#cb1-14" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">enabled</span><span class="kw">:</span><span class="at"> </span><span class="ch">true</span></span>
+<span id="cb1-15"><a href="#cb1-15" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">limits</span><span class="kw">:</span></span>
+<span id="cb1-16"><a href="#cb1-16" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="kw">-</span><span class="at"> </span><span class="fu">metric</span><span class="kw">:</span><span class="at"> requests_per_hour</span></span>
+<span id="cb1-17"><a href="#cb1-17" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">warn</span><span class="kw">:</span><span class="at"> </span><span class="dv">4000</span></span>
+<span id="cb1-18"><a href="#cb1-18" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">pause</span><span class="kw">:</span><span class="at"> </span><span class="dv">4800</span></span>
+<span id="cb1-19"><a href="#cb1-19" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">hard_stop</span><span class="kw">:</span><span class="at"> </span><span class="dv">5000</span></span>
+<span id="cb1-20"><a href="#cb1-20" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="kw">-</span><span class="at"> </span><span class="fu">metric</span><span class="kw">:</span><span class="at"> cost_per_day</span></span>
+<span id="cb1-21"><a href="#cb1-21" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">warn</span><span class="kw">:</span><span class="at"> </span><span class="fl">5.00</span></span>
+<span id="cb1-22"><a href="#cb1-22" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">pause</span><span class="kw">:</span><span class="at"> </span><span class="fl">10.00</span></span>
+<span id="cb1-23"><a href="#cb1-23" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">hard_stop</span><span class="kw">:</span><span class="at"> </span><span class="fl">50.00</span></span>
+<span id="cb1-24"><a href="#cb1-24" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">currency</span><span class="kw">:</span><span class="at"> USD</span></span>
+<span id="cb1-25"><a href="#cb1-25" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb1-26"><a href="#cb1-26" aria-hidden="true" tabindex="-1"></a><span class="co">  # Cost estimation for paid APIs</span></span>
+<span id="cb1-27"><a href="#cb1-27" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">cost</span><span class="kw">:</span></span>
+<span id="cb1-28"><a href="#cb1-28" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">model</span><span class="kw">:</span><span class="at"> per_call</span></span>
+<span id="cb1-29"><a href="#cb1-29" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">currency</span><span class="kw">:</span><span class="at"> USD</span></span>
+<span id="cb1-30"><a href="#cb1-30" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">pricing</span><span class="kw">:</span></span>
+<span id="cb1-31"><a href="#cb1-31" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="kw">-</span><span class="at"> </span><span class="fu">endpoint</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;*&quot;</span></span>
+<span id="cb1-32"><a href="#cb1-32" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">cost_per_call</span><span class="kw">:</span><span class="at"> </span><span class="fl">0.001</span></span>
+<span id="cb1-33"><a href="#cb1-33" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="kw">-</span><span class="at"> </span><span class="fu">endpoint</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;POST /premium/*&quot;</span></span>
+<span id="cb1-34"><a href="#cb1-34" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">cost_per_call</span><span class="kw">:</span><span class="at"> </span><span class="fl">0.01</span></span></code></pre></div>
+<h3 id="22-api_limits-block">2.2 api_limits Block</h3>
+<p>Declares rate limits imposed by the target API.</p>
+<div class="sourceCode" id="cb2"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="kw">interface</span> ApiLimit {</span>
+<span id="cb2-2"><a href="#cb2-2" aria-hidden="true" tabindex="-1"></a>  <span class="co">/**</span></span>
+<span id="cb2-3"><a href="#cb2-3" aria-hidden="true" tabindex="-1"></a><span class="co">   * Scope of the limit</span></span>
+<span id="cb2-4"><a href="#cb2-4" aria-hidden="true" tabindex="-1"></a><span class="co">   * - global: Applies to all operations</span></span>
+<span id="cb2-5"><a href="#cb2-5" aria-hidden="true" tabindex="-1"></a><span class="co">   * - endpoint: Applies to specific endpoint</span></span>
+<span id="cb2-6"><a href="#cb2-6" aria-hidden="true" tabindex="-1"></a><span class="co">   * - category: Applies to CRUDE category</span></span>
+<span id="cb2-7"><a href="#cb2-7" aria-hidden="true" tabindex="-1"></a><span class="co">   */</span></span>
+<span id="cb2-8"><a href="#cb2-8" aria-hidden="true" tabindex="-1"></a>  scope<span class="op">:</span> <span class="st">&#39;global&#39;</span> <span class="op">|</span> <span class="st">&#39;endpoint&#39;</span> <span class="op">|</span> <span class="st">&#39;category&#39;</span><span class="op">;</span></span>
+<span id="cb2-9"><a href="#cb2-9" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb2-10"><a href="#cb2-10" aria-hidden="true" tabindex="-1"></a>  <span class="co">/**</span></span>
+<span id="cb2-11"><a href="#cb2-11" aria-hidden="true" tabindex="-1"></a><span class="co">   * Endpoint pattern (when scope is &#39;endpoint&#39;)</span></span>
+<span id="cb2-12"><a href="#cb2-12" aria-hidden="true" tabindex="-1"></a><span class="co">   * Supports wildcards: &quot;GET /users/*&quot;</span></span>
+<span id="cb2-13"><a href="#cb2-13" aria-hidden="true" tabindex="-1"></a><span class="co">   */</span></span>
+<span id="cb2-14"><a href="#cb2-14" aria-hidden="true" tabindex="-1"></a>  endpoint<span class="op">?:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb2-15"><a href="#cb2-15" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb2-16"><a href="#cb2-16" aria-hidden="true" tabindex="-1"></a>  <span class="co">/**</span></span>
+<span id="cb2-17"><a href="#cb2-17" aria-hidden="true" tabindex="-1"></a><span class="co">   * CRUDE category (when scope is &#39;category&#39;)</span></span>
+<span id="cb2-18"><a href="#cb2-18" aria-hidden="true" tabindex="-1"></a><span class="co">   */</span></span>
+<span id="cb2-19"><a href="#cb2-19" aria-hidden="true" tabindex="-1"></a>  category<span class="op">?:</span> <span class="st">&#39;create&#39;</span> <span class="op">|</span> <span class="st">&#39;read&#39;</span> <span class="op">|</span> <span class="st">&#39;update&#39;</span> <span class="op">|</span> <span class="st">&#39;delete&#39;</span> <span class="op">|</span> <span class="st">&#39;execute&#39;</span><span class="op">;</span></span>
+<span id="cb2-20"><a href="#cb2-20" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb2-21"><a href="#cb2-21" aria-hidden="true" tabindex="-1"></a>  <span class="co">/**</span></span>
+<span id="cb2-22"><a href="#cb2-22" aria-hidden="true" tabindex="-1"></a><span class="co">   * Maximum number of requests in the window</span></span>
+<span id="cb2-23"><a href="#cb2-23" aria-hidden="true" tabindex="-1"></a><span class="co">   */</span></span>
+<span id="cb2-24"><a href="#cb2-24" aria-hidden="true" tabindex="-1"></a>  limit<span class="op">:</span> <span class="dt">number</span><span class="op">;</span></span>
+<span id="cb2-25"><a href="#cb2-25" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb2-26"><a href="#cb2-26" aria-hidden="true" tabindex="-1"></a>  <span class="co">/**</span></span>
+<span id="cb2-27"><a href="#cb2-27" aria-hidden="true" tabindex="-1"></a><span class="co">   * Time window for the limit</span></span>
+<span id="cb2-28"><a href="#cb2-28" aria-hidden="true" tabindex="-1"></a><span class="co">   */</span></span>
+<span id="cb2-29"><a href="#cb2-29" aria-hidden="true" tabindex="-1"></a>  window<span class="op">:</span> <span class="st">&#39;second&#39;</span> <span class="op">|</span> <span class="st">&#39;minute&#39;</span> <span class="op">|</span> <span class="st">&#39;hour&#39;</span> <span class="op">|</span> <span class="st">&#39;day&#39;</span><span class="op">;</span></span>
+<span id="cb2-30"><a href="#cb2-30" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb2-31"><a href="#cb2-31" aria-hidden="true" tabindex="-1"></a>  <span class="co">/**</span></span>
+<span id="cb2-32"><a href="#cb2-32" aria-hidden="true" tabindex="-1"></a><span class="co">   * Header name containing remaining requests (for runtime tracking)</span></span>
+<span id="cb2-33"><a href="#cb2-33" aria-hidden="true" tabindex="-1"></a><span class="co">   */</span></span>
+<span id="cb2-34"><a href="#cb2-34" aria-hidden="true" tabindex="-1"></a>  remaining_header<span class="op">?:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb2-35"><a href="#cb2-35" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb2-36"><a href="#cb2-36" aria-hidden="true" tabindex="-1"></a>  <span class="co">/**</span></span>
+<span id="cb2-37"><a href="#cb2-37" aria-hidden="true" tabindex="-1"></a><span class="co">   * Header name containing reset timestamp</span></span>
+<span id="cb2-38"><a href="#cb2-38" aria-hidden="true" tabindex="-1"></a><span class="co">   */</span></span>
+<span id="cb2-39"><a href="#cb2-39" aria-hidden="true" tabindex="-1"></a>  reset_header<span class="op">?:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb2-40"><a href="#cb2-40" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<h3 id="23-common-api-limit-patterns">2.3 Common API Limit Patterns</h3>
+<div class="sourceCode" id="cb3"><pre class="sourceCode yaml"><code class="sourceCode yaml"><span id="cb3-1"><a href="#cb3-1" aria-hidden="true" tabindex="-1"></a><span class="co"># GitHub API pattern</span></span>
+<span id="cb3-2"><a href="#cb3-2" aria-hidden="true" tabindex="-1"></a><span class="fu">api_limits</span><span class="kw">:</span></span>
+<span id="cb3-3"><a href="#cb3-3" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="kw">-</span><span class="at"> </span><span class="fu">scope</span><span class="kw">:</span><span class="at"> global</span></span>
+<span id="cb3-4"><a href="#cb3-4" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">limit</span><span class="kw">:</span><span class="at"> </span><span class="dv">5000</span></span>
+<span id="cb3-5"><a href="#cb3-5" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">window</span><span class="kw">:</span><span class="at"> hour</span></span>
+<span id="cb3-6"><a href="#cb3-6" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">remaining_header</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;X-RateLimit-Remaining&quot;</span></span>
+<span id="cb3-7"><a href="#cb3-7" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">reset_header</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;X-RateLimit-Reset&quot;</span></span>
+<span id="cb3-8"><a href="#cb3-8" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb3-9"><a href="#cb3-9" aria-hidden="true" tabindex="-1"></a><span class="co"># OpenAI pattern (tokens per minute)</span></span>
+<span id="cb3-10"><a href="#cb3-10" aria-hidden="true" tabindex="-1"></a><span class="fu">api_limits</span><span class="kw">:</span></span>
+<span id="cb3-11"><a href="#cb3-11" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="kw">-</span><span class="at"> </span><span class="fu">scope</span><span class="kw">:</span><span class="at"> global</span></span>
+<span id="cb3-12"><a href="#cb3-12" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">limit</span><span class="kw">:</span><span class="at"> </span><span class="dv">90000</span></span>
+<span id="cb3-13"><a href="#cb3-13" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">window</span><span class="kw">:</span><span class="at"> minute</span></span>
+<span id="cb3-14"><a href="#cb3-14" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">metric</span><span class="kw">:</span><span class="at"> tokens_per_minute</span></span>
+<span id="cb3-15"><a href="#cb3-15" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb3-16"><a href="#cb3-16" aria-hidden="true" tabindex="-1"></a><span class="co"># Stripe pattern (different limits by CRUDE category)</span></span>
+<span id="cb3-17"><a href="#cb3-17" aria-hidden="true" tabindex="-1"></a><span class="fu">api_limits</span><span class="kw">:</span></span>
+<span id="cb3-18"><a href="#cb3-18" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="kw">-</span><span class="at"> </span><span class="fu">scope</span><span class="kw">:</span><span class="at"> category</span></span>
+<span id="cb3-19"><a href="#cb3-19" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">category</span><span class="kw">:</span><span class="at"> read</span></span>
+<span id="cb3-20"><a href="#cb3-20" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">limit</span><span class="kw">:</span><span class="at"> </span><span class="dv">100</span></span>
+<span id="cb3-21"><a href="#cb3-21" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">window</span><span class="kw">:</span><span class="at"> second</span></span>
+<span id="cb3-22"><a href="#cb3-22" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="kw">-</span><span class="at"> </span><span class="fu">scope</span><span class="kw">:</span><span class="at"> category</span></span>
+<span id="cb3-23"><a href="#cb3-23" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">category</span><span class="kw">:</span><span class="at"> create</span></span>
+<span id="cb3-24"><a href="#cb3-24" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">limit</span><span class="kw">:</span><span class="at"> </span><span class="dv">25</span></span>
+<span id="cb3-25"><a href="#cb3-25" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">window</span><span class="kw">:</span><span class="at"> second</span></span></code></pre></div>
+<hr />
+<h2 id="3-quota-management">3. Quota Management</h2>
+<h3 id="31-quotas-block">3.1 Quotas Block</h3>
+<p>User-configurable limits that can be stricter than API limits.</p>
+<div class="sourceCode" id="cb4"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb4-1"><a href="#cb4-1" aria-hidden="true" tabindex="-1"></a><span class="kw">interface</span> QuotaConfig {</span>
+<span id="cb4-2"><a href="#cb4-2" aria-hidden="true" tabindex="-1"></a>  <span class="co">/**</span></span>
+<span id="cb4-3"><a href="#cb4-3" aria-hidden="true" tabindex="-1"></a><span class="co">   * Whether quota enforcement is enabled</span></span>
+<span id="cb4-4"><a href="#cb4-4" aria-hidden="true" tabindex="-1"></a><span class="co">   */</span></span>
+<span id="cb4-5"><a href="#cb4-5" aria-hidden="true" tabindex="-1"></a>  enabled<span class="op">:</span> <span class="dt">boolean</span><span class="op">;</span></span>
+<span id="cb4-6"><a href="#cb4-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb4-7"><a href="#cb4-7" aria-hidden="true" tabindex="-1"></a>  <span class="co">/**</span></span>
+<span id="cb4-8"><a href="#cb4-8" aria-hidden="true" tabindex="-1"></a><span class="co">   * Individual quota limits</span></span>
+<span id="cb4-9"><a href="#cb4-9" aria-hidden="true" tabindex="-1"></a><span class="co">   */</span></span>
+<span id="cb4-10"><a href="#cb4-10" aria-hidden="true" tabindex="-1"></a>  limits<span class="op">:</span> QuotaLimit[]<span class="op">;</span></span>
+<span id="cb4-11"><a href="#cb4-11" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb4-12"><a href="#cb4-12" aria-hidden="true" tabindex="-1"></a>  <span class="co">/**</span></span>
+<span id="cb4-13"><a href="#cb4-13" aria-hidden="true" tabindex="-1"></a><span class="co">   * How to persist quota tracking</span></span>
+<span id="cb4-14"><a href="#cb4-14" aria-hidden="true" tabindex="-1"></a><span class="co">   */</span></span>
+<span id="cb4-15"><a href="#cb4-15" aria-hidden="true" tabindex="-1"></a>  persistence<span class="op">?:</span> <span class="st">&#39;memory&#39;</span> <span class="op">|</span> <span class="st">&#39;file&#39;</span> <span class="op">|</span> <span class="st">&#39;database&#39;</span><span class="op">;</span></span>
+<span id="cb4-16"><a href="#cb4-16" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb4-17"><a href="#cb4-17" aria-hidden="true" tabindex="-1"></a>  <span class="co">/**</span></span>
+<span id="cb4-18"><a href="#cb4-18" aria-hidden="true" tabindex="-1"></a><span class="co">   * When to reset counters</span></span>
+<span id="cb4-19"><a href="#cb4-19" aria-hidden="true" tabindex="-1"></a><span class="co">   */</span></span>
+<span id="cb4-20"><a href="#cb4-20" aria-hidden="true" tabindex="-1"></a>  reset_schedule<span class="op">?:</span> <span class="dt">string</span><span class="op">;</span>  <span class="co">// Cron expression</span></span>
+<span id="cb4-21"><a href="#cb4-21" aria-hidden="true" tabindex="-1"></a>}</span>
+<span id="cb4-22"><a href="#cb4-22" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb4-23"><a href="#cb4-23" aria-hidden="true" tabindex="-1"></a><span class="kw">interface</span> QuotaLimit {</span>
+<span id="cb4-24"><a href="#cb4-24" aria-hidden="true" tabindex="-1"></a>  <span class="co">/**</span></span>
+<span id="cb4-25"><a href="#cb4-25" aria-hidden="true" tabindex="-1"></a><span class="co">   * What is being measured</span></span>
+<span id="cb4-26"><a href="#cb4-26" aria-hidden="true" tabindex="-1"></a><span class="co">   */</span></span>
+<span id="cb4-27"><a href="#cb4-27" aria-hidden="true" tabindex="-1"></a>  metric<span class="op">:</span> QuotaMetric<span class="op">;</span></span>
+<span id="cb4-28"><a href="#cb4-28" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb4-29"><a href="#cb4-29" aria-hidden="true" tabindex="-1"></a>  <span class="co">/**</span></span>
+<span id="cb4-30"><a href="#cb4-30" aria-hidden="true" tabindex="-1"></a><span class="co">   * Threshold for warning notification</span></span>
+<span id="cb4-31"><a href="#cb4-31" aria-hidden="true" tabindex="-1"></a><span class="co">   */</span></span>
+<span id="cb4-32"><a href="#cb4-32" aria-hidden="true" tabindex="-1"></a>  warn<span class="op">:</span> <span class="dt">number</span><span class="op">;</span></span>
+<span id="cb4-33"><a href="#cb4-33" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb4-34"><a href="#cb4-34" aria-hidden="true" tabindex="-1"></a>  <span class="co">/**</span></span>
+<span id="cb4-35"><a href="#cb4-35" aria-hidden="true" tabindex="-1"></a><span class="co">   * Threshold for pause (require confirmation to continue)</span></span>
+<span id="cb4-36"><a href="#cb4-36" aria-hidden="true" tabindex="-1"></a><span class="co">   */</span></span>
+<span id="cb4-37"><a href="#cb4-37" aria-hidden="true" tabindex="-1"></a>  pause<span class="op">:</span> <span class="dt">number</span><span class="op">;</span></span>
+<span id="cb4-38"><a href="#cb4-38" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb4-39"><a href="#cb4-39" aria-hidden="true" tabindex="-1"></a>  <span class="co">/**</span></span>
+<span id="cb4-40"><a href="#cb4-40" aria-hidden="true" tabindex="-1"></a><span class="co">   * Threshold for hard stop (block all requests)</span></span>
+<span id="cb4-41"><a href="#cb4-41" aria-hidden="true" tabindex="-1"></a><span class="co">   */</span></span>
+<span id="cb4-42"><a href="#cb4-42" aria-hidden="true" tabindex="-1"></a>  hard_stop<span class="op">?:</span> <span class="dt">number</span><span class="op">;</span></span>
+<span id="cb4-43"><a href="#cb4-43" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb4-44"><a href="#cb4-44" aria-hidden="true" tabindex="-1"></a>  <span class="co">/**</span></span>
+<span id="cb4-45"><a href="#cb4-45" aria-hidden="true" tabindex="-1"></a><span class="co">   * Currency for cost metrics</span></span>
+<span id="cb4-46"><a href="#cb4-46" aria-hidden="true" tabindex="-1"></a><span class="co">   */</span></span>
+<span id="cb4-47"><a href="#cb4-47" aria-hidden="true" tabindex="-1"></a>  currency<span class="op">?:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb4-48"><a href="#cb4-48" aria-hidden="true" tabindex="-1"></a>}</span>
+<span id="cb4-49"><a href="#cb4-49" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb4-50"><a href="#cb4-50" aria-hidden="true" tabindex="-1"></a><span class="kw">type</span> QuotaMetric <span class="op">=</span></span>
+<span id="cb4-51"><a href="#cb4-51" aria-hidden="true" tabindex="-1"></a>  <span class="op">|</span> <span class="st">&#39;requests_per_minute&#39;</span></span>
+<span id="cb4-52"><a href="#cb4-52" aria-hidden="true" tabindex="-1"></a>  <span class="op">|</span> <span class="st">&#39;requests_per_hour&#39;</span></span>
+<span id="cb4-53"><a href="#cb4-53" aria-hidden="true" tabindex="-1"></a>  <span class="op">|</span> <span class="st">&#39;requests_per_day&#39;</span></span>
+<span id="cb4-54"><a href="#cb4-54" aria-hidden="true" tabindex="-1"></a>  <span class="op">|</span> <span class="st">&#39;tokens_per_minute&#39;</span></span>
+<span id="cb4-55"><a href="#cb4-55" aria-hidden="true" tabindex="-1"></a>  <span class="op">|</span> <span class="st">&#39;tokens_per_hour&#39;</span></span>
+<span id="cb4-56"><a href="#cb4-56" aria-hidden="true" tabindex="-1"></a>  <span class="op">|</span> <span class="st">&#39;tokens_per_day&#39;</span></span>
+<span id="cb4-57"><a href="#cb4-57" aria-hidden="true" tabindex="-1"></a>  <span class="op">|</span> <span class="st">&#39;cost_per_hour&#39;</span></span>
+<span id="cb4-58"><a href="#cb4-58" aria-hidden="true" tabindex="-1"></a>  <span class="op">|</span> <span class="st">&#39;cost_per_day&#39;</span></span>
+<span id="cb4-59"><a href="#cb4-59" aria-hidden="true" tabindex="-1"></a>  <span class="op">|</span> <span class="st">&#39;cost_per_month&#39;</span><span class="op">;</span></span></code></pre></div>
+<h3 id="32-threshold-behaviors">3.2 Threshold Behaviors</h3>
+<table>
+<thead>
+<tr>
+<th>Threshold</th>
+<th>Behavior</th>
+<th>User Experience</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>warn</code></td>
+<td>Log warning, continue</td>
+<td>Notification displayed</td>
+</tr>
+<tr>
+<td><code>pause</code></td>
+<td>Require confirmation</td>
+<td>"Continue?" prompt</td>
+</tr>
+<tr>
+<td><code>hard_stop</code></td>
+<td>Block all requests</td>
+<td>Error response</td>
+</tr>
+</tbody>
+</table>
+<h3 id="33-example-quota-configurations">3.3 Example Quota Configurations</h3>
+<p><strong>Conservative (cost-conscious):</strong></p>
+<div class="sourceCode" id="cb5"><pre class="sourceCode yaml"><code class="sourceCode yaml"><span id="cb5-1"><a href="#cb5-1" aria-hidden="true" tabindex="-1"></a><span class="fu">quotas</span><span class="kw">:</span></span>
+<span id="cb5-2"><a href="#cb5-2" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">enabled</span><span class="kw">:</span><span class="at"> </span><span class="ch">true</span></span>
+<span id="cb5-3"><a href="#cb5-3" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">limits</span><span class="kw">:</span></span>
+<span id="cb5-4"><a href="#cb5-4" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="kw">-</span><span class="at"> </span><span class="fu">metric</span><span class="kw">:</span><span class="at"> cost_per_day</span></span>
+<span id="cb5-5"><a href="#cb5-5" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">warn</span><span class="kw">:</span><span class="at"> </span><span class="fl">1.00</span></span>
+<span id="cb5-6"><a href="#cb5-6" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">pause</span><span class="kw">:</span><span class="at"> </span><span class="fl">5.00</span></span>
+<span id="cb5-7"><a href="#cb5-7" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">hard_stop</span><span class="kw">:</span><span class="at"> </span><span class="fl">10.00</span></span>
+<span id="cb5-8"><a href="#cb5-8" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">currency</span><span class="kw">:</span><span class="at"> USD</span></span></code></pre></div>
+<p><strong>Development (permissive):</strong></p>
+<div class="sourceCode" id="cb6"><pre class="sourceCode yaml"><code class="sourceCode yaml"><span id="cb6-1"><a href="#cb6-1" aria-hidden="true" tabindex="-1"></a><span class="fu">quotas</span><span class="kw">:</span></span>
+<span id="cb6-2"><a href="#cb6-2" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">enabled</span><span class="kw">:</span><span class="at"> </span><span class="ch">true</span></span>
+<span id="cb6-3"><a href="#cb6-3" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">limits</span><span class="kw">:</span></span>
+<span id="cb6-4"><a href="#cb6-4" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="kw">-</span><span class="at"> </span><span class="fu">metric</span><span class="kw">:</span><span class="at"> requests_per_hour</span></span>
+<span id="cb6-5"><a href="#cb6-5" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">warn</span><span class="kw">:</span><span class="at"> </span><span class="dv">1000</span></span>
+<span id="cb6-6"><a href="#cb6-6" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">pause</span><span class="kw">:</span><span class="at"> </span><span class="dv">5000</span></span>
+<span id="cb6-7"><a href="#cb6-7" aria-hidden="true" tabindex="-1"></a><span class="co">      # No hard_stop - never fully block</span></span></code></pre></div>
+<p><strong>Production (strict):</strong></p>
+<div class="sourceCode" id="cb7"><pre class="sourceCode yaml"><code class="sourceCode yaml"><span id="cb7-1"><a href="#cb7-1" aria-hidden="true" tabindex="-1"></a><span class="fu">quotas</span><span class="kw">:</span></span>
+<span id="cb7-2"><a href="#cb7-2" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">enabled</span><span class="kw">:</span><span class="at"> </span><span class="ch">true</span></span>
+<span id="cb7-3"><a href="#cb7-3" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">limits</span><span class="kw">:</span></span>
+<span id="cb7-4"><a href="#cb7-4" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="kw">-</span><span class="at"> </span><span class="fu">metric</span><span class="kw">:</span><span class="at"> requests_per_minute</span></span>
+<span id="cb7-5"><a href="#cb7-5" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">warn</span><span class="kw">:</span><span class="at"> </span><span class="dv">50</span></span>
+<span id="cb7-6"><a href="#cb7-6" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">pause</span><span class="kw">:</span><span class="at"> </span><span class="dv">80</span></span>
+<span id="cb7-7"><a href="#cb7-7" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">hard_stop</span><span class="kw">:</span><span class="at"> </span><span class="dv">100</span></span>
+<span id="cb7-8"><a href="#cb7-8" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="kw">-</span><span class="at"> </span><span class="fu">metric</span><span class="kw">:</span><span class="at"> cost_per_day</span></span>
+<span id="cb7-9"><a href="#cb7-9" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">warn</span><span class="kw">:</span><span class="at"> </span><span class="fl">100.00</span></span>
+<span id="cb7-10"><a href="#cb7-10" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">pause</span><span class="kw">:</span><span class="at"> </span><span class="fl">200.00</span></span>
+<span id="cb7-11"><a href="#cb7-11" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">hard_stop</span><span class="kw">:</span><span class="at"> </span><span class="fl">500.00</span></span>
+<span id="cb7-12"><a href="#cb7-12" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">currency</span><span class="kw">:</span><span class="at"> USD</span></span></code></pre></div>
+<hr />
+<h2 id="4-enforcement-behavior">4. Enforcement Behavior</h2>
+<h3 id="41-enforcement-flow">4.1 Enforcement Flow</h3>
+<pre><code>Request → Check API Limits → Check Quotas → Execute or Block
+              │                    │
+              ▼                    ▼
+         API blocked?        Quota exceeded?
+              │                    │
+              ▼                    ▼
+         Wait/Retry         Warn/Pause/Stop</code></pre>
+<h3 id="42-api-limit-enforcement">4.2 API Limit Enforcement</h3>
+<p>When API rate limit is reached:</p>
+<ol type="1">
+<li><strong>Check remaining</strong> - Read from response headers if available</li>
+<li><strong>Predict limit</strong> - Track request counts if no headers</li>
+<li><strong>Pre-flight block</strong> - Block request before sending if limit would be exceeded</li>
+<li><strong>Retry-After</strong> - Respect <code>Retry-After</code> header from API responses</li>
+</ol>
+<p><strong>Pre-flight block response:</strong></p>
+<div class="sourceCode" id="cb9"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb9-1"><a href="#cb9-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb9-2"><a href="#cb9-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb9-3"><a href="#cb9-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;error&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb9-4"><a href="#cb9-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;code&quot;</span><span class="fu">:</span> <span class="st">&quot;RATE_LIMIT_EXCEEDED&quot;</span><span class="fu">,</span></span>
+<span id="cb9-5"><a href="#cb9-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;API rate limit would be exceeded&quot;</span><span class="fu">,</span></span>
+<span id="cb9-6"><a href="#cb9-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;details&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb9-7"><a href="#cb9-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;limit&quot;</span><span class="fu">:</span> <span class="dv">5000</span><span class="fu">,</span></span>
+<span id="cb9-8"><a href="#cb9-8" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;remaining&quot;</span><span class="fu">:</span> <span class="dv">0</span><span class="fu">,</span></span>
+<span id="cb9-9"><a href="#cb9-9" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;window&quot;</span><span class="fu">:</span> <span class="st">&quot;hour&quot;</span><span class="fu">,</span></span>
+<span id="cb9-10"><a href="#cb9-10" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;resets_at&quot;</span><span class="fu">:</span> <span class="st">&quot;2026-01-28T13:00:00Z&quot;</span><span class="fu">,</span></span>
+<span id="cb9-11"><a href="#cb9-11" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;retry_after_seconds&quot;</span><span class="fu">:</span> <span class="dv">1847</span></span>
+<span id="cb9-12"><a href="#cb9-12" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb9-13"><a href="#cb9-13" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb9-14"><a href="#cb9-14" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<h3 id="43-quota-enforcement">4.3 Quota Enforcement</h3>
+<p>Warnings are included in successful responses via the <code>warnings</code> array. See <a href="../features/warnings.html">Warnings Specification</a> for the complete schema and client handling requirements.</p>
+<p><strong>Warning (warn threshold):</strong></p>
+<div class="sourceCode" id="cb10"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb10-1"><a href="#cb10-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb10-2"><a href="#cb10-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb10-3"><a href="#cb10-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;data&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="er">...</span> <span class="fu">},</span></span>
+<span id="cb10-4"><a href="#cb10-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;warnings&quot;</span><span class="fu">:</span> <span class="ot">[</span></span>
+<span id="cb10-5"><a href="#cb10-5" aria-hidden="true" tabindex="-1"></a>    <span class="fu">{</span></span>
+<span id="cb10-6"><a href="#cb10-6" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;code&quot;</span><span class="fu">:</span> <span class="st">&quot;RATE_LIMIT_QUOTA_WARNING&quot;</span><span class="fu">,</span></span>
+<span id="cb10-7"><a href="#cb10-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;Approaching quota limit&quot;</span><span class="fu">,</span></span>
+<span id="cb10-8"><a href="#cb10-8" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;details&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb10-9"><a href="#cb10-9" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;metric&quot;</span><span class="fu">:</span> <span class="st">&quot;requests_per_hour&quot;</span><span class="fu">,</span></span>
+<span id="cb10-10"><a href="#cb10-10" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;current&quot;</span><span class="fu">:</span> <span class="dv">4100</span><span class="fu">,</span></span>
+<span id="cb10-11"><a href="#cb10-11" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;warn_threshold&quot;</span><span class="fu">:</span> <span class="dv">4000</span><span class="fu">,</span></span>
+<span id="cb10-12"><a href="#cb10-12" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;pause_threshold&quot;</span><span class="fu">:</span> <span class="dv">4800</span></span>
+<span id="cb10-13"><a href="#cb10-13" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span></span>
+<span id="cb10-14"><a href="#cb10-14" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb10-15"><a href="#cb10-15" aria-hidden="true" tabindex="-1"></a>  <span class="ot">]</span></span>
+<span id="cb10-16"><a href="#cb10-16" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<p><strong>Pause (pause threshold):</strong></p>
+<div class="sourceCode" id="cb11"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb11-1"><a href="#cb11-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb11-2"><a href="#cb11-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb11-3"><a href="#cb11-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;error&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb11-4"><a href="#cb11-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;code&quot;</span><span class="fu">:</span> <span class="st">&quot;RATE_LIMIT_QUOTA_PAUSE&quot;</span><span class="fu">,</span></span>
+<span id="cb11-5"><a href="#cb11-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;Quota pause threshold reached&quot;</span><span class="fu">,</span></span>
+<span id="cb11-6"><a href="#cb11-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;details&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb11-7"><a href="#cb11-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;metric&quot;</span><span class="fu">:</span> <span class="st">&quot;requests_per_hour&quot;</span><span class="fu">,</span></span>
+<span id="cb11-8"><a href="#cb11-8" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;current&quot;</span><span class="fu">:</span> <span class="dv">4850</span><span class="fu">,</span></span>
+<span id="cb11-9"><a href="#cb11-9" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;pause_threshold&quot;</span><span class="fu">:</span> <span class="dv">4800</span><span class="fu">,</span></span>
+<span id="cb11-10"><a href="#cb11-10" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;hard_stop_threshold&quot;</span><span class="fu">:</span> <span class="dv">5000</span><span class="fu">,</span></span>
+<span id="cb11-11"><a href="#cb11-11" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;confirmation_token&quot;</span><span class="fu">:</span> <span class="st">&quot;quota_continue_abc123&quot;</span><span class="fu">,</span></span>
+<span id="cb11-12"><a href="#cb11-12" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;expires_at&quot;</span><span class="fu">:</span> <span class="st">&quot;2026-01-28T12:05:00Z&quot;</span></span>
+<span id="cb11-13"><a href="#cb11-13" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb11-14"><a href="#cb11-14" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb11-15"><a href="#cb11-15" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<p><strong>Hard stop (hard_stop threshold):</strong></p>
+<div class="sourceCode" id="cb12"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb12-1"><a href="#cb12-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb12-2"><a href="#cb12-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb12-3"><a href="#cb12-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;error&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb12-4"><a href="#cb12-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;code&quot;</span><span class="fu">:</span> <span class="st">&quot;RATE_LIMIT_QUOTA_EXHAUSTED&quot;</span><span class="fu">,</span></span>
+<span id="cb12-5"><a href="#cb12-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;Quota exhausted&quot;</span><span class="fu">,</span></span>
+<span id="cb12-6"><a href="#cb12-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;details&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb12-7"><a href="#cb12-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;metric&quot;</span><span class="fu">:</span> <span class="st">&quot;requests_per_hour&quot;</span><span class="fu">,</span></span>
+<span id="cb12-8"><a href="#cb12-8" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;current&quot;</span><span class="fu">:</span> <span class="dv">5000</span><span class="fu">,</span></span>
+<span id="cb12-9"><a href="#cb12-9" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;hard_stop_threshold&quot;</span><span class="fu">:</span> <span class="dv">5000</span><span class="fu">,</span></span>
+<span id="cb12-10"><a href="#cb12-10" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;resets_at&quot;</span><span class="fu">:</span> <span class="st">&quot;2026-01-28T13:00:00Z&quot;</span></span>
+<span id="cb12-11"><a href="#cb12-11" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb12-12"><a href="#cb12-12" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb12-13"><a href="#cb12-13" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<h3 id="44-continuing-after-pause">4.4 Continuing After Pause</h3>
+<p>To continue after pause threshold, include the confirmation token from the <code>RATE_LIMIT_QUOTA_PAUSE</code> response. See <a href="../security/confirmation-tokens.html">Confirmation Token Specification</a> for token validation and lifecycle details.</p>
+<div class="sourceCode" id="cb13"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb13-1"><a href="#cb13-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb13-2"><a href="#cb13-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;get_user&quot;</span><span class="op">,</span></span>
+<span id="cb13-3"><a href="#cb13-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> {</span>
+<span id="cb13-4"><a href="#cb13-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">user_id</span><span class="op">:</span> <span class="st">&quot;alice&quot;</span><span class="op">,</span></span>
+<span id="cb13-5"><a href="#cb13-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">_quota_continue</span><span class="op">:</span> <span class="st">&quot;quota_continue_abc123&quot;</span></span>
+<span id="cb13-6"><a href="#cb13-6" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb13-7"><a href="#cb13-7" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<hr />
+<h2 id="5-error-codes">5. Error Codes</h2>
+<h3 id="51-rate-limit-error-codes">5.1 Rate Limit Error Codes</h3>
+<table>
+<thead>
+<tr>
+<th>Code</th>
+<th>Description</th>
+<th>Recovery</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>RATE_LIMIT_EXCEEDED</code></td>
+<td>Target API rate limit reached</td>
+<td>Wait for reset</td>
+</tr>
+<tr>
+<td><code>RATE_LIMIT_QUOTA_PAUSE</code></td>
+<td>User quota pause threshold</td>
+<td>Confirm to continue</td>
+</tr>
+<tr>
+<td><code>RATE_LIMIT_QUOTA_EXHAUSTED</code></td>
+<td>User quota hard stop</td>
+<td>Wait for reset</td>
+</tr>
+<tr>
+<td><code>RATE_LIMIT_QUOTA_WARNING</code></td>
+<td>Approaching limit (in warnings)</td>
+<td>Consider slowing</td>
+</tr>
+</tbody>
+</table>
+<h3 id="52-error-response-schema">5.2 Error Response Schema</h3>
+<div class="sourceCode" id="cb14"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb14-1"><a href="#cb14-1" aria-hidden="true" tabindex="-1"></a><span class="kw">interface</span> RateLimitError {</span>
+<span id="cb14-2"><a href="#cb14-2" aria-hidden="true" tabindex="-1"></a>  code<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb14-3"><a href="#cb14-3" aria-hidden="true" tabindex="-1"></a>  message<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb14-4"><a href="#cb14-4" aria-hidden="true" tabindex="-1"></a>  details<span class="op">:</span> {</span>
+<span id="cb14-5"><a href="#cb14-5" aria-hidden="true" tabindex="-1"></a>    <span class="co">/** What metric triggered the limit */</span></span>
+<span id="cb14-6"><a href="#cb14-6" aria-hidden="true" tabindex="-1"></a>    metric<span class="op">?:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb14-7"><a href="#cb14-7" aria-hidden="true" tabindex="-1"></a>    <span class="co">/** Current usage count/amount */</span></span>
+<span id="cb14-8"><a href="#cb14-8" aria-hidden="true" tabindex="-1"></a>    current<span class="op">?:</span> <span class="dt">number</span><span class="op">;</span></span>
+<span id="cb14-9"><a href="#cb14-9" aria-hidden="true" tabindex="-1"></a>    <span class="co">/** The limit that was exceeded */</span></span>
+<span id="cb14-10"><a href="#cb14-10" aria-hidden="true" tabindex="-1"></a>    limit<span class="op">?:</span> <span class="dt">number</span><span class="op">;</span></span>
+<span id="cb14-11"><a href="#cb14-11" aria-hidden="true" tabindex="-1"></a>    <span class="co">/** Time window of the limit */</span></span>
+<span id="cb14-12"><a href="#cb14-12" aria-hidden="true" tabindex="-1"></a>    window<span class="op">?:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb14-13"><a href="#cb14-13" aria-hidden="true" tabindex="-1"></a>    <span class="co">/** When the limit resets */</span></span>
+<span id="cb14-14"><a href="#cb14-14" aria-hidden="true" tabindex="-1"></a>    resets_at<span class="op">?:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb14-15"><a href="#cb14-15" aria-hidden="true" tabindex="-1"></a>    <span class="co">/** Seconds until retry is allowed */</span></span>
+<span id="cb14-16"><a href="#cb14-16" aria-hidden="true" tabindex="-1"></a>    retry_after_seconds<span class="op">?:</span> <span class="dt">number</span><span class="op">;</span></span>
+<span id="cb14-17"><a href="#cb14-17" aria-hidden="true" tabindex="-1"></a>    <span class="co">/** Token to continue after pause */</span></span>
+<span id="cb14-18"><a href="#cb14-18" aria-hidden="true" tabindex="-1"></a>    confirmation_token<span class="op">?:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb14-19"><a href="#cb14-19" aria-hidden="true" tabindex="-1"></a>    <span class="co">/** When confirmation expires */</span></span>
+<span id="cb14-20"><a href="#cb14-20" aria-hidden="true" tabindex="-1"></a>    expires_at<span class="op">?:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb14-21"><a href="#cb14-21" aria-hidden="true" tabindex="-1"></a>  }<span class="op">;</span></span>
+<span id="cb14-22"><a href="#cb14-22" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<hr />
+<h2 id="6-introspection">6. Introspection</h2>
+<h3 id="61-quota-status-query">6.1 Quota Status Query</h3>
+<div class="sourceCode" id="cb15"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb15-1"><a href="#cb15-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb15-2"><a href="#cb15-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;introspect&quot;</span><span class="op">,</span></span>
+<span id="cb15-3"><a href="#cb15-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> {</span>
+<span id="cb15-4"><a href="#cb15-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">query</span><span class="op">:</span> <span class="st">&quot;quota_status&quot;</span></span>
+<span id="cb15-5"><a href="#cb15-5" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb15-6"><a href="#cb15-6" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<h3 id="62-quota-status-response">6.2 Quota Status Response</h3>
+<div class="sourceCode" id="cb16"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb16-1"><a href="#cb16-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb16-2"><a href="#cb16-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb16-3"><a href="#cb16-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;data&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb16-4"><a href="#cb16-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;adapter&quot;</span><span class="fu">:</span> <span class="st">&quot;github-api&quot;</span><span class="fu">,</span></span>
+<span id="cb16-5"><a href="#cb16-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;api_limits&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb16-6"><a href="#cb16-6" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;global&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb16-7"><a href="#cb16-7" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;limit&quot;</span><span class="fu">:</span> <span class="dv">5000</span><span class="fu">,</span></span>
+<span id="cb16-8"><a href="#cb16-8" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;remaining&quot;</span><span class="fu">:</span> <span class="dv">3500</span><span class="fu">,</span></span>
+<span id="cb16-9"><a href="#cb16-9" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;window&quot;</span><span class="fu">:</span> <span class="st">&quot;hour&quot;</span><span class="fu">,</span></span>
+<span id="cb16-10"><a href="#cb16-10" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;resets_at&quot;</span><span class="fu">:</span> <span class="st">&quot;2026-01-28T13:00:00Z&quot;</span></span>
+<span id="cb16-11"><a href="#cb16-11" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span></span>
+<span id="cb16-12"><a href="#cb16-12" aria-hidden="true" tabindex="-1"></a>    <span class="fu">},</span></span>
+<span id="cb16-13"><a href="#cb16-13" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;quotas&quot;</span><span class="fu">:</span> <span class="ot">[</span></span>
+<span id="cb16-14"><a href="#cb16-14" aria-hidden="true" tabindex="-1"></a>      <span class="fu">{</span></span>
+<span id="cb16-15"><a href="#cb16-15" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;metric&quot;</span><span class="fu">:</span> <span class="st">&quot;requests_per_hour&quot;</span><span class="fu">,</span></span>
+<span id="cb16-16"><a href="#cb16-16" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;current&quot;</span><span class="fu">:</span> <span class="dv">1500</span><span class="fu">,</span></span>
+<span id="cb16-17"><a href="#cb16-17" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;warn&quot;</span><span class="fu">:</span> <span class="dv">4000</span><span class="fu">,</span></span>
+<span id="cb16-18"><a href="#cb16-18" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;pause&quot;</span><span class="fu">:</span> <span class="dv">4800</span><span class="fu">,</span></span>
+<span id="cb16-19"><a href="#cb16-19" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;hard_stop&quot;</span><span class="fu">:</span> <span class="dv">5000</span><span class="fu">,</span></span>
+<span id="cb16-20"><a href="#cb16-20" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;status&quot;</span><span class="fu">:</span> <span class="st">&quot;ok&quot;</span></span>
+<span id="cb16-21"><a href="#cb16-21" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb16-22"><a href="#cb16-22" aria-hidden="true" tabindex="-1"></a>      <span class="fu">{</span></span>
+<span id="cb16-23"><a href="#cb16-23" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;metric&quot;</span><span class="fu">:</span> <span class="st">&quot;cost_per_day&quot;</span><span class="fu">,</span></span>
+<span id="cb16-24"><a href="#cb16-24" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;current&quot;</span><span class="fu">:</span> <span class="fl">4.50</span><span class="fu">,</span></span>
+<span id="cb16-25"><a href="#cb16-25" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;warn&quot;</span><span class="fu">:</span> <span class="fl">5.00</span><span class="fu">,</span></span>
+<span id="cb16-26"><a href="#cb16-26" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;pause&quot;</span><span class="fu">:</span> <span class="fl">10.00</span><span class="fu">,</span></span>
+<span id="cb16-27"><a href="#cb16-27" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;hard_stop&quot;</span><span class="fu">:</span> <span class="fl">50.00</span><span class="fu">,</span></span>
+<span id="cb16-28"><a href="#cb16-28" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;status&quot;</span><span class="fu">:</span> <span class="st">&quot;warn&quot;</span><span class="fu">,</span></span>
+<span id="cb16-29"><a href="#cb16-29" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;currency&quot;</span><span class="fu">:</span> <span class="st">&quot;USD&quot;</span></span>
+<span id="cb16-30"><a href="#cb16-30" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span></span>
+<span id="cb16-31"><a href="#cb16-31" aria-hidden="true" tabindex="-1"></a>    <span class="ot">]</span><span class="fu">,</span></span>
+<span id="cb16-32"><a href="#cb16-32" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;next_reset&quot;</span><span class="fu">:</span> <span class="st">&quot;2026-01-28T13:00:00Z&quot;</span></span>
+<span id="cb16-33"><a href="#cb16-33" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb16-34"><a href="#cb16-34" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<h3 id="63-status-values">6.3 Status Values</h3>
+<table>
+<thead>
+<tr>
+<th>Status</th>
+<th>Meaning</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>ok</code></td>
+<td>Below warn threshold</td>
+</tr>
+<tr>
+<td><code>warn</code></td>
+<td>Above warn, below pause</td>
+</tr>
+<tr>
+<td><code>paused</code></td>
+<td>At pause threshold, confirmation required</td>
+</tr>
+<tr>
+<td><code>exhausted</code></td>
+<td>At hard stop, requests blocked</td>
+</tr>
+</tbody>
+</table>
+<hr />
+<h2 id="7-implementation-requirements">7. Implementation Requirements</h2>
+<h3 id="71-must-requirements">7.1 MUST Requirements</h3>
+<p>Implementations supporting rate limiting MUST:</p>
+<ol type="1">
+<li>Respect <code>api_limits</code> and not exceed target API constraints</li>
+<li>Return proper error codes when limits are reached</li>
+<li>Include <code>retry_after_seconds</code> when blocking requests</li>
+<li>Support introspection of current quota status</li>
+</ol>
+<h3 id="72-should-requirements">7.2 SHOULD Requirements</h3>
+<p>Implementations supporting rate limiting SHOULD:</p>
+<ol type="1">
+<li>Track API response headers for remaining/reset info</li>
+<li>Implement the three-tier quota system (warn/pause/hard_stop)</li>
+<li>Persist quota counters across sessions</li>
+<li>Provide warnings in successful responses when approaching limits</li>
+</ol>
+<h3 id="73-may-requirements">7.3 MAY Requirements</h3>
+<p>Implementations supporting rate limiting MAY:</p>
+<ol type="1">
+<li>Support cost estimation and tracking</li>
+<li>Implement automatic request queuing and retry</li>
+<li>Support per-operation rate limits</li>
+<li>Integrate with external rate limit services</li>
+</ol>
+<h3 id="74-cost-tracking">7.4 Cost Tracking</h3>
+<p>For adapters with cost estimation:</p>
+<div class="sourceCode" id="cb17"><pre class="sourceCode yaml"><code class="sourceCode yaml"><span id="cb17-1"><a href="#cb17-1" aria-hidden="true" tabindex="-1"></a><span class="fu">cost</span><span class="kw">:</span></span>
+<span id="cb17-2"><a href="#cb17-2" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">model</span><span class="kw">:</span><span class="at"> per_call</span><span class="co">    # per_call | per_token | per_byte | tiered</span></span>
+<span id="cb17-3"><a href="#cb17-3" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">currency</span><span class="kw">:</span><span class="at"> USD</span></span>
+<span id="cb17-4"><a href="#cb17-4" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">pricing</span><span class="kw">:</span></span>
+<span id="cb17-5"><a href="#cb17-5" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="kw">-</span><span class="at"> </span><span class="fu">endpoint</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;*&quot;</span></span>
+<span id="cb17-6"><a href="#cb17-6" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">cost_per_call</span><span class="kw">:</span><span class="at"> </span><span class="fl">0.001</span></span>
+<span id="cb17-7"><a href="#cb17-7" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="kw">-</span><span class="at"> </span><span class="fu">endpoint</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;POST /completions&quot;</span></span>
+<span id="cb17-8"><a href="#cb17-8" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">cost_per_call</span><span class="kw">:</span><span class="at"> </span><span class="fl">0.002</span></span>
+<span id="cb17-9"><a href="#cb17-9" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">cost_per_token</span><span class="kw">:</span></span>
+<span id="cb17-10"><a href="#cb17-10" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">input</span><span class="kw">:</span><span class="at"> </span><span class="fl">0.00001</span></span>
+<span id="cb17-11"><a href="#cb17-11" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">output</span><span class="kw">:</span><span class="at"> </span><span class="fl">0.00003</span></span></code></pre></div>
+<hr />
+<h2 id="8-future-extensions">8. Future Extensions</h2>
+<h3 id="81-cross-adapter-aggregation">8.1 Cross-Adapter Aggregation</h3>
+<p>For APIs with shared rate limits across endpoints:</p>
+<div class="sourceCode" id="cb18"><pre class="sourceCode yaml"><code class="sourceCode yaml"><span id="cb18-1"><a href="#cb18-1" aria-hidden="true" tabindex="-1"></a><span class="fu">rate_limits</span><span class="kw">:</span></span>
+<span id="cb18-2"><a href="#cb18-2" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">shared_pools</span><span class="kw">:</span></span>
+<span id="cb18-3"><a href="#cb18-3" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="kw">-</span><span class="at"> </span><span class="fu">name</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;github_core&quot;</span></span>
+<span id="cb18-4"><a href="#cb18-4" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">endpoints</span><span class="kw">:</span></span>
+<span id="cb18-5"><a href="#cb18-5" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="kw">-</span><span class="at"> </span><span class="st">&quot;GET /repos/*&quot;</span></span>
+<span id="cb18-6"><a href="#cb18-6" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="kw">-</span><span class="at"> </span><span class="st">&quot;GET /users/*&quot;</span></span>
+<span id="cb18-7"><a href="#cb18-7" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="kw">-</span><span class="at"> </span><span class="st">&quot;GET /orgs/*&quot;</span></span>
+<span id="cb18-8"><a href="#cb18-8" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">limit</span><span class="kw">:</span><span class="at"> </span><span class="dv">5000</span></span>
+<span id="cb18-9"><a href="#cb18-9" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">window</span><span class="kw">:</span><span class="at"> hour</span></span></code></pre></div>
+<h3 id="82-intelligent-request-scheduling">8.2 Intelligent Request Scheduling</h3>
+<p>Automatic request queuing and batching:</p>
+<div class="sourceCode" id="cb19"><pre class="sourceCode yaml"><code class="sourceCode yaml"><span id="cb19-1"><a href="#cb19-1" aria-hidden="true" tabindex="-1"></a><span class="fu">rate_limits</span><span class="kw">:</span></span>
+<span id="cb19-2"><a href="#cb19-2" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">scheduling</span><span class="kw">:</span></span>
+<span id="cb19-3"><a href="#cb19-3" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">enabled</span><span class="kw">:</span><span class="at"> </span><span class="ch">true</span></span>
+<span id="cb19-4"><a href="#cb19-4" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">max_queue_size</span><span class="kw">:</span><span class="at"> </span><span class="dv">100</span></span>
+<span id="cb19-5"><a href="#cb19-5" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">batch_similar_requests</span><span class="kw">:</span><span class="at"> </span><span class="ch">true</span></span>
+<span id="cb19-6"><a href="#cb19-6" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">priority_by_danger_level</span><span class="kw">:</span><span class="at"> </span><span class="ch">true</span></span></code></pre></div>
+<h3 id="83-token-based-rate-limiting">8.3 Token-Based Rate Limiting</h3>
+<p>For LLM APIs with token-based limits:</p>
+<div class="sourceCode" id="cb20"><pre class="sourceCode yaml"><code class="sourceCode yaml"><span id="cb20-1"><a href="#cb20-1" aria-hidden="true" tabindex="-1"></a><span class="fu">rate_limits</span><span class="kw">:</span></span>
+<span id="cb20-2"><a href="#cb20-2" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">api_limits</span><span class="kw">:</span></span>
+<span id="cb20-3"><a href="#cb20-3" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="kw">-</span><span class="at"> </span><span class="fu">scope</span><span class="kw">:</span><span class="at"> global</span></span>
+<span id="cb20-4"><a href="#cb20-4" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">metric</span><span class="kw">:</span><span class="at"> tokens</span></span>
+<span id="cb20-5"><a href="#cb20-5" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">limit</span><span class="kw">:</span><span class="at"> </span><span class="dv">90000</span></span>
+<span id="cb20-6"><a href="#cb20-6" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">window</span><span class="kw">:</span><span class="at"> minute</span></span>
+<span id="cb20-7"><a href="#cb20-7" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">count_method</span><span class="kw">:</span><span class="at"> tiktoken</span><span class="co">  # Token counting method</span></span></code></pre></div>
+<h3 id="84-budget-alerts">8.4 Budget Alerts</h3>
+<p>External notification integration:</p>
+<div class="sourceCode" id="cb21"><pre class="sourceCode yaml"><code class="sourceCode yaml"><span id="cb21-1"><a href="#cb21-1" aria-hidden="true" tabindex="-1"></a><span class="fu">quotas</span><span class="kw">:</span></span>
+<span id="cb21-2"><a href="#cb21-2" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">alerts</span><span class="kw">:</span></span>
+<span id="cb21-3"><a href="#cb21-3" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="kw">-</span><span class="at"> </span><span class="fu">trigger</span><span class="kw">:</span><span class="at"> warn</span></span>
+<span id="cb21-4"><a href="#cb21-4" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">action</span><span class="kw">:</span><span class="at"> webhook</span></span>
+<span id="cb21-5"><a href="#cb21-5" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">url</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;https://alerts.example.com/budget&quot;</span></span>
+<span id="cb21-6"><a href="#cb21-6" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="kw">-</span><span class="at"> </span><span class="fu">trigger</span><span class="kw">:</span><span class="at"> pause</span></span>
+<span id="cb21-7"><a href="#cb21-7" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">action</span><span class="kw">:</span><span class="at"> email</span></span>
+<span id="cb21-8"><a href="#cb21-8" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">to</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;admin@example.com&quot;</span></span></code></pre></div>
+<h3 id="85-distributed-rate-limiting">8.5 Distributed Rate Limiting</h3>
+<p>For multi-instance deployments:</p>
+<div class="sourceCode" id="cb22"><pre class="sourceCode yaml"><code class="sourceCode yaml"><span id="cb22-1"><a href="#cb22-1" aria-hidden="true" tabindex="-1"></a><span class="fu">rate_limits</span><span class="kw">:</span></span>
+<span id="cb22-2"><a href="#cb22-2" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">coordination</span><span class="kw">:</span></span>
+<span id="cb22-3"><a href="#cb22-3" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">backend</span><span class="kw">:</span><span class="at"> redis</span></span>
+<span id="cb22-4"><a href="#cb22-4" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">connection</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;${REDIS_URL}&quot;</span></span>
+<span id="cb22-5"><a href="#cb22-5" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">key_prefix</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;mcpaql:ratelimit:&quot;</span></span></code></pre></div>
+<hr />
+<h2 id="references">References</h2>
+<ul>
+<li><a href="element-type.html">Adapter Element Type Specification</a></li>
+<li><a href="danger-levels.html">Dangerous Operation Classification</a></li>
+<li><a href="../security/confirmation-tokens.html">Confirmation Token Specification</a></li>
+<li><a href="../error-codes.html">Error Codes Specification</a></li>
+<li><a href="trust-levels.html">Trust Levels Specification</a></li>
+<li><a href="../features/warnings.html">Warnings Specification</a></li>
+<li>GitHub Issue: <a href="https://github.com/MCPAQL/spec/issues/60">#60</a></li>
+</ul>
+
+          </div>
+        </section>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div class="container">
+      <p>&copy; 2026 DollhouseMCP Inc. d/b/a Dollhouse Research. MCP-AQL public draft documentation portal.</p>
+      <div class="footer-links">
+        <a href="../../docs/index.html">Docs Library</a>
+        <a href="../index.html">Repo-Synced Spec</a>
+        <a href="https://github.com/MCPAQL">MCPAQL Organization</a>
+        <a href="https://dollhouseresearch.com">Dollhouse Research</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../../js/search.js"></script>
+</body>
+</html>

--- a/public/spec/adapter/rate-limiting.html
+++ b/public/spec/adapter/rate-limiting.html
@@ -23,7 +23,7 @@
         </ul>
         <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
-          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <input id="site-search-input" data-search-input type="search" placeholder="Search MCP-AQL docs, spec pages, and adapter patterns...">
           <span class="search-count" data-search-count></span>
           <ul class="search-results" data-search-results hidden></ul>
         </form>
@@ -44,7 +44,7 @@
   <ul><li><a href="../versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Adapter</h3>
-  <ul><li><a href="danger-levels.html">Dangerous Operation Classification Specification</a></li><li><a href="discovery-bundle.html">MCP Server Discovery Bundle</a></li><li><a href="element-type.html">Adapter Element Type Specification</a></li><li><a href="generator.html">Adapter Generator Specification</a></li><li><a class="current" href="rate-limiting.html">Rate Limiting and Quota Management Specification</a></li><li><a href="trust-levels.html">Trust Levels Specification</a></li></ul>
+  <ul><li><a href="danger-levels.html">Dangerous Operation Classification Specification</a></li><li><a href="discovery-bundle.html">MCP Server Discovery Bundle</a></li><li><a href="element-type.html">Adapter Element Type Specification</a></li><li><a href="generator.html">Adapter Generator Specification</a></li><li><a class="current" aria-current="page" href="rate-limiting.html">Rate Limiting and Quota Management Specification</a></li><li><a href="trust-levels.html">Trust Levels Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Security</h3>
   <ul><li><a href="../security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="../security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="../security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
@@ -696,6 +696,16 @@
 
           </div>
         </section>
+        <nav class="page-nav" aria-label="Page navigation">
+  <a class="page-nav-link prev" href="generator.html">
+    <span class="page-nav-eyebrow">Previous spec page</span>
+    <strong class="page-nav-label">Adapter Generator Specification</strong>
+  </a>
+  <a class="page-nav-link next" href="trust-levels.html">
+    <span class="page-nav-eyebrow">Next spec page</span>
+    <strong class="page-nav-label">Trust Levels Specification</strong>
+  </a>
+</nav>
       </article>
     </div>
   </main>

--- a/public/spec/adapter/rate-limiting.html
+++ b/public/spec/adapter/rate-limiting.html
@@ -73,6 +73,13 @@
       </aside>
 
       <article class="docs-main">
+        <nav class="breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../../index.html">Home</a></li>
+            <li><a href="../index.html">Full Spec</a></li>
+            <li><span class="current">Rate Limiting and Quota Management Specification</span></li>
+          </ol>
+        </nav>
         <section class="hero docs-hero">
           <div class="hero-inner">
             <span class="status-pill">REPO-SYNCED SPEC DOC</span>

--- a/public/spec/adapter/rate-limiting.html
+++ b/public/spec/adapter/rate-limiting.html
@@ -38,7 +38,7 @@
         <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
         <div class="docs-side-group">
   <h3>Core</h3>
-  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li></ul>
+  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li><li><a href="../repo/README.html">MCP-AQL Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Versions</h3>
   <ul><li><a href="../versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
@@ -56,7 +56,7 @@
   <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
-  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li></ul>
+  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li><li><a href="../repo/CHANGELOG.html">Changelog</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Architecture</h3>
   <ul><li><a href="../architecture/README.html">Architecture Documentation</a></li></ul>

--- a/public/spec/adapter/trust-levels.html
+++ b/public/spec/adapter/trust-levels.html
@@ -73,6 +73,13 @@
       </aside>
 
       <article class="docs-main">
+        <nav class="breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../../index.html">Home</a></li>
+            <li><a href="../index.html">Full Spec</a></li>
+            <li><span class="current">Trust Levels Specification</span></li>
+          </ol>
+        </nav>
         <section class="hero docs-hero">
           <div class="hero-inner">
             <span class="status-pill">REPO-SYNCED SPEC DOC</span>

--- a/public/spec/adapter/trust-levels.html
+++ b/public/spec/adapter/trust-levels.html
@@ -38,7 +38,7 @@
         <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
         <div class="docs-side-group">
   <h3>Core</h3>
-  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li></ul>
+  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li><li><a href="../repo/README.html">MCP-AQL Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Versions</h3>
   <ul><li><a href="../versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
@@ -56,7 +56,7 @@
   <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
-  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li></ul>
+  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li><li><a href="../repo/CHANGELOG.html">Changelog</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Architecture</h3>
   <ul><li><a href="../architecture/README.html">Architecture Documentation</a></li></ul>

--- a/public/spec/adapter/trust-levels.html
+++ b/public/spec/adapter/trust-levels.html
@@ -23,7 +23,7 @@
         </ul>
         <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
-          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <input id="site-search-input" data-search-input type="search" placeholder="Search MCP-AQL docs, spec pages, and adapter patterns...">
           <span class="search-count" data-search-count></span>
           <ul class="search-results" data-search-results hidden></ul>
         </form>
@@ -44,7 +44,7 @@
   <ul><li><a href="../versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Adapter</h3>
-  <ul><li><a href="danger-levels.html">Dangerous Operation Classification Specification</a></li><li><a href="discovery-bundle.html">MCP Server Discovery Bundle</a></li><li><a href="element-type.html">Adapter Element Type Specification</a></li><li><a href="generator.html">Adapter Generator Specification</a></li><li><a href="rate-limiting.html">Rate Limiting and Quota Management Specification</a></li><li><a class="current" href="trust-levels.html">Trust Levels Specification</a></li></ul>
+  <ul><li><a href="danger-levels.html">Dangerous Operation Classification Specification</a></li><li><a href="discovery-bundle.html">MCP Server Discovery Bundle</a></li><li><a href="element-type.html">Adapter Element Type Specification</a></li><li><a href="generator.html">Adapter Generator Specification</a></li><li><a href="rate-limiting.html">Rate Limiting and Quota Management Specification</a></li><li><a class="current" aria-current="page" href="trust-levels.html">Trust Levels Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Security</h3>
   <ul><li><a href="../security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="../security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="../security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
@@ -704,6 +704,16 @@
 
           </div>
         </section>
+        <nav class="page-nav" aria-label="Page navigation">
+  <a class="page-nav-link prev" href="rate-limiting.html">
+    <span class="page-nav-eyebrow">Previous spec page</span>
+    <strong class="page-nav-label">Rate Limiting and Quota Management Specification</strong>
+  </a>
+  <a class="page-nav-link next" href="../security/confirmation-tokens.html">
+    <span class="page-nav-eyebrow">Next spec page</span>
+    <strong class="page-nav-label">Confirmation Token Specification</strong>
+  </a>
+</nav>
       </article>
     </div>
   </main>

--- a/public/spec/adapter/trust-levels.html
+++ b/public/spec/adapter/trust-levels.html
@@ -1,0 +1,718 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="This document defines the trust level system for MCP-AQL adapters. Trust levels indicate the verification and validation status of an adapter, enabling systems to make informed decisions about which operations to permit ">
+  <title>MCP-AQL Spec | Trust Levels Specification</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../../css/style.css">
+</head>
+<body>
+  <header>
+    <div class="container">
+      <nav>
+        <a class="logo" href="../../index.html"><span class="logo-mark"></span>MCP-AQL</a>
+        <ul class="nav-links">
+          <li><a href="../../index.html">Home</a></li>
+          <li><a href="../../docs/index.html">Docs</a></li>
+          <li><a href="../../launch-checklist.html">Launch Checklist</a></li>
+          <li><a href="../../apis/mcp-server.html">Adapter Patterns</a></li>
+        </ul>
+        <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
+          <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
+          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <span class="search-count" data-search-count></span>
+          <ul class="search-results" data-search-results hidden></ul>
+        </form>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <div class="container docs-shell">
+      <aside class="docs-side">
+        <h2>Repo-Synced Spec</h2>
+        <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
+        <div class="docs-side-group">
+  <h3>Core</h3>
+  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Versions</h3>
+  <ul><li><a href="../versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Adapter</h3>
+  <ul><li><a href="danger-levels.html">Dangerous Operation Classification Specification</a></li><li><a href="discovery-bundle.html">MCP Server Discovery Bundle</a></li><li><a href="element-type.html">Adapter Element Type Specification</a></li><li><a href="generator.html">Adapter Generator Specification</a></li><li><a href="rate-limiting.html">Rate Limiting and Quota Management Specification</a></li><li><a class="current" href="trust-levels.html">Trust Levels Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Security</h3>
+  <ul><li><a href="../security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="../security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="../security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Features</h3>
+  <ul><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Guides</h3>
+  <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Process</h3>
+  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Architecture</h3>
+  <ul><li><a href="../architecture/README.html">Architecture Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Research</h3>
+  <ul><li><a href="../research/mcp-vs-mcpaql-vs-a2a.html">Protocol Landscape: MCP vs MCP-AQL vs A2A</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Reference</h3>
+  <ul><li><a href="../reference/README.html">Reference Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>ADRs</h3>
+  <ul><li><a href="../adr/ADR-001-crude-pattern.html">ADR-001: CRUDE Pattern (Extending CRUD with Execute)</a></li><li><a href="../adr/ADR-002-graphql-style-input.html">ADR-002: GraphQL-Style Input Objects for Updates</a></li><li><a href="../adr/ADR-003-snake-case-parameters.html">ADR-003: snake_case Parameter Convention</a></li><li><a href="../adr/ADR-004-schema-driven-operations.html">ADR-004: Schema-Driven Operation Definitions</a></li><li><a href="../adr/ADR-005-introspection-system.html">ADR-005: GraphQL-Style Introspection System</a></li><li><a href="../adr/ADR-006-discriminated-responses.html">ADR-006: Discriminated Response Format</a></li><li><a href="../adr/index.html">Architecture Decision Records</a></li><li><a href="../adr/README.html">Architecture Decision Records</a></li></ul>
+</div>
+      </aside>
+
+      <article class="docs-main">
+        <section class="hero docs-hero">
+          <div class="hero-inner">
+            <span class="status-pill">REPO-SYNCED SPEC DOC</span>
+            <h1>Trust Levels Specification</h1>
+            <p class="lede">This document defines the trust level system for MCP-AQL adapters. Trust levels indicate the verification and validation status of an adapter, enabling systems to make informed decisions about which operations to permit </p>
+            <div class="spec-meta"><span class="state-chip live">Support document</span><span class="state-chip pending">Draft</span><span class="state-chip">1.0.0-draft</span><span class="state-chip">2026-01-28</span></div>
+            <p class="spec-source">Source: <a href="https://github.com/MCPAQL/spec/blob/main/docs/adapter/trust-levels.md">spec/docs/adapter/trust-levels.md</a></p>
+            <div class="hero-actions">
+              <a class="btn btn-primary" href="https://github.com/MCPAQL/spec/blob/main/docs/adapter/trust-levels.md">Open Source Markdown</a>
+              <a class="btn btn-secondary" href="../index.html">Browse Full Spec Reference</a>
+            </div>
+          </div>
+        </section>
+
+        <section>
+          <div class="card spec-prose">
+            <p><strong>Version:</strong> 1.0.0-draft <strong>Status:</strong> Draft <strong>Last Updated:</strong> 2026-01-28</p>
+<h2 id="abstract">Abstract</h2>
+<p>This document defines the trust level system for MCP-AQL adapters. Trust levels indicate the verification and validation status of an adapter, enabling systems to make informed decisions about which operations to permit based on adapter provenance and reliability.</p>
+<hr />
+<h2 id="table-of-contents">Table of Contents</h2>
+<ol type="1">
+<li><a href="#1-overview">Overview</a></li>
+<li><a href="#2-trust-level-enum">Trust Level Enum</a></li>
+<li><a href="#3-trust-metadata-schema">Trust Metadata Schema</a></li>
+<li><a href="#4-promotion-rules">Promotion Rules</a></li>
+<li><a href="#5-permission-gating">Permission Gating</a></li>
+<li><a href="#6-implementation-requirements">Implementation Requirements</a></li>
+<li><a href="#7-future-extensions">Future Extensions</a></li>
+</ol>
+<hr />
+<h2 id="1-overview">1. Overview</h2>
+<h3 id="11-purpose">1.1 Purpose</h3>
+<p>Adapters can originate from multiple sources with varying reliability guarantees:</p>
+<ul>
+<li><strong>Dynamically generated</strong> from API interrogation or OpenAPI specs</li>
+<li><strong>Hand-crafted</strong> by developers with domain knowledge</li>
+<li><strong>Community-contributed</strong> via collection submissions</li>
+<li><strong>Officially certified</strong> by API vendors or trusted authorities</li>
+</ul>
+<p>Trust levels provide a standardized way to communicate adapter reliability, enabling:</p>
+<ul>
+<li><strong>Progressive permission unlocking</strong> - Higher trust enables more operations</li>
+<li><strong>Risk-appropriate defaults</strong> - New adapters start with minimal permissions</li>
+<li><strong>Audit trail</strong> - Track how and when trust was established</li>
+<li><strong>Automated gating</strong> - Systems can enforce trust requirements programmatically</li>
+</ul>
+<h3 id="12-design-principles">1.2 Design Principles</h3>
+<ol type="1">
+<li><strong>Conservative defaults</strong> - Untrusted adapters have minimal permissions</li>
+<li><strong>Earned trust</strong> - Higher levels require explicit validation or certification</li>
+<li><strong>Transparent provenance</strong> - Trust metadata is auditable</li>
+<li><strong>Graceful degradation</strong> - Missing trust info treated as lowest level</li>
+</ol>
+<h3 id="13-relationship-to-danger-levels">1.3 Relationship to Danger Levels</h3>
+<p>Trust levels work in conjunction with danger levels (see <a href="danger-levels.html">Dangerous Operation Classification</a>):</p>
+<ul>
+<li><strong>Trust levels</strong> describe adapter reliability (who vouches for it)</li>
+<li><strong>Danger levels</strong> describe operation risk (what harm could occur)</li>
+<li><strong>Gating matrix</strong> combines both to determine permission</li>
+</ul>
+<hr />
+<h2 id="2-trust-level-enum">2. Trust Level Enum</h2>
+<h3 id="21-trust-level-values">2.1 Trust Level Values</h3>
+<table>
+<thead>
+<tr>
+<th>Level</th>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Untested</td>
+<td><code>untested</code></td>
+<td>Newly created, no validation performed</td>
+</tr>
+<tr>
+<td>Generated</td>
+<td><code>generated</code></td>
+<td>Programmatically generated, basic schema validation passed</td>
+</tr>
+<tr>
+<td>Validated</td>
+<td><code>validated</code></td>
+<td>Passed programmatic test harness</td>
+</tr>
+<tr>
+<td>Community Reviewed</td>
+<td><code>community_reviewed</code></td>
+<td>Validated plus community vetting process</td>
+</tr>
+<tr>
+<td>Certified</td>
+<td><code>certified</code></td>
+<td>Official verification by vendor or trusted authority</td>
+</tr>
+</tbody>
+</table>
+<h3 id="22-level-descriptions">2.2 Level Descriptions</h3>
+<h4 id="221-untested">2.2.1 untested</h4>
+<p>The adapter has been created but not validated in any way.</p>
+<p><strong>Typical sources:</strong></p>
+<ul>
+<li>Freshly generated from API interrogation</li>
+<li>User-created adapters not yet tested</li>
+<li>Imported from unknown sources</li>
+</ul>
+<p><strong>Characteristics:</strong></p>
+<ul>
+<li>Schema may be malformed</li>
+<li>Operations may not match actual API</li>
+<li>Parameters may be incorrect or missing</li>
+</ul>
+<h4 id="222-generated">2.2.2 generated</h4>
+<p>The adapter was programmatically generated and passes basic schema validation.</p>
+<p><strong>Validation requirements:</strong></p>
+<ul>
+<li>YAML front matter parses correctly</li>
+<li>Required fields present (name, type, version, description)</li>
+<li>Target configuration is valid</li>
+<li>All operations have valid structure</li>
+</ul>
+<p><strong>Characteristics:</strong></p>
+<ul>
+<li>Schema is structurally correct</li>
+<li>No guarantee operations work at runtime</li>
+<li>May have incorrect parameter types or mappings</li>
+</ul>
+<h4 id="223-validated">2.2.3 validated</h4>
+<p>The adapter has passed automated test harness validation against the target API.</p>
+<p><strong>Validation requirements:</strong></p>
+<ul>
+<li>All <code>generated</code> requirements PLUS:</li>
+<li>Test harness executed against live API</li>
+<li>Read operations return valid responses</li>
+<li>Create operations succeed with valid inputs</li>
+<li>Error handling behaves as documented</li>
+</ul>
+<p><strong>Characteristics:</strong></p>
+<ul>
+<li>Operations verified to work at time of validation</li>
+<li>May break if API changes</li>
+<li>Validation report available for review</li>
+</ul>
+<h4 id="224-community_reviewed">2.2.4 community_reviewed</h4>
+<p>The adapter has been validated and reviewed by the community.</p>
+<p><strong>Validation requirements:</strong></p>
+<ul>
+<li>All <code>validated</code> requirements PLUS:</li>
+<li>Submitted to community collection</li>
+<li>Reviewed by at least N community members (configurable, recommended default: 2)</li>
+<li>No security concerns raised</li>
+<li>Documentation quality verified</li>
+</ul>
+<p><strong>Characteristics:</strong></p>
+<ul>
+<li>Human eyes have reviewed the adapter</li>
+<li>Security implications considered</li>
+<li>Higher confidence in production use</li>
+</ul>
+<h4 id="225-certified">2.2.5 certified</h4>
+<p>The adapter has official certification from the API vendor or a trusted authority.</p>
+<p><strong>Validation requirements:</strong></p>
+<ul>
+<li>All <code>community_reviewed</code> requirements PLUS:</li>
+<li>Vendor signature or authority attestation</li>
+<li>Formal certification process completed</li>
+<li>Ongoing maintenance commitment</li>
+</ul>
+<p><strong>Characteristics:</strong></p>
+<ul>
+<li>Highest confidence level</li>
+<li>Official support available</li>
+<li>Production-ready for all operations</li>
+</ul>
+<hr />
+<h2 id="3-trust-metadata-schema">3. Trust Metadata Schema</h2>
+<h3 id="31-schema-structure">3.1 Schema Structure</h3>
+<p>The <code>trust</code> block in adapter front matter:</p>
+<div class="sourceCode" id="cb1"><pre class="sourceCode yaml"><code class="sourceCode yaml"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a><span class="fu">trust</span><span class="kw">:</span></span>
+<span id="cb1-2"><a href="#cb1-2" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">level</span><span class="kw">:</span><span class="at"> validated</span></span>
+<span id="cb1-3"><a href="#cb1-3" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">generated_at</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;2026-01-15T10:00:00Z&quot;</span></span>
+<span id="cb1-4"><a href="#cb1-4" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">generated_by</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;mcpaql-adapter-generator-v1.2.0&quot;</span></span>
+<span id="cb1-5"><a href="#cb1-5" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">validated_at</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;2026-01-15T12:00:00Z&quot;</span></span>
+<span id="cb1-6"><a href="#cb1-6" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">validated_by</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;mcpaql-test-harness-v2.0.0&quot;</span></span>
+<span id="cb1-7"><a href="#cb1-7" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">validation_report</span><span class="kw">:</span></span>
+<span id="cb1-8"><a href="#cb1-8" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">tests_passed</span><span class="kw">:</span><span class="at"> </span><span class="dv">47</span></span>
+<span id="cb1-9"><a href="#cb1-9" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">tests_total</span><span class="kw">:</span><span class="at"> </span><span class="dv">47</span></span>
+<span id="cb1-10"><a href="#cb1-10" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">endpoints_verified</span><span class="kw">:</span><span class="at"> </span><span class="dv">23</span></span>
+<span id="cb1-11"><a href="#cb1-11" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">coverage_percent</span><span class="kw">:</span><span class="at"> </span><span class="dv">95</span></span>
+<span id="cb1-12"><a href="#cb1-12" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">last_api_response</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;2026-01-15T12:00:00Z&quot;</span></span>
+<span id="cb1-13"><a href="#cb1-13" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">promoted_from</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;generated&quot;</span></span>
+<span id="cb1-14"><a href="#cb1-14" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">promotion_history</span><span class="kw">:</span></span>
+<span id="cb1-15"><a href="#cb1-15" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="kw">-</span><span class="at"> </span><span class="fu">from</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;untested&quot;</span></span>
+<span id="cb1-16"><a href="#cb1-16" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">to</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;generated&quot;</span></span>
+<span id="cb1-17"><a href="#cb1-17" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">at</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;2026-01-15T10:00:00Z&quot;</span></span>
+<span id="cb1-18"><a href="#cb1-18" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">by</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;mcpaql-adapter-generator-v1.2.0&quot;</span></span>
+<span id="cb1-19"><a href="#cb1-19" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="kw">-</span><span class="at"> </span><span class="fu">from</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;generated&quot;</span></span>
+<span id="cb1-20"><a href="#cb1-20" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">to</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;validated&quot;</span></span>
+<span id="cb1-21"><a href="#cb1-21" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">at</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;2026-01-15T12:00:00Z&quot;</span></span>
+<span id="cb1-22"><a href="#cb1-22" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">by</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;mcpaql-test-harness-v2.0.0&quot;</span></span>
+<span id="cb1-23"><a href="#cb1-23" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">certification</span><span class="kw">:</span><span class="at"> </span><span class="ch">null</span></span></code></pre></div>
+<h3 id="32-field-definitions">3.2 Field Definitions</h3>
+<h4 id="321-level-required">3.2.1 level (required)</h4>
+<p><strong>Type:</strong> string (enum) <strong>Values:</strong> <code>untested</code>, <code>generated</code>, <code>validated</code>, <code>community_reviewed</code>, <code>certified</code></p>
+<p>The current trust level of the adapter.</p>
+<div class="sourceCode" id="cb2"><pre class="sourceCode yaml"><code class="sourceCode yaml"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="fu">level</span><span class="kw">:</span><span class="at"> validated</span></span></code></pre></div>
+<h4 id="322-generated_at">3.2.2 generated_at</h4>
+<p><strong>Type:</strong> string (ISO 8601 timestamp)</p>
+<p>When the adapter was initially generated or created.</p>
+<div class="sourceCode" id="cb3"><pre class="sourceCode yaml"><code class="sourceCode yaml"><span id="cb3-1"><a href="#cb3-1" aria-hidden="true" tabindex="-1"></a><span class="fu">generated_at</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;2026-01-15T10:00:00Z&quot;</span></span></code></pre></div>
+<h4 id="323-generated_by">3.2.3 generated_by</h4>
+<p><strong>Type:</strong> string</p>
+<p>Identifier of the tool or person that created the adapter.</p>
+<div class="sourceCode" id="cb4"><pre class="sourceCode yaml"><code class="sourceCode yaml"><span id="cb4-1"><a href="#cb4-1" aria-hidden="true" tabindex="-1"></a><span class="fu">generated_by</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;mcpaql-adapter-generator-v1.2.0&quot;</span></span></code></pre></div>
+<h4 id="324-validated_at">3.2.4 validated_at</h4>
+<p><strong>Type:</strong> string (ISO 8601 timestamp)</p>
+<p>When the adapter was last validated against the target API.</p>
+<div class="sourceCode" id="cb5"><pre class="sourceCode yaml"><code class="sourceCode yaml"><span id="cb5-1"><a href="#cb5-1" aria-hidden="true" tabindex="-1"></a><span class="fu">validated_at</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;2026-01-15T12:00:00Z&quot;</span></span></code></pre></div>
+<h4 id="325-validated_by">3.2.5 validated_by</h4>
+<p><strong>Type:</strong> string</p>
+<p>Identifier of the validation tool or process.</p>
+<div class="sourceCode" id="cb6"><pre class="sourceCode yaml"><code class="sourceCode yaml"><span id="cb6-1"><a href="#cb6-1" aria-hidden="true" tabindex="-1"></a><span class="fu">validated_by</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;mcpaql-test-harness-v2.0.0&quot;</span></span></code></pre></div>
+<h4 id="326-validation_report">3.2.6 validation_report</h4>
+<p><strong>Type:</strong> object</p>
+<p>Detailed results from the validation process.</p>
+<div class="sourceCode" id="cb7"><pre class="sourceCode yaml"><code class="sourceCode yaml"><span id="cb7-1"><a href="#cb7-1" aria-hidden="true" tabindex="-1"></a><span class="fu">validation_report</span><span class="kw">:</span></span>
+<span id="cb7-2"><a href="#cb7-2" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">tests_passed</span><span class="kw">:</span><span class="at"> </span><span class="dv">47</span></span>
+<span id="cb7-3"><a href="#cb7-3" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">tests_total</span><span class="kw">:</span><span class="at"> </span><span class="dv">47</span></span>
+<span id="cb7-4"><a href="#cb7-4" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">endpoints_verified</span><span class="kw">:</span><span class="at"> </span><span class="dv">23</span></span>
+<span id="cb7-5"><a href="#cb7-5" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">coverage_percent</span><span class="kw">:</span><span class="at"> </span><span class="dv">95</span></span>
+<span id="cb7-6"><a href="#cb7-6" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">last_api_response</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;2026-01-15T12:00:00Z&quot;</span></span></code></pre></div>
+<p><strong>Fields:</strong></p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Type</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>tests_passed</code></td>
+<td>integer</td>
+<td>Number of tests that passed</td>
+</tr>
+<tr>
+<td><code>tests_total</code></td>
+<td>integer</td>
+<td>Total number of tests executed</td>
+</tr>
+<tr>
+<td><code>endpoints_verified</code></td>
+<td>integer</td>
+<td>Number of API endpoints tested</td>
+</tr>
+<tr>
+<td><code>coverage_percent</code></td>
+<td>number</td>
+<td>Percentage of operations covered by tests</td>
+</tr>
+<tr>
+<td><code>last_api_response</code></td>
+<td>string</td>
+<td>Timestamp of last successful API response</td>
+</tr>
+</tbody>
+</table>
+<h4 id="327-promoted_from">3.2.7 promoted_from</h4>
+<p><strong>Type:</strong> string (enum)</p>
+<p>The previous trust level before the most recent promotion.</p>
+<div class="sourceCode" id="cb8"><pre class="sourceCode yaml"><code class="sourceCode yaml"><span id="cb8-1"><a href="#cb8-1" aria-hidden="true" tabindex="-1"></a><span class="fu">promoted_from</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;generated&quot;</span></span></code></pre></div>
+<h4 id="328-promotion_history">3.2.8 promotion_history</h4>
+<p><strong>Type:</strong> array of promotion records</p>
+<p>Complete history of trust level changes.</p>
+<div class="sourceCode" id="cb9"><pre class="sourceCode yaml"><code class="sourceCode yaml"><span id="cb9-1"><a href="#cb9-1" aria-hidden="true" tabindex="-1"></a><span class="fu">promotion_history</span><span class="kw">:</span></span>
+<span id="cb9-2"><a href="#cb9-2" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="kw">-</span><span class="at"> </span><span class="fu">from</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;untested&quot;</span></span>
+<span id="cb9-3"><a href="#cb9-3" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">to</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;generated&quot;</span></span>
+<span id="cb9-4"><a href="#cb9-4" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">at</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;2026-01-15T10:00:00Z&quot;</span></span>
+<span id="cb9-5"><a href="#cb9-5" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">by</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;mcpaql-adapter-generator-v1.2.0&quot;</span></span>
+<span id="cb9-6"><a href="#cb9-6" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">reason</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;Schema validation passed&quot;</span></span></code></pre></div>
+<p><strong>Promotion record fields:</strong></p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Type</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>from</code></td>
+<td>string</td>
+<td>Previous trust level</td>
+</tr>
+<tr>
+<td><code>to</code></td>
+<td>string</td>
+<td>New trust level</td>
+</tr>
+<tr>
+<td><code>at</code></td>
+<td>string</td>
+<td>ISO 8601 timestamp</td>
+</tr>
+<tr>
+<td><code>by</code></td>
+<td>string</td>
+<td>Tool or person identifier</td>
+</tr>
+<tr>
+<td><code>reason</code></td>
+<td>string</td>
+<td>Optional explanation</td>
+</tr>
+</tbody>
+</table>
+<h4 id="329-certification">3.2.9 certification</h4>
+<p><strong>Type:</strong> object or null</p>
+<p>Certification details for <code>certified</code> level adapters.</p>
+<div class="sourceCode" id="cb10"><pre class="sourceCode yaml"><code class="sourceCode yaml"><span id="cb10-1"><a href="#cb10-1" aria-hidden="true" tabindex="-1"></a><span class="fu">certification</span><span class="kw">:</span></span>
+<span id="cb10-2"><a href="#cb10-2" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">authority</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;GitHub, Inc.&quot;</span></span>
+<span id="cb10-3"><a href="#cb10-3" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">signature</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;base64-encoded-signature&quot;</span></span>
+<span id="cb10-4"><a href="#cb10-4" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">certificate_id</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;GH-CERT-2026-001&quot;</span></span>
+<span id="cb10-5"><a href="#cb10-5" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">issued_at</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;2026-01-20T00:00:00Z&quot;</span></span>
+<span id="cb10-6"><a href="#cb10-6" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">expires_at</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;2027-01-20T00:00:00Z&quot;</span></span>
+<span id="cb10-7"><a href="#cb10-7" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">scope</span><span class="kw">:</span></span>
+<span id="cb10-8"><a href="#cb10-8" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="kw">-</span><span class="at"> </span><span class="st">&quot;all_operations&quot;</span></span></code></pre></div>
+<p><strong>Certification fields:</strong></p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Type</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>authority</code></td>
+<td>string</td>
+<td>Certifying organization name</td>
+</tr>
+<tr>
+<td><code>signature</code></td>
+<td>string</td>
+<td>Cryptographic signature (base64)</td>
+</tr>
+<tr>
+<td><code>certificate_id</code></td>
+<td>string</td>
+<td>Unique certificate identifier</td>
+</tr>
+<tr>
+<td><code>issued_at</code></td>
+<td>string</td>
+<td>When certification was granted</td>
+</tr>
+<tr>
+<td><code>expires_at</code></td>
+<td>string</td>
+<td>When certification expires</td>
+</tr>
+<tr>
+<td><code>scope</code></td>
+<td>array</td>
+<td>What the certification covers</td>
+</tr>
+</tbody>
+</table>
+<hr />
+<h2 id="4-promotion-rules">4. Promotion Rules</h2>
+<h3 id="41-promotion-path">4.1 Promotion Path</h3>
+<p>Trust levels follow a linear promotion path:</p>
+<pre><code>untested → generated → validated → community_reviewed → certified</code></pre>
+<p>Adapters MUST NOT skip levels during promotion. Each level builds on the requirements of previous levels.</p>
+<h3 id="42-promotion-triggers">4.2 Promotion Triggers</h3>
+<table>
+<thead>
+<tr>
+<th>Transition</th>
+<th>Trigger</th>
+<th>Requirements</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>untested → generated</td>
+<td>Schema validation</td>
+<td>YAML parses, required fields present, valid structure</td>
+</tr>
+<tr>
+<td>generated → validated</td>
+<td>Test harness pass</td>
+<td>All read ops succeed, representative create/update tested</td>
+</tr>
+<tr>
+<td>validated → community_reviewed</td>
+<td>Community review</td>
+<td>N reviewers approve, no security flags</td>
+</tr>
+<tr>
+<td>community_reviewed → certified</td>
+<td>Vendor attestation</td>
+<td>Signed certificate from recognized authority</td>
+</tr>
+</tbody>
+</table>
+<h3 id="43-demotion-rules">4.3 Demotion Rules</h3>
+<p>Trust levels MAY be demoted when:</p>
+<ol type="1">
+<li><strong>Validation failure</strong> - Re-validation against API fails</li>
+<li><strong>Security issue</strong> - Vulnerability discovered in adapter</li>
+<li><strong>API change</strong> - Target API changed, adapter no longer valid</li>
+<li><strong>Certificate expiry</strong> - Certification has expired</li>
+</ol>
+<p><strong>Demotion behavior:</strong></p>
+<ul>
+<li>Demotion MUST be recorded in <code>promotion_history</code> with negative transition</li>
+<li>Systems SHOULD notify users when adapter trust is demoted</li>
+<li>Demoted adapters retain their <code>validated_at</code> timestamp for audit purposes</li>
+</ul>
+<div class="sourceCode" id="cb12"><pre class="sourceCode yaml"><code class="sourceCode yaml"><span id="cb12-1"><a href="#cb12-1" aria-hidden="true" tabindex="-1"></a><span class="fu">promotion_history</span><span class="kw">:</span></span>
+<span id="cb12-2"><a href="#cb12-2" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="kw">-</span><span class="at"> </span><span class="fu">from</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;validated&quot;</span></span>
+<span id="cb12-3"><a href="#cb12-3" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">to</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;generated&quot;</span></span>
+<span id="cb12-4"><a href="#cb12-4" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">at</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;2026-02-01T08:00:00Z&quot;</span></span>
+<span id="cb12-5"><a href="#cb12-5" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">by</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;mcpaql-test-harness-v2.0.0&quot;</span></span>
+<span id="cb12-6"><a href="#cb12-6" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">reason</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;API endpoint /users deprecated, 3 operations failing&quot;</span></span></code></pre></div>
+<h3 id="44-re-validation">4.4 Re-validation</h3>
+<p>Adapters SHOULD be periodically re-validated to maintain trust level:</p>
+<table>
+<thead>
+<tr>
+<th>Trust Level</th>
+<th>Recommended Re-validation</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>generated</td>
+<td>On each use (schema check)</td>
+</tr>
+<tr>
+<td>validated</td>
+<td>Weekly or on API version change</td>
+</tr>
+<tr>
+<td>community_reviewed</td>
+<td>Monthly</td>
+</tr>
+<tr>
+<td>certified</td>
+<td>Per certification terms</td>
+</tr>
+</tbody>
+</table>
+<hr />
+<h2 id="5-permission-gating">5. Permission Gating</h2>
+<h3 id="51-trust-to-operation-gating">5.1 Trust-to-Operation Gating</h3>
+<p>Systems SHOULD enforce minimum trust levels for operations based on risk:</p>
+<table>
+<thead>
+<tr>
+<th>Operation Category</th>
+<th>Minimum Trust Level</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Introspection</td>
+<td><code>untested</code></td>
+</tr>
+<tr>
+<td>Read operations</td>
+<td><code>generated</code></td>
+</tr>
+<tr>
+<td>Safe create operations</td>
+<td><code>validated</code></td>
+</tr>
+<tr>
+<td>Update operations</td>
+<td><code>validated</code></td>
+</tr>
+<tr>
+<td>Delete operations</td>
+<td><code>community_reviewed</code></td>
+</tr>
+<tr>
+<td>Dangerous operations</td>
+<td><code>certified</code></td>
+</tr>
+</tbody>
+</table>
+<h3 id="52-trust-to-danger-matrix">5.2 Trust-to-Danger Matrix</h3>
+<p>The complete trust-to-danger gating matrix is defined in the <a href="danger-levels.html#4-trust-to-danger-gating">Dangerous Operation Classification</a> specification. The matrix determines which operations are allowed, require confirmation, or are denied based on the combination of adapter trust level and operation danger level.</p>
+<p><strong>Behavior summary:</strong></p>
+<ul>
+<li><code>allow</code> - Operation executes without additional gates</li>
+<li><code>confirm</code> - Operation requires explicit user confirmation</li>
+<li><code>deny</code> - Operation blocked with error response</li>
+<li><code>introspect_only</code> - Only introspection operations permitted; all other operations are blocked</li>
+</ul>
+<h3 id="53-configuration-override">5.3 Configuration Override</h3>
+<p>Systems MAY allow administrators to override default gating:</p>
+<div class="sourceCode" id="cb13"><pre class="sourceCode yaml"><code class="sourceCode yaml"><span id="cb13-1"><a href="#cb13-1" aria-hidden="true" tabindex="-1"></a><span class="co"># System configuration</span></span>
+<span id="cb13-2"><a href="#cb13-2" aria-hidden="true" tabindex="-1"></a><span class="fu">trust_policy</span><span class="kw">:</span></span>
+<span id="cb13-3"><a href="#cb13-3" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">minimum_trust_for_writes</span><span class="kw">:</span><span class="at"> validated</span></span>
+<span id="cb13-4"><a href="#cb13-4" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">minimum_trust_for_deletes</span><span class="kw">:</span><span class="at"> community_reviewed</span></span>
+<span id="cb13-5"><a href="#cb13-5" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">allow_untested_introspection</span><span class="kw">:</span><span class="at"> </span><span class="ch">true</span></span>
+<span id="cb13-6"><a href="#cb13-6" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">require_confirmation_below</span><span class="kw">:</span><span class="at"> validated</span></span></code></pre></div>
+<h3 id="54-error-response">5.4 Error Response</h3>
+<p>When an operation is denied due to insufficient trust:</p>
+<div class="sourceCode" id="cb14"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb14-1"><a href="#cb14-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb14-2"><a href="#cb14-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb14-3"><a href="#cb14-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;error&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb14-4"><a href="#cb14-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;code&quot;</span><span class="fu">:</span> <span class="st">&quot;PERMISSION_TRUST_LEVEL_INSUFFICIENT&quot;</span><span class="fu">,</span></span>
+<span id="cb14-5"><a href="#cb14-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;Operation &#39;delete_user&#39; requires trust level &#39;community_reviewed&#39;, adapter has &#39;validated&#39;&quot;</span><span class="fu">,</span></span>
+<span id="cb14-6"><a href="#cb14-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;details&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb14-7"><a href="#cb14-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;delete_user&quot;</span><span class="fu">,</span></span>
+<span id="cb14-8"><a href="#cb14-8" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;required_trust&quot;</span><span class="fu">:</span> <span class="st">&quot;community_reviewed&quot;</span><span class="fu">,</span></span>
+<span id="cb14-9"><a href="#cb14-9" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;actual_trust&quot;</span><span class="fu">:</span> <span class="st">&quot;validated&quot;</span><span class="fu">,</span></span>
+<span id="cb14-10"><a href="#cb14-10" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;danger_level&quot;</span><span class="fu">:</span> <span class="dv">2</span></span>
+<span id="cb14-11"><a href="#cb14-11" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb14-12"><a href="#cb14-12" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb14-13"><a href="#cb14-13" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<blockquote>
+<p><strong>Note:</strong> The <code>PERMISSION_TRUST_LEVEL_INSUFFICIENT</code> error code is introduced by this specification and should be added to the <a href="../error-codes.html">Error Codes Specification</a> as a future extension under the <code>PERMISSION_</code> category.</p>
+</blockquote>
+<hr />
+<h2 id="6-implementation-requirements">6. Implementation Requirements</h2>
+<h3 id="61-must-requirements">6.1 MUST Requirements</h3>
+<p>Implementations supporting trust levels MUST:</p>
+<ol type="1">
+<li>Default to <code>untested</code> when trust block is missing</li>
+<li>Validate trust level enum values</li>
+<li>Reject invalid trust metadata gracefully</li>
+<li>Record trust level in audit logs for security operations</li>
+</ol>
+<h3 id="62-should-requirements">6.2 SHOULD Requirements</h3>
+<p>Implementations supporting trust levels SHOULD:</p>
+<ol type="1">
+<li>Enforce the trust-to-operation gating matrix</li>
+<li>Provide introspection of current trust level</li>
+<li>Support trust level promotion workflows</li>
+<li>Preserve promotion history for audit</li>
+</ol>
+<h3 id="63-may-requirements">6.3 MAY Requirements</h3>
+<p>Implementations supporting trust levels MAY:</p>
+<ol type="1">
+<li>Implement custom gating policies</li>
+<li>Support automatic re-validation</li>
+<li>Integrate with external certification authorities</li>
+<li>Provide trust level comparison across adapters</li>
+</ol>
+<h3 id="64-introspection-support">6.4 Introspection Support</h3>
+<p>Trust information SHOULD be available via introspection:</p>
+<div class="sourceCode" id="cb15"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb15-1"><a href="#cb15-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb15-2"><a href="#cb15-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;introspect&quot;</span><span class="op">,</span></span>
+<span id="cb15-3"><a href="#cb15-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> { <span class="dt">query</span><span class="op">:</span> <span class="st">&quot;adapter_info&quot;</span> }</span>
+<span id="cb15-4"><a href="#cb15-4" aria-hidden="true" tabindex="-1"></a>}</span>
+<span id="cb15-5"><a href="#cb15-5" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb15-6"><a href="#cb15-6" aria-hidden="true" tabindex="-1"></a><span class="co">// Response</span></span>
+<span id="cb15-7"><a href="#cb15-7" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb15-8"><a href="#cb15-8" aria-hidden="true" tabindex="-1"></a>  <span class="dt">success</span><span class="op">:</span> <span class="kw">true</span><span class="op">,</span></span>
+<span id="cb15-9"><a href="#cb15-9" aria-hidden="true" tabindex="-1"></a>  <span class="dt">data</span><span class="op">:</span> {</span>
+<span id="cb15-10"><a href="#cb15-10" aria-hidden="true" tabindex="-1"></a>    <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;github-api&quot;</span><span class="op">,</span></span>
+<span id="cb15-11"><a href="#cb15-11" aria-hidden="true" tabindex="-1"></a>    <span class="dt">version</span><span class="op">:</span> <span class="st">&quot;1.0.0&quot;</span><span class="op">,</span></span>
+<span id="cb15-12"><a href="#cb15-12" aria-hidden="true" tabindex="-1"></a>    <span class="dt">trust</span><span class="op">:</span> {</span>
+<span id="cb15-13"><a href="#cb15-13" aria-hidden="true" tabindex="-1"></a>      <span class="dt">level</span><span class="op">:</span> <span class="st">&quot;validated&quot;</span><span class="op">,</span></span>
+<span id="cb15-14"><a href="#cb15-14" aria-hidden="true" tabindex="-1"></a>      <span class="dt">validated_at</span><span class="op">:</span> <span class="st">&quot;2026-01-15T12:00:00Z&quot;</span><span class="op">,</span></span>
+<span id="cb15-15"><a href="#cb15-15" aria-hidden="true" tabindex="-1"></a>      <span class="dt">validation_report</span><span class="op">:</span> {</span>
+<span id="cb15-16"><a href="#cb15-16" aria-hidden="true" tabindex="-1"></a>        <span class="dt">tests_passed</span><span class="op">:</span> <span class="dv">47</span><span class="op">,</span></span>
+<span id="cb15-17"><a href="#cb15-17" aria-hidden="true" tabindex="-1"></a>        <span class="dt">tests_total</span><span class="op">:</span> <span class="dv">47</span></span>
+<span id="cb15-18"><a href="#cb15-18" aria-hidden="true" tabindex="-1"></a>      }</span>
+<span id="cb15-19"><a href="#cb15-19" aria-hidden="true" tabindex="-1"></a>    }</span>
+<span id="cb15-20"><a href="#cb15-20" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb15-21"><a href="#cb15-21" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<hr />
+<h2 id="7-future-extensions">7. Future Extensions</h2>
+<h3 id="71-scoped-trust-levels">7.1 Scoped Trust Levels</h3>
+<p>Future versions may support per-operation trust levels:</p>
+<div class="sourceCode" id="cb16"><pre class="sourceCode yaml"><code class="sourceCode yaml"><span id="cb16-1"><a href="#cb16-1" aria-hidden="true" tabindex="-1"></a><span class="fu">trust</span><span class="kw">:</span></span>
+<span id="cb16-2"><a href="#cb16-2" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">level</span><span class="kw">:</span><span class="at"> validated</span></span>
+<span id="cb16-3"><a href="#cb16-3" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">operation_overrides</span><span class="kw">:</span></span>
+<span id="cb16-4"><a href="#cb16-4" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">delete_repo</span><span class="kw">:</span></span>
+<span id="cb16-5"><a href="#cb16-5" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">level</span><span class="kw">:</span><span class="at"> certified</span></span>
+<span id="cb16-6"><a href="#cb16-6" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">reason</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;Destructive operation requires higher trust&quot;</span></span></code></pre></div>
+<h3 id="72-trust-delegation">7.2 Trust Delegation</h3>
+<p>Organizations may delegate trust decisions:</p>
+<div class="sourceCode" id="cb17"><pre class="sourceCode yaml"><code class="sourceCode yaml"><span id="cb17-1"><a href="#cb17-1" aria-hidden="true" tabindex="-1"></a><span class="fu">trust</span><span class="kw">:</span></span>
+<span id="cb17-2"><a href="#cb17-2" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">level</span><span class="kw">:</span><span class="at"> community_reviewed</span></span>
+<span id="cb17-3"><a href="#cb17-3" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">delegated_from</span><span class="kw">:</span></span>
+<span id="cb17-4"><a href="#cb17-4" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">authority</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;acme-corp&quot;</span></span>
+<span id="cb17-5"><a href="#cb17-5" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">scope</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;internal-apis&quot;</span></span></code></pre></div>
+<h3 id="73-composite-trust">7.3 Composite Trust</h3>
+<p>For adapters aggregating multiple APIs:</p>
+<div class="sourceCode" id="cb18"><pre class="sourceCode yaml"><code class="sourceCode yaml"><span id="cb18-1"><a href="#cb18-1" aria-hidden="true" tabindex="-1"></a><span class="fu">trust</span><span class="kw">:</span></span>
+<span id="cb18-2"><a href="#cb18-2" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">composite</span><span class="kw">:</span><span class="at"> </span><span class="ch">true</span></span>
+<span id="cb18-3"><a href="#cb18-3" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">components</span><span class="kw">:</span></span>
+<span id="cb18-4"><a href="#cb18-4" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="kw">-</span><span class="at"> </span><span class="fu">api</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;github&quot;</span></span>
+<span id="cb18-5"><a href="#cb18-5" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">level</span><span class="kw">:</span><span class="at"> certified</span></span>
+<span id="cb18-6"><a href="#cb18-6" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="kw">-</span><span class="at"> </span><span class="fu">api</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;slack&quot;</span></span>
+<span id="cb18-7"><a href="#cb18-7" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">level</span><span class="kw">:</span><span class="at"> validated</span></span>
+<span id="cb18-8"><a href="#cb18-8" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">effective_level</span><span class="kw">:</span><span class="at"> validated</span><span class="co">  # Minimum of components</span></span></code></pre></div>
+<h3 id="74-trust-attestation-protocol">7.4 Trust Attestation Protocol</h3>
+<p>A future specification may define a protocol for trust attestation exchange between systems.</p>
+<hr />
+<h2 id="references">References</h2>
+<ul>
+<li><a href="element-type.html">Adapter Element Type Specification</a></li>
+<li><a href="danger-levels.html">Dangerous Operation Classification</a></li>
+<li><a href="rate-limiting.html">Rate Limiting Specification</a></li>
+<li><a href="../security/gatekeeper.html">Security Model: Gatekeeper</a></li>
+<li><a href="../error-codes.html">Error Codes Specification</a></li>
+<li>GitHub Issue: <a href="https://github.com/MCPAQL/spec/issues/59">#59</a></li>
+</ul>
+
+          </div>
+        </section>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div class="container">
+      <p>&copy; 2026 DollhouseMCP Inc. d/b/a Dollhouse Research. MCP-AQL public draft documentation portal.</p>
+      <div class="footer-links">
+        <a href="../../docs/index.html">Docs Library</a>
+        <a href="../index.html">Repo-Synced Spec</a>
+        <a href="https://github.com/MCPAQL">MCPAQL Organization</a>
+        <a href="https://dollhouseresearch.com">Dollhouse Research</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../../js/search.js"></script>
+</body>
+</html>

--- a/public/spec/adr/ADR-001-crude-pattern.html
+++ b/public/spec/adr/ADR-001-crude-pattern.html
@@ -73,6 +73,13 @@
       </aside>
 
       <article class="docs-main">
+        <nav class="breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../../index.html">Home</a></li>
+            <li><a href="../index.html">Full Spec</a></li>
+            <li><span class="current">ADR-001: CRUDE Pattern (Extending CRUD with Execute)</span></li>
+          </ol>
+        </nav>
         <section class="hero docs-hero">
           <div class="hero-inner">
             <span class="status-pill">REPO-SYNCED SPEC DOC</span>

--- a/public/spec/adr/ADR-001-crude-pattern.html
+++ b/public/spec/adr/ADR-001-crude-pattern.html
@@ -23,7 +23,7 @@
         </ul>
         <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
-          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <input id="site-search-input" data-search-input type="search" placeholder="Search MCP-AQL docs, spec pages, and adapter patterns...">
           <span class="search-count" data-search-count></span>
           <ul class="search-results" data-search-results hidden></ul>
         </form>
@@ -68,7 +68,7 @@
   <ul><li><a href="../reference/README.html">Reference Documentation</a></li></ul>
 </div><div class="docs-side-group">
   <h3>ADRs</h3>
-  <ul><li><a class="current" href="ADR-001-crude-pattern.html">ADR-001: CRUDE Pattern (Extending CRUD with Execute)</a></li><li><a href="ADR-002-graphql-style-input.html">ADR-002: GraphQL-Style Input Objects for Updates</a></li><li><a href="ADR-003-snake-case-parameters.html">ADR-003: snake_case Parameter Convention</a></li><li><a href="ADR-004-schema-driven-operations.html">ADR-004: Schema-Driven Operation Definitions</a></li><li><a href="ADR-005-introspection-system.html">ADR-005: GraphQL-Style Introspection System</a></li><li><a href="ADR-006-discriminated-responses.html">ADR-006: Discriminated Response Format</a></li><li><a href="index.html">Architecture Decision Records</a></li><li><a href="README.html">Architecture Decision Records</a></li></ul>
+  <ul><li><a class="current" aria-current="page" href="ADR-001-crude-pattern.html">ADR-001: CRUDE Pattern (Extending CRUD with Execute)</a></li><li><a href="ADR-002-graphql-style-input.html">ADR-002: GraphQL-Style Input Objects for Updates</a></li><li><a href="ADR-003-snake-case-parameters.html">ADR-003: snake_case Parameter Convention</a></li><li><a href="ADR-004-schema-driven-operations.html">ADR-004: Schema-Driven Operation Definitions</a></li><li><a href="ADR-005-introspection-system.html">ADR-005: GraphQL-Style Introspection System</a></li><li><a href="ADR-006-discriminated-responses.html">ADR-006: Discriminated Response Format</a></li><li><a href="index.html">Architecture Decision Records</a></li><li><a href="README.html">Architecture Decision Records</a></li></ul>
 </div>
       </aside>
 
@@ -170,6 +170,16 @@
 
           </div>
         </section>
+        <nav class="page-nav" aria-label="Page navigation">
+  <a class="page-nav-link prev" href="../reference/README.html">
+    <span class="page-nav-eyebrow">Previous spec page</span>
+    <strong class="page-nav-label">Reference Documentation</strong>
+  </a>
+  <a class="page-nav-link next" href="ADR-002-graphql-style-input.html">
+    <span class="page-nav-eyebrow">Next spec page</span>
+    <strong class="page-nav-label">ADR-002: GraphQL-Style Input Objects for Updates</strong>
+  </a>
+</nav>
       </article>
     </div>
   </main>

--- a/public/spec/adr/ADR-001-crude-pattern.html
+++ b/public/spec/adr/ADR-001-crude-pattern.html
@@ -1,0 +1,184 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Date: 2026-01-16">
+  <title>MCP-AQL Spec | ADR-001: CRUDE Pattern (Extending CRUD with Execute)</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../../css/style.css">
+</head>
+<body>
+  <header>
+    <div class="container">
+      <nav>
+        <a class="logo" href="../../index.html"><span class="logo-mark"></span>MCP-AQL</a>
+        <ul class="nav-links">
+          <li><a href="../../index.html">Home</a></li>
+          <li><a href="../../docs/index.html">Docs</a></li>
+          <li><a href="../../launch-checklist.html">Launch Checklist</a></li>
+          <li><a href="../../apis/mcp-server.html">Adapter Patterns</a></li>
+        </ul>
+        <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
+          <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
+          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <span class="search-count" data-search-count></span>
+          <ul class="search-results" data-search-results hidden></ul>
+        </form>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <div class="container docs-shell">
+      <aside class="docs-side">
+        <h2>Repo-Synced Spec</h2>
+        <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
+        <div class="docs-side-group">
+  <h3>Core</h3>
+  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Versions</h3>
+  <ul><li><a href="../versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Adapter</h3>
+  <ul><li><a href="../adapter/danger-levels.html">Dangerous Operation Classification Specification</a></li><li><a href="../adapter/discovery-bundle.html">MCP Server Discovery Bundle</a></li><li><a href="../adapter/element-type.html">Adapter Element Type Specification</a></li><li><a href="../adapter/generator.html">Adapter Generator Specification</a></li><li><a href="../adapter/rate-limiting.html">Rate Limiting and Quota Management Specification</a></li><li><a href="../adapter/trust-levels.html">Trust Levels Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Security</h3>
+  <ul><li><a href="../security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="../security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="../security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Features</h3>
+  <ul><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Guides</h3>
+  <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Process</h3>
+  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Architecture</h3>
+  <ul><li><a href="../architecture/README.html">Architecture Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Research</h3>
+  <ul><li><a href="../research/mcp-vs-mcpaql-vs-a2a.html">Protocol Landscape: MCP vs MCP-AQL vs A2A</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Reference</h3>
+  <ul><li><a href="../reference/README.html">Reference Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>ADRs</h3>
+  <ul><li><a class="current" href="ADR-001-crude-pattern.html">ADR-001: CRUDE Pattern (Extending CRUD with Execute)</a></li><li><a href="ADR-002-graphql-style-input.html">ADR-002: GraphQL-Style Input Objects for Updates</a></li><li><a href="ADR-003-snake-case-parameters.html">ADR-003: snake_case Parameter Convention</a></li><li><a href="ADR-004-schema-driven-operations.html">ADR-004: Schema-Driven Operation Definitions</a></li><li><a href="ADR-005-introspection-system.html">ADR-005: GraphQL-Style Introspection System</a></li><li><a href="ADR-006-discriminated-responses.html">ADR-006: Discriminated Response Format</a></li><li><a href="index.html">Architecture Decision Records</a></li><li><a href="README.html">Architecture Decision Records</a></li></ul>
+</div>
+      </aside>
+
+      <article class="docs-main">
+        <section class="hero docs-hero">
+          <div class="hero-inner">
+            <span class="status-pill">REPO-SYNCED SPEC DOC</span>
+            <h1>ADR-001: CRUDE Pattern (Extending CRUD with Execute)</h1>
+            <p class="lede">Date: 2026-01-16</p>
+            <div class="spec-meta"><span class="state-chip live">Support document</span><span class="state-chip pending">Accepted</span></div>
+            <p class="spec-source">Source: <a href="https://github.com/MCPAQL/spec/blob/main/docs/adr/ADR-001-crude-pattern.md">spec/docs/adr/ADR-001-crude-pattern.md</a></p>
+            <div class="hero-actions">
+              <a class="btn btn-primary" href="https://github.com/MCPAQL/spec/blob/main/docs/adr/ADR-001-crude-pattern.md">Open Source Markdown</a>
+              <a class="btn btn-secondary" href="../index.html">Browse Full Spec Reference</a>
+            </div>
+          </div>
+        </section>
+
+        <section>
+          <div class="card spec-prose">
+            <p><strong>Status:</strong> Accepted <strong>Date:</strong> 2026-01-16</p>
+<h2 id="context">Context</h2>
+<p>Traditional CRUD (Create, Read, Update, Delete) operations are well-suited for managing resource definitions and state. However, MCP-AQL needs to support runtime execution operations that have fundamentally different characteristics:</p>
+<table>
+<thead>
+<tr>
+<th>Characteristic</th>
+<th>CRUD Operations</th>
+<th>Execution Operations</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Idempotency</td>
+<td>Generally idempotent</td>
+<td>Non-idempotent</td>
+</tr>
+<tr>
+<td>Target</td>
+<td>Element definitions</td>
+<td>Runtime state</td>
+</tr>
+<tr>
+<td>Lifecycle</td>
+<td>Discrete operations</td>
+<td>Stateful lifecycle</td>
+</tr>
+<tr>
+<td>Side effects</td>
+<td>Predictable</td>
+<td>Unbounded</td>
+</tr>
+</tbody>
+</table>
+<p>Placing execution operations within existing CRUD endpoints creates semantic confusion. For example, placing <code>execute_agent</code> in the DELETE endpoint because it is "potentially destructive" obscures the operation's true intent.</p>
+<h2 id="decision">Decision</h2>
+<p>MCP-AQL extends traditional CRUD with an EXECUTE endpoint, creating the CRUDE pattern:</p>
+<ul>
+<li><strong>Create</strong> - Non-destructive, additive operations</li>
+<li><strong>Read</strong> - Safe, read-only operations</li>
+<li><strong>Update</strong> - Modifying operations that change existing state</li>
+<li><strong>Delete</strong> - Destructive operations that remove state</li>
+<li><strong>Execute</strong> - Runtime lifecycle operations (non-idempotent)</li>
+</ul>
+<p>Implementations MUST expose five distinct endpoints corresponding to these categories. Operations MUST be routed to the endpoint matching their semantic intent.</p>
+<p>The EXECUTE endpoint is designated for operations that:</p>
+<ol type="1">
+<li>Manage runtime execution state rather than definitions</li>
+<li>Are inherently non-idempotent</li>
+<li>May have unbounded side effects</li>
+<li>Follow a stateful lifecycle pattern</li>
+</ol>
+<h2 id="consequences">Consequences</h2>
+<h3 id="positive">Positive</h3>
+<ul>
+<li><strong>Semantic clarity</strong>: Operations are grouped by their actual behavior and intent</li>
+<li><strong>Clear execution boundary</strong>: Runtime operations are explicitly separated from definition management</li>
+<li><strong>Permission modeling</strong>: Security policies can treat execution operations distinctly</li>
+<li><strong>Future extensibility</strong>: The pattern accommodates workflow, pipeline, and agent execution patterns</li>
+</ul>
+<h3 id="negative">Negative</h3>
+<ul>
+<li><strong>Unfamiliar pattern</strong>: CRUDE is not a widely-known acronym like CRUD</li>
+<li><strong>Additional endpoint</strong>: Implementations must support five endpoints instead of four</li>
+<li><strong>Learning curve</strong>: Developers must understand when to use Execute vs other endpoints</li>
+</ul>
+<h2 id="references">References</h2>
+<ul>
+<li><a href="https://github.com/MCPAQL/spec/blob/main/docs/protocol/endpoints.md">Protocol Specification: Endpoints</a></li>
+<li>ADR-004: Schema-Driven Operations</li>
+</ul>
+
+          </div>
+        </section>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div class="container">
+      <p>&copy; 2026 DollhouseMCP Inc. d/b/a Dollhouse Research. MCP-AQL public draft documentation portal.</p>
+      <div class="footer-links">
+        <a href="../../docs/index.html">Docs Library</a>
+        <a href="../index.html">Repo-Synced Spec</a>
+        <a href="https://github.com/MCPAQL">MCPAQL Organization</a>
+        <a href="https://dollhouseresearch.com">Dollhouse Research</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../../js/search.js"></script>
+</body>
+</html>

--- a/public/spec/adr/ADR-001-crude-pattern.html
+++ b/public/spec/adr/ADR-001-crude-pattern.html
@@ -38,7 +38,7 @@
         <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
         <div class="docs-side-group">
   <h3>Core</h3>
-  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li></ul>
+  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li><li><a href="../repo/README.html">MCP-AQL Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Versions</h3>
   <ul><li><a href="../versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
@@ -56,7 +56,7 @@
   <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
-  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li></ul>
+  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li><li><a href="../repo/CHANGELOG.html">Changelog</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Architecture</h3>
   <ul><li><a href="../architecture/README.html">Architecture Documentation</a></li></ul>

--- a/public/spec/adr/ADR-002-graphql-style-input.html
+++ b/public/spec/adr/ADR-002-graphql-style-input.html
@@ -23,7 +23,7 @@
         </ul>
         <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
-          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <input id="site-search-input" data-search-input type="search" placeholder="Search MCP-AQL docs, spec pages, and adapter patterns...">
           <span class="search-count" data-search-count></span>
           <ul class="search-results" data-search-results hidden></ul>
         </form>
@@ -68,7 +68,7 @@
   <ul><li><a href="../reference/README.html">Reference Documentation</a></li></ul>
 </div><div class="docs-side-group">
   <h3>ADRs</h3>
-  <ul><li><a href="ADR-001-crude-pattern.html">ADR-001: CRUDE Pattern (Extending CRUD with Execute)</a></li><li><a class="current" href="ADR-002-graphql-style-input.html">ADR-002: GraphQL-Style Input Objects for Updates</a></li><li><a href="ADR-003-snake-case-parameters.html">ADR-003: snake_case Parameter Convention</a></li><li><a href="ADR-004-schema-driven-operations.html">ADR-004: Schema-Driven Operation Definitions</a></li><li><a href="ADR-005-introspection-system.html">ADR-005: GraphQL-Style Introspection System</a></li><li><a href="ADR-006-discriminated-responses.html">ADR-006: Discriminated Response Format</a></li><li><a href="index.html">Architecture Decision Records</a></li><li><a href="README.html">Architecture Decision Records</a></li></ul>
+  <ul><li><a href="ADR-001-crude-pattern.html">ADR-001: CRUDE Pattern (Extending CRUD with Execute)</a></li><li><a class="current" aria-current="page" href="ADR-002-graphql-style-input.html">ADR-002: GraphQL-Style Input Objects for Updates</a></li><li><a href="ADR-003-snake-case-parameters.html">ADR-003: snake_case Parameter Convention</a></li><li><a href="ADR-004-schema-driven-operations.html">ADR-004: Schema-Driven Operation Definitions</a></li><li><a href="ADR-005-introspection-system.html">ADR-005: GraphQL-Style Introspection System</a></li><li><a href="ADR-006-discriminated-responses.html">ADR-006: Discriminated Response Format</a></li><li><a href="index.html">Architecture Decision Records</a></li><li><a href="README.html">Architecture Decision Records</a></li></ul>
 </div>
       </aside>
 
@@ -170,6 +170,16 @@
 
           </div>
         </section>
+        <nav class="page-nav" aria-label="Page navigation">
+  <a class="page-nav-link prev" href="ADR-001-crude-pattern.html">
+    <span class="page-nav-eyebrow">Previous spec page</span>
+    <strong class="page-nav-label">ADR-001: CRUDE Pattern (Extending CRUD with Execute)</strong>
+  </a>
+  <a class="page-nav-link next" href="ADR-003-snake-case-parameters.html">
+    <span class="page-nav-eyebrow">Next spec page</span>
+    <strong class="page-nav-label">ADR-003: snake_case Parameter Convention</strong>
+  </a>
+</nav>
       </article>
     </div>
   </main>

--- a/public/spec/adr/ADR-002-graphql-style-input.html
+++ b/public/spec/adr/ADR-002-graphql-style-input.html
@@ -38,7 +38,7 @@
         <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
         <div class="docs-side-group">
   <h3>Core</h3>
-  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li></ul>
+  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li><li><a href="../repo/README.html">MCP-AQL Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Versions</h3>
   <ul><li><a href="../versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
@@ -56,7 +56,7 @@
   <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
-  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li></ul>
+  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li><li><a href="../repo/CHANGELOG.html">Changelog</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Architecture</h3>
   <ul><li><a href="../architecture/README.html">Architecture Documentation</a></li></ul>

--- a/public/spec/adr/ADR-002-graphql-style-input.html
+++ b/public/spec/adr/ADR-002-graphql-style-input.html
@@ -73,6 +73,13 @@
       </aside>
 
       <article class="docs-main">
+        <nav class="breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../../index.html">Home</a></li>
+            <li><a href="../index.html">Full Spec</a></li>
+            <li><span class="current">ADR-002: GraphQL-Style Input Objects for Updates</span></li>
+          </ol>
+        </nav>
         <section class="hero docs-hero">
           <div class="hero-inner">
             <span class="status-pill">REPO-SYNCED SPEC DOC</span>

--- a/public/spec/adr/ADR-002-graphql-style-input.html
+++ b/public/spec/adr/ADR-002-graphql-style-input.html
@@ -1,0 +1,184 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Date: 2026-01-16">
+  <title>MCP-AQL Spec | ADR-002: GraphQL-Style Input Objects for Updates</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../../css/style.css">
+</head>
+<body>
+  <header>
+    <div class="container">
+      <nav>
+        <a class="logo" href="../../index.html"><span class="logo-mark"></span>MCP-AQL</a>
+        <ul class="nav-links">
+          <li><a href="../../index.html">Home</a></li>
+          <li><a href="../../docs/index.html">Docs</a></li>
+          <li><a href="../../launch-checklist.html">Launch Checklist</a></li>
+          <li><a href="../../apis/mcp-server.html">Adapter Patterns</a></li>
+        </ul>
+        <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
+          <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
+          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <span class="search-count" data-search-count></span>
+          <ul class="search-results" data-search-results hidden></ul>
+        </form>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <div class="container docs-shell">
+      <aside class="docs-side">
+        <h2>Repo-Synced Spec</h2>
+        <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
+        <div class="docs-side-group">
+  <h3>Core</h3>
+  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Versions</h3>
+  <ul><li><a href="../versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Adapter</h3>
+  <ul><li><a href="../adapter/danger-levels.html">Dangerous Operation Classification Specification</a></li><li><a href="../adapter/discovery-bundle.html">MCP Server Discovery Bundle</a></li><li><a href="../adapter/element-type.html">Adapter Element Type Specification</a></li><li><a href="../adapter/generator.html">Adapter Generator Specification</a></li><li><a href="../adapter/rate-limiting.html">Rate Limiting and Quota Management Specification</a></li><li><a href="../adapter/trust-levels.html">Trust Levels Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Security</h3>
+  <ul><li><a href="../security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="../security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="../security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Features</h3>
+  <ul><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Guides</h3>
+  <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Process</h3>
+  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Architecture</h3>
+  <ul><li><a href="../architecture/README.html">Architecture Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Research</h3>
+  <ul><li><a href="../research/mcp-vs-mcpaql-vs-a2a.html">Protocol Landscape: MCP vs MCP-AQL vs A2A</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Reference</h3>
+  <ul><li><a href="../reference/README.html">Reference Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>ADRs</h3>
+  <ul><li><a href="ADR-001-crude-pattern.html">ADR-001: CRUDE Pattern (Extending CRUD with Execute)</a></li><li><a class="current" href="ADR-002-graphql-style-input.html">ADR-002: GraphQL-Style Input Objects for Updates</a></li><li><a href="ADR-003-snake-case-parameters.html">ADR-003: snake_case Parameter Convention</a></li><li><a href="ADR-004-schema-driven-operations.html">ADR-004: Schema-Driven Operation Definitions</a></li><li><a href="ADR-005-introspection-system.html">ADR-005: GraphQL-Style Introspection System</a></li><li><a href="ADR-006-discriminated-responses.html">ADR-006: Discriminated Response Format</a></li><li><a href="index.html">Architecture Decision Records</a></li><li><a href="README.html">Architecture Decision Records</a></li></ul>
+</div>
+      </aside>
+
+      <article class="docs-main">
+        <section class="hero docs-hero">
+          <div class="hero-inner">
+            <span class="status-pill">REPO-SYNCED SPEC DOC</span>
+            <h1>ADR-002: GraphQL-Style Input Objects for Updates</h1>
+            <p class="lede">Date: 2026-01-16</p>
+            <div class="spec-meta"><span class="state-chip live">Support document</span><span class="state-chip pending">Accepted</span></div>
+            <p class="spec-source">Source: <a href="https://github.com/MCPAQL/spec/blob/main/docs/adr/ADR-002-graphql-style-input.md">spec/docs/adr/ADR-002-graphql-style-input.md</a></p>
+            <div class="hero-actions">
+              <a class="btn btn-primary" href="https://github.com/MCPAQL/spec/blob/main/docs/adr/ADR-002-graphql-style-input.md">Open Source Markdown</a>
+              <a class="btn btn-secondary" href="../index.html">Browse Full Spec Reference</a>
+            </div>
+          </div>
+        </section>
+
+        <section>
+          <div class="card spec-prose">
+            <p><strong>Status:</strong> Accepted <strong>Date:</strong> 2026-01-16</p>
+<h2 id="context">Context</h2>
+<p>Update operations require a mechanism to specify which fields should be modified. Several approaches exist:</p>
+<ol type="1">
+<li><strong>Flat parameters</strong>: All updateable fields at the same level as identifiers</li>
+<li><strong>Patch operations</strong>: JSON Patch-style <code>{ op, path, value }</code> arrays</li>
+<li><strong>Field-specific operations</strong>: Separate operations like <code>set_description</code>, <code>set_metadata</code></li>
+<li><strong>Full replacement</strong>: Send complete resource data, overwriting everything</li>
+<li><strong>Nested input objects</strong>: GraphQL-style separation of identifiers from updateable fields</li>
+</ol>
+<p>Flat parameters create ambiguity about which fields are identifiers versus updateable values:</p>
+<div class="sourceCode" id="cb1"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb1-2"><a href="#cb1-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;edit_element&quot;</span><span class="op">,</span></span>
+<span id="cb1-3"><a href="#cb1-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> {</span>
+<span id="cb1-4"><a href="#cb1-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">element_name</span><span class="op">:</span> <span class="st">&quot;MyPersona&quot;</span><span class="op">,</span>  <span class="co">// Identifier</span></span>
+<span id="cb1-5"><a href="#cb1-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">element_type</span><span class="op">:</span> <span class="st">&quot;persona&quot;</span><span class="op">,</span>     <span class="co">// Identifier</span></span>
+<span id="cb1-6"><a href="#cb1-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">description</span><span class="op">:</span> <span class="st">&quot;new desc&quot;</span><span class="op">,</span>     <span class="co">// Updateable?</span></span>
+<span id="cb1-7"><a href="#cb1-7" aria-hidden="true" tabindex="-1"></a>    <span class="dt">triggers</span><span class="op">:</span> [<span class="st">&quot;new&quot;</span>]            <span class="co">// Updateable?</span></span>
+<span id="cb1-8"><a href="#cb1-8" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb1-9"><a href="#cb1-9" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<h2 id="decision">Decision</h2>
+<p>MCP-AQL adopts GraphQL-aligned nested <code>input</code> objects for update operations.</p>
+<p>Update operations MUST use a nested <code>input</code> object to contain all updateable fields:</p>
+<div class="sourceCode" id="cb2"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb2-2"><a href="#cb2-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;edit_element&quot;</span><span class="op">,</span></span>
+<span id="cb2-3"><a href="#cb2-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">element_type</span><span class="op">:</span> <span class="st">&quot;persona&quot;</span><span class="op">,</span></span>
+<span id="cb2-4"><a href="#cb2-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> {</span>
+<span id="cb2-5"><a href="#cb2-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">element_name</span><span class="op">:</span> <span class="st">&quot;MyPersona&quot;</span><span class="op">,</span></span>
+<span id="cb2-6"><a href="#cb2-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">input</span><span class="op">:</span> {</span>
+<span id="cb2-7"><a href="#cb2-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">description</span><span class="op">:</span> <span class="st">&quot;new desc&quot;</span><span class="op">,</span></span>
+<span id="cb2-8"><a href="#cb2-8" aria-hidden="true" tabindex="-1"></a>      <span class="dt">metadata</span><span class="op">:</span> {</span>
+<span id="cb2-9"><a href="#cb2-9" aria-hidden="true" tabindex="-1"></a>        <span class="dt">triggers</span><span class="op">:</span> [<span class="st">&quot;new&quot;</span><span class="op">,</span> <span class="st">&quot;triggers&quot;</span>]</span>
+<span id="cb2-10"><a href="#cb2-10" aria-hidden="true" tabindex="-1"></a>      }</span>
+<span id="cb2-11"><a href="#cb2-11" aria-hidden="true" tabindex="-1"></a>    }</span>
+<span id="cb2-12"><a href="#cb2-12" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb2-13"><a href="#cb2-13" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<p>Implementations MUST:</p>
+<ol type="1">
+<li>Clearly separate identifier parameters from updateable fields</li>
+<li>Deep-merge <code>input</code> contents with existing resource state</li>
+<li>Only modify fields explicitly present in <code>input</code></li>
+<li>Preserve fields not mentioned in <code>input</code></li>
+</ol>
+<h2 id="consequences">Consequences</h2>
+<h3 id="positive">Positive</h3>
+<ul>
+<li><strong>Clear separation</strong>: Identifiers and updateable fields are unambiguous</li>
+<li><strong>Deep merging</strong>: Nested structures merge cleanly without explicit field selection</li>
+<li><strong>Partial updates</strong>: Only specified fields change; others remain untouched</li>
+<li><strong>Familiar pattern</strong>: Aligns with GraphQL mutation conventions</li>
+<li><strong>Extensibility</strong>: New updateable fields can be added without breaking changes</li>
+</ul>
+<h3 id="negative">Negative</h3>
+<ul>
+<li><strong>Increased nesting</strong>: Requests are more deeply nested</li>
+<li><strong>Learning curve</strong>: Users unfamiliar with GraphQL may find pattern unusual</li>
+<li><strong>Payload size</strong>: Slight increase in request size due to <code>input</code> wrapper</li>
+</ul>
+<h2 id="specification-impact">Specification Impact</h2>
+<p>This ADR is codified in the normative specification:</p>
+<ul>
+<li><strong>Section 4.5</strong> of <a href="../versions/v1.0.0-draft.html#45-update-input-pattern">MCP-AQL Specification v1.0.0-draft</a> defines the <code>input</code> object structure, deep-merge semantics, field removal via <code>null</code>, and validation rules.</li>
+<li><strong>Section 4</strong> of <a href="../operations.html">Operations Reference</a> references the UPDATE input pattern for parameter conventions.</li>
+</ul>
+<p>Implementations MUST follow the normative specification. This ADR provides design rationale only.</p>
+<h2 id="references">References</h2>
+<ul>
+<li><a href="../versions/v1.0.0-draft.html#45-update-input-pattern">MCP-AQL Specification v1.0.0-draft — Section 4.5</a></li>
+<li><a href="../operations.html">Operations Reference</a></li>
+<li>ADR-003: snake_case Parameter Convention</li>
+</ul>
+
+          </div>
+        </section>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div class="container">
+      <p>&copy; 2026 DollhouseMCP Inc. d/b/a Dollhouse Research. MCP-AQL public draft documentation portal.</p>
+      <div class="footer-links">
+        <a href="../../docs/index.html">Docs Library</a>
+        <a href="../index.html">Repo-Synced Spec</a>
+        <a href="https://github.com/MCPAQL">MCPAQL Organization</a>
+        <a href="https://dollhouseresearch.com">Dollhouse Research</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../../js/search.js"></script>
+</body>
+</html>

--- a/public/spec/adr/ADR-003-snake-case-parameters.html
+++ b/public/spec/adr/ADR-003-snake-case-parameters.html
@@ -1,0 +1,162 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Date: 2026-01-16">
+  <title>MCP-AQL Spec | ADR-003: snake_case Parameter Convention</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../../css/style.css">
+</head>
+<body>
+  <header>
+    <div class="container">
+      <nav>
+        <a class="logo" href="../../index.html"><span class="logo-mark"></span>MCP-AQL</a>
+        <ul class="nav-links">
+          <li><a href="../../index.html">Home</a></li>
+          <li><a href="../../docs/index.html">Docs</a></li>
+          <li><a href="../../launch-checklist.html">Launch Checklist</a></li>
+          <li><a href="../../apis/mcp-server.html">Adapter Patterns</a></li>
+        </ul>
+        <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
+          <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
+          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <span class="search-count" data-search-count></span>
+          <ul class="search-results" data-search-results hidden></ul>
+        </form>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <div class="container docs-shell">
+      <aside class="docs-side">
+        <h2>Repo-Synced Spec</h2>
+        <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
+        <div class="docs-side-group">
+  <h3>Core</h3>
+  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Versions</h3>
+  <ul><li><a href="../versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Adapter</h3>
+  <ul><li><a href="../adapter/danger-levels.html">Dangerous Operation Classification Specification</a></li><li><a href="../adapter/discovery-bundle.html">MCP Server Discovery Bundle</a></li><li><a href="../adapter/element-type.html">Adapter Element Type Specification</a></li><li><a href="../adapter/generator.html">Adapter Generator Specification</a></li><li><a href="../adapter/rate-limiting.html">Rate Limiting and Quota Management Specification</a></li><li><a href="../adapter/trust-levels.html">Trust Levels Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Security</h3>
+  <ul><li><a href="../security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="../security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="../security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Features</h3>
+  <ul><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Guides</h3>
+  <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Process</h3>
+  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Architecture</h3>
+  <ul><li><a href="../architecture/README.html">Architecture Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Research</h3>
+  <ul><li><a href="../research/mcp-vs-mcpaql-vs-a2a.html">Protocol Landscape: MCP vs MCP-AQL vs A2A</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Reference</h3>
+  <ul><li><a href="../reference/README.html">Reference Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>ADRs</h3>
+  <ul><li><a href="ADR-001-crude-pattern.html">ADR-001: CRUDE Pattern (Extending CRUD with Execute)</a></li><li><a href="ADR-002-graphql-style-input.html">ADR-002: GraphQL-Style Input Objects for Updates</a></li><li><a class="current" href="ADR-003-snake-case-parameters.html">ADR-003: snake_case Parameter Convention</a></li><li><a href="ADR-004-schema-driven-operations.html">ADR-004: Schema-Driven Operation Definitions</a></li><li><a href="ADR-005-introspection-system.html">ADR-005: GraphQL-Style Introspection System</a></li><li><a href="ADR-006-discriminated-responses.html">ADR-006: Discriminated Response Format</a></li><li><a href="index.html">Architecture Decision Records</a></li><li><a href="README.html">Architecture Decision Records</a></li></ul>
+</div>
+      </aside>
+
+      <article class="docs-main">
+        <section class="hero docs-hero">
+          <div class="hero-inner">
+            <span class="status-pill">REPO-SYNCED SPEC DOC</span>
+            <h1>ADR-003: snake_case Parameter Convention</h1>
+            <p class="lede">Date: 2026-01-16</p>
+            <div class="spec-meta"><span class="state-chip live">Support document</span><span class="state-chip pending">Accepted</span></div>
+            <p class="spec-source">Source: <a href="https://github.com/MCPAQL/spec/blob/main/docs/adr/ADR-003-snake-case-parameters.md">spec/docs/adr/ADR-003-snake-case-parameters.md</a></p>
+            <div class="hero-actions">
+              <a class="btn btn-primary" href="https://github.com/MCPAQL/spec/blob/main/docs/adr/ADR-003-snake-case-parameters.md">Open Source Markdown</a>
+              <a class="btn btn-secondary" href="../index.html">Browse Full Spec Reference</a>
+            </div>
+          </div>
+        </section>
+
+        <section>
+          <div class="card spec-prose">
+            <p><strong>Status:</strong> Accepted <strong>Date:</strong> 2026-01-16</p>
+<h2 id="context">Context</h2>
+<p>MCP-AQL is designed for consumption by Large Language Models (LLMs) as well as traditional software clients. LLMs exhibit inconsistent behavior when generating identifiers in different naming conventions.</p>
+<p>Empirical observation shows LLMs may generate any of the following for the same conceptual parameter:</p>
+<div class="sourceCode" id="cb1"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a>{ <span class="dt">elementType</span><span class="op">:</span> <span class="st">&quot;persona&quot;</span> }      <span class="co">// camelCase</span></span>
+<span id="cb1-2"><a href="#cb1-2" aria-hidden="true" tabindex="-1"></a>{ <span class="dt">element_type</span><span class="op">:</span> <span class="st">&quot;persona&quot;</span> }     <span class="co">// snake_case</span></span>
+<span id="cb1-3"><a href="#cb1-3" aria-hidden="true" tabindex="-1"></a>{ <span class="dt">ElementType</span><span class="op">:</span> <span class="st">&quot;persona&quot;</span> }      <span class="co">// PascalCase</span></span>
+<span id="cb1-4"><a href="#cb1-4" aria-hidden="true" tabindex="-1"></a>{ <span class="dt">elementtype</span><span class="op">:</span> <span class="st">&quot;persona&quot;</span> }      <span class="co">// lowercase</span></span></code></pre></div>
+<p>This inconsistency leads to parameter resolution failures and degraded LLM performance. Additionally, snake_case aligns with:</p>
+<ul>
+<li>Python naming conventions (dominant in AI/ML ecosystems)</li>
+<li>JSON conventions in many REST APIs</li>
+<li>Clear word boundary visibility without case sensitivity</li>
+</ul>
+<h2 id="decision">Decision</h2>
+<p>MCP-AQL standardizes on snake_case for all public-facing parameter names.</p>
+<p>Parameter names MUST use snake_case format:</p>
+<ul>
+<li><code>element_name</code> instead of <code>elementName</code></li>
+<li><code>element_type</code> instead of <code>elementType</code></li>
+<li><code>page_size</code> instead of <code>pageSize</code></li>
+</ul>
+<p>Implementations SHOULD accept both snake_case and camelCase variants for backward compatibility and developer convenience, normalizing internally to snake_case.</p>
+<p>Example of both formats being accepted:</p>
+<div class="sourceCode" id="cb2"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Preferred (snake_case)</span></span>
+<span id="cb2-2"><a href="#cb2-2" aria-hidden="true" tabindex="-1"></a>{ <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;list_elements&quot;</span><span class="op">,</span> <span class="dt">element_type</span><span class="op">:</span> <span class="st">&quot;persona&quot;</span> }</span>
+<span id="cb2-3"><a href="#cb2-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb2-4"><a href="#cb2-4" aria-hidden="true" tabindex="-1"></a><span class="co">// Also accepted (camelCase)</span></span>
+<span id="cb2-5"><a href="#cb2-5" aria-hidden="true" tabindex="-1"></a>{ <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;list_elements&quot;</span><span class="op">,</span> <span class="dt">elementType</span><span class="op">:</span> <span class="st">&quot;persona&quot;</span> }</span></code></pre></div>
+<p>Internal implementation code MAY use any naming convention appropriate to the implementation language.</p>
+<h2 id="consequences">Consequences</h2>
+<h3 id="positive">Positive</h3>
+<ul>
+<li><strong>LLM reliability</strong>: snake_case is generated more consistently by LLMs across models</li>
+<li><strong>Ecosystem alignment</strong>: Matches Python/JSON conventions common in AI APIs</li>
+<li><strong>Readability</strong>: Clear word boundaries without case sensitivity ambiguity</li>
+<li><strong>Backward compatibility</strong>: Accepting both formats eases migration</li>
+</ul>
+<h3 id="negative">Negative</h3>
+<ul>
+<li><strong>JavaScript convention mismatch</strong>: JavaScript typically uses camelCase</li>
+<li><strong>Dual format support</strong>: Implementations must handle both formats</li>
+<li><strong>Documentation burden</strong>: Examples should show preferred snake_case format</li>
+</ul>
+<h2 id="references">References</h2>
+<ul>
+<li><a href="https://github.com/MCPAQL/spec/blob/main/docs/protocol/requests.md">Protocol Specification: Request Format</a></li>
+<li>ADR-002: GraphQL-Style Input Objects for Updates</li>
+</ul>
+
+          </div>
+        </section>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div class="container">
+      <p>&copy; 2026 DollhouseMCP Inc. d/b/a Dollhouse Research. MCP-AQL public draft documentation portal.</p>
+      <div class="footer-links">
+        <a href="../../docs/index.html">Docs Library</a>
+        <a href="../index.html">Repo-Synced Spec</a>
+        <a href="https://github.com/MCPAQL">MCPAQL Organization</a>
+        <a href="https://dollhouseresearch.com">Dollhouse Research</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../../js/search.js"></script>
+</body>
+</html>

--- a/public/spec/adr/ADR-003-snake-case-parameters.html
+++ b/public/spec/adr/ADR-003-snake-case-parameters.html
@@ -23,7 +23,7 @@
         </ul>
         <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
-          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <input id="site-search-input" data-search-input type="search" placeholder="Search MCP-AQL docs, spec pages, and adapter patterns...">
           <span class="search-count" data-search-count></span>
           <ul class="search-results" data-search-results hidden></ul>
         </form>
@@ -68,7 +68,7 @@
   <ul><li><a href="../reference/README.html">Reference Documentation</a></li></ul>
 </div><div class="docs-side-group">
   <h3>ADRs</h3>
-  <ul><li><a href="ADR-001-crude-pattern.html">ADR-001: CRUDE Pattern (Extending CRUD with Execute)</a></li><li><a href="ADR-002-graphql-style-input.html">ADR-002: GraphQL-Style Input Objects for Updates</a></li><li><a class="current" href="ADR-003-snake-case-parameters.html">ADR-003: snake_case Parameter Convention</a></li><li><a href="ADR-004-schema-driven-operations.html">ADR-004: Schema-Driven Operation Definitions</a></li><li><a href="ADR-005-introspection-system.html">ADR-005: GraphQL-Style Introspection System</a></li><li><a href="ADR-006-discriminated-responses.html">ADR-006: Discriminated Response Format</a></li><li><a href="index.html">Architecture Decision Records</a></li><li><a href="README.html">Architecture Decision Records</a></li></ul>
+  <ul><li><a href="ADR-001-crude-pattern.html">ADR-001: CRUDE Pattern (Extending CRUD with Execute)</a></li><li><a href="ADR-002-graphql-style-input.html">ADR-002: GraphQL-Style Input Objects for Updates</a></li><li><a class="current" aria-current="page" href="ADR-003-snake-case-parameters.html">ADR-003: snake_case Parameter Convention</a></li><li><a href="ADR-004-schema-driven-operations.html">ADR-004: Schema-Driven Operation Definitions</a></li><li><a href="ADR-005-introspection-system.html">ADR-005: GraphQL-Style Introspection System</a></li><li><a href="ADR-006-discriminated-responses.html">ADR-006: Discriminated Response Format</a></li><li><a href="index.html">Architecture Decision Records</a></li><li><a href="README.html">Architecture Decision Records</a></li></ul>
 </div>
       </aside>
 
@@ -148,6 +148,16 @@
 
           </div>
         </section>
+        <nav class="page-nav" aria-label="Page navigation">
+  <a class="page-nav-link prev" href="ADR-002-graphql-style-input.html">
+    <span class="page-nav-eyebrow">Previous spec page</span>
+    <strong class="page-nav-label">ADR-002: GraphQL-Style Input Objects for Updates</strong>
+  </a>
+  <a class="page-nav-link next" href="ADR-004-schema-driven-operations.html">
+    <span class="page-nav-eyebrow">Next spec page</span>
+    <strong class="page-nav-label">ADR-004: Schema-Driven Operation Definitions</strong>
+  </a>
+</nav>
       </article>
     </div>
   </main>

--- a/public/spec/adr/ADR-003-snake-case-parameters.html
+++ b/public/spec/adr/ADR-003-snake-case-parameters.html
@@ -38,7 +38,7 @@
         <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
         <div class="docs-side-group">
   <h3>Core</h3>
-  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li></ul>
+  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li><li><a href="../repo/README.html">MCP-AQL Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Versions</h3>
   <ul><li><a href="../versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
@@ -56,7 +56,7 @@
   <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
-  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li></ul>
+  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li><li><a href="../repo/CHANGELOG.html">Changelog</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Architecture</h3>
   <ul><li><a href="../architecture/README.html">Architecture Documentation</a></li></ul>

--- a/public/spec/adr/ADR-003-snake-case-parameters.html
+++ b/public/spec/adr/ADR-003-snake-case-parameters.html
@@ -73,6 +73,13 @@
       </aside>
 
       <article class="docs-main">
+        <nav class="breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../../index.html">Home</a></li>
+            <li><a href="../index.html">Full Spec</a></li>
+            <li><span class="current">ADR-003: snake_case Parameter Convention</span></li>
+          </ol>
+        </nav>
         <section class="hero docs-hero">
           <div class="hero-inner">
             <span class="status-pill">REPO-SYNCED SPEC DOC</span>

--- a/public/spec/adr/ADR-004-schema-driven-operations.html
+++ b/public/spec/adr/ADR-004-schema-driven-operations.html
@@ -73,6 +73,13 @@
       </aside>
 
       <article class="docs-main">
+        <nav class="breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../../index.html">Home</a></li>
+            <li><a href="../index.html">Full Spec</a></li>
+            <li><span class="current">ADR-004: Schema-Driven Operation Definitions</span></li>
+          </ol>
+        </nav>
         <section class="hero docs-hero">
           <div class="hero-inner">
             <span class="status-pill">REPO-SYNCED SPEC DOC</span>

--- a/public/spec/adr/ADR-004-schema-driven-operations.html
+++ b/public/spec/adr/ADR-004-schema-driven-operations.html
@@ -38,7 +38,7 @@
         <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
         <div class="docs-side-group">
   <h3>Core</h3>
-  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li></ul>
+  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li><li><a href="../repo/README.html">MCP-AQL Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Versions</h3>
   <ul><li><a href="../versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
@@ -56,7 +56,7 @@
   <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
-  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li></ul>
+  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li><li><a href="../repo/CHANGELOG.html">Changelog</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Architecture</h3>
   <ul><li><a href="../architecture/README.html">Architecture Documentation</a></li></ul>

--- a/public/spec/adr/ADR-004-schema-driven-operations.html
+++ b/public/spec/adr/ADR-004-schema-driven-operations.html
@@ -23,7 +23,7 @@
         </ul>
         <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
-          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <input id="site-search-input" data-search-input type="search" placeholder="Search MCP-AQL docs, spec pages, and adapter patterns...">
           <span class="search-count" data-search-count></span>
           <ul class="search-results" data-search-results hidden></ul>
         </form>
@@ -68,7 +68,7 @@
   <ul><li><a href="../reference/README.html">Reference Documentation</a></li></ul>
 </div><div class="docs-side-group">
   <h3>ADRs</h3>
-  <ul><li><a href="ADR-001-crude-pattern.html">ADR-001: CRUDE Pattern (Extending CRUD with Execute)</a></li><li><a href="ADR-002-graphql-style-input.html">ADR-002: GraphQL-Style Input Objects for Updates</a></li><li><a href="ADR-003-snake-case-parameters.html">ADR-003: snake_case Parameter Convention</a></li><li><a class="current" href="ADR-004-schema-driven-operations.html">ADR-004: Schema-Driven Operation Definitions</a></li><li><a href="ADR-005-introspection-system.html">ADR-005: GraphQL-Style Introspection System</a></li><li><a href="ADR-006-discriminated-responses.html">ADR-006: Discriminated Response Format</a></li><li><a href="index.html">Architecture Decision Records</a></li><li><a href="README.html">Architecture Decision Records</a></li></ul>
+  <ul><li><a href="ADR-001-crude-pattern.html">ADR-001: CRUDE Pattern (Extending CRUD with Execute)</a></li><li><a href="ADR-002-graphql-style-input.html">ADR-002: GraphQL-Style Input Objects for Updates</a></li><li><a href="ADR-003-snake-case-parameters.html">ADR-003: snake_case Parameter Convention</a></li><li><a class="current" aria-current="page" href="ADR-004-schema-driven-operations.html">ADR-004: Schema-Driven Operation Definitions</a></li><li><a href="ADR-005-introspection-system.html">ADR-005: GraphQL-Style Introspection System</a></li><li><a href="ADR-006-discriminated-responses.html">ADR-006: Discriminated Response Format</a></li><li><a href="index.html">Architecture Decision Records</a></li><li><a href="README.html">Architecture Decision Records</a></li></ul>
 </div>
       </aside>
 
@@ -183,6 +183,16 @@
 
           </div>
         </section>
+        <nav class="page-nav" aria-label="Page navigation">
+  <a class="page-nav-link prev" href="ADR-003-snake-case-parameters.html">
+    <span class="page-nav-eyebrow">Previous spec page</span>
+    <strong class="page-nav-label">ADR-003: snake_case Parameter Convention</strong>
+  </a>
+  <a class="page-nav-link next" href="ADR-005-introspection-system.html">
+    <span class="page-nav-eyebrow">Next spec page</span>
+    <strong class="page-nav-label">ADR-005: GraphQL-Style Introspection System</strong>
+  </a>
+</nav>
       </article>
     </div>
   </main>

--- a/public/spec/adr/ADR-004-schema-driven-operations.html
+++ b/public/spec/adr/ADR-004-schema-driven-operations.html
@@ -1,0 +1,197 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Date: 2026-01-16">
+  <title>MCP-AQL Spec | ADR-004: Schema-Driven Operation Definitions</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../../css/style.css">
+</head>
+<body>
+  <header>
+    <div class="container">
+      <nav>
+        <a class="logo" href="../../index.html"><span class="logo-mark"></span>MCP-AQL</a>
+        <ul class="nav-links">
+          <li><a href="../../index.html">Home</a></li>
+          <li><a href="../../docs/index.html">Docs</a></li>
+          <li><a href="../../launch-checklist.html">Launch Checklist</a></li>
+          <li><a href="../../apis/mcp-server.html">Adapter Patterns</a></li>
+        </ul>
+        <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
+          <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
+          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <span class="search-count" data-search-count></span>
+          <ul class="search-results" data-search-results hidden></ul>
+        </form>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <div class="container docs-shell">
+      <aside class="docs-side">
+        <h2>Repo-Synced Spec</h2>
+        <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
+        <div class="docs-side-group">
+  <h3>Core</h3>
+  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Versions</h3>
+  <ul><li><a href="../versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Adapter</h3>
+  <ul><li><a href="../adapter/danger-levels.html">Dangerous Operation Classification Specification</a></li><li><a href="../adapter/discovery-bundle.html">MCP Server Discovery Bundle</a></li><li><a href="../adapter/element-type.html">Adapter Element Type Specification</a></li><li><a href="../adapter/generator.html">Adapter Generator Specification</a></li><li><a href="../adapter/rate-limiting.html">Rate Limiting and Quota Management Specification</a></li><li><a href="../adapter/trust-levels.html">Trust Levels Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Security</h3>
+  <ul><li><a href="../security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="../security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="../security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Features</h3>
+  <ul><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Guides</h3>
+  <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Process</h3>
+  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Architecture</h3>
+  <ul><li><a href="../architecture/README.html">Architecture Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Research</h3>
+  <ul><li><a href="../research/mcp-vs-mcpaql-vs-a2a.html">Protocol Landscape: MCP vs MCP-AQL vs A2A</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Reference</h3>
+  <ul><li><a href="../reference/README.html">Reference Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>ADRs</h3>
+  <ul><li><a href="ADR-001-crude-pattern.html">ADR-001: CRUDE Pattern (Extending CRUD with Execute)</a></li><li><a href="ADR-002-graphql-style-input.html">ADR-002: GraphQL-Style Input Objects for Updates</a></li><li><a href="ADR-003-snake-case-parameters.html">ADR-003: snake_case Parameter Convention</a></li><li><a class="current" href="ADR-004-schema-driven-operations.html">ADR-004: Schema-Driven Operation Definitions</a></li><li><a href="ADR-005-introspection-system.html">ADR-005: GraphQL-Style Introspection System</a></li><li><a href="ADR-006-discriminated-responses.html">ADR-006: Discriminated Response Format</a></li><li><a href="index.html">Architecture Decision Records</a></li><li><a href="README.html">Architecture Decision Records</a></li></ul>
+</div>
+      </aside>
+
+      <article class="docs-main">
+        <section class="hero docs-hero">
+          <div class="hero-inner">
+            <span class="status-pill">REPO-SYNCED SPEC DOC</span>
+            <h1>ADR-004: Schema-Driven Operation Definitions</h1>
+            <p class="lede">Date: 2026-01-16</p>
+            <div class="spec-meta"><span class="state-chip live">Support document</span><span class="state-chip pending">Accepted</span></div>
+            <p class="spec-source">Source: <a href="https://github.com/MCPAQL/spec/blob/main/docs/adr/ADR-004-schema-driven-operations.md">spec/docs/adr/ADR-004-schema-driven-operations.md</a></p>
+            <div class="hero-actions">
+              <a class="btn btn-primary" href="https://github.com/MCPAQL/spec/blob/main/docs/adr/ADR-004-schema-driven-operations.md">Open Source Markdown</a>
+              <a class="btn btn-secondary" href="../index.html">Browse Full Spec Reference</a>
+            </div>
+          </div>
+        </section>
+
+        <section>
+          <div class="card spec-prose">
+            <p><strong>Status:</strong> Accepted <strong>Date:</strong> 2026-01-16</p>
+<h2 id="context">Context</h2>
+<p>As the number of operations grows, maintaining consistency across routing, validation, introspection, and documentation becomes challenging. Imperative approaches (switch statements, manual dispatch) require updates in multiple locations when adding or modifying operations.</p>
+<p>Adding a new operation traditionally required:</p>
+<ol type="1">
+<li>Adding endpoint routing logic</li>
+<li>Adding dispatch/handler mapping</li>
+<li>Adding parameter definitions for validation</li>
+<li>Adding introspection metadata</li>
+<li>Adding documentation examples</li>
+</ol>
+<p>This distributed approach leads to:</p>
+<ul>
+<li>Inconsistencies between validation and documentation</li>
+<li>Forgotten updates in some locations</li>
+<li>Difficulty maintaining operation metadata</li>
+<li>Duplicated information across files</li>
+</ul>
+<h2 id="decision">Decision</h2>
+<p>MCP-AQL adopts a schema-driven approach where operations are defined declaratively in a single schema definition.</p>
+<p>Each operation definition MUST include:</p>
+<ul>
+<li><strong>endpoint</strong>: The CRUDE endpoint category (CREATE, READ, UPDATE, DELETE, EXECUTE)</li>
+<li><strong>description</strong>: Human-readable description of the operation</li>
+<li><strong>params</strong>: Parameter definitions with types and requirements</li>
+</ul>
+<p>Each operation definition SHOULD include:</p>
+<ul>
+<li><strong>returns</strong>: Return type specification</li>
+<li><strong>examples</strong>: Usage examples for documentation and introspection</li>
+</ul>
+<p>Example schema structure:</p>
+<div class="sourceCode" id="cb1"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb1-2"><a href="#cb1-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">browse_collection</span><span class="op">:</span> {</span>
+<span id="cb1-3"><a href="#cb1-3" aria-hidden="true" tabindex="-1"></a>    <span class="dt">endpoint</span><span class="op">:</span> <span class="st">&quot;READ&quot;</span><span class="op">,</span></span>
+<span id="cb1-4"><a href="#cb1-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">description</span><span class="op">:</span> <span class="st">&quot;Browse the community collection&quot;</span><span class="op">,</span></span>
+<span id="cb1-5"><a href="#cb1-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">params</span><span class="op">:</span> {</span>
+<span id="cb1-6"><a href="#cb1-6" aria-hidden="true" tabindex="-1"></a>      <span class="dt">section</span><span class="op">:</span> {</span>
+<span id="cb1-7"><a href="#cb1-7" aria-hidden="true" tabindex="-1"></a>        <span class="dt">type</span><span class="op">:</span> <span class="st">&quot;string&quot;</span><span class="op">,</span></span>
+<span id="cb1-8"><a href="#cb1-8" aria-hidden="true" tabindex="-1"></a>        <span class="dt">description</span><span class="op">:</span> <span class="st">&quot;Collection section to browse&quot;</span></span>
+<span id="cb1-9"><a href="#cb1-9" aria-hidden="true" tabindex="-1"></a>      }<span class="op">,</span></span>
+<span id="cb1-10"><a href="#cb1-10" aria-hidden="true" tabindex="-1"></a>      <span class="dt">type</span><span class="op">:</span> {</span>
+<span id="cb1-11"><a href="#cb1-11" aria-hidden="true" tabindex="-1"></a>        <span class="dt">type</span><span class="op">:</span> <span class="st">&quot;string&quot;</span><span class="op">,</span></span>
+<span id="cb1-12"><a href="#cb1-12" aria-hidden="true" tabindex="-1"></a>        <span class="dt">description</span><span class="op">:</span> <span class="st">&quot;Element type filter&quot;</span></span>
+<span id="cb1-13"><a href="#cb1-13" aria-hidden="true" tabindex="-1"></a>      }</span>
+<span id="cb1-14"><a href="#cb1-14" aria-hidden="true" tabindex="-1"></a>    }<span class="op">,</span></span>
+<span id="cb1-15"><a href="#cb1-15" aria-hidden="true" tabindex="-1"></a>    <span class="dt">returns</span><span class="op">:</span> {</span>
+<span id="cb1-16"><a href="#cb1-16" aria-hidden="true" tabindex="-1"></a>      <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;CollectionBrowseResult&quot;</span><span class="op">,</span></span>
+<span id="cb1-17"><a href="#cb1-17" aria-hidden="true" tabindex="-1"></a>      <span class="dt">kind</span><span class="op">:</span> <span class="st">&quot;object&quot;</span></span>
+<span id="cb1-18"><a href="#cb1-18" aria-hidden="true" tabindex="-1"></a>    }<span class="op">,</span></span>
+<span id="cb1-19"><a href="#cb1-19" aria-hidden="true" tabindex="-1"></a>    <span class="dt">examples</span><span class="op">:</span> [</span>
+<span id="cb1-20"><a href="#cb1-20" aria-hidden="true" tabindex="-1"></a>      <span class="st">&#39;{ operation: &quot;browse_collection&quot;, params: { section: &quot;personas&quot; } }&#39;</span></span>
+<span id="cb1-21"><a href="#cb1-21" aria-hidden="true" tabindex="-1"></a>    ]</span>
+<span id="cb1-22"><a href="#cb1-22" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb1-23"><a href="#cb1-23" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<p>Implementations MUST derive the following from the operation schema:</p>
+<ol type="1">
+<li>Endpoint routing decisions</li>
+<li>Parameter validation rules</li>
+<li>Introspection responses</li>
+<li>Type checking</li>
+</ol>
+<h2 id="consequences">Consequences</h2>
+<h3 id="positive">Positive</h3>
+<ul>
+<li><strong>Single source of truth</strong>: One location defines all operation metadata</li>
+<li><strong>Auto-generated introspection</strong>: Schema powers runtime discovery</li>
+<li><strong>Reduced boilerplate</strong>: No manual dispatch code for new operations</li>
+<li><strong>Consistency</strong>: Validation, routing, and documentation stay synchronized</li>
+<li><strong>Type safety</strong>: Schema definitions enable compile-time checking</li>
+</ul>
+<h3 id="negative">Negative</h3>
+<ul>
+<li><strong>Schema complexity</strong>: Large schemas can be difficult to navigate</li>
+<li><strong>Runtime overhead</strong>: Schema lookup adds minor processing cost</li>
+<li><strong>Learning curve</strong>: Contributors must understand schema format</li>
+<li><strong>Flexibility limits</strong>: Edge cases may require schema extensions</li>
+</ul>
+<h2 id="references">References</h2>
+<ul>
+<li><a href="../operations.html">Operations Reference</a></li>
+<li>ADR-005: Introspection System</li>
+<li>ADR-001: CRUDE Pattern</li>
+</ul>
+
+          </div>
+        </section>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div class="container">
+      <p>&copy; 2026 DollhouseMCP Inc. d/b/a Dollhouse Research. MCP-AQL public draft documentation portal.</p>
+      <div class="footer-links">
+        <a href="../../docs/index.html">Docs Library</a>
+        <a href="../index.html">Repo-Synced Spec</a>
+        <a href="https://github.com/MCPAQL">MCPAQL Organization</a>
+        <a href="https://dollhouseresearch.com">Dollhouse Research</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../../js/search.js"></script>
+</body>
+</html>

--- a/public/spec/adr/ADR-005-introspection-system.html
+++ b/public/spec/adr/ADR-005-introspection-system.html
@@ -23,7 +23,7 @@
         </ul>
         <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
-          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <input id="site-search-input" data-search-input type="search" placeholder="Search MCP-AQL docs, spec pages, and adapter patterns...">
           <span class="search-count" data-search-count></span>
           <ul class="search-results" data-search-results hidden></ul>
         </form>
@@ -68,7 +68,7 @@
   <ul><li><a href="../reference/README.html">Reference Documentation</a></li></ul>
 </div><div class="docs-side-group">
   <h3>ADRs</h3>
-  <ul><li><a href="ADR-001-crude-pattern.html">ADR-001: CRUDE Pattern (Extending CRUD with Execute)</a></li><li><a href="ADR-002-graphql-style-input.html">ADR-002: GraphQL-Style Input Objects for Updates</a></li><li><a href="ADR-003-snake-case-parameters.html">ADR-003: snake_case Parameter Convention</a></li><li><a href="ADR-004-schema-driven-operations.html">ADR-004: Schema-Driven Operation Definitions</a></li><li><a class="current" href="ADR-005-introspection-system.html">ADR-005: GraphQL-Style Introspection System</a></li><li><a href="ADR-006-discriminated-responses.html">ADR-006: Discriminated Response Format</a></li><li><a href="index.html">Architecture Decision Records</a></li><li><a href="README.html">Architecture Decision Records</a></li></ul>
+  <ul><li><a href="ADR-001-crude-pattern.html">ADR-001: CRUDE Pattern (Extending CRUD with Execute)</a></li><li><a href="ADR-002-graphql-style-input.html">ADR-002: GraphQL-Style Input Objects for Updates</a></li><li><a href="ADR-003-snake-case-parameters.html">ADR-003: snake_case Parameter Convention</a></li><li><a href="ADR-004-schema-driven-operations.html">ADR-004: Schema-Driven Operation Definitions</a></li><li><a class="current" aria-current="page" href="ADR-005-introspection-system.html">ADR-005: GraphQL-Style Introspection System</a></li><li><a href="ADR-006-discriminated-responses.html">ADR-006: Discriminated Response Format</a></li><li><a href="index.html">Architecture Decision Records</a></li><li><a href="README.html">Architecture Decision Records</a></li></ul>
 </div>
       </aside>
 
@@ -163,6 +163,16 @@
 
           </div>
         </section>
+        <nav class="page-nav" aria-label="Page navigation">
+  <a class="page-nav-link prev" href="ADR-004-schema-driven-operations.html">
+    <span class="page-nav-eyebrow">Previous spec page</span>
+    <strong class="page-nav-label">ADR-004: Schema-Driven Operation Definitions</strong>
+  </a>
+  <a class="page-nav-link next" href="ADR-006-discriminated-responses.html">
+    <span class="page-nav-eyebrow">Next spec page</span>
+    <strong class="page-nav-label">ADR-006: Discriminated Response Format</strong>
+  </a>
+</nav>
       </article>
     </div>
   </main>

--- a/public/spec/adr/ADR-005-introspection-system.html
+++ b/public/spec/adr/ADR-005-introspection-system.html
@@ -73,6 +73,13 @@
       </aside>
 
       <article class="docs-main">
+        <nav class="breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../../index.html">Home</a></li>
+            <li><a href="../index.html">Full Spec</a></li>
+            <li><span class="current">ADR-005: GraphQL-Style Introspection System</span></li>
+          </ol>
+        </nav>
         <section class="hero docs-hero">
           <div class="hero-inner">
             <span class="status-pill">REPO-SYNCED SPEC DOC</span>

--- a/public/spec/adr/ADR-005-introspection-system.html
+++ b/public/spec/adr/ADR-005-introspection-system.html
@@ -1,0 +1,177 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Date: 2026-01-16">
+  <title>MCP-AQL Spec | ADR-005: GraphQL-Style Introspection System</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../../css/style.css">
+</head>
+<body>
+  <header>
+    <div class="container">
+      <nav>
+        <a class="logo" href="../../index.html"><span class="logo-mark"></span>MCP-AQL</a>
+        <ul class="nav-links">
+          <li><a href="../../index.html">Home</a></li>
+          <li><a href="../../docs/index.html">Docs</a></li>
+          <li><a href="../../launch-checklist.html">Launch Checklist</a></li>
+          <li><a href="../../apis/mcp-server.html">Adapter Patterns</a></li>
+        </ul>
+        <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
+          <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
+          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <span class="search-count" data-search-count></span>
+          <ul class="search-results" data-search-results hidden></ul>
+        </form>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <div class="container docs-shell">
+      <aside class="docs-side">
+        <h2>Repo-Synced Spec</h2>
+        <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
+        <div class="docs-side-group">
+  <h3>Core</h3>
+  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Versions</h3>
+  <ul><li><a href="../versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Adapter</h3>
+  <ul><li><a href="../adapter/danger-levels.html">Dangerous Operation Classification Specification</a></li><li><a href="../adapter/discovery-bundle.html">MCP Server Discovery Bundle</a></li><li><a href="../adapter/element-type.html">Adapter Element Type Specification</a></li><li><a href="../adapter/generator.html">Adapter Generator Specification</a></li><li><a href="../adapter/rate-limiting.html">Rate Limiting and Quota Management Specification</a></li><li><a href="../adapter/trust-levels.html">Trust Levels Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Security</h3>
+  <ul><li><a href="../security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="../security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="../security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Features</h3>
+  <ul><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Guides</h3>
+  <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Process</h3>
+  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Architecture</h3>
+  <ul><li><a href="../architecture/README.html">Architecture Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Research</h3>
+  <ul><li><a href="../research/mcp-vs-mcpaql-vs-a2a.html">Protocol Landscape: MCP vs MCP-AQL vs A2A</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Reference</h3>
+  <ul><li><a href="../reference/README.html">Reference Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>ADRs</h3>
+  <ul><li><a href="ADR-001-crude-pattern.html">ADR-001: CRUDE Pattern (Extending CRUD with Execute)</a></li><li><a href="ADR-002-graphql-style-input.html">ADR-002: GraphQL-Style Input Objects for Updates</a></li><li><a href="ADR-003-snake-case-parameters.html">ADR-003: snake_case Parameter Convention</a></li><li><a href="ADR-004-schema-driven-operations.html">ADR-004: Schema-Driven Operation Definitions</a></li><li><a class="current" href="ADR-005-introspection-system.html">ADR-005: GraphQL-Style Introspection System</a></li><li><a href="ADR-006-discriminated-responses.html">ADR-006: Discriminated Response Format</a></li><li><a href="index.html">Architecture Decision Records</a></li><li><a href="README.html">Architecture Decision Records</a></li></ul>
+</div>
+      </aside>
+
+      <article class="docs-main">
+        <section class="hero docs-hero">
+          <div class="hero-inner">
+            <span class="status-pill">REPO-SYNCED SPEC DOC</span>
+            <h1>ADR-005: GraphQL-Style Introspection System</h1>
+            <p class="lede">Date: 2026-01-16</p>
+            <div class="spec-meta"><span class="state-chip live">Support document</span><span class="state-chip pending">Accepted</span></div>
+            <p class="spec-source">Source: <a href="https://github.com/MCPAQL/spec/blob/main/docs/adr/ADR-005-introspection-system.md">spec/docs/adr/ADR-005-introspection-system.md</a></p>
+            <div class="hero-actions">
+              <a class="btn btn-primary" href="https://github.com/MCPAQL/spec/blob/main/docs/adr/ADR-005-introspection-system.md">Open Source Markdown</a>
+              <a class="btn btn-secondary" href="../index.html">Browse Full Spec Reference</a>
+            </div>
+          </div>
+        </section>
+
+        <section>
+          <div class="card spec-prose">
+            <p><strong>Status:</strong> Accepted <strong>Date:</strong> 2026-01-16</p>
+<h2 id="context">Context</h2>
+<p>MCP-AQL consolidates many operations into a small number of semantic endpoints, achieving significant token reduction (~96%) compared to discrete tool definitions. However, this consolidation means LLMs cannot rely on tool schemas alone to discover available operations.</p>
+<p>With traditional MCP approaches using 40+ discrete tools, tool schemas can consume ~30,000 tokens of context. LLMs must parse all schemas upfront, leaving limited context for actual work.</p>
+<p>An alternative is needed that allows:</p>
+<ol type="1">
+<li>On-demand discovery of operations</li>
+<li>Minimal upfront token consumption</li>
+<li>Detailed information when needed</li>
+<li>Self-documenting API behavior</li>
+</ol>
+<h2 id="decision">Decision</h2>
+<p>MCP-AQL implements GraphQL-style introspection via the <code>introspect</code> operation on the READ endpoint.</p>
+<p>Implementations MUST support the <code>introspect</code> operation with the following query types:</p>
+<h3 id="operations-query">Operations Query</h3>
+<div class="sourceCode" id="cb1"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a><span class="co">// List all available operations</span></span>
+<span id="cb1-2"><a href="#cb1-2" aria-hidden="true" tabindex="-1"></a>{ <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;introspect&quot;</span><span class="op">,</span> <span class="dt">params</span><span class="op">:</span> { <span class="dt">query</span><span class="op">:</span> <span class="st">&quot;operations&quot;</span> } }</span>
+<span id="cb1-3"><a href="#cb1-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb1-4"><a href="#cb1-4" aria-hidden="true" tabindex="-1"></a><span class="co">// Get details for a specific operation</span></span>
+<span id="cb1-5"><a href="#cb1-5" aria-hidden="true" tabindex="-1"></a>{ <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;introspect&quot;</span><span class="op">,</span> <span class="dt">params</span><span class="op">:</span> { <span class="dt">query</span><span class="op">:</span> <span class="st">&quot;operations&quot;</span><span class="op">,</span> <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;create_element&quot;</span> } }</span></code></pre></div>
+<h3 id="types-query">Types Query</h3>
+<div class="sourceCode" id="cb2"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="co">// List all types</span></span>
+<span id="cb2-2"><a href="#cb2-2" aria-hidden="true" tabindex="-1"></a>{ <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;introspect&quot;</span><span class="op">,</span> <span class="dt">params</span><span class="op">:</span> { <span class="dt">query</span><span class="op">:</span> <span class="st">&quot;types&quot;</span> } }</span>
+<span id="cb2-3"><a href="#cb2-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb2-4"><a href="#cb2-4" aria-hidden="true" tabindex="-1"></a><span class="co">// Get details for a specific type</span></span>
+<span id="cb2-5"><a href="#cb2-5" aria-hidden="true" tabindex="-1"></a>{ <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;introspect&quot;</span><span class="op">,</span> <span class="dt">params</span><span class="op">:</span> { <span class="dt">query</span><span class="op">:</span> <span class="st">&quot;types&quot;</span><span class="op">,</span> <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;ElementType&quot;</span> } }</span></code></pre></div>
+<p>Introspection responses MUST include:</p>
+<ul>
+<li>Operation names and descriptions</li>
+<li>Parameter definitions with types and requirements</li>
+<li>Return type information</li>
+<li>Usage examples (when available)</li>
+</ul>
+<p>The introspection workflow enables progressive discovery:</p>
+<div class="sourceCode" id="cb3"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb3-1"><a href="#cb3-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Step 1: Quick discovery (~50 tokens)</span></span>
+<span id="cb3-2"><a href="#cb3-2" aria-hidden="true" tabindex="-1"></a>{ <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;introspect&quot;</span><span class="op">,</span> <span class="dt">params</span><span class="op">:</span> { <span class="dt">query</span><span class="op">:</span> <span class="st">&quot;operations&quot;</span> } }</span>
+<span id="cb3-3"><a href="#cb3-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb3-4"><a href="#cb3-4" aria-hidden="true" tabindex="-1"></a><span class="co">// Step 2: Get details for relevant operation (~100 tokens)</span></span>
+<span id="cb3-5"><a href="#cb3-5" aria-hidden="true" tabindex="-1"></a>{ <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;introspect&quot;</span><span class="op">,</span> <span class="dt">params</span><span class="op">:</span> { <span class="dt">query</span><span class="op">:</span> <span class="st">&quot;operations&quot;</span><span class="op">,</span> <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;create_element&quot;</span> } }</span>
+<span id="cb3-6"><a href="#cb3-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb3-7"><a href="#cb3-7" aria-hidden="true" tabindex="-1"></a><span class="co">// Step 3: Use the operation with knowledge of parameters</span></span>
+<span id="cb3-8"><a href="#cb3-8" aria-hidden="true" tabindex="-1"></a>{ <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;create_element&quot;</span><span class="op">,</span> <span class="dt">element_type</span><span class="op">:</span> <span class="st">&quot;persona&quot;</span><span class="op">,</span> <span class="dt">params</span><span class="op">:</span> { <span class="op">...</span> } }</span></code></pre></div>
+<h2 id="consequences">Consequences</h2>
+<h3 id="positive">Positive</h3>
+<ul>
+<li><strong>Token efficiency</strong>: LLMs discover operations on-demand rather than parsing all upfront</li>
+<li><strong>Dynamic discovery</strong>: Available operations can vary by context or permissions</li>
+<li><strong>Self-documenting</strong>: API describes itself without external documentation</li>
+<li><strong>Familiar pattern</strong>: GraphQL introspection is a known paradigm</li>
+<li><strong>Graceful degradation</strong>: LLMs can work with partial knowledge</li>
+</ul>
+<h3 id="negative">Negative</h3>
+<ul>
+<li><strong>Multi-step discovery</strong>: LLMs may need multiple requests to understand the API</li>
+<li><strong>Runtime dependency</strong>: Discovery requires API availability</li>
+<li><strong>Caching complexity</strong>: Clients may need to cache introspection results</li>
+<li><strong>Incomplete discovery</strong>: LLMs might miss operations they do not explicitly query</li>
+</ul>
+<h2 id="references">References</h2>
+<ul>
+<li><a href="../introspection.html">Introspection Specification</a></li>
+<li>ADR-004: Schema-Driven Operation Definitions</li>
+<li>ADR-001: CRUDE Pattern</li>
+</ul>
+
+          </div>
+        </section>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div class="container">
+      <p>&copy; 2026 DollhouseMCP Inc. d/b/a Dollhouse Research. MCP-AQL public draft documentation portal.</p>
+      <div class="footer-links">
+        <a href="../../docs/index.html">Docs Library</a>
+        <a href="../index.html">Repo-Synced Spec</a>
+        <a href="https://github.com/MCPAQL">MCPAQL Organization</a>
+        <a href="https://dollhouseresearch.com">Dollhouse Research</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../../js/search.js"></script>
+</body>
+</html>

--- a/public/spec/adr/ADR-005-introspection-system.html
+++ b/public/spec/adr/ADR-005-introspection-system.html
@@ -38,7 +38,7 @@
         <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
         <div class="docs-side-group">
   <h3>Core</h3>
-  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li></ul>
+  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li><li><a href="../repo/README.html">MCP-AQL Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Versions</h3>
   <ul><li><a href="../versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
@@ -56,7 +56,7 @@
   <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
-  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li></ul>
+  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li><li><a href="../repo/CHANGELOG.html">Changelog</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Architecture</h3>
   <ul><li><a href="../architecture/README.html">Architecture Documentation</a></li></ul>

--- a/public/spec/adr/ADR-006-discriminated-responses.html
+++ b/public/spec/adr/ADR-006-discriminated-responses.html
@@ -1,0 +1,189 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Date: 2026-01-16">
+  <title>MCP-AQL Spec | ADR-006: Discriminated Response Format</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../../css/style.css">
+</head>
+<body>
+  <header>
+    <div class="container">
+      <nav>
+        <a class="logo" href="../../index.html"><span class="logo-mark"></span>MCP-AQL</a>
+        <ul class="nav-links">
+          <li><a href="../../index.html">Home</a></li>
+          <li><a href="../../docs/index.html">Docs</a></li>
+          <li><a href="../../launch-checklist.html">Launch Checklist</a></li>
+          <li><a href="../../apis/mcp-server.html">Adapter Patterns</a></li>
+        </ul>
+        <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
+          <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
+          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <span class="search-count" data-search-count></span>
+          <ul class="search-results" data-search-results hidden></ul>
+        </form>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <div class="container docs-shell">
+      <aside class="docs-side">
+        <h2>Repo-Synced Spec</h2>
+        <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
+        <div class="docs-side-group">
+  <h3>Core</h3>
+  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Versions</h3>
+  <ul><li><a href="../versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Adapter</h3>
+  <ul><li><a href="../adapter/danger-levels.html">Dangerous Operation Classification Specification</a></li><li><a href="../adapter/discovery-bundle.html">MCP Server Discovery Bundle</a></li><li><a href="../adapter/element-type.html">Adapter Element Type Specification</a></li><li><a href="../adapter/generator.html">Adapter Generator Specification</a></li><li><a href="../adapter/rate-limiting.html">Rate Limiting and Quota Management Specification</a></li><li><a href="../adapter/trust-levels.html">Trust Levels Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Security</h3>
+  <ul><li><a href="../security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="../security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="../security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Features</h3>
+  <ul><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Guides</h3>
+  <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Process</h3>
+  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Architecture</h3>
+  <ul><li><a href="../architecture/README.html">Architecture Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Research</h3>
+  <ul><li><a href="../research/mcp-vs-mcpaql-vs-a2a.html">Protocol Landscape: MCP vs MCP-AQL vs A2A</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Reference</h3>
+  <ul><li><a href="../reference/README.html">Reference Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>ADRs</h3>
+  <ul><li><a href="ADR-001-crude-pattern.html">ADR-001: CRUDE Pattern (Extending CRUD with Execute)</a></li><li><a href="ADR-002-graphql-style-input.html">ADR-002: GraphQL-Style Input Objects for Updates</a></li><li><a href="ADR-003-snake-case-parameters.html">ADR-003: snake_case Parameter Convention</a></li><li><a href="ADR-004-schema-driven-operations.html">ADR-004: Schema-Driven Operation Definitions</a></li><li><a href="ADR-005-introspection-system.html">ADR-005: GraphQL-Style Introspection System</a></li><li><a class="current" href="ADR-006-discriminated-responses.html">ADR-006: Discriminated Response Format</a></li><li><a href="index.html">Architecture Decision Records</a></li><li><a href="README.html">Architecture Decision Records</a></li></ul>
+</div>
+      </aside>
+
+      <article class="docs-main">
+        <section class="hero docs-hero">
+          <div class="hero-inner">
+            <span class="status-pill">REPO-SYNCED SPEC DOC</span>
+            <h1>ADR-006: Discriminated Response Format</h1>
+            <p class="lede">Date: 2026-01-16</p>
+            <div class="spec-meta"><span class="state-chip live">Support document</span><span class="state-chip pending">Accepted</span></div>
+            <p class="spec-source">Source: <a href="https://github.com/MCPAQL/spec/blob/main/docs/adr/ADR-006-discriminated-responses.md">spec/docs/adr/ADR-006-discriminated-responses.md</a></p>
+            <div class="hero-actions">
+              <a class="btn btn-primary" href="https://github.com/MCPAQL/spec/blob/main/docs/adr/ADR-006-discriminated-responses.md">Open Source Markdown</a>
+              <a class="btn btn-secondary" href="../index.html">Browse Full Spec Reference</a>
+            </div>
+          </div>
+        </section>
+
+        <section>
+          <div class="card spec-prose">
+            <p><strong>Status:</strong> Accepted <strong>Date:</strong> 2026-01-16</p>
+<h2 id="context">Context</h2>
+<p>API responses need to clearly indicate success or failure in a way that is:</p>
+<ol type="1">
+<li>Unambiguous for programmatic handling</li>
+<li>Easy for LLMs to parse and understand</li>
+<li>Consistent across all operations</li>
+<li>Informative when errors occur</li>
+</ol>
+<p>Common approaches include:</p>
+<ul>
+<li>HTTP status codes (not applicable to MCP tool responses)</li>
+<li>Exception throwing (varies by implementation)</li>
+<li>Null/undefined returns (ambiguous)</li>
+<li>Boolean success flags (lacks error details)</li>
+<li>Discriminated unions (explicit success/failure with data)</li>
+</ul>
+<p>LLMs particularly benefit from explicit, consistent response structures that do not require inference about success or failure states.</p>
+<h2 id="decision">Decision</h2>
+<p>MCP-AQL adopts a discriminated response format where all responses include an explicit <code>success</code> boolean discriminator.</p>
+<p>Successful responses MUST have the following structure:</p>
+<div class="sourceCode" id="cb1"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb1-2"><a href="#cb1-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">success</span><span class="op">:</span> <span class="kw">true</span><span class="op">,</span></span>
+<span id="cb1-3"><a href="#cb1-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">data</span><span class="op">:</span> { <span class="co">/* operation-specific response data */</span> }<span class="op">,</span></span>
+<span id="cb1-4"><a href="#cb1-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">warnings</span><span class="op">:</span> [ <span class="co">/* optional array of warning objects */</span> ]</span>
+<span id="cb1-5"><a href="#cb1-5" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<p>The <code>warnings</code> field is optional and contains non-fatal conditions that warrant attention. See the <a href="../features/warnings.html">Warnings Specification</a> for details.</p>
+<p>Failed responses MUST have the following structure:</p>
+<div class="sourceCode" id="cb2"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb2-2"><a href="#cb2-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">success</span><span class="op">:</span> <span class="kw">false</span><span class="op">,</span></span>
+<span id="cb2-3"><a href="#cb2-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">error</span><span class="op">:</span> {</span>
+<span id="cb2-4"><a href="#cb2-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">code</span><span class="op">:</span> <span class="st">&quot;ERROR_CODE&quot;</span><span class="op">,</span></span>
+<span id="cb2-5"><a href="#cb2-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">message</span><span class="op">:</span> <span class="st">&quot;Human-readable error description&quot;</span></span>
+<span id="cb2-6"><a href="#cb2-6" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb2-7"><a href="#cb2-7" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<p>Additional fields MAY be included in error responses for debugging:</p>
+<div class="sourceCode" id="cb3"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb3-1"><a href="#cb3-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb3-2"><a href="#cb3-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">success</span><span class="op">:</span> <span class="kw">false</span><span class="op">,</span></span>
+<span id="cb3-3"><a href="#cb3-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">error</span><span class="op">:</span> {</span>
+<span id="cb3-4"><a href="#cb3-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">code</span><span class="op">:</span> <span class="st">&quot;VALIDATION_ERROR&quot;</span><span class="op">,</span></span>
+<span id="cb3-5"><a href="#cb3-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">message</span><span class="op">:</span> <span class="st">&quot;Required parameter &#39;element_name&#39; is missing&quot;</span><span class="op">,</span></span>
+<span id="cb3-6"><a href="#cb3-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">details</span><span class="op">:</span> {</span>
+<span id="cb3-7"><a href="#cb3-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">parameter</span><span class="op">:</span> <span class="st">&quot;element_name&quot;</span><span class="op">,</span></span>
+<span id="cb3-8"><a href="#cb3-8" aria-hidden="true" tabindex="-1"></a>      <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;create_element&quot;</span></span>
+<span id="cb3-9"><a href="#cb3-9" aria-hidden="true" tabindex="-1"></a>    }</span>
+<span id="cb3-10"><a href="#cb3-10" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb3-11"><a href="#cb3-11" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<p>Implementations MUST:</p>
+<ol type="1">
+<li>Always include the <code>success</code> boolean at the top level</li>
+<li>Include <code>data</code> when <code>success</code> is true</li>
+<li>Include <code>error</code> with at least <code>code</code> and <code>message</code> when <code>success</code> is false</li>
+<li>Use consistent error codes across the implementation</li>
+<li>Include <code>warnings</code> array only in successful responses (when present)</li>
+</ol>
+<h2 id="consequences">Consequences</h2>
+<h3 id="positive">Positive</h3>
+<ul>
+<li><strong>Unambiguous parsing</strong>: The <code>success</code> field clearly indicates response state</li>
+<li><strong>LLM-friendly</strong>: Explicit structure is easy for models to understand</li>
+<li><strong>Consistent handling</strong>: All operations return the same response shape</li>
+<li><strong>Rich error information</strong>: Structured errors enable better debugging</li>
+<li><strong>Type safety</strong>: Discriminated unions enable compile-time type narrowing</li>
+</ul>
+<h3 id="negative">Negative</h3>
+<ul>
+<li><strong>Response overhead</strong>: Every response includes the discriminator</li>
+<li><strong>Verbosity</strong>: Simple operations have wrapper structure</li>
+<li><strong>Migration effort</strong>: Existing implementations must adapt response format</li>
+</ul>
+<h2 id="references">References</h2>
+<ul>
+<li><a href="../features/warnings.html">Warnings Specification</a></li>
+<li><a href="../error-codes.html">Error Codes Specification</a></li>
+<li>ADR-004: Schema-Driven Operation Definitions</li>
+</ul>
+
+          </div>
+        </section>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div class="container">
+      <p>&copy; 2026 DollhouseMCP Inc. d/b/a Dollhouse Research. MCP-AQL public draft documentation portal.</p>
+      <div class="footer-links">
+        <a href="../../docs/index.html">Docs Library</a>
+        <a href="../index.html">Repo-Synced Spec</a>
+        <a href="https://github.com/MCPAQL">MCPAQL Organization</a>
+        <a href="https://dollhouseresearch.com">Dollhouse Research</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../../js/search.js"></script>
+</body>
+</html>

--- a/public/spec/adr/ADR-006-discriminated-responses.html
+++ b/public/spec/adr/ADR-006-discriminated-responses.html
@@ -73,6 +73,13 @@
       </aside>
 
       <article class="docs-main">
+        <nav class="breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../../index.html">Home</a></li>
+            <li><a href="../index.html">Full Spec</a></li>
+            <li><span class="current">ADR-006: Discriminated Response Format</span></li>
+          </ol>
+        </nav>
         <section class="hero docs-hero">
           <div class="hero-inner">
             <span class="status-pill">REPO-SYNCED SPEC DOC</span>

--- a/public/spec/adr/ADR-006-discriminated-responses.html
+++ b/public/spec/adr/ADR-006-discriminated-responses.html
@@ -23,7 +23,7 @@
         </ul>
         <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
-          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <input id="site-search-input" data-search-input type="search" placeholder="Search MCP-AQL docs, spec pages, and adapter patterns...">
           <span class="search-count" data-search-count></span>
           <ul class="search-results" data-search-results hidden></ul>
         </form>
@@ -68,7 +68,7 @@
   <ul><li><a href="../reference/README.html">Reference Documentation</a></li></ul>
 </div><div class="docs-side-group">
   <h3>ADRs</h3>
-  <ul><li><a href="ADR-001-crude-pattern.html">ADR-001: CRUDE Pattern (Extending CRUD with Execute)</a></li><li><a href="ADR-002-graphql-style-input.html">ADR-002: GraphQL-Style Input Objects for Updates</a></li><li><a href="ADR-003-snake-case-parameters.html">ADR-003: snake_case Parameter Convention</a></li><li><a href="ADR-004-schema-driven-operations.html">ADR-004: Schema-Driven Operation Definitions</a></li><li><a href="ADR-005-introspection-system.html">ADR-005: GraphQL-Style Introspection System</a></li><li><a class="current" href="ADR-006-discriminated-responses.html">ADR-006: Discriminated Response Format</a></li><li><a href="index.html">Architecture Decision Records</a></li><li><a href="README.html">Architecture Decision Records</a></li></ul>
+  <ul><li><a href="ADR-001-crude-pattern.html">ADR-001: CRUDE Pattern (Extending CRUD with Execute)</a></li><li><a href="ADR-002-graphql-style-input.html">ADR-002: GraphQL-Style Input Objects for Updates</a></li><li><a href="ADR-003-snake-case-parameters.html">ADR-003: snake_case Parameter Convention</a></li><li><a href="ADR-004-schema-driven-operations.html">ADR-004: Schema-Driven Operation Definitions</a></li><li><a href="ADR-005-introspection-system.html">ADR-005: GraphQL-Style Introspection System</a></li><li><a class="current" aria-current="page" href="ADR-006-discriminated-responses.html">ADR-006: Discriminated Response Format</a></li><li><a href="index.html">Architecture Decision Records</a></li><li><a href="README.html">Architecture Decision Records</a></li></ul>
 </div>
       </aside>
 
@@ -175,6 +175,16 @@
 
           </div>
         </section>
+        <nav class="page-nav" aria-label="Page navigation">
+  <a class="page-nav-link prev" href="ADR-005-introspection-system.html">
+    <span class="page-nav-eyebrow">Previous spec page</span>
+    <strong class="page-nav-label">ADR-005: GraphQL-Style Introspection System</strong>
+  </a>
+  <a class="page-nav-link next" href="index.html">
+    <span class="page-nav-eyebrow">Next spec page</span>
+    <strong class="page-nav-label">Architecture Decision Records</strong>
+  </a>
+</nav>
       </article>
     </div>
   </main>

--- a/public/spec/adr/ADR-006-discriminated-responses.html
+++ b/public/spec/adr/ADR-006-discriminated-responses.html
@@ -38,7 +38,7 @@
         <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
         <div class="docs-side-group">
   <h3>Core</h3>
-  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li></ul>
+  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li><li><a href="../repo/README.html">MCP-AQL Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Versions</h3>
   <ul><li><a href="../versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
@@ -56,7 +56,7 @@
   <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
-  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li></ul>
+  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li><li><a href="../repo/CHANGELOG.html">Changelog</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Architecture</h3>
   <ul><li><a href="../architecture/README.html">Architecture Documentation</a></li></ul>

--- a/public/spec/adr/README.html
+++ b/public/spec/adr/README.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="See index.md for the complete list of ADRs.">
+  <title>MCP-AQL Spec | Architecture Decision Records</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../../css/style.css">
+</head>
+<body>
+  <header>
+    <div class="container">
+      <nav>
+        <a class="logo" href="../../index.html"><span class="logo-mark"></span>MCP-AQL</a>
+        <ul class="nav-links">
+          <li><a href="../../index.html">Home</a></li>
+          <li><a href="../../docs/index.html">Docs</a></li>
+          <li><a href="../../launch-checklist.html">Launch Checklist</a></li>
+          <li><a href="../../apis/mcp-server.html">Adapter Patterns</a></li>
+        </ul>
+        <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
+          <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
+          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <span class="search-count" data-search-count></span>
+          <ul class="search-results" data-search-results hidden></ul>
+        </form>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <div class="container docs-shell">
+      <aside class="docs-side">
+        <h2>Repo-Synced Spec</h2>
+        <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
+        <div class="docs-side-group">
+  <h3>Core</h3>
+  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Versions</h3>
+  <ul><li><a href="../versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Adapter</h3>
+  <ul><li><a href="../adapter/danger-levels.html">Dangerous Operation Classification Specification</a></li><li><a href="../adapter/discovery-bundle.html">MCP Server Discovery Bundle</a></li><li><a href="../adapter/element-type.html">Adapter Element Type Specification</a></li><li><a href="../adapter/generator.html">Adapter Generator Specification</a></li><li><a href="../adapter/rate-limiting.html">Rate Limiting and Quota Management Specification</a></li><li><a href="../adapter/trust-levels.html">Trust Levels Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Security</h3>
+  <ul><li><a href="../security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="../security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="../security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Features</h3>
+  <ul><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Guides</h3>
+  <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Process</h3>
+  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Architecture</h3>
+  <ul><li><a href="../architecture/README.html">Architecture Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Research</h3>
+  <ul><li><a href="../research/mcp-vs-mcpaql-vs-a2a.html">Protocol Landscape: MCP vs MCP-AQL vs A2A</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Reference</h3>
+  <ul><li><a href="../reference/README.html">Reference Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>ADRs</h3>
+  <ul><li><a href="ADR-001-crude-pattern.html">ADR-001: CRUDE Pattern (Extending CRUD with Execute)</a></li><li><a href="ADR-002-graphql-style-input.html">ADR-002: GraphQL-Style Input Objects for Updates</a></li><li><a href="ADR-003-snake-case-parameters.html">ADR-003: snake_case Parameter Convention</a></li><li><a href="ADR-004-schema-driven-operations.html">ADR-004: Schema-Driven Operation Definitions</a></li><li><a href="ADR-005-introspection-system.html">ADR-005: GraphQL-Style Introspection System</a></li><li><a href="ADR-006-discriminated-responses.html">ADR-006: Discriminated Response Format</a></li><li><a href="index.html">Architecture Decision Records</a></li><li><a class="current" href="README.html">Architecture Decision Records</a></li></ul>
+</div>
+      </aside>
+
+      <article class="docs-main">
+        <section class="hero docs-hero">
+          <div class="hero-inner">
+            <span class="status-pill">REPO-SYNCED SPEC DOC</span>
+            <h1>Architecture Decision Records</h1>
+            <p class="lede">See index.md for the complete list of ADRs.</p>
+            <div class="spec-meta"><span class="state-chip live">Support document</span></div>
+            <p class="spec-source">Source: <a href="https://github.com/MCPAQL/spec/blob/main/docs/adr/README.md">spec/docs/adr/README.md</a></p>
+            <div class="hero-actions">
+              <a class="btn btn-primary" href="https://github.com/MCPAQL/spec/blob/main/docs/adr/README.md">Open Source Markdown</a>
+              <a class="btn btn-secondary" href="../index.html">Browse Full Spec Reference</a>
+            </div>
+          </div>
+        </section>
+
+        <section>
+          <div class="card spec-prose">
+            <p>See <a href="index.html">index.md</a> for the complete list of ADRs.</p>
+
+          </div>
+        </section>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div class="container">
+      <p>&copy; 2026 DollhouseMCP Inc. d/b/a Dollhouse Research. MCP-AQL public draft documentation portal.</p>
+      <div class="footer-links">
+        <a href="../../docs/index.html">Docs Library</a>
+        <a href="../index.html">Repo-Synced Spec</a>
+        <a href="https://github.com/MCPAQL">MCPAQL Organization</a>
+        <a href="https://dollhouseresearch.com">Dollhouse Research</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../../js/search.js"></script>
+</body>
+</html>

--- a/public/spec/adr/README.html
+++ b/public/spec/adr/README.html
@@ -73,6 +73,13 @@
       </aside>
 
       <article class="docs-main">
+        <nav class="breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../../index.html">Home</a></li>
+            <li><a href="../index.html">Full Spec</a></li>
+            <li><span class="current">Architecture Decision Records</span></li>
+          </ol>
+        </nav>
         <section class="hero docs-hero">
           <div class="hero-inner">
             <span class="status-pill">REPO-SYNCED SPEC DOC</span>

--- a/public/spec/adr/README.html
+++ b/public/spec/adr/README.html
@@ -38,7 +38,7 @@
         <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
         <div class="docs-side-group">
   <h3>Core</h3>
-  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li></ul>
+  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li><li><a href="../repo/README.html">MCP-AQL Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Versions</h3>
   <ul><li><a href="../versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
@@ -56,7 +56,7 @@
   <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
-  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li></ul>
+  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li><li><a href="../repo/CHANGELOG.html">Changelog</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Architecture</h3>
   <ul><li><a href="../architecture/README.html">Architecture Documentation</a></li></ul>

--- a/public/spec/adr/README.html
+++ b/public/spec/adr/README.html
@@ -23,7 +23,7 @@
         </ul>
         <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
-          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <input id="site-search-input" data-search-input type="search" placeholder="Search MCP-AQL docs, spec pages, and adapter patterns...">
           <span class="search-count" data-search-count></span>
           <ul class="search-results" data-search-results hidden></ul>
         </form>
@@ -68,7 +68,7 @@
   <ul><li><a href="../reference/README.html">Reference Documentation</a></li></ul>
 </div><div class="docs-side-group">
   <h3>ADRs</h3>
-  <ul><li><a href="ADR-001-crude-pattern.html">ADR-001: CRUDE Pattern (Extending CRUD with Execute)</a></li><li><a href="ADR-002-graphql-style-input.html">ADR-002: GraphQL-Style Input Objects for Updates</a></li><li><a href="ADR-003-snake-case-parameters.html">ADR-003: snake_case Parameter Convention</a></li><li><a href="ADR-004-schema-driven-operations.html">ADR-004: Schema-Driven Operation Definitions</a></li><li><a href="ADR-005-introspection-system.html">ADR-005: GraphQL-Style Introspection System</a></li><li><a href="ADR-006-discriminated-responses.html">ADR-006: Discriminated Response Format</a></li><li><a href="index.html">Architecture Decision Records</a></li><li><a class="current" href="README.html">Architecture Decision Records</a></li></ul>
+  <ul><li><a href="ADR-001-crude-pattern.html">ADR-001: CRUDE Pattern (Extending CRUD with Execute)</a></li><li><a href="ADR-002-graphql-style-input.html">ADR-002: GraphQL-Style Input Objects for Updates</a></li><li><a href="ADR-003-snake-case-parameters.html">ADR-003: snake_case Parameter Convention</a></li><li><a href="ADR-004-schema-driven-operations.html">ADR-004: Schema-Driven Operation Definitions</a></li><li><a href="ADR-005-introspection-system.html">ADR-005: GraphQL-Style Introspection System</a></li><li><a href="ADR-006-discriminated-responses.html">ADR-006: Discriminated Response Format</a></li><li><a href="index.html">Architecture Decision Records</a></li><li><a class="current" aria-current="page" href="README.html">Architecture Decision Records</a></li></ul>
 </div>
       </aside>
 
@@ -100,6 +100,16 @@
 
           </div>
         </section>
+        <nav class="page-nav" aria-label="Page navigation">
+  <a class="page-nav-link prev" href="index.html">
+    <span class="page-nav-eyebrow">Previous spec page</span>
+    <strong class="page-nav-label">Architecture Decision Records</strong>
+  </a>
+  <a class="page-nav-link next" href="../index.html">
+    <span class="page-nav-eyebrow">Back to index</span>
+    <strong class="page-nav-label">Full Spec Reference</strong>
+  </a>
+</nav>
       </article>
     </div>
   </main>

--- a/public/spec/adr/index.html
+++ b/public/spec/adr/index.html
@@ -1,0 +1,197 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="This directory contains Architecture Decision Records (ADRs) documenting significant design decisions in the MCP-AQL protocol specification.">
+  <title>MCP-AQL Spec | Architecture Decision Records</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../../css/style.css">
+</head>
+<body>
+  <header>
+    <div class="container">
+      <nav>
+        <a class="logo" href="../../index.html"><span class="logo-mark"></span>MCP-AQL</a>
+        <ul class="nav-links">
+          <li><a href="../../index.html">Home</a></li>
+          <li><a href="../../docs/index.html">Docs</a></li>
+          <li><a href="../../launch-checklist.html">Launch Checklist</a></li>
+          <li><a href="../../apis/mcp-server.html">Adapter Patterns</a></li>
+        </ul>
+        <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
+          <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
+          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <span class="search-count" data-search-count></span>
+          <ul class="search-results" data-search-results hidden></ul>
+        </form>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <div class="container docs-shell">
+      <aside class="docs-side">
+        <h2>Repo-Synced Spec</h2>
+        <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
+        <div class="docs-side-group">
+  <h3>Core</h3>
+  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Versions</h3>
+  <ul><li><a href="../versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Adapter</h3>
+  <ul><li><a href="../adapter/danger-levels.html">Dangerous Operation Classification Specification</a></li><li><a href="../adapter/discovery-bundle.html">MCP Server Discovery Bundle</a></li><li><a href="../adapter/element-type.html">Adapter Element Type Specification</a></li><li><a href="../adapter/generator.html">Adapter Generator Specification</a></li><li><a href="../adapter/rate-limiting.html">Rate Limiting and Quota Management Specification</a></li><li><a href="../adapter/trust-levels.html">Trust Levels Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Security</h3>
+  <ul><li><a href="../security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="../security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="../security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Features</h3>
+  <ul><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Guides</h3>
+  <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Process</h3>
+  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Architecture</h3>
+  <ul><li><a href="../architecture/README.html">Architecture Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Research</h3>
+  <ul><li><a href="../research/mcp-vs-mcpaql-vs-a2a.html">Protocol Landscape: MCP vs MCP-AQL vs A2A</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Reference</h3>
+  <ul><li><a href="../reference/README.html">Reference Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>ADRs</h3>
+  <ul><li><a href="ADR-001-crude-pattern.html">ADR-001: CRUDE Pattern (Extending CRUD with Execute)</a></li><li><a href="ADR-002-graphql-style-input.html">ADR-002: GraphQL-Style Input Objects for Updates</a></li><li><a href="ADR-003-snake-case-parameters.html">ADR-003: snake_case Parameter Convention</a></li><li><a href="ADR-004-schema-driven-operations.html">ADR-004: Schema-Driven Operation Definitions</a></li><li><a href="ADR-005-introspection-system.html">ADR-005: GraphQL-Style Introspection System</a></li><li><a href="ADR-006-discriminated-responses.html">ADR-006: Discriminated Response Format</a></li><li><a class="current" href="index.html">Architecture Decision Records</a></li><li><a href="README.html">Architecture Decision Records</a></li></ul>
+</div>
+      </aside>
+
+      <article class="docs-main">
+        <section class="hero docs-hero">
+          <div class="hero-inner">
+            <span class="status-pill">REPO-SYNCED SPEC DOC</span>
+            <h1>Architecture Decision Records</h1>
+            <p class="lede">This directory contains Architecture Decision Records (ADRs) documenting significant design decisions in the MCP-AQL protocol specification.</p>
+            <div class="spec-meta"><span class="state-chip live">Support document</span><span class="state-chip pending">Accepted | Proposed | Deprecated | Superseded</span></div>
+            <p class="spec-source">Source: <a href="https://github.com/MCPAQL/spec/blob/main/docs/adr/index.md">spec/docs/adr/index.md</a></p>
+            <div class="hero-actions">
+              <a class="btn btn-primary" href="https://github.com/MCPAQL/spec/blob/main/docs/adr/index.md">Open Source Markdown</a>
+              <a class="btn btn-secondary" href="../index.html">Browse Full Spec Reference</a>
+            </div>
+          </div>
+        </section>
+
+        <section>
+          <div class="card spec-prose">
+            <p>This directory contains Architecture Decision Records (ADRs) documenting significant design decisions in the MCP-AQL protocol specification.</p>
+<h2 id="adr-index">ADR Index</h2>
+<table>
+<thead>
+<tr>
+<th>ADR</th>
+<th>Title</th>
+<th>Status</th>
+<th>Summary</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a href="ADR-001-crude-pattern.html">ADR-001</a></td>
+<td>CRUDE Pattern</td>
+<td>Accepted</td>
+<td>Extends CRUD with Execute endpoint for runtime operations</td>
+</tr>
+<tr>
+<td><a href="ADR-002-graphql-style-input.html">ADR-002</a></td>
+<td>GraphQL-Style Input Objects</td>
+<td>Accepted</td>
+<td>Nested <code>input</code> objects for update operations</td>
+</tr>
+<tr>
+<td><a href="ADR-003-snake-case-parameters.html">ADR-003</a></td>
+<td>snake_case Parameters</td>
+<td>Accepted</td>
+<td>Standardizes on snake_case for LLM compatibility</td>
+</tr>
+<tr>
+<td><a href="ADR-004-schema-driven-operations.html">ADR-004</a></td>
+<td>Schema-Driven Operations</td>
+<td>Accepted</td>
+<td>Declarative operation definitions as single source of truth</td>
+</tr>
+<tr>
+<td><a href="ADR-005-introspection-system.html">ADR-005</a></td>
+<td>Introspection System</td>
+<td>Accepted</td>
+<td>GraphQL-style runtime discovery via <code>introspect</code> operation</td>
+</tr>
+<tr>
+<td><a href="ADR-006-discriminated-responses.html">ADR-006</a></td>
+<td>Discriminated Responses</td>
+<td>Accepted</td>
+<td><code>{ success, data }</code> or <code>{ success, error }</code> response format</td>
+</tr>
+</tbody>
+</table>
+<h2 id="adr-format">ADR Format</h2>
+<p>Each ADR follows this structure:</p>
+<div class="sourceCode" id="cb1"><pre class="sourceCode markdown"><code class="sourceCode markdown"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a><span class="fu"># ADR-NNN: Title</span></span>
+<span id="cb1-2"><a href="#cb1-2" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb1-3"><a href="#cb1-3" aria-hidden="true" tabindex="-1"></a>**Status:** Accepted | Proposed | Deprecated | Superseded</span>
+<span id="cb1-4"><a href="#cb1-4" aria-hidden="true" tabindex="-1"></a>**Date:** YYYY-MM-DD</span>
+<span id="cb1-5"><a href="#cb1-5" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb1-6"><a href="#cb1-6" aria-hidden="true" tabindex="-1"></a><span class="fu">## Context</span></span>
+<span id="cb1-7"><a href="#cb1-7" aria-hidden="true" tabindex="-1"></a><span class="co">[</span><span class="ot">Why this decision was needed</span><span class="co">]</span></span>
+<span id="cb1-8"><a href="#cb1-8" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb1-9"><a href="#cb1-9" aria-hidden="true" tabindex="-1"></a><span class="fu">## Decision</span></span>
+<span id="cb1-10"><a href="#cb1-10" aria-hidden="true" tabindex="-1"></a><span class="co">[</span><span class="ot">What was decided, with RFC 2119 language where appropriate</span><span class="co">]</span></span>
+<span id="cb1-11"><a href="#cb1-11" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb1-12"><a href="#cb1-12" aria-hidden="true" tabindex="-1"></a><span class="fu">## Consequences</span></span>
+<span id="cb1-13"><a href="#cb1-13" aria-hidden="true" tabindex="-1"></a><span class="co">[</span><span class="ot">Positive and negative outcomes</span><span class="co">]</span></span>
+<span id="cb1-14"><a href="#cb1-14" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb1-15"><a href="#cb1-15" aria-hidden="true" tabindex="-1"></a><span class="fu">## References</span></span>
+<span id="cb1-16"><a href="#cb1-16" aria-hidden="true" tabindex="-1"></a><span class="co">[</span><span class="ot">Related ADRs or spec sections</span><span class="co">]</span></span></code></pre></div>
+<h2 id="status-definitions">Status Definitions</h2>
+<ul>
+<li><strong>Proposed</strong>: Under discussion, not yet accepted</li>
+<li><strong>Accepted</strong>: Approved and in effect</li>
+<li><strong>Deprecated</strong>: No longer recommended but still supported</li>
+<li><strong>Superseded</strong>: Replaced by a newer ADR (link to replacement)</li>
+</ul>
+<h2 id="contributing">Contributing</h2>
+<p>When proposing a new ADR:</p>
+<ol type="1">
+<li>Use the next available number (ADR-007, etc.)</li>
+<li>Follow the naming convention: <code>ADR-NNN-short-title.md</code></li>
+<li>Use RFC 2119 keywords (MUST, SHOULD, MAY) for normative statements</li>
+<li>Focus on protocol-level decisions, not implementation details</li>
+<li>Update this index when adding new ADRs</li>
+</ol>
+
+          </div>
+        </section>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div class="container">
+      <p>&copy; 2026 DollhouseMCP Inc. d/b/a Dollhouse Research. MCP-AQL public draft documentation portal.</p>
+      <div class="footer-links">
+        <a href="../../docs/index.html">Docs Library</a>
+        <a href="../index.html">Repo-Synced Spec</a>
+        <a href="https://github.com/MCPAQL">MCPAQL Organization</a>
+        <a href="https://dollhouseresearch.com">Dollhouse Research</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../../js/search.js"></script>
+</body>
+</html>

--- a/public/spec/adr/index.html
+++ b/public/spec/adr/index.html
@@ -73,6 +73,13 @@
       </aside>
 
       <article class="docs-main">
+        <nav class="breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../../index.html">Home</a></li>
+            <li><a href="../index.html">Full Spec</a></li>
+            <li><span class="current">Architecture Decision Records</span></li>
+          </ol>
+        </nav>
         <section class="hero docs-hero">
           <div class="hero-inner">
             <span class="status-pill">REPO-SYNCED SPEC DOC</span>

--- a/public/spec/adr/index.html
+++ b/public/spec/adr/index.html
@@ -38,7 +38,7 @@
         <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
         <div class="docs-side-group">
   <h3>Core</h3>
-  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li></ul>
+  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li><li><a href="../repo/README.html">MCP-AQL Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Versions</h3>
   <ul><li><a href="../versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
@@ -56,7 +56,7 @@
   <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
-  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li></ul>
+  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li><li><a href="../repo/CHANGELOG.html">Changelog</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Architecture</h3>
   <ul><li><a href="../architecture/README.html">Architecture Documentation</a></li></ul>

--- a/public/spec/adr/index.html
+++ b/public/spec/adr/index.html
@@ -23,7 +23,7 @@
         </ul>
         <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
-          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <input id="site-search-input" data-search-input type="search" placeholder="Search MCP-AQL docs, spec pages, and adapter patterns...">
           <span class="search-count" data-search-count></span>
           <ul class="search-results" data-search-results hidden></ul>
         </form>
@@ -68,7 +68,7 @@
   <ul><li><a href="../reference/README.html">Reference Documentation</a></li></ul>
 </div><div class="docs-side-group">
   <h3>ADRs</h3>
-  <ul><li><a href="ADR-001-crude-pattern.html">ADR-001: CRUDE Pattern (Extending CRUD with Execute)</a></li><li><a href="ADR-002-graphql-style-input.html">ADR-002: GraphQL-Style Input Objects for Updates</a></li><li><a href="ADR-003-snake-case-parameters.html">ADR-003: snake_case Parameter Convention</a></li><li><a href="ADR-004-schema-driven-operations.html">ADR-004: Schema-Driven Operation Definitions</a></li><li><a href="ADR-005-introspection-system.html">ADR-005: GraphQL-Style Introspection System</a></li><li><a href="ADR-006-discriminated-responses.html">ADR-006: Discriminated Response Format</a></li><li><a class="current" href="index.html">Architecture Decision Records</a></li><li><a href="README.html">Architecture Decision Records</a></li></ul>
+  <ul><li><a href="ADR-001-crude-pattern.html">ADR-001: CRUDE Pattern (Extending CRUD with Execute)</a></li><li><a href="ADR-002-graphql-style-input.html">ADR-002: GraphQL-Style Input Objects for Updates</a></li><li><a href="ADR-003-snake-case-parameters.html">ADR-003: snake_case Parameter Convention</a></li><li><a href="ADR-004-schema-driven-operations.html">ADR-004: Schema-Driven Operation Definitions</a></li><li><a href="ADR-005-introspection-system.html">ADR-005: GraphQL-Style Introspection System</a></li><li><a href="ADR-006-discriminated-responses.html">ADR-006: Discriminated Response Format</a></li><li><a class="current" aria-current="page" href="index.html">Architecture Decision Records</a></li><li><a href="README.html">Architecture Decision Records</a></li></ul>
 </div>
       </aside>
 
@@ -183,6 +183,16 @@
 
           </div>
         </section>
+        <nav class="page-nav" aria-label="Page navigation">
+  <a class="page-nav-link prev" href="ADR-006-discriminated-responses.html">
+    <span class="page-nav-eyebrow">Previous spec page</span>
+    <strong class="page-nav-label">ADR-006: Discriminated Response Format</strong>
+  </a>
+  <a class="page-nav-link next" href="README.html">
+    <span class="page-nav-eyebrow">Next spec page</span>
+    <strong class="page-nav-label">Architecture Decision Records</strong>
+  </a>
+</nav>
       </article>
     </div>
   </main>

--- a/public/spec/architecture/README.html
+++ b/public/spec/architecture/README.html
@@ -23,7 +23,7 @@
         </ul>
         <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
-          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <input id="site-search-input" data-search-input type="search" placeholder="Search MCP-AQL docs, spec pages, and adapter patterns...">
           <span class="search-count" data-search-count></span>
           <ul class="search-results" data-search-results hidden></ul>
         </form>
@@ -59,7 +59,7 @@
   <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li><li><a href="../repo/CHANGELOG.html">Changelog</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Architecture</h3>
-  <ul><li><a class="current" href="README.html">Architecture Documentation</a></li></ul>
+  <ul><li><a class="current" aria-current="page" href="README.html">Architecture Documentation</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Research</h3>
   <ul><li><a href="../research/mcp-vs-mcpaql-vs-a2a.html">Protocol Landscape: MCP vs MCP-AQL vs A2A</a></li></ul>
@@ -135,6 +135,16 @@
 
           </div>
         </section>
+        <nav class="page-nav" aria-label="Page navigation">
+  <a class="page-nav-link prev" href="../repo/CHANGELOG.html">
+    <span class="page-nav-eyebrow">Previous spec page</span>
+    <strong class="page-nav-label">Changelog</strong>
+  </a>
+  <a class="page-nav-link next" href="../research/mcp-vs-mcpaql-vs-a2a.html">
+    <span class="page-nav-eyebrow">Next spec page</span>
+    <strong class="page-nav-label">Protocol Landscape: MCP vs MCP-AQL vs A2A</strong>
+  </a>
+</nav>
       </article>
     </div>
   </main>

--- a/public/spec/architecture/README.html
+++ b/public/spec/architecture/README.html
@@ -1,0 +1,149 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Implementation architecture documentation has moved to the mcpaql-adapter repository.">
+  <title>MCP-AQL Spec | Architecture Documentation</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../../css/style.css">
+</head>
+<body>
+  <header>
+    <div class="container">
+      <nav>
+        <a class="logo" href="../../index.html"><span class="logo-mark"></span>MCP-AQL</a>
+        <ul class="nav-links">
+          <li><a href="../../index.html">Home</a></li>
+          <li><a href="../../docs/index.html">Docs</a></li>
+          <li><a href="../../launch-checklist.html">Launch Checklist</a></li>
+          <li><a href="../../apis/mcp-server.html">Adapter Patterns</a></li>
+        </ul>
+        <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
+          <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
+          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <span class="search-count" data-search-count></span>
+          <ul class="search-results" data-search-results hidden></ul>
+        </form>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <div class="container docs-shell">
+      <aside class="docs-side">
+        <h2>Repo-Synced Spec</h2>
+        <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
+        <div class="docs-side-group">
+  <h3>Core</h3>
+  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Versions</h3>
+  <ul><li><a href="../versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Adapter</h3>
+  <ul><li><a href="../adapter/danger-levels.html">Dangerous Operation Classification Specification</a></li><li><a href="../adapter/discovery-bundle.html">MCP Server Discovery Bundle</a></li><li><a href="../adapter/element-type.html">Adapter Element Type Specification</a></li><li><a href="../adapter/generator.html">Adapter Generator Specification</a></li><li><a href="../adapter/rate-limiting.html">Rate Limiting and Quota Management Specification</a></li><li><a href="../adapter/trust-levels.html">Trust Levels Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Security</h3>
+  <ul><li><a href="../security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="../security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="../security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Features</h3>
+  <ul><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Guides</h3>
+  <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Process</h3>
+  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Architecture</h3>
+  <ul><li><a class="current" href="README.html">Architecture Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Research</h3>
+  <ul><li><a href="../research/mcp-vs-mcpaql-vs-a2a.html">Protocol Landscape: MCP vs MCP-AQL vs A2A</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Reference</h3>
+  <ul><li><a href="../reference/README.html">Reference Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>ADRs</h3>
+  <ul><li><a href="../adr/ADR-001-crude-pattern.html">ADR-001: CRUDE Pattern (Extending CRUD with Execute)</a></li><li><a href="../adr/ADR-002-graphql-style-input.html">ADR-002: GraphQL-Style Input Objects for Updates</a></li><li><a href="../adr/ADR-003-snake-case-parameters.html">ADR-003: snake_case Parameter Convention</a></li><li><a href="../adr/ADR-004-schema-driven-operations.html">ADR-004: Schema-Driven Operation Definitions</a></li><li><a href="../adr/ADR-005-introspection-system.html">ADR-005: GraphQL-Style Introspection System</a></li><li><a href="../adr/ADR-006-discriminated-responses.html">ADR-006: Discriminated Response Format</a></li><li><a href="../adr/index.html">Architecture Decision Records</a></li><li><a href="../adr/README.html">Architecture Decision Records</a></li></ul>
+</div>
+      </aside>
+
+      <article class="docs-main">
+        <section class="hero docs-hero">
+          <div class="hero-inner">
+            <span class="status-pill">REPO-SYNCED SPEC DOC</span>
+            <h1>Architecture Documentation</h1>
+            <p class="lede">Implementation architecture documentation has moved to the mcpaql-adapter repository.</p>
+            <div class="spec-meta"><span class="state-chip live">Support document</span></div>
+            <p class="spec-source">Source: <a href="https://github.com/MCPAQL/spec/blob/main/docs/architecture/README.md">spec/docs/architecture/README.md</a></p>
+            <div class="hero-actions">
+              <a class="btn btn-primary" href="https://github.com/MCPAQL/spec/blob/main/docs/architecture/README.md">Open Source Markdown</a>
+              <a class="btn btn-secondary" href="../index.html">Browse Full Spec Reference</a>
+            </div>
+          </div>
+        </section>
+
+        <section>
+          <div class="card spec-prose">
+            <p>Implementation architecture documentation has moved to the <a href="https://github.com/MCPAQL/mcpaql-adapter">mcpaql-adapter</a> repository.</p>
+<h2 id="moved-documents">Moved Documents</h2>
+<table>
+<thead>
+<tr>
+<th>Former Location</th>
+<th>New Location</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>overview.md</code></td>
+<td><a href="https://github.com/MCPAQL/mcpaql-adapter/blob/develop/docs/architecture/overview.md">mcpaql-adapter/docs/architecture/overview.md</a></td>
+</tr>
+<tr>
+<td><code>adapter-runtime.md</code></td>
+<td><a href="https://github.com/MCPAQL/mcpaql-adapter/blob/develop/docs/architecture/runtime.md">mcpaql-adapter/docs/architecture/runtime.md</a></td>
+</tr>
+<tr>
+<td><code>plugin-interface.md</code></td>
+<td>Split: normative contracts in <a href="../plugin-contracts.html">plugin-contracts.md</a>, implementation in <a href="https://github.com/MCPAQL/mcpaql-adapter/blob/develop/docs/architecture/plugin-system.md">mcpaql-adapter/docs/architecture/plugin-system.md</a></td>
+</tr>
+<tr>
+<td><code>schema-driven-dispatch.md</code></td>
+<td><a href="https://github.com/MCPAQL/mcpaql-adapter/blob/develop/docs/architecture/dispatch.md">mcpaql-adapter/docs/architecture/dispatch.md</a></td>
+</tr>
+</tbody>
+</table>
+<h2 id="normative-protocol-documents">Normative Protocol Documents</h2>
+<p>For normative protocol specifications that remain in this repository, see:</p>
+<ul>
+<li><a href="../plugin-contracts.html">Plugin Interface Contracts</a> - What each plugin type MUST provide</li>
+<li><a href="../versions/v1.0.0-draft.html">Core Specification</a> - Protocol wire format and semantics</li>
+<li><a href="../adapter/element-type.html">Adapter Element Type</a> - Declarative adapter schema format</li>
+<li><a href="../error-codes.html">Error Codes</a> - Structured error code system</li>
+</ul>
+
+          </div>
+        </section>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div class="container">
+      <p>&copy; 2026 DollhouseMCP Inc. d/b/a Dollhouse Research. MCP-AQL public draft documentation portal.</p>
+      <div class="footer-links">
+        <a href="../../docs/index.html">Docs Library</a>
+        <a href="../index.html">Repo-Synced Spec</a>
+        <a href="https://github.com/MCPAQL">MCPAQL Organization</a>
+        <a href="https://dollhouseresearch.com">Dollhouse Research</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../../js/search.js"></script>
+</body>
+</html>

--- a/public/spec/architecture/README.html
+++ b/public/spec/architecture/README.html
@@ -38,7 +38,7 @@
         <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
         <div class="docs-side-group">
   <h3>Core</h3>
-  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li></ul>
+  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li><li><a href="../repo/README.html">MCP-AQL Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Versions</h3>
   <ul><li><a href="../versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
@@ -56,7 +56,7 @@
   <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
-  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li></ul>
+  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li><li><a href="../repo/CHANGELOG.html">Changelog</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Architecture</h3>
   <ul><li><a class="current" href="README.html">Architecture Documentation</a></li></ul>

--- a/public/spec/architecture/README.html
+++ b/public/spec/architecture/README.html
@@ -73,6 +73,13 @@
       </aside>
 
       <article class="docs-main">
+        <nav class="breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../../index.html">Home</a></li>
+            <li><a href="../index.html">Full Spec</a></li>
+            <li><span class="current">Architecture Documentation</span></li>
+          </ol>
+        </nav>
         <section class="hero docs-hero">
           <div class="hero-inner">
             <span class="status-pill">REPO-SYNCED SPEC DOC</span>

--- a/public/spec/conformance-testing.html
+++ b/public/spec/conformance-testing.html
@@ -1,0 +1,700 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Document Status: This document is an informative conformance framework specification aligned to the normative protocol requirements in docs/versions/v1.0.0-draft.md. Implementation Status: The full mcpaql-conformance run">
+  <title>MCP-AQL Spec | MCP-AQL Conformance Testing Specification</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../css/style.css">
+</head>
+<body>
+  <header>
+    <div class="container">
+      <nav>
+        <a class="logo" href="../index.html"><span class="logo-mark"></span>MCP-AQL</a>
+        <ul class="nav-links">
+          <li><a href="../index.html">Home</a></li>
+          <li><a href="../docs/index.html">Docs</a></li>
+          <li><a href="../launch-checklist.html">Launch Checklist</a></li>
+          <li><a href="../apis/mcp-server.html">Adapter Patterns</a></li>
+        </ul>
+        <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
+          <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
+          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <span class="search-count" data-search-count></span>
+          <ul class="search-results" data-search-results hidden></ul>
+        </form>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <div class="container docs-shell">
+      <aside class="docs-side">
+        <h2>Repo-Synced Spec</h2>
+        <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
+        <div class="docs-side-group">
+  <h3>Core</h3>
+  <ul><li><a class="current" href="conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="error-codes.html">Structured Error Codes Specification</a></li><li><a href="introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="mcp-integration.html">MCP Integration Specification</a></li><li><a href="operations.html">MCP-AQL Operations Specification</a></li><li><a href="overview.html">MCP-AQL Protocol Overview</a></li><li><a href="plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="README.html">MCP-AQL Specification Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Versions</h3>
+  <ul><li><a href="versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Adapter</h3>
+  <ul><li><a href="adapter/danger-levels.html">Dangerous Operation Classification Specification</a></li><li><a href="adapter/discovery-bundle.html">MCP Server Discovery Bundle</a></li><li><a href="adapter/element-type.html">Adapter Element Type Specification</a></li><li><a href="adapter/generator.html">Adapter Generator Specification</a></li><li><a href="adapter/rate-limiting.html">Rate Limiting and Quota Management Specification</a></li><li><a href="adapter/trust-levels.html">Trust Levels Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Security</h3>
+  <ul><li><a href="security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Features</h3>
+  <ul><li><a href="features/field-selection.html">Field Selection Specification</a></li><li><a href="features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="features/warnings.html">Warnings Array Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Guides</h3>
+  <ul><li><a href="guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="guides/README.html">Developer Guides</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Process</h3>
+  <ul><li><a href="process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="process/versioning.html">Versioning Strategy</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Architecture</h3>
+  <ul><li><a href="architecture/README.html">Architecture Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Research</h3>
+  <ul><li><a href="research/mcp-vs-mcpaql-vs-a2a.html">Protocol Landscape: MCP vs MCP-AQL vs A2A</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Reference</h3>
+  <ul><li><a href="reference/README.html">Reference Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>ADRs</h3>
+  <ul><li><a href="adr/ADR-001-crude-pattern.html">ADR-001: CRUDE Pattern (Extending CRUD with Execute)</a></li><li><a href="adr/ADR-002-graphql-style-input.html">ADR-002: GraphQL-Style Input Objects for Updates</a></li><li><a href="adr/ADR-003-snake-case-parameters.html">ADR-003: snake_case Parameter Convention</a></li><li><a href="adr/ADR-004-schema-driven-operations.html">ADR-004: Schema-Driven Operation Definitions</a></li><li><a href="adr/ADR-005-introspection-system.html">ADR-005: GraphQL-Style Introspection System</a></li><li><a href="adr/ADR-006-discriminated-responses.html">ADR-006: Discriminated Response Format</a></li><li><a href="adr/index.html">Architecture Decision Records</a></li><li><a href="adr/README.html">Architecture Decision Records</a></li></ul>
+</div>
+      </aside>
+
+      <article class="docs-main">
+        <section class="hero docs-hero">
+          <div class="hero-inner">
+            <span class="status-pill">REPO-SYNCED SPEC DOC</span>
+            <h1>MCP-AQL Conformance Testing Specification</h1>
+            <p class="lede">Document Status: This document is an informative conformance framework specification aligned to the normative protocol requirements in docs/versions/v1.0.0-draft.md. Implementation Status: The full mcpaql-conformance run</p>
+            <div class="spec-meta"><span class="state-chip live">Support document</span><span class="state-chip pending">Draft</span><span class="state-chip">1.0.0-draft</span><span class="state-chip">2026-03-06</span></div>
+            <p class="spec-source">Source: <a href="https://github.com/MCPAQL/spec/blob/main/docs/conformance-testing.md">spec/docs/conformance-testing.md</a></p>
+            <div class="hero-actions">
+              <a class="btn btn-primary" href="https://github.com/MCPAQL/spec/blob/main/docs/conformance-testing.md">Open Source Markdown</a>
+              <a class="btn btn-secondary" href="index.html">Browse Full Spec Reference</a>
+            </div>
+          </div>
+        </section>
+
+        <section>
+          <div class="card spec-prose">
+            <p><strong>Version:</strong> 1.0.0-draft <strong>Status:</strong> Draft <strong>Last Updated:</strong> 2026-03-06</p>
+<blockquote>
+<p><strong>Document Status:</strong> This document is an <strong>informative conformance framework specification</strong> aligned to the normative protocol requirements in <code>docs/versions/v1.0.0-draft.md</code>.</p>
+<p><strong>Implementation Status:</strong> The full <code>mcpaql-conformance</code> runner defined here is not yet published in this repository. Current implemented checks are schema/example validation in <code>scripts/validate-schema-examples.mjs</code>.</p>
+</blockquote>
+<h2 id="abstract">Abstract</h2>
+<p>This document specifies the conformance testing requirements for MCP-AQL implementations. It defines conformance levels, test categories, pass/fail criteria, and evaluation methodologies including LLM-based semantic evaluation.</p>
+<hr />
+<h2 id="table-of-contents">Table of Contents</h2>
+<ol type="1">
+<li><a href="#1-introduction">Introduction</a></li>
+<li><a href="#2-conformance-levels">Conformance Levels</a></li>
+<li><a href="#3-test-categories">Test Categories</a></li>
+<li><a href="#4-test-requirements">Test Requirements</a></li>
+<li><a href="#5-evaluation-methodology">Evaluation Methodology</a></li>
+<li><a href="#6-reporting">Reporting</a></li>
+<li><a href="#7-command-line-interface">Command-Line Interface</a></li>
+</ol>
+<hr />
+<h2 id="1-introduction">1. Introduction</h2>
+<h3 id="11-purpose">1.1 Purpose</h3>
+<p>MCP-AQL conformance testing ensures implementations meet the protocol specification and provide consistent, discoverable APIs for LLM interaction. This specification defines:</p>
+<ul>
+<li>What implementations MUST test</li>
+<li>How to evaluate test results</li>
+<li>How to report conformance levels</li>
+</ul>
+<h3 id="12-terminology">1.2 Terminology</h3>
+<p>The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in <a href="https://www.rfc-editor.org/rfc/rfc2119">RFC 2119</a>.</p>
+<h3 id="13-test-result-classifications">1.3 Test Result Classifications</h3>
+<table>
+<thead>
+<tr>
+<th>Result</th>
+<th>Meaning</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>PASS</strong></td>
+<td>Test criteria fully satisfied</td>
+</tr>
+<tr>
+<td><strong>FAIL</strong></td>
+<td>Test criteria not met, conformance blocked</td>
+</tr>
+<tr>
+<td><strong>WARN</strong></td>
+<td>Test criteria partially met, conformance not blocked</td>
+</tr>
+<tr>
+<td><strong>SKIP</strong></td>
+<td>Test not applicable to this implementation</td>
+</tr>
+</tbody>
+</table>
+<hr />
+<h2 id="2-conformance-levels">2. Conformance Levels</h2>
+<h3 id="21-level-1-basic-conformance">2.1 Level 1: Basic Conformance</h3>
+<p>Level 1 conformance establishes the minimum viable MCP-AQL implementation.</p>
+<p><strong>Requirements:</strong></p>
+<table>
+<thead>
+<tr>
+<th>Requirement</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Introspect (operations)</td>
+<td><code>introspect</code> operation with <code>query: "operations"</code> implemented</td>
+</tr>
+<tr>
+<td>Introspect (types)</td>
+<td><code>introspect</code> operation with <code>query: "types"</code> implemented</td>
+</tr>
+<tr>
+<td>Endpoint routing</td>
+<td>Operations routed to correct CRUDE endpoint</td>
+</tr>
+<tr>
+<td>Response format</td>
+<td>Discriminated union responses (<code>{ success, data }</code> or <code>{ success, error }</code>)</td>
+</tr>
+<tr>
+<td>Error handling</td>
+<td>Structured error responses with code and message</td>
+</tr>
+<tr>
+<td>Parameter naming</td>
+<td>snake_case parameter naming convention</td>
+</tr>
+</tbody>
+</table>
+<p><strong>Test Categories Required:</strong></p>
+<ul>
+<li>Introspection Fidelity (MUST PASS)</li>
+<li>Parameter Handling (MUST PASS)</li>
+<li>Error Quality (MUST PASS)</li>
+<li>Round-Trip Integrity (MUST PASS)</li>
+</ul>
+<h3 id="22-level-2-full-conformance">2.2 Level 2: Full Conformance</h3>
+<p>Level 2 conformance indicates a complete MCP-AQL implementation with all optional features.</p>
+<p><strong>Requirements:</strong></p>
+<table>
+<thead>
+<tr>
+<th>Requirement</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Level 1</td>
+<td>All Level 1 requirements</td>
+</tr>
+<tr>
+<td>Endpoint modes</td>
+<td>Both CRUDE mode and Single-endpoint mode supported</td>
+</tr>
+<tr>
+<td>Field selection</td>
+<td><code>fields</code> and <code>preset</code> parameters on READ operations</td>
+</tr>
+<tr>
+<td>Batch operations</td>
+<td>Multi-operation batching with individual results</td>
+</tr>
+<tr>
+<td>Cross-cutting params</td>
+<td>Consistent <code>limit</code>, <code>offset</code>, <code>sort</code>, <code>order</code> support</td>
+</tr>
+</tbody>
+</table>
+<p><strong>Test Categories Required:</strong></p>
+<ul>
+<li>All Level 1 test categories</li>
+<li>Constraint Documentation (SHOULD PASS)</li>
+<li>Semantic Evaluation (SHOULD PASS)</li>
+</ul>
+<h3 id="23-conformance-certification">2.3 Conformance Certification</h3>
+<p>Implementations MAY claim conformance levels as follows:</p>
+<pre><code>MCP-AQL Level 1 Conformant
+MCP-AQL Level 2 Conformant</code></pre>
+<p>Claims MUST include the specification version tested against.</p>
+<hr />
+<h2 id="3-test-categories">3. Test Categories</h2>
+<h3 id="31-introspection-fidelity-tests-must-pass">3.1 Introspection Fidelity Tests (MUST PASS)</h3>
+<p>Verifies that introspection accurately describes the implementation.</p>
+<pre><code>TEST: Introspection Parameter Accuracy
+  FOR EACH operation in introspection response:
+    1. Extract parameter names and types
+    2. Construct a valid request using ONLY introspection guidance
+    3. Verify the request succeeds OR fails with a documented error
+
+  PASS: All documented parameters work as described
+  FAIL: Following introspection exactly produces unexpected errors</code></pre>
+<pre><code>TEST: Introspection Completeness
+  FOR EACH operation in implementation:
+    1. Get documented parameters from introspection
+    2. Attempt operation with each documented parameter
+    3. Attempt operation with known cross-cutting parameters
+    4. Compare accepted vs documented parameters
+
+  PASS: All accepted parameters appear in introspection
+  FAIL: Operation accepts parameters not in introspection
+  WARN: Introspection documents parameters not accepted</code></pre>
+<h3 id="32-parameter-handling-tests-must-pass">3.2 Parameter Handling Tests (MUST PASS)</h3>
+<p>Verifies consistent parameter behavior.</p>
+<pre><code>TEST: Required Parameter Enforcement
+  FOR EACH operation with required parameters:
+    1. Omit each required parameter in turn
+    2. Verify operation fails with clear error
+
+  PASS: Missing required params produce &quot;missing parameter&quot; errors
+  FAIL: Operation succeeds without required parameter
+  FAIL: Error message does not identify the missing parameter</code></pre>
+<pre><code>TEST: Unknown Parameter Handling
+  FOR EACH operation:
+    1. Send valid request with one additional unknown parameter
+    2. Verify server either:
+       a) Accepts request (param ignored with optional warning), OR
+       b) Rejects with clear &quot;unknown parameter&quot; error
+
+  PASS: Behavior is explicit (warning OR error)
+  FAIL: Unknown parameters silently ignored with no indication</code></pre>
+<pre><code>TEST: Optional Parameter Defaults
+  FOR EACH optional parameter with documented default:
+    1. Send request without the parameter
+    2. Verify response reflects documented default behavior
+
+  PASS: Defaults applied as documented
+  FAIL: Behavior differs from documented default</code></pre>
+<h3 id="33-error-quality-tests-must-pass">3.3 Error Quality Tests (MUST PASS)</h3>
+<p>Verifies error messages are user-appropriate.</p>
+<pre><code>TEST: No Implementation Leakage
+  FOR EACH error condition:
+    1. Trigger the error
+    2. Verify error message does NOT contain:
+       - Programming language artifacts (TypeError, #&lt;Object&gt;, .js:, .ts:)
+       - Stack traces (at Function, at Module)
+       - Internal paths (/src/, /node_modules/)
+
+  PASS: Error messages are implementation-agnostic
+  FAIL: Raw implementation errors exposed</code></pre>
+<pre><code>TEST: Actionable Error Messages
+  FOR EACH validation error:
+    1. Trigger the error
+    2. Verify error message includes:
+       - What went wrong
+       - Which parameter/field is affected
+       - Expected type or format (for type errors)
+
+  PASS: Error messages enable self-correction
+  WARN: Error messages lack actionable guidance</code></pre>
+<p><strong>Recommended Error Format:</strong></p>
+<pre><code>Missing required parameter &#39;{paramName}&#39;. Expected: {type} ({description})</code></pre>
+<h3 id="34-round-trip-integrity-tests-must-pass">3.4 Round-Trip Integrity Tests (MUST PASS)</h3>
+<p>Verifies data consistency through create-read cycles.</p>
+<pre><code>TEST: Create-Read Consistency
+  FOR EACH element type:
+    1. Create element with all documented optional fields
+    2. Read element back via get operation
+    3. Compare all fields
+
+  PASS: All submitted fields present and unchanged
+  FAIL: Data silently dropped during create
+  FAIL: Field values modified unexpectedly</code></pre>
+<pre><code>TEST: Update Preservation
+  FOR EACH element type:
+    1. Create element with initial values
+    2. Update subset of fields
+    3. Read element back
+    4. Verify non-updated fields unchanged
+
+  PASS: Unmodified fields preserved
+  FAIL: Update operation affects non-targeted fields</code></pre>
+<h3 id="35-constraint-documentation-tests-should-pass">3.5 Constraint Documentation Tests (SHOULD PASS)</h3>
+<p>Verifies element-specific constraints are discoverable.</p>
+<pre><code>TEST: Read-Only Field Protection
+  FOR EACH element type with read-only fields:
+    1. Attempt to update a read-only field
+    2. Verify operation fails with constraint error
+    3. Verify introspection documents the constraint
+
+  PASS: Constraint enforced AND documented
+  WARN: Constraint enforced but not in introspection
+  FAIL: Read-only field can be modified</code></pre>
+<pre><code>TEST: Append-Only Semantics
+  FOR EACH append-only data type (e.g., Memory entries):
+    1. Verify content cannot be modified via update
+    2. Verify error message explains append-only behavior
+    3. Verify introspection documents the constraint
+
+  PASS: Append-only enforced AND documented
+  WARN: Enforced but not documented</code></pre>
+<hr />
+<h2 id="4-test-requirements">4. Test Requirements</h2>
+<h3 id="41-must-pass-requirements">4.1 MUST PASS Requirements</h3>
+<p>The following test categories MUST pass for Level 1 conformance:</p>
+<table>
+<thead>
+<tr>
+<th>Category</th>
+<th>Tests</th>
+<th>Rationale</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Introspection Fidelity</td>
+<td>2</td>
+<td>LLMs must trust introspection</td>
+</tr>
+<tr>
+<td>Parameter Handling</td>
+<td>3</td>
+<td>Consistent behavior across operations</td>
+</tr>
+<tr>
+<td>Error Quality</td>
+<td>2</td>
+<td>Usable error messages</td>
+</tr>
+<tr>
+<td>Round-Trip Integrity</td>
+<td>2</td>
+<td>Data consistency guarantee</td>
+</tr>
+</tbody>
+</table>
+<p><strong>Total MUST PASS tests:</strong> 9</p>
+<h3 id="42-should-pass-requirements">4.2 SHOULD PASS Requirements</h3>
+<p>The following test categories SHOULD pass for Level 2 conformance:</p>
+<table>
+<thead>
+<tr>
+<th>Category</th>
+<th>Tests</th>
+<th>Rationale</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Constraint Documentation</td>
+<td>2</td>
+<td>Discoverable constraints</td>
+</tr>
+<tr>
+<td>Semantic Evaluation</td>
+<td>Per implementation</td>
+<td>LLM discoverability</td>
+</tr>
+</tbody>
+</table>
+<p><strong>Failure in SHOULD PASS tests:</strong> Produces WARN, does not block conformance</p>
+<hr />
+<h2 id="5-evaluation-methodology">5. Evaluation Methodology</h2>
+<h3 id="51-two-tier-evaluation-approach">5.1 Two-Tier Evaluation Approach</h3>
+<p>Conformance tests SHOULD use a two-tier evaluation approach:</p>
+<h4 id="tier-1-structural-validation-fast-deterministic">Tier 1: Structural Validation (Fast, Deterministic)</h4>
+<ul>
+<li>Pattern matching for expected response elements</li>
+<li>JSON schema validation for response structure</li>
+<li>Presence checks for required fields</li>
+<li>Regex validation for error message patterns</li>
+</ul>
+<p><strong>Characteristics:</strong></p>
+<ul>
+<li>Fast execution</li>
+<li>Deterministic results</li>
+<li>Catches obvious failures</li>
+</ul>
+<h4 id="tier-2-semantic-validation-comprehensive-ai-assisted">Tier 2: Semantic Validation (Comprehensive, AI-Assisted)</h4>
+<ul>
+<li>LLM evaluation of response correctness</li>
+<li>Semantic similarity scoring</li>
+<li>Intent classification for operation selection</li>
+<li>Natural language understanding of guidance</li>
+</ul>
+<p><strong>Characteristics:</strong></p>
+<ul>
+<li>Comprehensive coverage</li>
+<li>Handles natural language variation</li>
+<li>Catches subtle usability issues</li>
+</ul>
+<h3 id="52-semantic-evaluation-requirements">5.2 Semantic Evaluation Requirements</h3>
+<p>Tests for LLM discoverability SHOULD use semantic evaluation:</p>
+<pre><code>TEST: API Discoverability
+  1. Prompt LLM with discovery task
+  2. Capture LLM response and tool calls
+  3. Tier 1: Check for expected patterns (fast fail)
+  4. Tier 2: If Tier 1 inconclusive, evaluate semantic correctness
+  5. Report both structural and semantic results
+
+  PASS: Tier 1 passes AND Tier 2 confirms understanding
+  WARN: Tier 1 fails but Tier 2 passes (potential pattern update needed)
+  FAIL: Both tiers fail OR Tier 1 passes but Tier 2 fails</code></pre>
+<h3 id="53-test-categories-requiring-semantic-evaluation">5.3 Test Categories Requiring Semantic Evaluation</h3>
+<table>
+<thead>
+<tr>
+<th>Category</th>
+<th>Example Prompt</th>
+<th>Why Semantic Matters</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Introspection Discovery</td>
+<td>"List available operations"</td>
+<td>LLM may describe operations differently</td>
+</tr>
+<tr>
+<td>Field Selection Discovery</td>
+<td>"Does search support field selection?"</td>
+<td>Affirmative answer may use varied phrasing</td>
+</tr>
+<tr>
+<td>Error Understanding</td>
+<td>"Handle this error gracefully"</td>
+<td>Recovery strategies may vary</td>
+</tr>
+<tr>
+<td>Operation Selection</td>
+<td>"Create an element"</td>
+<td>Correct tool choice matters more than exact call format</td>
+</tr>
+</tbody>
+</table>
+<h3 id="54-evaluation-workflow">5.4 Evaluation Workflow</h3>
+<pre class="mermaid"><code>graph TD
+    A[Run Test] --&gt; B{Tier 1 Pass?}
+    B --&gt;|Yes| C{Tier 2 Required?}
+    B --&gt;|No| D{Tier 2 Pass?}
+    C --&gt;|No| E[PASS]
+    C --&gt;|Yes| F{Tier 2 Pass?}
+    D --&gt;|Yes| G[WARN: Update patterns]
+    D --&gt;|No| H[FAIL]
+    F --&gt;|Yes| E
+    F --&gt;|No| H</code></pre>
+<hr />
+<h2 id="6-reporting">6. Reporting</h2>
+<h3 id="61-conformance-report-format">6.1 Conformance Report Format</h3>
+<p>Implementations SHOULD generate conformance reports:</p>
+<div class="sourceCode" id="cb16"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb16-1"><a href="#cb16-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb16-2"><a href="#cb16-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;implementation&quot;</span><span class="fu">:</span> <span class="st">&quot;example-adapter&quot;</span><span class="fu">,</span></span>
+<span id="cb16-3"><a href="#cb16-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;version&quot;</span><span class="fu">:</span> <span class="st">&quot;1.0.0&quot;</span><span class="fu">,</span></span>
+<span id="cb16-4"><a href="#cb16-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;specVersion&quot;</span><span class="fu">:</span> <span class="st">&quot;1.0.0-draft&quot;</span><span class="fu">,</span></span>
+<span id="cb16-5"><a href="#cb16-5" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;testDate&quot;</span><span class="fu">:</span> <span class="st">&quot;2026-01-29T00:00:00Z&quot;</span><span class="fu">,</span></span>
+<span id="cb16-6"><a href="#cb16-6" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;conformanceLevel&quot;</span><span class="fu">:</span> <span class="dv">1</span><span class="fu">,</span></span>
+<span id="cb16-7"><a href="#cb16-7" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;summary&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb16-8"><a href="#cb16-8" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;total&quot;</span><span class="fu">:</span> <span class="dv">11</span><span class="fu">,</span></span>
+<span id="cb16-9"><a href="#cb16-9" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;passed&quot;</span><span class="fu">:</span> <span class="dv">9</span><span class="fu">,</span></span>
+<span id="cb16-10"><a href="#cb16-10" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;warned&quot;</span><span class="fu">:</span> <span class="dv">2</span><span class="fu">,</span></span>
+<span id="cb16-11"><a href="#cb16-11" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;failed&quot;</span><span class="fu">:</span> <span class="dv">0</span><span class="fu">,</span></span>
+<span id="cb16-12"><a href="#cb16-12" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;skipped&quot;</span><span class="fu">:</span> <span class="dv">0</span></span>
+<span id="cb16-13"><a href="#cb16-13" aria-hidden="true" tabindex="-1"></a>  <span class="fu">},</span></span>
+<span id="cb16-14"><a href="#cb16-14" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;categories&quot;</span><span class="fu">:</span> <span class="ot">[</span></span>
+<span id="cb16-15"><a href="#cb16-15" aria-hidden="true" tabindex="-1"></a>    <span class="fu">{</span></span>
+<span id="cb16-16"><a href="#cb16-16" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;Introspection Fidelity&quot;</span><span class="fu">,</span></span>
+<span id="cb16-17"><a href="#cb16-17" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;required&quot;</span><span class="fu">:</span> <span class="st">&quot;MUST&quot;</span><span class="fu">,</span></span>
+<span id="cb16-18"><a href="#cb16-18" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;result&quot;</span><span class="fu">:</span> <span class="st">&quot;PASS&quot;</span><span class="fu">,</span></span>
+<span id="cb16-19"><a href="#cb16-19" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;tests&quot;</span><span class="fu">:</span> <span class="ot">[</span></span>
+<span id="cb16-20"><a href="#cb16-20" aria-hidden="true" tabindex="-1"></a>        <span class="fu">{</span> <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;Parameter Accuracy&quot;</span><span class="fu">,</span> <span class="dt">&quot;result&quot;</span><span class="fu">:</span> <span class="st">&quot;PASS&quot;</span> <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb16-21"><a href="#cb16-21" aria-hidden="true" tabindex="-1"></a>        <span class="fu">{</span> <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;Completeness&quot;</span><span class="fu">,</span> <span class="dt">&quot;result&quot;</span><span class="fu">:</span> <span class="st">&quot;PASS&quot;</span> <span class="fu">}</span></span>
+<span id="cb16-22"><a href="#cb16-22" aria-hidden="true" tabindex="-1"></a>      <span class="ot">]</span></span>
+<span id="cb16-23"><a href="#cb16-23" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb16-24"><a href="#cb16-24" aria-hidden="true" tabindex="-1"></a>  <span class="ot">]</span></span>
+<span id="cb16-25"><a href="#cb16-25" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<h3 id="62-badge-format">6.2 Badge Format</h3>
+<p>Conformant implementations MAY display badges:</p>
+<div class="sourceCode" id="cb17"><pre class="sourceCode markdown"><code class="sourceCode markdown"><span id="cb17-1"><a href="#cb17-1" aria-hidden="true" tabindex="-1"></a><span class="al">![MCP-AQL Level 1](https://img.shields.io/badge/MCP--AQL-Level%201-green)</span></span>
+<span id="cb17-2"><a href="#cb17-2" aria-hidden="true" tabindex="-1"></a><span class="al">![MCP-AQL Level 2](https://img.shields.io/badge/MCP--AQL-Level%202-blue)</span></span></code></pre></div>
+<h3 id="63-certification-registry">6.3 Certification Registry</h3>
+<p>A future certification registry MAY track conformant implementations.</p>
+<hr />
+<h2 id="7-command-line-interface">7. Command-Line Interface</h2>
+<h3 id="71-cli-invocation">7.1 CLI Invocation</h3>
+<p>Conformance test runners SHOULD provide a command-line interface:</p>
+<div class="sourceCode" id="cb18"><pre class="sourceCode bash"><code class="sourceCode bash"><span id="cb18-1"><a href="#cb18-1" aria-hidden="true" tabindex="-1"></a><span class="ex">mcpaql-conformance</span> <span class="op">&lt;</span>command<span class="op">&gt;</span> <span class="pp">[</span><span class="ss">options</span><span class="pp">]</span></span></code></pre></div>
+<h3 id="72-commands">7.2 Commands</h3>
+<table>
+<thead>
+<tr>
+<th>Command</th>
+<th>Description</th>
+<th>Example</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>test</code></td>
+<td>Run conformance tests against an adapter</td>
+<td><code>mcpaql-conformance test ./adapter</code></td>
+</tr>
+<tr>
+<td><code>report</code></td>
+<td>Generate formatted report from test results file</td>
+<td><code>mcpaql-conformance report ./results.json</code></td>
+</tr>
+<tr>
+<td><code>version</code></td>
+<td>Print tool version</td>
+<td><code>mcpaql-conformance version</code></td>
+</tr>
+</tbody>
+</table>
+<p><strong>Note:</strong> The <code>report</code> command takes a JSON results file (produced by <code>test --format json --output results.json</code>) as input and generates human-readable or markdown output.</p>
+<h3 id="73-test-command-options">7.3 Test Command Options</h3>
+<table>
+<thead>
+<tr>
+<th>Option</th>
+<th>Description</th>
+<th>Default</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>--level</code>, <code>-l</code></td>
+<td>Conformance level to test (1 or 2)</td>
+<td><code>1</code></td>
+</tr>
+<tr>
+<td><code>--output</code>, <code>-o</code></td>
+<td>Output file for results</td>
+<td>stdout</td>
+</tr>
+<tr>
+<td><code>--format</code>, <code>-f</code></td>
+<td>Output format (<code>json</code>, <code>text</code>, <code>markdown</code>)</td>
+<td><code>text</code></td>
+</tr>
+<tr>
+<td><code>--verbose</code>, <code>-v</code></td>
+<td>Enable verbose output</td>
+<td><code>false</code></td>
+</tr>
+<tr>
+<td><code>--tier</code></td>
+<td>Evaluation tier (<code>1</code>, <code>2</code>, <code>both</code>)</td>
+<td><code>both</code></td>
+</tr>
+<tr>
+<td><code>--category</code>, <code>-c</code></td>
+<td>Run specific test category only</td>
+<td>All</td>
+</tr>
+<tr>
+<td><code>--timeout</code></td>
+<td>Test timeout in seconds</td>
+<td><code>30</code></td>
+</tr>
+</tbody>
+</table>
+<h3 id="74-exit-codes">7.4 Exit Codes</h3>
+<table>
+<thead>
+<tr>
+<th>Code</th>
+<th>Meaning</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>0</code></td>
+<td>All tests passed</td>
+<td>Conformance achieved at requested level</td>
+</tr>
+<tr>
+<td><code>1</code></td>
+<td>Tests failed</td>
+<td>One or more MUST PASS tests failed</td>
+</tr>
+<tr>
+<td><code>2</code></td>
+<td>Tests warned</td>
+<td>All MUST PASS passed, but SHOULD PASS tests warned</td>
+</tr>
+<tr>
+<td><code>3</code></td>
+<td>Configuration error</td>
+<td>Invalid adapter path or configuration</td>
+</tr>
+<tr>
+<td><code>4</code></td>
+<td>Timeout</td>
+<td>Tests exceeded timeout limit</td>
+</tr>
+<tr>
+<td><code>5</code></td>
+<td>Internal error</td>
+<td>Unexpected error in test runner</td>
+</tr>
+</tbody>
+</table>
+<h3 id="75-example-usage">7.5 Example Usage</h3>
+<p><strong>Run Level 1 conformance tests:</strong></p>
+<div class="sourceCode" id="cb19"><pre class="sourceCode bash"><code class="sourceCode bash"><span id="cb19-1"><a href="#cb19-1" aria-hidden="true" tabindex="-1"></a><span class="ex">mcpaql-conformance</span> test ./generated-adapter <span class="at">--level</span> 1</span></code></pre></div>
+<p><strong>Run Level 2 tests with JSON output:</strong></p>
+<div class="sourceCode" id="cb20"><pre class="sourceCode bash"><code class="sourceCode bash"><span id="cb20-1"><a href="#cb20-1" aria-hidden="true" tabindex="-1"></a><span class="ex">mcpaql-conformance</span> test ./adapter <span class="at">--level</span> 2 <span class="at">--format</span> json <span class="at">--output</span> results.json</span></code></pre></div>
+<p><strong>Run specific test category:</strong></p>
+<div class="sourceCode" id="cb21"><pre class="sourceCode bash"><code class="sourceCode bash"><span id="cb21-1"><a href="#cb21-1" aria-hidden="true" tabindex="-1"></a><span class="ex">mcpaql-conformance</span> test ./adapter <span class="at">--category</span> <span class="st">&quot;Introspection Fidelity&quot;</span></span></code></pre></div>
+<p><strong>Verbose output with Tier 2 semantic evaluation:</strong></p>
+<div class="sourceCode" id="cb22"><pre class="sourceCode bash"><code class="sourceCode bash"><span id="cb22-1"><a href="#cb22-1" aria-hidden="true" tabindex="-1"></a><span class="ex">mcpaql-conformance</span> test ./adapter <span class="at">--level</span> 2 <span class="at">--tier</span> both <span class="at">--verbose</span></span></code></pre></div>
+<p><strong>Generate markdown report from results:</strong></p>
+<div class="sourceCode" id="cb23"><pre class="sourceCode bash"><code class="sourceCode bash"><span id="cb23-1"><a href="#cb23-1" aria-hidden="true" tabindex="-1"></a><span class="ex">mcpaql-conformance</span> report ./results.json <span class="at">--format</span> markdown <span class="op">&gt;</span> CONFORMANCE.md</span></code></pre></div>
+<h3 id="76-integration-with-generator">7.6 Integration with Generator</h3>
+<p>The adapter generator (see <a href="adapter/generator.html">Adapter Generator Specification</a>) SHOULD invoke conformance tests as part of the generation workflow:</p>
+<div class="sourceCode" id="cb24"><pre class="sourceCode bash"><code class="sourceCode bash"><span id="cb24-1"><a href="#cb24-1" aria-hidden="true" tabindex="-1"></a><span class="co"># Generate adapter and run conformance tests</span></span>
+<span id="cb24-2"><a href="#cb24-2" aria-hidden="true" tabindex="-1"></a><span class="ex">mcpaql-generate</span> <span class="at">--schema</span> adapter.yaml <span class="at">--target</span> typescript <span class="at">--output</span> ./adapter</span>
+<span id="cb24-3"><a href="#cb24-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb24-4"><a href="#cb24-4" aria-hidden="true" tabindex="-1"></a><span class="co"># Test generated adapter</span></span>
+<span id="cb24-5"><a href="#cb24-5" aria-hidden="true" tabindex="-1"></a><span class="ex">mcpaql-conformance</span> test ./adapter <span class="at">--level</span> 1</span></code></pre></div>
+<hr />
+<h2 id="references">References</h2>
+<ul>
+<li><a href="versions/v1.0.0-draft.html">MCP-AQL Specification v1.0.0-draft</a></li>
+<li><a href="introspection.html">Introspection Specification</a></li>
+<li><a href="operations.html">Operations Specification</a></li>
+<li><a href="https://github.com/MCPAQL/spec/issues/10">GitHub Issue #10</a> - Conformance test suite</li>
+<li><a href="https://github.com/MCPAQL/spec/issues/55">GitHub Issue #55</a> - Conformance test requirements</li>
+<li><a href="https://github.com/MCPAQL/spec/issues/56">GitHub Issue #56</a> - LLM semantic evaluation</li>
+</ul>
+
+          </div>
+        </section>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div class="container">
+      <p>&copy; 2026 DollhouseMCP Inc. d/b/a Dollhouse Research. MCP-AQL public draft documentation portal.</p>
+      <div class="footer-links">
+        <a href="../docs/index.html">Docs Library</a>
+        <a href="index.html">Repo-Synced Spec</a>
+        <a href="https://github.com/MCPAQL">MCPAQL Organization</a>
+        <a href="https://dollhouseresearch.com">Dollhouse Research</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../js/search.js"></script>
+</body>
+</html>

--- a/public/spec/conformance-testing.html
+++ b/public/spec/conformance-testing.html
@@ -73,6 +73,13 @@
       </aside>
 
       <article class="docs-main">
+        <nav class="breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../index.html">Home</a></li>
+            <li><a href="index.html">Full Spec</a></li>
+            <li><span class="current">MCP-AQL Conformance Testing Specification</span></li>
+          </ol>
+        </nav>
         <section class="hero docs-hero">
           <div class="hero-inner">
             <span class="status-pill">REPO-SYNCED SPEC DOC</span>

--- a/public/spec/conformance-testing.html
+++ b/public/spec/conformance-testing.html
@@ -38,7 +38,7 @@
         <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
         <div class="docs-side-group">
   <h3>Core</h3>
-  <ul><li><a class="current" href="conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="error-codes.html">Structured Error Codes Specification</a></li><li><a href="introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="mcp-integration.html">MCP Integration Specification</a></li><li><a href="operations.html">MCP-AQL Operations Specification</a></li><li><a href="overview.html">MCP-AQL Protocol Overview</a></li><li><a href="plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="README.html">MCP-AQL Specification Documentation</a></li></ul>
+  <ul><li><a class="current" href="conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="error-codes.html">Structured Error Codes Specification</a></li><li><a href="introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="mcp-integration.html">MCP Integration Specification</a></li><li><a href="operations.html">MCP-AQL Operations Specification</a></li><li><a href="overview.html">MCP-AQL Protocol Overview</a></li><li><a href="plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="README.html">MCP-AQL Specification Documentation</a></li><li><a href="repo/README.html">MCP-AQL Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Versions</h3>
   <ul><li><a href="versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
@@ -56,7 +56,7 @@
   <ul><li><a href="guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
-  <ul><li><a href="process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="process/versioning.html">Versioning Strategy</a></li></ul>
+  <ul><li><a href="process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="process/versioning.html">Versioning Strategy</a></li><li><a href="repo/CHANGELOG.html">Changelog</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Architecture</h3>
   <ul><li><a href="architecture/README.html">Architecture Documentation</a></li></ul>

--- a/public/spec/conformance-testing.html
+++ b/public/spec/conformance-testing.html
@@ -23,7 +23,7 @@
         </ul>
         <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
-          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <input id="site-search-input" data-search-input type="search" placeholder="Search MCP-AQL docs, spec pages, and adapter patterns...">
           <span class="search-count" data-search-count></span>
           <ul class="search-results" data-search-results hidden></ul>
         </form>
@@ -38,7 +38,7 @@
         <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
         <div class="docs-side-group">
   <h3>Core</h3>
-  <ul><li><a class="current" href="conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="error-codes.html">Structured Error Codes Specification</a></li><li><a href="introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="mcp-integration.html">MCP Integration Specification</a></li><li><a href="operations.html">MCP-AQL Operations Specification</a></li><li><a href="overview.html">MCP-AQL Protocol Overview</a></li><li><a href="plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="README.html">MCP-AQL Specification Documentation</a></li><li><a href="repo/README.html">MCP-AQL Specification</a></li></ul>
+  <ul><li><a class="current" aria-current="page" href="conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="error-codes.html">Structured Error Codes Specification</a></li><li><a href="introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="mcp-integration.html">MCP Integration Specification</a></li><li><a href="operations.html">MCP-AQL Operations Specification</a></li><li><a href="overview.html">MCP-AQL Protocol Overview</a></li><li><a href="plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="README.html">MCP-AQL Specification Documentation</a></li><li><a href="repo/README.html">MCP-AQL Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Versions</h3>
   <ul><li><a href="versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
@@ -686,6 +686,16 @@ MCP-AQL Level 2 Conformant</code></pre>
 
           </div>
         </section>
+        <nav class="page-nav" aria-label="Page navigation">
+  <a class="page-nav-link prev" href="index.html">
+    <span class="page-nav-eyebrow">Reference overview</span>
+    <strong class="page-nav-label">Full Spec Reference</strong>
+  </a>
+  <a class="page-nav-link next" href="crude-pattern.html">
+    <span class="page-nav-eyebrow">Next spec page</span>
+    <strong class="page-nav-label">MCP-AQL CRUDE Pattern Specification</strong>
+  </a>
+</nav>
       </article>
     </div>
   </main>

--- a/public/spec/crude-pattern.html
+++ b/public/spec/crude-pattern.html
@@ -23,7 +23,7 @@
         </ul>
         <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
-          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <input id="site-search-input" data-search-input type="search" placeholder="Search MCP-AQL docs, spec pages, and adapter patterns...">
           <span class="search-count" data-search-count></span>
           <ul class="search-results" data-search-results hidden></ul>
         </form>
@@ -38,7 +38,7 @@
         <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
         <div class="docs-side-group">
   <h3>Core</h3>
-  <ul><li><a href="conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a class="current" href="crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="error-codes.html">Structured Error Codes Specification</a></li><li><a href="introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="mcp-integration.html">MCP Integration Specification</a></li><li><a href="operations.html">MCP-AQL Operations Specification</a></li><li><a href="overview.html">MCP-AQL Protocol Overview</a></li><li><a href="plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="README.html">MCP-AQL Specification Documentation</a></li><li><a href="repo/README.html">MCP-AQL Specification</a></li></ul>
+  <ul><li><a href="conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a class="current" aria-current="page" href="crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="error-codes.html">Structured Error Codes Specification</a></li><li><a href="introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="mcp-integration.html">MCP Integration Specification</a></li><li><a href="operations.html">MCP-AQL Operations Specification</a></li><li><a href="overview.html">MCP-AQL Protocol Overview</a></li><li><a href="plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="README.html">MCP-AQL Specification Documentation</a></li><li><a href="repo/README.html">MCP-AQL Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Versions</h3>
   <ul><li><a href="versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
@@ -438,6 +438,16 @@ mcp_aql_execute  - EXECUTE operations</code></pre>
 
           </div>
         </section>
+        <nav class="page-nav" aria-label="Page navigation">
+  <a class="page-nav-link prev" href="conformance-testing.html">
+    <span class="page-nav-eyebrow">Previous spec page</span>
+    <strong class="page-nav-label">MCP-AQL Conformance Testing Specification</strong>
+  </a>
+  <a class="page-nav-link next" href="endpoint-modes.html">
+    <span class="page-nav-eyebrow">Next spec page</span>
+    <strong class="page-nav-label">MCP-AQL Endpoint Modes Specification</strong>
+  </a>
+</nav>
       </article>
     </div>
   </main>

--- a/public/spec/crude-pattern.html
+++ b/public/spec/crude-pattern.html
@@ -38,7 +38,7 @@
         <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
         <div class="docs-side-group">
   <h3>Core</h3>
-  <ul><li><a href="conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a class="current" href="crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="error-codes.html">Structured Error Codes Specification</a></li><li><a href="introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="mcp-integration.html">MCP Integration Specification</a></li><li><a href="operations.html">MCP-AQL Operations Specification</a></li><li><a href="overview.html">MCP-AQL Protocol Overview</a></li><li><a href="plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="README.html">MCP-AQL Specification Documentation</a></li></ul>
+  <ul><li><a href="conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a class="current" href="crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="error-codes.html">Structured Error Codes Specification</a></li><li><a href="introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="mcp-integration.html">MCP Integration Specification</a></li><li><a href="operations.html">MCP-AQL Operations Specification</a></li><li><a href="overview.html">MCP-AQL Protocol Overview</a></li><li><a href="plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="README.html">MCP-AQL Specification Documentation</a></li><li><a href="repo/README.html">MCP-AQL Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Versions</h3>
   <ul><li><a href="versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
@@ -56,7 +56,7 @@
   <ul><li><a href="guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
-  <ul><li><a href="process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="process/versioning.html">Versioning Strategy</a></li></ul>
+  <ul><li><a href="process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="process/versioning.html">Versioning Strategy</a></li><li><a href="repo/CHANGELOG.html">Changelog</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Architecture</h3>
   <ul><li><a href="architecture/README.html">Architecture Documentation</a></li></ul>

--- a/public/spec/crude-pattern.html
+++ b/public/spec/crude-pattern.html
@@ -73,6 +73,13 @@
       </aside>
 
       <article class="docs-main">
+        <nav class="breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../index.html">Home</a></li>
+            <li><a href="index.html">Full Spec</a></li>
+            <li><span class="current">MCP-AQL CRUDE Pattern Specification</span></li>
+          </ol>
+        </nav>
         <section class="hero docs-hero">
           <div class="hero-inner">
             <span class="status-pill">REPO-SYNCED SPEC DOC</span>

--- a/public/spec/crude-pattern.html
+++ b/public/spec/crude-pattern.html
@@ -1,0 +1,452 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Document Status: This document is informative. For normative requirements, see MCP-AQL Specification v1.0.0.">
+  <title>MCP-AQL Spec | MCP-AQL CRUDE Pattern Specification</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../css/style.css">
+</head>
+<body>
+  <header>
+    <div class="container">
+      <nav>
+        <a class="logo" href="../index.html"><span class="logo-mark"></span>MCP-AQL</a>
+        <ul class="nav-links">
+          <li><a href="../index.html">Home</a></li>
+          <li><a href="../docs/index.html">Docs</a></li>
+          <li><a href="../launch-checklist.html">Launch Checklist</a></li>
+          <li><a href="../apis/mcp-server.html">Adapter Patterns</a></li>
+        </ul>
+        <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
+          <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
+          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <span class="search-count" data-search-count></span>
+          <ul class="search-results" data-search-results hidden></ul>
+        </form>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <div class="container docs-shell">
+      <aside class="docs-side">
+        <h2>Repo-Synced Spec</h2>
+        <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
+        <div class="docs-side-group">
+  <h3>Core</h3>
+  <ul><li><a href="conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a class="current" href="crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="error-codes.html">Structured Error Codes Specification</a></li><li><a href="introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="mcp-integration.html">MCP Integration Specification</a></li><li><a href="operations.html">MCP-AQL Operations Specification</a></li><li><a href="overview.html">MCP-AQL Protocol Overview</a></li><li><a href="plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="README.html">MCP-AQL Specification Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Versions</h3>
+  <ul><li><a href="versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Adapter</h3>
+  <ul><li><a href="adapter/danger-levels.html">Dangerous Operation Classification Specification</a></li><li><a href="adapter/discovery-bundle.html">MCP Server Discovery Bundle</a></li><li><a href="adapter/element-type.html">Adapter Element Type Specification</a></li><li><a href="adapter/generator.html">Adapter Generator Specification</a></li><li><a href="adapter/rate-limiting.html">Rate Limiting and Quota Management Specification</a></li><li><a href="adapter/trust-levels.html">Trust Levels Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Security</h3>
+  <ul><li><a href="security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Features</h3>
+  <ul><li><a href="features/field-selection.html">Field Selection Specification</a></li><li><a href="features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="features/warnings.html">Warnings Array Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Guides</h3>
+  <ul><li><a href="guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="guides/README.html">Developer Guides</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Process</h3>
+  <ul><li><a href="process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="process/versioning.html">Versioning Strategy</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Architecture</h3>
+  <ul><li><a href="architecture/README.html">Architecture Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Research</h3>
+  <ul><li><a href="research/mcp-vs-mcpaql-vs-a2a.html">Protocol Landscape: MCP vs MCP-AQL vs A2A</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Reference</h3>
+  <ul><li><a href="reference/README.html">Reference Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>ADRs</h3>
+  <ul><li><a href="adr/ADR-001-crude-pattern.html">ADR-001: CRUDE Pattern (Extending CRUD with Execute)</a></li><li><a href="adr/ADR-002-graphql-style-input.html">ADR-002: GraphQL-Style Input Objects for Updates</a></li><li><a href="adr/ADR-003-snake-case-parameters.html">ADR-003: snake_case Parameter Convention</a></li><li><a href="adr/ADR-004-schema-driven-operations.html">ADR-004: Schema-Driven Operation Definitions</a></li><li><a href="adr/ADR-005-introspection-system.html">ADR-005: GraphQL-Style Introspection System</a></li><li><a href="adr/ADR-006-discriminated-responses.html">ADR-006: Discriminated Response Format</a></li><li><a href="adr/index.html">Architecture Decision Records</a></li><li><a href="adr/README.html">Architecture Decision Records</a></li></ul>
+</div>
+      </aside>
+
+      <article class="docs-main">
+        <section class="hero docs-hero">
+          <div class="hero-inner">
+            <span class="status-pill">REPO-SYNCED SPEC DOC</span>
+            <h1>MCP-AQL CRUDE Pattern Specification</h1>
+            <p class="lede">Document Status: This document is informative. For normative requirements, see MCP-AQL Specification v1.0.0.</p>
+            <div class="spec-meta"><span class="state-chip live">Support document</span><span class="state-chip pending">Draft</span><span class="state-chip">1.0.0-draft</span><span class="state-chip">2026-02-18</span></div>
+            <p class="spec-source">Source: <a href="https://github.com/MCPAQL/spec/blob/main/docs/crude-pattern.md">spec/docs/crude-pattern.md</a></p>
+            <div class="hero-actions">
+              <a class="btn btn-primary" href="https://github.com/MCPAQL/spec/blob/main/docs/crude-pattern.md">Open Source Markdown</a>
+              <a class="btn btn-secondary" href="index.html">Browse Full Spec Reference</a>
+            </div>
+          </div>
+        </section>
+
+        <section>
+          <div class="card spec-prose">
+            <p><strong>Version:</strong> 1.0.0-draft <strong>Status:</strong> Draft <strong>Last Updated:</strong> 2026-02-18</p>
+<blockquote>
+<p><strong>Document Status:</strong> This document is <strong>informative</strong>. For normative requirements, see <a href="versions/v1.0.0-draft.html">MCP-AQL Specification v1.0.0</a>.</p>
+</blockquote>
+<h2 id="abstract">Abstract</h2>
+<p>This document specifies the CRUDE (Create, Read, Update, Delete, Execute) endpoint pattern, which extends traditional CRUD semantics with an Execute endpoint for runtime lifecycle operations.</p>
+<h2 id="table-of-contents">Table of Contents</h2>
+<ol type="1">
+<li><a href="#1-introduction">Introduction</a></li>
+<li><a href="#2-endpoint-definitions">Endpoint Definitions</a></li>
+<li><a href="#3-permission-model">Permission Model</a></li>
+<li><a href="#4-endpoint-modes">Endpoint Modes</a></li>
+<li><a href="#5-operation-routing">Operation Routing</a></li>
+<li><a href="#6-classification-guidelines">Classification Guidelines</a></li>
+<li><a href="#7-conformance-requirements">Conformance Requirements</a></li>
+</ol>
+<hr />
+<h2 id="1-introduction">1. Introduction</h2>
+<h3 id="11-purpose">1.1 Purpose</h3>
+<p>The CRUDE pattern provides semantic grouping of operations by their effect on system state. This grouping enables:</p>
+<ul>
+<li>Permission-based access control at the endpoint level</li>
+<li>Clear separation of read-only, additive, modifying, and destructive operations</li>
+<li>Explicit handling of runtime execution lifecycle operations</li>
+</ul>
+<h3 id="12-rationale-for-execute">1.2 Rationale for EXECUTE</h3>
+<p>Traditional CRUD patterns assume operations are primarily concerned with data persistence. However, many services provide executable functionality (jobs, workflows, tasks, processes) that require:</p>
+<ul>
+<li><strong>Non-idempotent operations</strong> - Calling <code>execute_job</code> twice creates two separate executions</li>
+<li><strong>Lifecycle management</strong> - Start, monitor, update progress, complete</li>
+<li><strong>Runtime state</strong> - Distinct from stored data</li>
+</ul>
+<p>The EXECUTE endpoint addresses these requirements explicitly.</p>
+<h3 id="13-adapter-responsibility">1.3 Adapter Responsibility</h3>
+<p>Each adapter implementing MCP-AQL:</p>
+<ul>
+<li>Defines its own operations</li>
+<li>Classifies each operation into the appropriate CRUDE endpoint</li>
+<li>Documents its operation-to-endpoint mapping via introspection</li>
+</ul>
+<hr />
+<h2 id="2-endpoint-definitions">2. Endpoint Definitions</h2>
+<h3 id="21-create-endpoint">2.1 CREATE Endpoint</h3>
+<p><strong>Identifier:</strong> <code>CREATE</code> <strong>MCP Tool Name:</strong> <code>mcp_aql_create</code></p>
+<p>Operations that add new state without removing or modifying existing state.</p>
+<p><strong>Characteristics:</strong></p>
+<ul>
+<li>Non-destructive</li>
+<li>Additive only</li>
+<li>May fail if duplicate state would be created</li>
+</ul>
+<p><strong>Example Operations:</strong> | Operation | Description | |-----------|-------------| | <code>create_user</code> | Create a new user account | | <code>upload_file</code> | Upload a new file | | <code>add_comment</code> | Add a comment to a resource | | <code>register_webhook</code> | Register a new webhook |</p>
+<h3 id="22-read-endpoint">2.2 READ Endpoint</h3>
+<p><strong>Identifier:</strong> <code>READ</code> <strong>MCP Tool Name:</strong> <code>mcp_aql_read</code></p>
+<p>Operations that query state without modification.</p>
+<p><strong>Characteristics:</strong></p>
+<ul>
+<li>Read-only</li>
+<li>No side effects on stored state</li>
+<li>Safe to call repeatedly (idempotent)</li>
+</ul>
+<p><strong>Example Operations:</strong> | Operation | Description | |-----------|-------------| | <code>list_users</code> | List users with filtering | | <code>get_document</code> | Retrieve a document by ID | | <code>search</code> | Search across resources | | <code>introspect</code> | Discover available operations | | <code>get_status</code> | Get current system status | | <code>get_execution_status</code> | Query execution progress | | <code>export_data</code> | Export data to portable format |</p>
+<blockquote>
+<p><strong>Note:</strong> Operations that query execution state are READ operations, not EXECUTE. See <a href="#61-classification-principle">Section 6.1</a> for classification guidelines.</p>
+</blockquote>
+<h3 id="23-update-endpoint">2.3 UPDATE Endpoint</h3>
+<p><strong>Identifier:</strong> <code>UPDATE</code> <strong>MCP Tool Name:</strong> <code>mcp_aql_update</code></p>
+<p>Operations that modify existing state.</p>
+<p><strong>Characteristics:</strong></p>
+<ul>
+<li>Modifying</li>
+<li>Requires existing state to modify</li>
+<li>May be destructive to prior values</li>
+</ul>
+<p><strong>Example Operations:</strong> | Operation | Description | |-----------|-------------| | <code>update_user</code> | Modify user properties | | <code>rename_file</code> | Rename an existing file | | <code>set_config</code> | Update configuration | | <code>move_resource</code> | Move resource to new location |</p>
+<h3 id="24-delete-endpoint">2.4 DELETE Endpoint</h3>
+<p><strong>Identifier:</strong> <code>DELETE</code> <strong>MCP Tool Name:</strong> <code>mcp_aql_delete</code></p>
+<p>Operations that remove state permanently.</p>
+<p><strong>Characteristics:</strong></p>
+<ul>
+<li>Destructive</li>
+<li>Irreversible without backup</li>
+<li>MAY require confirmation</li>
+</ul>
+<p><strong>Example Operations:</strong> | Operation | Description | |-----------|-------------| | <code>delete_user</code> | Permanently delete a user | | <code>remove_file</code> | Remove a file | | <code>purge_cache</code> | Clear cached data | | <code>unregister_webhook</code> | Remove a webhook |</p>
+<h3 id="25-execute-endpoint">2.5 EXECUTE Endpoint</h3>
+<p><strong>Identifier:</strong> <code>EXECUTE</code> <strong>MCP Tool Name:</strong> <code>mcp_aql_execute</code></p>
+<p>Operations that manage the runtime execution lifecycle.</p>
+<p><strong>Characteristics:</strong></p>
+<ul>
+<li>Stateful (maintains execution context)</li>
+<li>Non-idempotent (each call may create new state)</li>
+<li>Potentially destructive (may modify external state)</li>
+<li>Lifecycle-oriented</li>
+</ul>
+<p><strong>Example Operations:</strong> | Operation | Description | |-----------|-------------| | <code>execute_job</code> | Start a background job | | <code>cancel_task</code> | Cancel a running task | | <code>resume_workflow</code> | Resume a paused workflow | | <code>trigger_build</code> | Trigger a build process |</p>
+<blockquote>
+<p><strong>Note:</strong> Operations that only query execution state (like <code>get_execution_status</code>) belong to READ, not EXECUTE. See <a href="#61-classification-principle">Section 6.1</a> for classification guidelines.</p>
+</blockquote>
+<p>For operations that manage long-running processes, see <a href="versions/v1.0.0-draft.html#84-execution-lifecycle">Execution Lifecycle</a> in the normative specification.</p>
+<hr />
+<h2 id="3-permission-model">3. Permission Model</h2>
+<h3 id="31-endpoint-permissions">3.1 Endpoint Permissions</h3>
+<p>Each endpoint has defined permission characteristics:</p>
+<pre><code>Endpoint    Read-Only    Destructive
+--------    ---------    -----------
+CREATE      false        false
+READ        true         false
+UPDATE      false        true
+DELETE      false        true
+EXECUTE     false        true</code></pre>
+<h3 id="32-permission-flags">3.2 Permission Flags</h3>
+<p><strong>readOnly:</strong></p>
+<ul>
+<li><code>true</code>: Operation does not modify any state</li>
+<li><code>false</code>: Operation may modify state</li>
+</ul>
+<p><strong>destructive:</strong></p>
+<ul>
+<li><code>true</code>: Operation may remove or irreversibly modify state</li>
+<li><code>false</code>: Operation only adds or queries state</li>
+</ul>
+<h3 id="33-mcp-tool-annotations">3.3 MCP Tool Annotations</h3>
+<p>When registering MCP tools, adapters SHOULD include permission hints:</p>
+<div class="sourceCode" id="cb2"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb2-2"><a href="#cb2-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;mcp_aql_read&quot;</span><span class="fu">,</span></span>
+<span id="cb2-3"><a href="#cb2-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;annotations&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb2-4"><a href="#cb2-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;readOnlyHint&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb2-5"><a href="#cb2-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;destructiveHint&quot;</span><span class="fu">:</span> <span class="kw">false</span></span>
+<span id="cb2-6"><a href="#cb2-6" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb2-7"><a href="#cb2-7" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<h3 id="34-confirmation-requirements">3.4 Confirmation Requirements</h3>
+<p>Implementations MAY require explicit confirmation for:</p>
+<ul>
+<li>All DELETE operations</li>
+<li>EXECUTE operations with external side effects</li>
+<li>UPDATE operations that modify critical data</li>
+</ul>
+<hr />
+<h2 id="4-endpoint-modes">4. Endpoint Modes</h2>
+<h3 id="41-crude-mode">4.1 CRUDE Mode</h3>
+<p>Exposes five separate MCP tools, one per endpoint:</p>
+<pre><code>mcp_aql_create   - CREATE operations
+mcp_aql_read     - READ operations
+mcp_aql_update   - UPDATE operations
+mcp_aql_delete   - DELETE operations
+mcp_aql_execute  - EXECUTE operations</code></pre>
+<p><strong>Advantages:</strong></p>
+<ul>
+<li>Endpoint-level permission control</li>
+<li>Client can selectively expose endpoints</li>
+<li>Clear semantic separation</li>
+<li>Platform permission hints</li>
+</ul>
+<p><strong>Typical Token Cost:</strong> ~4,300 tokens for tool registration</p>
+<h3 id="42-single-mode">4.2 Single Mode</h3>
+<p>Exposes one unified MCP tool that routes internally:</p>
+<pre><code>mcp_aql - All operations through single entry point</code></pre>
+<p><strong>Advantages:</strong></p>
+<ul>
+<li>Minimal token footprint</li>
+<li>Simpler client integration</li>
+<li>Server-side routing enforcement</li>
+</ul>
+<p><strong>Typical Token Cost:</strong> ~1,100 tokens for tool registration</p>
+<h3 id="43-mode-selection">4.3 Mode Selection</h3>
+<p>Implementations MUST support at least one mode. Implementations SHOULD support both modes with runtime configuration.</p>
+<p>The recommended environment variable for mode selection:</p>
+<pre><code>MCP_AQL_ENDPOINT_MODE=crude|single</code></pre>
+<hr />
+<h2 id="5-operation-routing">5. Operation Routing</h2>
+<h3 id="51-routing-rules">5.1 Routing Rules</h3>
+<p>Each operation MUST be routed to exactly one endpoint. Implementations MUST reject operations sent to incorrect endpoints in CRUDE mode.</p>
+<h3 id="52-route-validation">5.2 Route Validation</h3>
+<p>When an operation is received:</p>
+<ol type="1">
+<li>Extract the <code>operation</code> field from the request</li>
+<li>Look up the correct endpoint for that operation</li>
+<li>If in CRUDE mode, verify the operation was sent to the correct endpoint</li>
+<li>If endpoint mismatch, return an error with the correct endpoint</li>
+</ol>
+<p><strong>Error Response for Route Mismatch:</strong></p>
+<div class="sourceCode" id="cb6"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb6-1"><a href="#cb6-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb6-2"><a href="#cb6-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb6-3"><a href="#cb6-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;error&quot;</span><span class="fu">:</span> <span class="st">&quot;Operation &#39;create_user&#39; must be called via mcp_aql_create, not mcp_aql_read&quot;</span></span>
+<span id="cb6-4"><a href="#cb6-4" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<h3 id="53-single-mode-routing">5.3 Single Mode Routing</h3>
+<p>In Single mode, the implementation:</p>
+<ol type="1">
+<li>Accepts all operations through <code>mcp_aql</code></li>
+<li>Internally routes to the correct handler based on operation</li>
+<li>Enforces the same semantic rules as CRUDE mode</li>
+</ol>
+<h3 id="54-server-side-authority">5.4 Server-Side Authority</h3>
+<blockquote>
+<p>"LLM instructions are suggestions. Adapter policies are enforcement."</p>
+</blockquote>
+<p>The adapter is authoritative for operation routing. Clients cannot bypass routing rules by sending operations to different endpoints.</p>
+<hr />
+<h2 id="6-classification-guidelines">6. Classification Guidelines</h2>
+<h3 id="61-classification-principle">6.1 Classification Principle</h3>
+<p>Operations are classified by their <strong>effect on state</strong>, not by their <strong>subject matter</strong>.</p>
+<p>An operation that queries the status of an EXECUTE operation (like <code>get_execution_status</code>) is still a READ operation because it only reads data.</p>
+<p><strong>Examples:</strong></p>
+<ul>
+<li><code>get_execution_status</code> → READ (queries state, no side effects)</li>
+<li><code>get_task_log</code> → READ (retrieves execution output, no side effects)</li>
+<li><code>execute_job</code> → EXECUTE (creates new execution, non-idempotent)</li>
+<li><code>cancel_task</code> → EXECUTE (modifies execution state)</li>
+<li><code>pause_execution</code> → EXECUTE (modifies execution state)</li>
+</ul>
+<h3 id="62-how-to-classify-operations">6.2 How to Classify Operations</h3>
+<p>When building an adapter, classify each operation by asking:</p>
+<ol type="1">
+<li><strong>Does it only read data?</strong> → READ</li>
+<li><strong>Does it add new data without modifying existing?</strong> → CREATE</li>
+<li><strong>Does it modify existing data?</strong> → UPDATE</li>
+<li><strong>Does it remove data permanently?</strong> → DELETE</li>
+<li><strong>Does it manage runtime execution?</strong> → EXECUTE</li>
+</ol>
+<h3 id="63-decision-tree">6.3 Decision Tree</h3>
+<pre><code>                    Does it modify state?
+                          /     \
+                        No       Yes
+                        |         |
+                      READ    Is it additive only?
+                               /     \
+                             Yes      No
+                             |         |
+                          CREATE   Does it remove data?
+                                     /     \
+                                   Yes      No
+                                   |         |
+                                DELETE   Is it runtime/lifecycle?
+                                            /     \
+                                          Yes      No
+                                          |         |
+                                       EXECUTE   UPDATE</code></pre>
+<blockquote>
+<p><strong>Important:</strong> Classification is by <strong>effect</strong>, not subject. See <a href="#61-classification-principle">Section 6.1</a> for the guiding principle.</p>
+</blockquote>
+<h3 id="64-edge-cases">6.4 Edge Cases</h3>
+<p><strong>Upsert Operations:</strong></p>
+<ul>
+<li>If creates when not exists, updates when exists: Prefer CREATE</li>
+<li>Document behavior in operation description</li>
+</ul>
+<p><strong>Soft Delete:</strong></p>
+<ul>
+<li>If marks as deleted but doesn't remove: Could be UPDATE</li>
+<li>If removes from normal queries: Prefer DELETE</li>
+<li>Document behavior clearly</li>
+</ul>
+<p><strong>Triggering Actions:</strong></p>
+<ul>
+<li>If triggers external action (email, webhook): EXECUTE</li>
+<li>If just saves data that will trigger later: CREATE</li>
+</ul>
+<p><strong>Import Operations:</strong></p>
+<ul>
+<li>If imports without overwriting: CREATE</li>
+<li>If may overwrite existing: Discuss in operation description</li>
+</ul>
+<h3 id="65-canonical-verbs">6.5 Canonical Verbs</h3>
+<p>Each endpoint has canonical verbs that adapters SHOULD use for standard operations:</p>
+<table>
+<thead>
+<tr>
+<th>Endpoint</th>
+<th>Canonical Verb</th>
+<th>Example Operation</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>CREATE</td>
+<td><code>create</code></td>
+<td><code>create_user</code></td>
+</tr>
+<tr>
+<td>READ</td>
+<td><code>get</code> (single), <code>list</code> (multiple)</td>
+<td><code>get_document</code>, <code>list_users</code></td>
+</tr>
+<tr>
+<td>UPDATE</td>
+<td><code>update</code></td>
+<td><code>update_profile</code></td>
+</tr>
+<tr>
+<td>DELETE</td>
+<td><code>delete</code></td>
+<td><code>delete_account</code></td>
+</tr>
+<tr>
+<td>EXECUTE</td>
+<td><code>execute</code> (initiate), <code>cancel</code> (terminate)</td>
+<td><code>execute_workflow</code>, <code>cancel_task</code></td>
+</tr>
+</tbody>
+</table>
+<p>Non-canonical verbs (e.g., <code>upload</code>, <code>search</code>, <code>remove</code>) MAY be used when domain semantics require it. See <a href="versions/v1.0.0-draft.html#85-operation-naming-grammar">Section 8.5</a> of the normative specification for the full naming grammar.</p>
+<h3 id="66-documentation-requirement">6.6 Documentation Requirement</h3>
+<p>Adapters MUST document their operation classification via introspection. Each operation's endpoint MUST be discoverable.</p>
+<hr />
+<h2 id="7-conformance-requirements">7. Conformance Requirements</h2>
+<h3 id="71-must-requirements">7.1 MUST Requirements</h3>
+<p>Conforming implementations MUST:</p>
+<ol type="1">
+<li>Implement all five CRUDE endpoints OR the single unified endpoint</li>
+<li>Route operations to their correct endpoints according to classification</li>
+<li>Return errors for operations sent to incorrect endpoints (CRUDE mode)</li>
+<li>Apply permission flags accurately for each endpoint</li>
+<li>Implement the <code>introspect</code> operation (READ endpoint)</li>
+</ol>
+<h3 id="72-should-requirements">7.2 SHOULD Requirements</h3>
+<p>Conforming implementations SHOULD:</p>
+<ol type="1">
+<li>Support both CRUDE and Single endpoint modes</li>
+<li>Provide configuration for mode selection</li>
+<li>Implement confirmation for destructive operations</li>
+<li>Log EXECUTE operations for audit purposes</li>
+<li>Include MCP tool annotations for permissions</li>
+</ol>
+<h3 id="73-may-requirements">7.3 MAY Requirements</h3>
+<p>Conforming implementations MAY:</p>
+<ol type="1">
+<li>Add additional operations to any endpoint</li>
+<li>Implement additional permission levels</li>
+<li>Provide endpoint-level access control lists</li>
+<li>Support operation-level confirmation requirements</li>
+<li>Implement rate limiting per endpoint</li>
+</ol>
+<hr />
+<h2 id="references">References</h2>
+<ul>
+<li><a href="versions/v1.0.0-draft.html">MCP-AQL Specification v1.0.0-draft</a></li>
+<li><a href="introspection.html">Introspection Specification</a></li>
+</ul>
+
+          </div>
+        </section>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div class="container">
+      <p>&copy; 2026 DollhouseMCP Inc. d/b/a Dollhouse Research. MCP-AQL public draft documentation portal.</p>
+      <div class="footer-links">
+        <a href="../docs/index.html">Docs Library</a>
+        <a href="index.html">Repo-Synced Spec</a>
+        <a href="https://github.com/MCPAQL">MCPAQL Organization</a>
+        <a href="https://dollhouseresearch.com">Dollhouse Research</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../js/search.js"></script>
+</body>
+</html>

--- a/public/spec/endpoint-modes.html
+++ b/public/spec/endpoint-modes.html
@@ -73,6 +73,13 @@
       </aside>
 
       <article class="docs-main">
+        <nav class="breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../index.html">Home</a></li>
+            <li><a href="index.html">Full Spec</a></li>
+            <li><span class="current">MCP-AQL Endpoint Modes Specification</span></li>
+          </ol>
+        </nav>
         <section class="hero docs-hero">
           <div class="hero-inner">
             <span class="status-pill">REPO-SYNCED SPEC DOC</span>

--- a/public/spec/endpoint-modes.html
+++ b/public/spec/endpoint-modes.html
@@ -23,7 +23,7 @@
         </ul>
         <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
-          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <input id="site-search-input" data-search-input type="search" placeholder="Search MCP-AQL docs, spec pages, and adapter patterns...">
           <span class="search-count" data-search-count></span>
           <ul class="search-results" data-search-results hidden></ul>
         </form>
@@ -38,7 +38,7 @@
         <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
         <div class="docs-side-group">
   <h3>Core</h3>
-  <ul><li><a href="conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a class="current" href="endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="error-codes.html">Structured Error Codes Specification</a></li><li><a href="introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="mcp-integration.html">MCP Integration Specification</a></li><li><a href="operations.html">MCP-AQL Operations Specification</a></li><li><a href="overview.html">MCP-AQL Protocol Overview</a></li><li><a href="plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="README.html">MCP-AQL Specification Documentation</a></li><li><a href="repo/README.html">MCP-AQL Specification</a></li></ul>
+  <ul><li><a href="conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a class="current" aria-current="page" href="endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="error-codes.html">Structured Error Codes Specification</a></li><li><a href="introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="mcp-integration.html">MCP Integration Specification</a></li><li><a href="operations.html">MCP-AQL Operations Specification</a></li><li><a href="overview.html">MCP-AQL Protocol Overview</a></li><li><a href="plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="README.html">MCP-AQL Specification Documentation</a></li><li><a href="repo/README.html">MCP-AQL Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Versions</h3>
   <ul><li><a href="versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
@@ -575,6 +575,16 @@ Use introspection to discover available operations:
 
           </div>
         </section>
+        <nav class="page-nav" aria-label="Page navigation">
+  <a class="page-nav-link prev" href="crude-pattern.html">
+    <span class="page-nav-eyebrow">Previous spec page</span>
+    <strong class="page-nav-label">MCP-AQL CRUDE Pattern Specification</strong>
+  </a>
+  <a class="page-nav-link next" href="error-codes.html">
+    <span class="page-nav-eyebrow">Next spec page</span>
+    <strong class="page-nav-label">Structured Error Codes Specification</strong>
+  </a>
+</nav>
       </article>
     </div>
   </main>

--- a/public/spec/endpoint-modes.html
+++ b/public/spec/endpoint-modes.html
@@ -38,7 +38,7 @@
         <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
         <div class="docs-side-group">
   <h3>Core</h3>
-  <ul><li><a href="conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a class="current" href="endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="error-codes.html">Structured Error Codes Specification</a></li><li><a href="introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="mcp-integration.html">MCP Integration Specification</a></li><li><a href="operations.html">MCP-AQL Operations Specification</a></li><li><a href="overview.html">MCP-AQL Protocol Overview</a></li><li><a href="plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="README.html">MCP-AQL Specification Documentation</a></li></ul>
+  <ul><li><a href="conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a class="current" href="endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="error-codes.html">Structured Error Codes Specification</a></li><li><a href="introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="mcp-integration.html">MCP Integration Specification</a></li><li><a href="operations.html">MCP-AQL Operations Specification</a></li><li><a href="overview.html">MCP-AQL Protocol Overview</a></li><li><a href="plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="README.html">MCP-AQL Specification Documentation</a></li><li><a href="repo/README.html">MCP-AQL Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Versions</h3>
   <ul><li><a href="versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
@@ -56,7 +56,7 @@
   <ul><li><a href="guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
-  <ul><li><a href="process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="process/versioning.html">Versioning Strategy</a></li></ul>
+  <ul><li><a href="process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="process/versioning.html">Versioning Strategy</a></li><li><a href="repo/CHANGELOG.html">Changelog</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Architecture</h3>
   <ul><li><a href="architecture/README.html">Architecture Documentation</a></li></ul>

--- a/public/spec/endpoint-modes.html
+++ b/public/spec/endpoint-modes.html
@@ -1,0 +1,589 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Document Status: This document is informative. For normative requirements, see MCP-AQL Specification v1.0.0.">
+  <title>MCP-AQL Spec | MCP-AQL Endpoint Modes Specification</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../css/style.css">
+</head>
+<body>
+  <header>
+    <div class="container">
+      <nav>
+        <a class="logo" href="../index.html"><span class="logo-mark"></span>MCP-AQL</a>
+        <ul class="nav-links">
+          <li><a href="../index.html">Home</a></li>
+          <li><a href="../docs/index.html">Docs</a></li>
+          <li><a href="../launch-checklist.html">Launch Checklist</a></li>
+          <li><a href="../apis/mcp-server.html">Adapter Patterns</a></li>
+        </ul>
+        <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
+          <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
+          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <span class="search-count" data-search-count></span>
+          <ul class="search-results" data-search-results hidden></ul>
+        </form>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <div class="container docs-shell">
+      <aside class="docs-side">
+        <h2>Repo-Synced Spec</h2>
+        <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
+        <div class="docs-side-group">
+  <h3>Core</h3>
+  <ul><li><a href="conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a class="current" href="endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="error-codes.html">Structured Error Codes Specification</a></li><li><a href="introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="mcp-integration.html">MCP Integration Specification</a></li><li><a href="operations.html">MCP-AQL Operations Specification</a></li><li><a href="overview.html">MCP-AQL Protocol Overview</a></li><li><a href="plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="README.html">MCP-AQL Specification Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Versions</h3>
+  <ul><li><a href="versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Adapter</h3>
+  <ul><li><a href="adapter/danger-levels.html">Dangerous Operation Classification Specification</a></li><li><a href="adapter/discovery-bundle.html">MCP Server Discovery Bundle</a></li><li><a href="adapter/element-type.html">Adapter Element Type Specification</a></li><li><a href="adapter/generator.html">Adapter Generator Specification</a></li><li><a href="adapter/rate-limiting.html">Rate Limiting and Quota Management Specification</a></li><li><a href="adapter/trust-levels.html">Trust Levels Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Security</h3>
+  <ul><li><a href="security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Features</h3>
+  <ul><li><a href="features/field-selection.html">Field Selection Specification</a></li><li><a href="features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="features/warnings.html">Warnings Array Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Guides</h3>
+  <ul><li><a href="guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="guides/README.html">Developer Guides</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Process</h3>
+  <ul><li><a href="process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="process/versioning.html">Versioning Strategy</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Architecture</h3>
+  <ul><li><a href="architecture/README.html">Architecture Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Research</h3>
+  <ul><li><a href="research/mcp-vs-mcpaql-vs-a2a.html">Protocol Landscape: MCP vs MCP-AQL vs A2A</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Reference</h3>
+  <ul><li><a href="reference/README.html">Reference Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>ADRs</h3>
+  <ul><li><a href="adr/ADR-001-crude-pattern.html">ADR-001: CRUDE Pattern (Extending CRUD with Execute)</a></li><li><a href="adr/ADR-002-graphql-style-input.html">ADR-002: GraphQL-Style Input Objects for Updates</a></li><li><a href="adr/ADR-003-snake-case-parameters.html">ADR-003: snake_case Parameter Convention</a></li><li><a href="adr/ADR-004-schema-driven-operations.html">ADR-004: Schema-Driven Operation Definitions</a></li><li><a href="adr/ADR-005-introspection-system.html">ADR-005: GraphQL-Style Introspection System</a></li><li><a href="adr/ADR-006-discriminated-responses.html">ADR-006: Discriminated Response Format</a></li><li><a href="adr/index.html">Architecture Decision Records</a></li><li><a href="adr/README.html">Architecture Decision Records</a></li></ul>
+</div>
+      </aside>
+
+      <article class="docs-main">
+        <section class="hero docs-hero">
+          <div class="hero-inner">
+            <span class="status-pill">REPO-SYNCED SPEC DOC</span>
+            <h1>MCP-AQL Endpoint Modes Specification</h1>
+            <p class="lede">Document Status: This document is informative. For normative requirements, see MCP-AQL Specification v1.0.0.</p>
+            <div class="spec-meta"><span class="state-chip live">Support document</span><span class="state-chip pending">Draft</span><span class="state-chip">1.0.0-draft</span><span class="state-chip">2026-01-16</span></div>
+            <p class="spec-source">Source: <a href="https://github.com/MCPAQL/spec/blob/main/docs/endpoint-modes.md">spec/docs/endpoint-modes.md</a></p>
+            <div class="hero-actions">
+              <a class="btn btn-primary" href="https://github.com/MCPAQL/spec/blob/main/docs/endpoint-modes.md">Open Source Markdown</a>
+              <a class="btn btn-secondary" href="index.html">Browse Full Spec Reference</a>
+            </div>
+          </div>
+        </section>
+
+        <section>
+          <div class="card spec-prose">
+            <p><strong>Version:</strong> 1.0.0-draft <strong>Status:</strong> Draft <strong>Last Updated:</strong> 2026-01-16</p>
+<blockquote>
+<p><strong>Document Status:</strong> This document is <strong>informative</strong>. For normative requirements, see <a href="versions/v1.0.0-draft.html">MCP-AQL Specification v1.0.0</a>.</p>
+</blockquote>
+<h2 id="abstract">Abstract</h2>
+<p>MCP-AQL supports two operational modes for exposing endpoints to clients: CRUDE mode (5 semantic endpoints) and Single mode (1 unified endpoint). This document specifies configuration, routing behavior, security implications, and trade-offs for each mode.</p>
+<hr />
+<h2 id="table-of-contents">Table of Contents</h2>
+<ol type="1">
+<li><a href="#1-introduction">Introduction</a></li>
+<li><a href="#2-mode-comparison">Mode Comparison</a></li>
+<li><a href="#3-configuration">Configuration</a></li>
+<li><a href="#4-crude-mode">CRUDE Mode</a></li>
+<li><a href="#5-single-mode">Single Mode</a></li>
+<li><a href="#6-security-considerations">Security Considerations</a></li>
+<li><a href="#7-tool-registration">Tool Registration</a></li>
+<li><a href="#8-conformance-requirements">Conformance Requirements</a></li>
+</ol>
+<hr />
+<h2 id="1-introduction">1. Introduction</h2>
+<h3 id="11-purpose">1.1 Purpose</h3>
+<p>Endpoint modes determine how MCP-AQL operations are exposed to clients. The choice affects:</p>
+<ul>
+<li>Token cost for tool registration</li>
+<li>Client routing complexity</li>
+<li>Permission granularity</li>
+<li>Error message specificity</li>
+</ul>
+<h3 id="12-scope">1.2 Scope</h3>
+<p>This specification covers:</p>
+<ul>
+<li>How each mode exposes operations</li>
+<li>Routing behavior in each mode</li>
+<li>Security enforcement differences</li>
+<li>Implementation requirements</li>
+</ul>
+<h3 id="13-terminology">1.3 Terminology</h3>
+<table>
+<thead>
+<tr>
+<th>Term</th>
+<th>Definition</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>CRUDE Mode</strong></td>
+<td>Five separate MCP tools, one per semantic endpoint</td>
+</tr>
+<tr>
+<td><strong>Single Mode</strong></td>
+<td>One unified MCP tool that routes internally</td>
+</tr>
+<tr>
+<td><strong>Endpoint</strong></td>
+<td>An MCP tool registered with the client</td>
+</tr>
+<tr>
+<td><strong>Operation</strong></td>
+<td>A named action within an endpoint</td>
+</tr>
+</tbody>
+</table>
+<hr />
+<h2 id="2-mode-comparison">2. Mode Comparison</h2>
+<h3 id="21-summary">2.1 Summary</h3>
+<table>
+<thead>
+<tr>
+<th>Aspect</th>
+<th>CRUDE Mode (5 Endpoints)</th>
+<th>Single Mode (1 Endpoint)</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>Endpoints</strong></td>
+<td>5 semantic endpoints</td>
+<td>1 unified endpoint</td>
+</tr>
+<tr>
+<td><strong>Typical Token Cost</strong></td>
+<td>~4,300 tokens</td>
+<td>~1,100 tokens</td>
+</tr>
+<tr>
+<td><strong>Routing</strong></td>
+<td>Client chooses endpoint</td>
+<td>Server routes internally</td>
+</tr>
+<tr>
+<td><strong>Permission Control</strong></td>
+<td>Endpoint-level granularity</td>
+<td>Operation-level only</td>
+</tr>
+<tr>
+<td><strong>Client Complexity</strong></td>
+<td>Client MUST select correct endpoint</td>
+<td>Simple single entry point</td>
+</tr>
+<tr>
+<td><strong>Error Messages</strong></td>
+<td>Semantic endpoint mismatch errors</td>
+<td>Generic routing errors</td>
+</tr>
+</tbody>
+</table>
+<h3 id="22-visual-comparison">2.2 Visual Comparison</h3>
+<pre><code>CRUDE Mode                          Single Mode
+============                        ===========
+
+Client                              Client
+  |                                   |
+  +---&gt; mcp_aql_create                +---&gt; mcp_aql
+  |                                         |
+  +---&gt; mcp_aql_read                        v
+  |                                   [Internal Router]
+  +---&gt; mcp_aql_update                      |
+  |                                   +-----+-----+-----+-----+
+  +---&gt; mcp_aql_delete                |     |     |     |     |
+  |                                   C     R     U     D     E
+  +---&gt; mcp_aql_execute</code></pre>
+<h3 id="23-token-efficiency">2.3 Token Efficiency</h3>
+<p>Endpoint consolidation provides significant token reduction compared to discrete tools:</p>
+<table>
+<thead>
+<tr>
+<th>Configuration</th>
+<th>Typical Token Cost</th>
+<th>Reduction</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Discrete tools (e.g., 40+ tools)</td>
+<td>~30,000 tokens</td>
+<td>baseline</td>
+</tr>
+<tr>
+<td>CRUDE mode (5 endpoints)</td>
+<td>~4,300 tokens</td>
+<td>~85%</td>
+</tr>
+<tr>
+<td>Single mode (1 endpoint)</td>
+<td>~1,100 tokens</td>
+<td>~96%</td>
+</tr>
+</tbody>
+</table>
+<p>Note: Actual token costs vary based on operation count and description length.</p>
+<hr />
+<h2 id="3-configuration">3. Configuration</h2>
+<h3 id="31-mode-selection">3.1 Mode Selection</h3>
+<p>Implementations SHOULD provide runtime configuration for endpoint mode selection.</p>
+<p><strong>Recommended Environment Variable:</strong></p>
+<pre><code>MCP_AQL_ENDPOINT_MODE=crude|single|all</code></pre>
+<p><strong>Values:</strong> | Value | Behavior | |-------|----------| | <code>crude</code> | Register 5 semantic endpoints | | <code>single</code> | Register 1 unified endpoint | | <code>all</code> | Register all 6 endpoints |</p>
+<h3 id="32-default-mode">3.2 Default Mode</h3>
+<p>If no configuration is provided, implementations SHOULD default to CRUDE mode, which provides the best balance of token efficiency and permission granularity.</p>
+<h3 id="33-runtime-configuration">3.3 Runtime Configuration</h3>
+<p>Implementations MAY support additional configuration methods:</p>
+<ul>
+<li>Configuration files</li>
+<li>Programmatic API</li>
+<li>Environment-specific defaults</li>
+</ul>
+<hr />
+<h2 id="4-crude-mode">4. CRUDE Mode</h2>
+<h3 id="41-endpoint-registration">4.1 Endpoint Registration</h3>
+<p>In CRUDE mode, five MCP tools are registered:</p>
+<table>
+<thead>
+<tr>
+<th>Tool Name</th>
+<th>Semantic Category</th>
+<th>Operations</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>mcp_aql_create</code></td>
+<td>Additive, non-destructive</td>
+<td>Create, add, register</td>
+</tr>
+<tr>
+<td><code>mcp_aql_read</code></td>
+<td>Safe, read-only</td>
+<td>List, get, search, introspect</td>
+</tr>
+<tr>
+<td><code>mcp_aql_update</code></td>
+<td>Modifying</td>
+<td>Edit, modify, update</td>
+</tr>
+<tr>
+<td><code>mcp_aql_delete</code></td>
+<td>Destructive</td>
+<td>Delete, remove, clear</td>
+</tr>
+<tr>
+<td><code>mcp_aql_execute</code></td>
+<td>Runtime lifecycle</td>
+<td>Run, start, stop, cancel</td>
+</tr>
+</tbody>
+</table>
+<h3 id="42-client-responsibility">4.2 Client Responsibility</h3>
+<p>In CRUDE mode, clients MUST select the correct endpoint for each operation. If a client sends an operation to the wrong endpoint, the adapter MUST reject the request.</p>
+<p><strong>Example: Correct Usage</strong></p>
+<div class="sourceCode" id="cb3"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb3-1"><a href="#cb3-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Via mcp_aql_read endpoint</span></span>
+<span id="cb3-2"><a href="#cb3-2" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb3-3"><a href="#cb3-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;list_items&quot;</span><span class="op">,</span></span>
+<span id="cb3-4"><a href="#cb3-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> { <span class="dt">limit</span><span class="op">:</span> <span class="dv">10</span> }</span>
+<span id="cb3-5"><a href="#cb3-5" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<p><strong>Example: Incorrect Usage</strong></p>
+<div class="sourceCode" id="cb4"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb4-1"><a href="#cb4-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Via mcp_aql_create endpoint (WRONG - list_items is a READ operation)</span></span>
+<span id="cb4-2"><a href="#cb4-2" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb4-3"><a href="#cb4-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;list_items&quot;</span><span class="op">,</span></span>
+<span id="cb4-4"><a href="#cb4-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> { <span class="dt">limit</span><span class="op">:</span> <span class="dv">10</span> }</span>
+<span id="cb4-5"><a href="#cb4-5" aria-hidden="true" tabindex="-1"></a>}</span>
+<span id="cb4-6"><a href="#cb4-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb4-7"><a href="#cb4-7" aria-hidden="true" tabindex="-1"></a><span class="co">// Response:</span></span>
+<span id="cb4-8"><a href="#cb4-8" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb4-9"><a href="#cb4-9" aria-hidden="true" tabindex="-1"></a>  <span class="dt">success</span><span class="op">:</span> <span class="kw">false</span><span class="op">,</span></span>
+<span id="cb4-10"><a href="#cb4-10" aria-hidden="true" tabindex="-1"></a>  <span class="dt">error</span><span class="op">:</span> <span class="st">&quot;Operation &#39;list_items&#39; must be called via mcp_aql_read, not mcp_aql_create&quot;</span></span>
+<span id="cb4-11"><a href="#cb4-11" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<h3 id="43-route-enforcement">4.3 Route Enforcement</h3>
+<p>Adapters MUST validate that operations are sent to their assigned endpoint.</p>
+<p><strong>Validation Logic:</strong></p>
+<ol type="1">
+<li>Extract operation name from request</li>
+<li>Look up the correct endpoint for that operation</li>
+<li>Compare with the endpoint that received the request</li>
+<li>If mismatch, return an error specifying the correct endpoint</li>
+</ol>
+<h3 id="44-endpoint-descriptions">4.4 Endpoint Descriptions</h3>
+<p>Each endpoint SHOULD include a description listing:</p>
+<ul>
+<li>The semantic category</li>
+<li>Available operations (or a sample with introspection guidance)</li>
+<li>Quick-start examples</li>
+</ul>
+<p><strong>Example Description Format:</strong></p>
+<pre><code>Additive, non-destructive operations.
+
+Supported operations: create_item, add_entry, register_callback
+
+These operations add new data without removing or overwriting existing content.
+
+Quick start example:
+{ operation: &quot;create_item&quot;, params: { name: &quot;example&quot; } }
+
+Use introspection to discover all available operations:
+{ operation: &quot;introspect&quot;, params: { query: &quot;operations&quot; } }</code></pre>
+<hr />
+<h2 id="5-single-mode">5. Single Mode</h2>
+<h3 id="51-endpoint-registration">5.1 Endpoint Registration</h3>
+<p>In Single mode, one MCP tool is registered:</p>
+<table>
+<thead>
+<tr>
+<th>Tool Name</th>
+<th>Purpose</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>mcp_aql</code></td>
+<td>All operations through unified entry point</td>
+</tr>
+</tbody>
+</table>
+<h3 id="52-server-side-routing">5.2 Server-Side Routing</h3>
+<p>The adapter routes operations internally based on their classification:</p>
+<pre><code>Client Request
+     |
+     v
+mcp_aql endpoint
+     |
+     v
+[Operation Router]
+     |
+     +---&gt; Determines correct CRUDE category
+     |
+     v
+[Appropriate Handler]
+     |
+     v
+Response</code></pre>
+<h3 id="53-routing-behavior">5.3 Routing Behavior</h3>
+<p>In Single mode:</p>
+<ol type="1">
+<li>All operations are accepted through <code>mcp_aql</code></li>
+<li>The adapter determines the correct handler based on operation classification</li>
+<li>The same semantic rules apply as CRUDE mode</li>
+<li>Permission enforcement occurs server-side</li>
+</ol>
+<h3 id="54-unknown-operations">5.4 Unknown Operations</h3>
+<p>If an operation is not recognized:</p>
+<div class="sourceCode" id="cb7"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb7-1"><a href="#cb7-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb7-2"><a href="#cb7-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">success</span><span class="op">:</span> <span class="kw">false</span><span class="op">,</span></span>
+<span id="cb7-3"><a href="#cb7-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">error</span><span class="op">:</span> <span class="st">&quot;Unknown operation: &#39;invalid_op&#39;. Use introspect to discover available operations.&quot;</span></span>
+<span id="cb7-4"><a href="#cb7-4" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<h3 id="55-endpoint-description">5.5 Endpoint Description</h3>
+<p>The unified endpoint SHOULD provide:</p>
+<ul>
+<li>Overview of available operation categories</li>
+<li>Guidance to use introspection for discovery</li>
+<li>Quick-start examples</li>
+</ul>
+<p><strong>Example Description:</strong></p>
+<pre><code>Unified MCP-AQL endpoint for all operations.
+
+Operations are automatically routed based on their semantic category (Create, Read, Update, Delete, Execute).
+
+Use introspection to discover available operations:
+{ operation: &quot;introspect&quot;, params: { query: &quot;operations&quot; } }</code></pre>
+<hr />
+<h2 id="6-security-considerations">6. Security Considerations</h2>
+<h3 id="61-crude-mode-security">6.1 CRUDE Mode Security</h3>
+<p><strong>Advantages:</strong></p>
+<ul>
+<li>Endpoint-level permission blocking (e.g., disable <code>mcp_aql_delete</code> entirely)</li>
+<li>Semantic errors help clients self-correct</li>
+<li>Platform-level permission hints via MCP annotations</li>
+<li>Clear audit separation by operation category</li>
+</ul>
+<p><strong>Characteristics:</strong></p>
+<ul>
+<li>Client is responsible for endpoint selection</li>
+<li>Adapter enforces route validation</li>
+<li>Dangerous operations isolated to DELETE/EXECUTE endpoints</li>
+</ul>
+<h3 id="62-single-mode-security">6.2 Single Mode Security</h3>
+<p><strong>Advantages:</strong></p>
+<ul>
+<li>Smaller attack surface (one endpoint)</li>
+<li>Server-side routing prevents endpoint bypass</li>
+<li>Simpler client implementation reduces error risk</li>
+</ul>
+<p><strong>Characteristics:</strong></p>
+<ul>
+<li>Cannot block operations by endpoint</li>
+<li>All routing decisions made server-side</li>
+<li>Audit logging requires operation-level granularity</li>
+</ul>
+<h3 id="63-security-trade-offs">6.3 Security Trade-offs</h3>
+<table>
+<thead>
+<tr>
+<th>Security Aspect</th>
+<th>CRUDE Mode</th>
+<th>Single Mode</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Endpoint-level blocking</td>
+<td>Yes</td>
+<td>No</td>
+</tr>
+<tr>
+<td>Client error prevention</td>
+<td>Better (semantic errors)</td>
+<td>Worse (generic errors)</td>
+</tr>
+<tr>
+<td>Attack surface</td>
+<td>Larger (5 endpoints)</td>
+<td>Smaller (1 endpoint)</td>
+</tr>
+<tr>
+<td>Audit granularity</td>
+<td>Endpoint + Operation</td>
+<td>Operation only</td>
+</tr>
+<tr>
+<td>Bypass resistance</td>
+<td>Client-dependent</td>
+<td>Server-enforced</td>
+</tr>
+</tbody>
+</table>
+<h3 id="64-common-security-enforcement">6.4 Common Security Enforcement</h3>
+<p>Both modes MUST:</p>
+<ul>
+<li>Validate operation parameters</li>
+<li>Enforce the same permission model</li>
+<li>Apply safety tier classifications</li>
+<li>Support confirmation for destructive operations (if implemented)</li>
+</ul>
+<hr />
+<h2 id="7-tool-registration">7. Tool Registration</h2>
+<h3 id="71-mcp-tool-annotations">7.1 MCP Tool Annotations</h3>
+<p>Adapters SHOULD include MCP tool annotations to hint at operation safety:</p>
+<p><strong>CRUDE Mode Annotations:</strong></p>
+<div class="sourceCode" id="cb9"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb9-1"><a href="#cb9-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb9-2"><a href="#cb9-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;mcp_aql_read&quot;</span><span class="fu">,</span></span>
+<span id="cb9-3"><a href="#cb9-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;annotations&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb9-4"><a href="#cb9-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;readOnlyHint&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb9-5"><a href="#cb9-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;destructiveHint&quot;</span><span class="fu">:</span> <span class="kw">false</span></span>
+<span id="cb9-6"><a href="#cb9-6" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb9-7"><a href="#cb9-7" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span>
+<span id="cb9-8"><a href="#cb9-8" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb9-9"><a href="#cb9-9" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb9-10"><a href="#cb9-10" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;mcp_aql_delete&quot;</span><span class="fu">,</span></span>
+<span id="cb9-11"><a href="#cb9-11" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;annotations&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb9-12"><a href="#cb9-12" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;readOnlyHint&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb9-13"><a href="#cb9-13" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;destructiveHint&quot;</span><span class="fu">:</span> <span class="kw">true</span></span>
+<span id="cb9-14"><a href="#cb9-14" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb9-15"><a href="#cb9-15" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<p><strong>Single Mode Annotations:</strong></p>
+<div class="sourceCode" id="cb10"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb10-1"><a href="#cb10-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb10-2"><a href="#cb10-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;mcp_aql&quot;</span><span class="fu">,</span></span>
+<span id="cb10-3"><a href="#cb10-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;annotations&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb10-4"><a href="#cb10-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;readOnlyHint&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb10-5"><a href="#cb10-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;destructiveHint&quot;</span><span class="fu">:</span> <span class="kw">true</span></span>
+<span id="cb10-6"><a href="#cb10-6" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb10-7"><a href="#cb10-7" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<p>Note: Single mode uses <code>destructiveHint: true</code> because it can route to destructive operations.</p>
+<h3 id="72-input-schema">7.2 Input Schema</h3>
+<p>Both modes use the same input schema:</p>
+<div class="sourceCode" id="cb11"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb11-1"><a href="#cb11-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb11-2"><a href="#cb11-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;object&quot;</span><span class="fu">,</span></span>
+<span id="cb11-3"><a href="#cb11-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;properties&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb11-4"><a href="#cb11-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb11-5"><a href="#cb11-5" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;string&quot;</span><span class="fu">,</span></span>
+<span id="cb11-6"><a href="#cb11-6" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Operation name to execute&quot;</span></span>
+<span id="cb11-7"><a href="#cb11-7" aria-hidden="true" tabindex="-1"></a>    <span class="fu">},</span></span>
+<span id="cb11-8"><a href="#cb11-8" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb11-9"><a href="#cb11-9" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;object&quot;</span><span class="fu">,</span></span>
+<span id="cb11-10"><a href="#cb11-10" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Operation parameters&quot;</span></span>
+<span id="cb11-11"><a href="#cb11-11" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb11-12"><a href="#cb11-12" aria-hidden="true" tabindex="-1"></a>  <span class="fu">},</span></span>
+<span id="cb11-13"><a href="#cb11-13" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;required&quot;</span><span class="fu">:</span> <span class="ot">[</span><span class="st">&quot;operation&quot;</span><span class="ot">]</span></span>
+<span id="cb11-14"><a href="#cb11-14" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<p>Adapters MAY extend this schema with additional common properties (e.g., <code>resource_type</code>, <code>fields</code>).</p>
+<hr />
+<h2 id="8-conformance-requirements">8. Conformance Requirements</h2>
+<h3 id="81-must-requirements">8.1 MUST Requirements</h3>
+<p>Conforming implementations MUST:</p>
+<ol type="1">
+<li>Support at least one endpoint mode (CRUDE or Single)</li>
+<li>Enforce operation routing validation in CRUDE mode</li>
+<li>Return proper error responses for unknown operations</li>
+<li>Route operations to correct handlers in Single mode</li>
+<li>Apply consistent permission enforcement regardless of mode</li>
+</ol>
+<h3 id="82-should-requirements">8.2 SHOULD Requirements</h3>
+<p>Conforming implementations SHOULD:</p>
+<ol type="1">
+<li>Support both CRUDE and Single endpoint modes</li>
+<li>Provide runtime configuration for mode selection</li>
+<li>Include MCP tool annotations for permission hints</li>
+<li>Provide helpful error messages that guide clients to correct usage</li>
+<li>Document available operations via introspection</li>
+</ol>
+<h3 id="83-may-requirements">8.3 MAY Requirements</h3>
+<p>Conforming implementations MAY:</p>
+<ol type="1">
+<li>Support "all" mode exposing all 6 endpoints simultaneously</li>
+<li>Implement per-endpoint access control</li>
+<li>Provide mode-specific audit logging</li>
+<li>Support dynamic mode switching without restart</li>
+<li>Implement custom endpoint naming conventions</li>
+</ol>
+<hr />
+<h2 id="references">References</h2>
+<ul>
+<li><a href="versions/v1.0.0-draft.html">MCP-AQL Specification v1.0.0-draft</a></li>
+<li><a href="crude-pattern.html">CRUDE Pattern Specification</a></li>
+<li><a href="mcp-integration.html">MCP Integration Specification</a></li>
+<li><a href="security/gatekeeper.html">Gatekeeper Security Model</a></li>
+<li><a href="introspection.html">Introspection Specification</a></li>
+</ul>
+
+          </div>
+        </section>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div class="container">
+      <p>&copy; 2026 DollhouseMCP Inc. d/b/a Dollhouse Research. MCP-AQL public draft documentation portal.</p>
+      <div class="footer-links">
+        <a href="../docs/index.html">Docs Library</a>
+        <a href="index.html">Repo-Synced Spec</a>
+        <a href="https://github.com/MCPAQL">MCPAQL Organization</a>
+        <a href="https://dollhouseresearch.com">Dollhouse Research</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../js/search.js"></script>
+</body>
+</html>

--- a/public/spec/error-codes.html
+++ b/public/spec/error-codes.html
@@ -38,7 +38,7 @@
         <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
         <div class="docs-side-group">
   <h3>Core</h3>
-  <ul><li><a href="conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a class="current" href="error-codes.html">Structured Error Codes Specification</a></li><li><a href="introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="mcp-integration.html">MCP Integration Specification</a></li><li><a href="operations.html">MCP-AQL Operations Specification</a></li><li><a href="overview.html">MCP-AQL Protocol Overview</a></li><li><a href="plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="README.html">MCP-AQL Specification Documentation</a></li></ul>
+  <ul><li><a href="conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a class="current" href="error-codes.html">Structured Error Codes Specification</a></li><li><a href="introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="mcp-integration.html">MCP Integration Specification</a></li><li><a href="operations.html">MCP-AQL Operations Specification</a></li><li><a href="overview.html">MCP-AQL Protocol Overview</a></li><li><a href="plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="README.html">MCP-AQL Specification Documentation</a></li><li><a href="repo/README.html">MCP-AQL Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Versions</h3>
   <ul><li><a href="versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
@@ -56,7 +56,7 @@
   <ul><li><a href="guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
-  <ul><li><a href="process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="process/versioning.html">Versioning Strategy</a></li></ul>
+  <ul><li><a href="process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="process/versioning.html">Versioning Strategy</a></li><li><a href="repo/CHANGELOG.html">Changelog</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Architecture</h3>
   <ul><li><a href="architecture/README.html">Architecture Documentation</a></li></ul>

--- a/public/spec/error-codes.html
+++ b/public/spec/error-codes.html
@@ -1,0 +1,1219 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="This document defines the structured error code system for MCP-AQL protocol responses. Structured error codes enable machine-readable error handling, consistent error categorization, and reliable error mapping across ada">
+  <title>MCP-AQL Spec | Structured Error Codes Specification</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../css/style.css">
+</head>
+<body>
+  <header>
+    <div class="container">
+      <nav>
+        <a class="logo" href="../index.html"><span class="logo-mark"></span>MCP-AQL</a>
+        <ul class="nav-links">
+          <li><a href="../index.html">Home</a></li>
+          <li><a href="../docs/index.html">Docs</a></li>
+          <li><a href="../launch-checklist.html">Launch Checklist</a></li>
+          <li><a href="../apis/mcp-server.html">Adapter Patterns</a></li>
+        </ul>
+        <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
+          <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
+          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <span class="search-count" data-search-count></span>
+          <ul class="search-results" data-search-results hidden></ul>
+        </form>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <div class="container docs-shell">
+      <aside class="docs-side">
+        <h2>Repo-Synced Spec</h2>
+        <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
+        <div class="docs-side-group">
+  <h3>Core</h3>
+  <ul><li><a href="conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a class="current" href="error-codes.html">Structured Error Codes Specification</a></li><li><a href="introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="mcp-integration.html">MCP Integration Specification</a></li><li><a href="operations.html">MCP-AQL Operations Specification</a></li><li><a href="overview.html">MCP-AQL Protocol Overview</a></li><li><a href="plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="README.html">MCP-AQL Specification Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Versions</h3>
+  <ul><li><a href="versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Adapter</h3>
+  <ul><li><a href="adapter/danger-levels.html">Dangerous Operation Classification Specification</a></li><li><a href="adapter/discovery-bundle.html">MCP Server Discovery Bundle</a></li><li><a href="adapter/element-type.html">Adapter Element Type Specification</a></li><li><a href="adapter/generator.html">Adapter Generator Specification</a></li><li><a href="adapter/rate-limiting.html">Rate Limiting and Quota Management Specification</a></li><li><a href="adapter/trust-levels.html">Trust Levels Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Security</h3>
+  <ul><li><a href="security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Features</h3>
+  <ul><li><a href="features/field-selection.html">Field Selection Specification</a></li><li><a href="features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="features/warnings.html">Warnings Array Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Guides</h3>
+  <ul><li><a href="guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="guides/README.html">Developer Guides</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Process</h3>
+  <ul><li><a href="process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="process/versioning.html">Versioning Strategy</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Architecture</h3>
+  <ul><li><a href="architecture/README.html">Architecture Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Research</h3>
+  <ul><li><a href="research/mcp-vs-mcpaql-vs-a2a.html">Protocol Landscape: MCP vs MCP-AQL vs A2A</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Reference</h3>
+  <ul><li><a href="reference/README.html">Reference Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>ADRs</h3>
+  <ul><li><a href="adr/ADR-001-crude-pattern.html">ADR-001: CRUDE Pattern (Extending CRUD with Execute)</a></li><li><a href="adr/ADR-002-graphql-style-input.html">ADR-002: GraphQL-Style Input Objects for Updates</a></li><li><a href="adr/ADR-003-snake-case-parameters.html">ADR-003: snake_case Parameter Convention</a></li><li><a href="adr/ADR-004-schema-driven-operations.html">ADR-004: Schema-Driven Operation Definitions</a></li><li><a href="adr/ADR-005-introspection-system.html">ADR-005: GraphQL-Style Introspection System</a></li><li><a href="adr/ADR-006-discriminated-responses.html">ADR-006: Discriminated Response Format</a></li><li><a href="adr/index.html">Architecture Decision Records</a></li><li><a href="adr/README.html">Architecture Decision Records</a></li></ul>
+</div>
+      </aside>
+
+      <article class="docs-main">
+        <section class="hero docs-hero">
+          <div class="hero-inner">
+            <span class="status-pill">REPO-SYNCED SPEC DOC</span>
+            <h1>Structured Error Codes Specification</h1>
+            <p class="lede">This document defines the structured error code system for MCP-AQL protocol responses. Structured error codes enable machine-readable error handling, consistent error categorization, and reliable error mapping across ada</p>
+            <div class="spec-meta"><span class="state-chip live">Support document</span><span class="state-chip pending">Draft (MVP)</span><span class="state-chip">1.0.0-draft</span><span class="state-chip">2026-01-28</span></div>
+            <p class="spec-source">Source: <a href="https://github.com/MCPAQL/spec/blob/main/docs/error-codes.md">spec/docs/error-codes.md</a></p>
+            <div class="hero-actions">
+              <a class="btn btn-primary" href="https://github.com/MCPAQL/spec/blob/main/docs/error-codes.md">Open Source Markdown</a>
+              <a class="btn btn-secondary" href="index.html">Browse Full Spec Reference</a>
+            </div>
+          </div>
+        </section>
+
+        <section>
+          <div class="card spec-prose">
+            <p><strong>Version:</strong> 1.0.0-draft <strong>Status:</strong> Draft (MVP) <strong>Last Updated:</strong> 2026-01-28</p>
+<h2 id="abstract">Abstract</h2>
+<p>This document defines the structured error code system for MCP-AQL protocol responses. Structured error codes enable machine-readable error handling, consistent error categorization, and reliable error mapping across adapter implementations.</p>
+<hr />
+<h2 id="table-of-contents">Table of Contents</h2>
+<ol type="1">
+<li><a href="#1-overview">Overview</a></li>
+<li><a href="#2-error-response-structure">Error Response Structure</a></li>
+<li><a href="#3-error-code-format">Error Code Format</a></li>
+<li><a href="#4-mvp-error-codes">MVP Error Codes</a></li>
+<li><a href="#5-phase-1-robustness-error-codes">Phase 1: Robustness Error Codes</a></li>
+<li><a href="#6-http-status-mapping">HTTP Status Mapping</a></li>
+<li><a href="#7-implementation-requirements">Implementation Requirements</a></li>
+<li><a href="#8-future-extensions">Future Extensions</a></li>
+</ol>
+<hr />
+<h2 id="1-overview">1. Overview</h2>
+<h3 id="11-purpose">1.1 Purpose</h3>
+<p>Structured error codes address several challenges with string-based error messages:</p>
+<ul>
+<li><strong>Machine-readable</strong> - Programs can take action based on error type</li>
+<li><strong>Consistent categorization</strong> - Monitoring systems can categorize and alert</li>
+<li><strong>Adapter mapping</strong> - Errors map reliably to target protocol codes</li>
+<li><strong>Localization</strong> - Clients can provide localized error messages</li>
+</ul>
+<h3 id="12-design-principles">1.2 Design Principles</h3>
+<ol type="1">
+<li><strong>Category-based</strong> - Codes follow <code>CATEGORY_SPECIFIC</code> naming pattern</li>
+<li><strong>Self-documenting</strong> - Code names describe the error condition</li>
+<li><strong>Deterministic</strong> - Each error code maps to a specific recovery strategy</li>
+<li><strong>Extensible</strong> - New codes can be added without breaking existing clients</li>
+</ol>
+<h3 id="13-mvp-scope">1.3 MVP Scope</h3>
+<p>This specification covers the Minimum Viable Product error codes:</p>
+<p><strong>Included:</strong></p>
+<ul>
+<li>8 essential error codes (MVP)</li>
+<li>7 Phase 1 robustness error codes</li>
+<li>Basic error response structure</li>
+<li>HTTP status code mapping</li>
+<li>Generator error code category reference</li>
+</ul>
+<p><strong>Deferred to future specifications:</strong></p>
+<ul>
+<li>Full error code taxonomy</li>
+<li>Conflict error codes</li>
+<li>Detailed error context schemas</li>
+<li>Per-adapter error overrides</li>
+<li>Error code extension mechanism</li>
+</ul>
+<h3 id="14-error-format">1.4 Error Format</h3>
+<p>This specification defines the canonical error response format for MCP-AQL:</p>
+<div class="sourceCode" id="cb1"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb1-2"><a href="#cb1-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb1-3"><a href="#cb1-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;error&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb1-4"><a href="#cb1-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;code&quot;</span><span class="fu">:</span> <span class="st">&quot;VALIDATION_MISSING_PARAM&quot;</span><span class="fu">,</span></span>
+<span id="cb1-5"><a href="#cb1-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;Missing required parameter &#39;owner&#39;&quot;</span></span>
+<span id="cb1-6"><a href="#cb1-6" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb1-7"><a href="#cb1-7" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<p>Implementations MUST use structured error objects with <code>code</code> and <code>message</code> fields. The optional <code>details</code> field MAY provide additional context.</p>
+<hr />
+<h2 id="2-error-response-structure">2. Error Response Structure</h2>
+<h3 id="21-structured-error-format">2.1 Structured Error Format</h3>
+<div class="sourceCode" id="cb2"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="kw">interface</span> ErrorResponse {</span>
+<span id="cb2-2"><a href="#cb2-2" aria-hidden="true" tabindex="-1"></a>  success<span class="op">:</span> <span class="kw">false</span><span class="op">;</span></span>
+<span id="cb2-3"><a href="#cb2-3" aria-hidden="true" tabindex="-1"></a>  error<span class="op">:</span> ErrorDetail<span class="op">;</span></span>
+<span id="cb2-4"><a href="#cb2-4" aria-hidden="true" tabindex="-1"></a>}</span>
+<span id="cb2-5"><a href="#cb2-5" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb2-6"><a href="#cb2-6" aria-hidden="true" tabindex="-1"></a><span class="kw">interface</span> ErrorDetail {</span>
+<span id="cb2-7"><a href="#cb2-7" aria-hidden="true" tabindex="-1"></a>  <span class="co">/**</span></span>
+<span id="cb2-8"><a href="#cb2-8" aria-hidden="true" tabindex="-1"></a><span class="co">   * Machine-readable error code</span></span>
+<span id="cb2-9"><a href="#cb2-9" aria-hidden="true" tabindex="-1"></a><span class="co">   * Format: CATEGORY_SPECIFIC_ERROR</span></span>
+<span id="cb2-10"><a href="#cb2-10" aria-hidden="true" tabindex="-1"></a><span class="co">   */</span></span>
+<span id="cb2-11"><a href="#cb2-11" aria-hidden="true" tabindex="-1"></a>  code<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb2-12"><a href="#cb2-12" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb2-13"><a href="#cb2-13" aria-hidden="true" tabindex="-1"></a>  <span class="co">/**</span></span>
+<span id="cb2-14"><a href="#cb2-14" aria-hidden="true" tabindex="-1"></a><span class="co">   * Human-readable error message</span></span>
+<span id="cb2-15"><a href="#cb2-15" aria-hidden="true" tabindex="-1"></a><span class="co">   */</span></span>
+<span id="cb2-16"><a href="#cb2-16" aria-hidden="true" tabindex="-1"></a>  message<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb2-17"><a href="#cb2-17" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb2-18"><a href="#cb2-18" aria-hidden="true" tabindex="-1"></a>  <span class="co">/**</span></span>
+<span id="cb2-19"><a href="#cb2-19" aria-hidden="true" tabindex="-1"></a><span class="co">   * Optional contextual details</span></span>
+<span id="cb2-20"><a href="#cb2-20" aria-hidden="true" tabindex="-1"></a><span class="co">   */</span></span>
+<span id="cb2-21"><a href="#cb2-21" aria-hidden="true" tabindex="-1"></a>  details<span class="op">?:</span> <span class="bu">Record</span><span class="op">&lt;</span><span class="dt">string</span><span class="op">,</span> <span class="dt">unknown</span><span class="op">&gt;;</span></span>
+<span id="cb2-22"><a href="#cb2-22" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<h3 id="22-example-responses">2.2 Example Responses</h3>
+<p><strong>Minimal error:</strong></p>
+<div class="sourceCode" id="cb3"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb3-1"><a href="#cb3-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb3-2"><a href="#cb3-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb3-3"><a href="#cb3-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;error&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb3-4"><a href="#cb3-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;code&quot;</span><span class="fu">:</span> <span class="st">&quot;VALIDATION_MISSING_PARAM&quot;</span><span class="fu">,</span></span>
+<span id="cb3-5"><a href="#cb3-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;Missing required parameter &#39;owner&#39;&quot;</span></span>
+<span id="cb3-6"><a href="#cb3-6" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb3-7"><a href="#cb3-7" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<p><strong>Error with details:</strong></p>
+<div class="sourceCode" id="cb4"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb4-1"><a href="#cb4-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb4-2"><a href="#cb4-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb4-3"><a href="#cb4-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;error&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb4-4"><a href="#cb4-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;code&quot;</span><span class="fu">:</span> <span class="st">&quot;NOT_FOUND_RESOURCE&quot;</span><span class="fu">,</span></span>
+<span id="cb4-5"><a href="#cb4-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;Repository &#39;octocat/nonexistent&#39; not found&quot;</span><span class="fu">,</span></span>
+<span id="cb4-6"><a href="#cb4-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;details&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb4-7"><a href="#cb4-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;resource_type&quot;</span><span class="fu">:</span> <span class="st">&quot;repository&quot;</span><span class="fu">,</span></span>
+<span id="cb4-8"><a href="#cb4-8" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;resource_id&quot;</span><span class="fu">:</span> <span class="st">&quot;octocat/nonexistent&quot;</span></span>
+<span id="cb4-9"><a href="#cb4-9" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb4-10"><a href="#cb4-10" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb4-11"><a href="#cb4-11" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<hr />
+<h2 id="3-error-code-format">3. Error Code Format</h2>
+<h3 id="31-naming-convention">3.1 Naming Convention</h3>
+<p>Error codes follow the pattern:</p>
+<pre><code>CATEGORY_SPECIFIC_CONDITION</code></pre>
+<p><strong>Rules:</strong></p>
+<ul>
+<li>All uppercase with underscores</li>
+<li>Category prefix identifies error class</li>
+<li>Specific suffix describes the condition</li>
+<li>2-4 word components typical</li>
+</ul>
+<p><strong>Examples:</strong></p>
+<ul>
+<li><code>VALIDATION_MISSING_PARAM</code></li>
+<li><code>NOT_FOUND_OPERATION</code></li>
+<li><code>PERMISSION_DENIED</code></li>
+<li><code>INTERNAL_ERROR</code></li>
+</ul>
+<h3 id="32-category-prefixes">3.2 Category Prefixes</h3>
+<table>
+<thead>
+<tr>
+<th>Category</th>
+<th>Description</th>
+<th>HTTP Range</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>VALIDATION_</code></td>
+<td>Input validation errors</td>
+<td>400, 422</td>
+</tr>
+<tr>
+<td><code>NOT_FOUND_</code></td>
+<td>Resource not found</td>
+<td>404</td>
+</tr>
+<tr>
+<td><code>PERMISSION_</code></td>
+<td>Authentication/authorization</td>
+<td>401, 403</td>
+</tr>
+<tr>
+<td><code>CONFLICT_</code></td>
+<td>Resource conflicts</td>
+<td>409</td>
+</tr>
+<tr>
+<td><code>RATE_LIMIT_</code></td>
+<td>Rate limiting</td>
+<td>429</td>
+</tr>
+<tr>
+<td><code>TOKEN_</code></td>
+<td>Confirmation token errors</td>
+<td>400, 403</td>
+</tr>
+<tr>
+<td><code>SCHEMA_</code></td>
+<td>Schema validation errors (generators)</td>
+<td>N/A</td>
+</tr>
+<tr>
+<td><code>INTERNAL_</code></td>
+<td>Server errors</td>
+<td>500+</td>
+</tr>
+</tbody>
+</table>
+<blockquote>
+<p><strong>Note on <code>SCHEMA_</code> category:</strong> Unlike other error categories which occur at runtime, <code>SCHEMA_</code> errors are produced by adapter generators during schema validation. These errors do not map to HTTP status codes because they occur during code generation, not API requests. See <a href="adapter/generator.html">Adapter Generator Specification</a> Section 2.2 for the complete list of schema validation error codes.</p>
+</blockquote>
+<hr />
+<h2 id="4-mvp-error-codes">4. MVP Error Codes</h2>
+<h3 id="41-error-code-registry">4.1 Error Code Registry</h3>
+<p>The MVP includes 8 essential error codes:</p>
+<table>
+<thead>
+<tr>
+<th>Code</th>
+<th>Category</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>VALIDATION_MISSING_PARAM</code></td>
+<td>Validation</td>
+<td>Required parameter not provided</td>
+</tr>
+<tr>
+<td><code>VALIDATION_INVALID_TYPE</code></td>
+<td>Validation</td>
+<td>Parameter has wrong type</td>
+</tr>
+<tr>
+<td><code>VALIDATION_UNKNOWN_PARAM</code></td>
+<td>Validation</td>
+<td>Request contains parameter not defined in operation schema</td>
+</tr>
+<tr>
+<td><code>VALIDATION_INVALID_ENCODING</code></td>
+<td>Validation</td>
+<td>Request contains invalid character encoding</td>
+</tr>
+<tr>
+<td><code>VALIDATION_PAYLOAD_TOO_LARGE</code></td>
+<td>Validation</td>
+<td>Request or response exceeds size limits</td>
+</tr>
+<tr>
+<td><code>NOT_FOUND_OPERATION</code></td>
+<td>Not Found</td>
+<td>Requested operation does not exist</td>
+</tr>
+<tr>
+<td><code>NOT_FOUND_RESOURCE</code></td>
+<td>Not Found</td>
+<td>Target resource not found (HTTP 404)</td>
+</tr>
+<tr>
+<td><code>PERMISSION_DENIED</code></td>
+<td>Permission</td>
+<td>Access denied (HTTP 401/403)</td>
+</tr>
+<tr>
+<td><code>INTERNAL_ERROR</code></td>
+<td>Internal</td>
+<td>Server error or unexpected failure</td>
+</tr>
+</tbody>
+</table>
+<h3 id="42-message-template-conventions">4.2 Message Template Conventions</h3>
+<p>All error codes define a <strong>message format</strong> template that implementations SHOULD follow for consistency. Templates use the following conventions:</p>
+<ul>
+<li>Variable placeholders use <code>{variable_name}</code> syntax matching keys in the <code>details</code> object</li>
+<li>Dynamic values MUST be wrapped in single quotes within the message (e.g., <code>'{param_name}'</code>)</li>
+<li>The message prefix MUST match the error category (e.g., <code>VALIDATION_</code> codes start with the validation context, <code>NOT_FOUND_</code> codes reference what was not found)</li>
+<li>Implementations MAY substitute the target API's error message when it provides more specific context, but SHOULD prefer the template format for consistency</li>
+</ul>
+<h3 id="43-validation_missing_param">4.3 VALIDATION_MISSING_PARAM</h3>
+<p><strong>When used:</strong> A required parameter was not provided in the request.</p>
+<p><strong>Message format:</strong> <code>Missing required parameter '{param_name}'</code></p>
+<p><strong>Details:</strong></p>
+<div class="sourceCode" id="cb6"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb6-1"><a href="#cb6-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb6-2"><a href="#cb6-2" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** Name of the missing parameter */</span></span>
+<span id="cb6-3"><a href="#cb6-3" aria-hidden="true" tabindex="-1"></a>  param_name<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb6-4"><a href="#cb6-4" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** Operation that requires this parameter */</span></span>
+<span id="cb6-5"><a href="#cb6-5" aria-hidden="true" tabindex="-1"></a>  operation<span class="op">?:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb6-6"><a href="#cb6-6" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<p><strong>Example:</strong></p>
+<div class="sourceCode" id="cb7"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb7-1"><a href="#cb7-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb7-2"><a href="#cb7-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb7-3"><a href="#cb7-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;error&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb7-4"><a href="#cb7-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;code&quot;</span><span class="fu">:</span> <span class="st">&quot;VALIDATION_MISSING_PARAM&quot;</span><span class="fu">,</span></span>
+<span id="cb7-5"><a href="#cb7-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;Missing required parameter &#39;owner&#39;&quot;</span><span class="fu">,</span></span>
+<span id="cb7-6"><a href="#cb7-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;details&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb7-7"><a href="#cb7-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;param_name&quot;</span><span class="fu">:</span> <span class="st">&quot;owner&quot;</span><span class="fu">,</span></span>
+<span id="cb7-8"><a href="#cb7-8" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;get_repo&quot;</span></span>
+<span id="cb7-9"><a href="#cb7-9" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb7-10"><a href="#cb7-10" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb7-11"><a href="#cb7-11" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<p><strong>Reference:</strong> This specification (MVP error code)</p>
+<h3 id="44-validation_invalid_type">4.4 VALIDATION_INVALID_TYPE</h3>
+<p><strong>When used:</strong> A parameter was provided with an incorrect type.</p>
+<p><strong>Message format:</strong> <code>Parameter '{param_name}' expected '{expected_type}', got '{actual_type}'</code></p>
+<p><strong>Details:</strong></p>
+<div class="sourceCode" id="cb8"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb8-1"><a href="#cb8-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb8-2"><a href="#cb8-2" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** Name of the invalid parameter */</span></span>
+<span id="cb8-3"><a href="#cb8-3" aria-hidden="true" tabindex="-1"></a>  param_name<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb8-4"><a href="#cb8-4" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** Expected type (string, integer, etc.) */</span></span>
+<span id="cb8-5"><a href="#cb8-5" aria-hidden="true" tabindex="-1"></a>  expected_type<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb8-6"><a href="#cb8-6" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** Type that was received */</span></span>
+<span id="cb8-7"><a href="#cb8-7" aria-hidden="true" tabindex="-1"></a>  actual_type<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb8-8"><a href="#cb8-8" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** The invalid value (if safe to include) */</span></span>
+<span id="cb8-9"><a href="#cb8-9" aria-hidden="true" tabindex="-1"></a>  value<span class="op">?:</span> <span class="dt">unknown</span><span class="op">;</span></span>
+<span id="cb8-10"><a href="#cb8-10" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<p><strong>Example:</strong></p>
+<div class="sourceCode" id="cb9"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb9-1"><a href="#cb9-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb9-2"><a href="#cb9-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb9-3"><a href="#cb9-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;error&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb9-4"><a href="#cb9-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;code&quot;</span><span class="fu">:</span> <span class="st">&quot;VALIDATION_INVALID_TYPE&quot;</span><span class="fu">,</span></span>
+<span id="cb9-5"><a href="#cb9-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;Parameter &#39;per_page&#39; expected &#39;integer&#39;, got &#39;string&#39;&quot;</span><span class="fu">,</span></span>
+<span id="cb9-6"><a href="#cb9-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;details&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb9-7"><a href="#cb9-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;param_name&quot;</span><span class="fu">:</span> <span class="st">&quot;per_page&quot;</span><span class="fu">,</span></span>
+<span id="cb9-8"><a href="#cb9-8" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;expected_type&quot;</span><span class="fu">:</span> <span class="st">&quot;integer&quot;</span><span class="fu">,</span></span>
+<span id="cb9-9"><a href="#cb9-9" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;actual_type&quot;</span><span class="fu">:</span> <span class="st">&quot;string&quot;</span><span class="fu">,</span></span>
+<span id="cb9-10"><a href="#cb9-10" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;value&quot;</span><span class="fu">:</span> <span class="st">&quot;fifty&quot;</span></span>
+<span id="cb9-11"><a href="#cb9-11" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb9-12"><a href="#cb9-12" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb9-13"><a href="#cb9-13" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<p><strong>Reference:</strong> This specification (MVP error code)</p>
+<h3 id="45-validation_unknown_param">4.5 VALIDATION_UNKNOWN_PARAM</h3>
+<p><strong>When used:</strong> A request contains one or more parameters not defined in the operation schema at the <code>params</code> level.</p>
+<blockquote>
+<p><strong>Note:</strong> This code applies to unknown parameters in the <code>params</code> object. For unknown fields within the nested <code>input</code> object (used in UPDATE operations per Section 4.5 of the normative spec), use <code>VALIDATION_UNKNOWN_FIELD</code> instead. The distinction enables precise error handling: <code>VALIDATION_UNKNOWN_PARAM</code> indicates a top-level parameter error, while <code>VALIDATION_UNKNOWN_FIELD</code> indicates an error within the update payload.</p>
+</blockquote>
+<p><strong>Message format:</strong> <code>Unknown parameter(s) for operation '{operation}': {param_list}</code></p>
+<p>When multiple unknown parameters are detected, adapters SHOULD either:</p>
+<ul>
+<li>List all unknown parameters in a comma-separated format: <code>Unknown parameter(s) for operation 'create_user': force_create, admin_override</code></li>
+<li>Report the first unknown parameter with a count: <code>Unknown parameter 'force_create' for operation 'create_user' (and 1 other)</code></li>
+</ul>
+<p><strong>Details:</strong></p>
+<div class="sourceCode" id="cb10"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb10-1"><a href="#cb10-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb10-2"><a href="#cb10-2" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** The operation being called */</span></span>
+<span id="cb10-3"><a href="#cb10-3" aria-hidden="true" tabindex="-1"></a>  operation<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb10-4"><a href="#cb10-4" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** List of unknown parameter names */</span></span>
+<span id="cb10-5"><a href="#cb10-5" aria-hidden="true" tabindex="-1"></a>  unknown_params<span class="op">:</span> <span class="dt">string</span>[]<span class="op">;</span></span>
+<span id="cb10-6"><a href="#cb10-6" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** List of valid parameter names for this operation */</span></span>
+<span id="cb10-7"><a href="#cb10-7" aria-hidden="true" tabindex="-1"></a>  valid_params<span class="op">:</span> <span class="dt">string</span>[]<span class="op">;</span></span>
+<span id="cb10-8"><a href="#cb10-8" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<p><strong>Example (multiple unknown parameters):</strong></p>
+<div class="sourceCode" id="cb11"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb11-1"><a href="#cb11-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb11-2"><a href="#cb11-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb11-3"><a href="#cb11-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;error&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb11-4"><a href="#cb11-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;code&quot;</span><span class="fu">:</span> <span class="st">&quot;VALIDATION_UNKNOWN_PARAM&quot;</span><span class="fu">,</span></span>
+<span id="cb11-5"><a href="#cb11-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;Unknown parameter(s) for operation &#39;create_user&#39;: force_create, admin_override&quot;</span><span class="fu">,</span></span>
+<span id="cb11-6"><a href="#cb11-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;details&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb11-7"><a href="#cb11-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;create_user&quot;</span><span class="fu">,</span></span>
+<span id="cb11-8"><a href="#cb11-8" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;unknown_params&quot;</span><span class="fu">:</span> <span class="ot">[</span><span class="st">&quot;force_create&quot;</span><span class="ot">,</span> <span class="st">&quot;admin_override&quot;</span><span class="ot">]</span><span class="fu">,</span></span>
+<span id="cb11-9"><a href="#cb11-9" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;valid_params&quot;</span><span class="fu">:</span> <span class="ot">[</span><span class="st">&quot;user_name&quot;</span><span class="ot">,</span> <span class="st">&quot;password&quot;</span><span class="ot">,</span> <span class="st">&quot;email&quot;</span><span class="ot">]</span></span>
+<span id="cb11-10"><a href="#cb11-10" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb11-11"><a href="#cb11-11" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb11-12"><a href="#cb11-12" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<p><strong>Example (single unknown parameter):</strong></p>
+<div class="sourceCode" id="cb12"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb12-1"><a href="#cb12-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb12-2"><a href="#cb12-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb12-3"><a href="#cb12-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;error&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb12-4"><a href="#cb12-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;code&quot;</span><span class="fu">:</span> <span class="st">&quot;VALIDATION_UNKNOWN_PARAM&quot;</span><span class="fu">,</span></span>
+<span id="cb12-5"><a href="#cb12-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;Unknown parameter(s) for operation &#39;create_user&#39;: force_create&quot;</span><span class="fu">,</span></span>
+<span id="cb12-6"><a href="#cb12-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;details&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb12-7"><a href="#cb12-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;create_user&quot;</span><span class="fu">,</span></span>
+<span id="cb12-8"><a href="#cb12-8" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;unknown_params&quot;</span><span class="fu">:</span> <span class="ot">[</span><span class="st">&quot;force_create&quot;</span><span class="ot">]</span><span class="fu">,</span></span>
+<span id="cb12-9"><a href="#cb12-9" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;valid_params&quot;</span><span class="fu">:</span> <span class="ot">[</span><span class="st">&quot;user_name&quot;</span><span class="ot">,</span> <span class="st">&quot;password&quot;</span><span class="ot">,</span> <span class="st">&quot;email&quot;</span><span class="ot">]</span></span>
+<span id="cb12-10"><a href="#cb12-10" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb12-11"><a href="#cb12-11" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb12-12"><a href="#cb12-12" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<blockquote>
+<p><strong>Note:</strong> The <code>parameter(s)</code> format and array structure work for both singular and plural cases. Implementers do not need special-case logic based on the count.</p>
+</blockquote>
+<p><strong>HTTP Status Mapping:</strong> This error SHOULD map to HTTP 400 (Bad Request) or 422 (Unprocessable Entity).</p>
+<p><strong>Reference:</strong> <a href="versions/v1.0.0-draft.html#46-unknown-parameter-handling">MCP-AQL Specification Section 4.6</a></p>
+<h3 id="46-validation_invalid_encoding">4.6 VALIDATION_INVALID_ENCODING</h3>
+<p><strong>When used:</strong> A request contains invalid character encoding (non-UTF-8 sequences).</p>
+<p><strong>Message format:</strong> <code>Invalid character encoding in request</code></p>
+<p><strong>Details:</strong></p>
+<div class="sourceCode" id="cb13"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb13-1"><a href="#cb13-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb13-2"><a href="#cb13-2" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** Location where invalid encoding was detected */</span></span>
+<span id="cb13-3"><a href="#cb13-3" aria-hidden="true" tabindex="-1"></a>  location<span class="op">?:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb13-4"><a href="#cb13-4" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** Byte offset of the invalid sequence (if available) */</span></span>
+<span id="cb13-5"><a href="#cb13-5" aria-hidden="true" tabindex="-1"></a>  byte_offset<span class="op">?:</span> <span class="dt">number</span><span class="op">;</span></span>
+<span id="cb13-6"><a href="#cb13-6" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<p><strong>Example:</strong></p>
+<div class="sourceCode" id="cb14"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb14-1"><a href="#cb14-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb14-2"><a href="#cb14-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb14-3"><a href="#cb14-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;error&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb14-4"><a href="#cb14-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;code&quot;</span><span class="fu">:</span> <span class="st">&quot;VALIDATION_INVALID_ENCODING&quot;</span><span class="fu">,</span></span>
+<span id="cb14-5"><a href="#cb14-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;Invalid character encoding in request&quot;</span><span class="fu">,</span></span>
+<span id="cb14-6"><a href="#cb14-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;details&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb14-7"><a href="#cb14-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;location&quot;</span><span class="fu">:</span> <span class="st">&quot;params.description&quot;</span><span class="fu">,</span></span>
+<span id="cb14-8"><a href="#cb14-8" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;byte_offset&quot;</span><span class="fu">:</span> <span class="dv">42</span></span>
+<span id="cb14-9"><a href="#cb14-9" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb14-10"><a href="#cb14-10" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb14-11"><a href="#cb14-11" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<p><strong>Reference:</strong> <a href="versions/v1.0.0-draft.html#471-character-encoding">MCP-AQL Specification Section 4.7.1</a></p>
+<h3 id="47-validation_payload_too_large">4.7 VALIDATION_PAYLOAD_TOO_LARGE</h3>
+<p><strong>When used:</strong> A request or response exceeds configured size limits.</p>
+<p><strong>Message format:</strong> <code>Payload exceeds {limit_type} limit of {limit_value}</code></p>
+<p><strong>Details:</strong></p>
+<div class="sourceCode" id="cb15"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb15-1"><a href="#cb15-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb15-2"><a href="#cb15-2" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** Type of limit exceeded */</span></span>
+<span id="cb15-3"><a href="#cb15-3" aria-hidden="true" tabindex="-1"></a>  limit_type<span class="op">:</span> <span class="st">&#39;request_size&#39;</span> <span class="op">|</span> <span class="st">&#39;response_size&#39;</span> <span class="op">|</span> <span class="st">&#39;string_length&#39;</span> <span class="op">|</span> <span class="st">&#39;array_elements&#39;</span> <span class="op">|</span> <span class="st">&#39;nesting_depth&#39;</span><span class="op">;</span></span>
+<span id="cb15-4"><a href="#cb15-4" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** The configured limit */</span></span>
+<span id="cb15-5"><a href="#cb15-5" aria-hidden="true" tabindex="-1"></a>  limit_value<span class="op">:</span> <span class="dt">number</span><span class="op">;</span></span>
+<span id="cb15-6"><a href="#cb15-6" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** The actual size/count */</span></span>
+<span id="cb15-7"><a href="#cb15-7" aria-hidden="true" tabindex="-1"></a>  actual_value<span class="op">:</span> <span class="dt">number</span><span class="op">;</span></span>
+<span id="cb15-8"><a href="#cb15-8" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** Unit of measurement */</span></span>
+<span id="cb15-9"><a href="#cb15-9" aria-hidden="true" tabindex="-1"></a>  unit<span class="op">:</span> <span class="st">&#39;bytes&#39;</span> <span class="op">|</span> <span class="st">&#39;elements&#39;</span> <span class="op">|</span> <span class="st">&#39;levels&#39;</span><span class="op">;</span></span>
+<span id="cb15-10"><a href="#cb15-10" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<p><strong>Example:</strong></p>
+<div class="sourceCode" id="cb16"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb16-1"><a href="#cb16-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb16-2"><a href="#cb16-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb16-3"><a href="#cb16-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;error&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb16-4"><a href="#cb16-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;code&quot;</span><span class="fu">:</span> <span class="st">&quot;VALIDATION_PAYLOAD_TOO_LARGE&quot;</span><span class="fu">,</span></span>
+<span id="cb16-5"><a href="#cb16-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;Payload exceeds request_size limit of 1048576&quot;</span><span class="fu">,</span></span>
+<span id="cb16-6"><a href="#cb16-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;details&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb16-7"><a href="#cb16-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;limit_type&quot;</span><span class="fu">:</span> <span class="st">&quot;request_size&quot;</span><span class="fu">,</span></span>
+<span id="cb16-8"><a href="#cb16-8" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;limit_value&quot;</span><span class="fu">:</span> <span class="dv">1048576</span><span class="fu">,</span></span>
+<span id="cb16-9"><a href="#cb16-9" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;actual_value&quot;</span><span class="fu">:</span> <span class="dv">2500000</span><span class="fu">,</span></span>
+<span id="cb16-10"><a href="#cb16-10" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;unit&quot;</span><span class="fu">:</span> <span class="st">&quot;bytes&quot;</span></span>
+<span id="cb16-11"><a href="#cb16-11" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb16-12"><a href="#cb16-12" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb16-13"><a href="#cb16-13" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<p><strong>Reference:</strong> <a href="versions/v1.0.0-draft.html#475-payload-size-limits">MCP-AQL Specification Section 4.7.5</a></p>
+<h3 id="48-not_found_operation">4.8 NOT_FOUND_OPERATION</h3>
+<p><strong>When used:</strong> The requested operation does not exist in the adapter schema.</p>
+<blockquote>
+<p><strong>Design note:</strong> This code uses the <code>NOT_FOUND_</code> category rather than <code>VALIDATION_</code> because the error signals a fundamentally different recovery strategy. A <code>VALIDATION_</code> error tells the client to fix its input and retry the same operation. A <code>NOT_FOUND_OPERATION</code> error tells the client that the operation itself does not exist and it should discover valid operations via introspection. This distinction is especially important for LLM clients, which use the error category to determine whether to adjust parameters or switch to a different operation entirely.</p>
+</blockquote>
+<p><strong>Message format:</strong> <code>Unknown operation: '{operation_name}'</code></p>
+<p><strong>Details:</strong></p>
+<div class="sourceCode" id="cb17"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb17-1"><a href="#cb17-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb17-2"><a href="#cb17-2" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** The operation name that was requested */</span></span>
+<span id="cb17-3"><a href="#cb17-3" aria-hidden="true" tabindex="-1"></a>  operation<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb17-4"><a href="#cb17-4" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** Valid operation names the client can use instead */</span></span>
+<span id="cb17-5"><a href="#cb17-5" aria-hidden="true" tabindex="-1"></a>  available<span class="op">?:</span> <span class="dt">string</span>[]<span class="op">;</span></span>
+<span id="cb17-6"><a href="#cb17-6" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<p><strong>Example:</strong></p>
+<div class="sourceCode" id="cb18"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb18-1"><a href="#cb18-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb18-2"><a href="#cb18-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb18-3"><a href="#cb18-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;error&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb18-4"><a href="#cb18-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;code&quot;</span><span class="fu">:</span> <span class="st">&quot;NOT_FOUND_OPERATION&quot;</span><span class="fu">,</span></span>
+<span id="cb18-5"><a href="#cb18-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;Unknown operation: &#39;get_users&#39;&quot;</span><span class="fu">,</span></span>
+<span id="cb18-6"><a href="#cb18-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;details&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb18-7"><a href="#cb18-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;get_users&quot;</span></span>
+<span id="cb18-8"><a href="#cb18-8" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb18-9"><a href="#cb18-9" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb18-10"><a href="#cb18-10" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<p><strong>Reference:</strong> This specification (MVP error code)</p>
+<h3 id="49-not_found_resource">4.9 NOT_FOUND_RESOURCE</h3>
+<p><strong>When used:</strong> The target API returned HTTP 404 - the requested resource does not exist.</p>
+<p><strong>Message format:</strong> <code>Resource '{resource_type}' not found: '{resource_id}'</code></p>
+<p><strong>Details:</strong></p>
+<div class="sourceCode" id="cb19"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb19-1"><a href="#cb19-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb19-2"><a href="#cb19-2" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** Type of resource (e.g., &quot;repository&quot;, &quot;user&quot;, &quot;issue&quot;) */</span></span>
+<span id="cb19-3"><a href="#cb19-3" aria-hidden="true" tabindex="-1"></a>  resource_type<span class="op">?:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb19-4"><a href="#cb19-4" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** Identifier that was not found */</span></span>
+<span id="cb19-5"><a href="#cb19-5" aria-hidden="true" tabindex="-1"></a>  resource_id<span class="op">?:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb19-6"><a href="#cb19-6" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** HTTP status code from the target API */</span></span>
+<span id="cb19-7"><a href="#cb19-7" aria-hidden="true" tabindex="-1"></a>  http_status<span class="op">?:</span> <span class="dt">number</span><span class="op">;</span></span>
+<span id="cb19-8"><a href="#cb19-8" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<p><strong>Example:</strong></p>
+<div class="sourceCode" id="cb20"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb20-1"><a href="#cb20-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb20-2"><a href="#cb20-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb20-3"><a href="#cb20-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;error&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb20-4"><a href="#cb20-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;code&quot;</span><span class="fu">:</span> <span class="st">&quot;NOT_FOUND_RESOURCE&quot;</span><span class="fu">,</span></span>
+<span id="cb20-5"><a href="#cb20-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;Repository &#39;octocat/nonexistent&#39; not found&quot;</span><span class="fu">,</span></span>
+<span id="cb20-6"><a href="#cb20-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;details&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb20-7"><a href="#cb20-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;resource_type&quot;</span><span class="fu">:</span> <span class="st">&quot;repository&quot;</span><span class="fu">,</span></span>
+<span id="cb20-8"><a href="#cb20-8" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;resource_id&quot;</span><span class="fu">:</span> <span class="st">&quot;octocat/nonexistent&quot;</span><span class="fu">,</span></span>
+<span id="cb20-9"><a href="#cb20-9" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;http_status&quot;</span><span class="fu">:</span> <span class="dv">404</span></span>
+<span id="cb20-10"><a href="#cb20-10" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb20-11"><a href="#cb20-11" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb20-12"><a href="#cb20-12" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<p><strong>Reference:</strong> This specification (MVP error code); <a href="https://www.rfc-editor.org/rfc/rfc9110#section-15.5.5">RFC 9110 Section 15.5.5</a> (HTTP 404)</p>
+<h3 id="410-permission_denied">4.10 PERMISSION_DENIED</h3>
+<p><strong>When used:</strong> The target API returned HTTP 401 (unauthorized) or 403 (forbidden).</p>
+<p><strong>Message format:</strong> <code>Permission denied: '{reason}'</code></p>
+<p><strong>Details:</strong></p>
+<div class="sourceCode" id="cb21"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb21-1"><a href="#cb21-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb21-2"><a href="#cb21-2" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** Human-readable explanation of why permission was denied */</span></span>
+<span id="cb21-3"><a href="#cb21-3" aria-hidden="true" tabindex="-1"></a>  reason<span class="op">?:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb21-4"><a href="#cb21-4" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** HTTP status code from the target API (401 or 403) */</span></span>
+<span id="cb21-5"><a href="#cb21-5" aria-hidden="true" tabindex="-1"></a>  http_status<span class="op">?:</span> <span class="dt">number</span><span class="op">;</span></span>
+<span id="cb21-6"><a href="#cb21-6" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** OAuth scope required for this operation, if known */</span></span>
+<span id="cb21-7"><a href="#cb21-7" aria-hidden="true" tabindex="-1"></a>  required_scope<span class="op">?:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb21-8"><a href="#cb21-8" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<p><strong>Example:</strong></p>
+<div class="sourceCode" id="cb22"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb22-1"><a href="#cb22-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb22-2"><a href="#cb22-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb22-3"><a href="#cb22-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;error&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb22-4"><a href="#cb22-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;code&quot;</span><span class="fu">:</span> <span class="st">&quot;PERMISSION_DENIED&quot;</span><span class="fu">,</span></span>
+<span id="cb22-5"><a href="#cb22-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;Permission denied: requires &#39;repo&#39; scope&quot;</span><span class="fu">,</span></span>
+<span id="cb22-6"><a href="#cb22-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;details&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb22-7"><a href="#cb22-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;http_status&quot;</span><span class="fu">:</span> <span class="dv">403</span><span class="fu">,</span></span>
+<span id="cb22-8"><a href="#cb22-8" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;required_scope&quot;</span><span class="fu">:</span> <span class="st">&quot;repo&quot;</span></span>
+<span id="cb22-9"><a href="#cb22-9" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb22-10"><a href="#cb22-10" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb22-11"><a href="#cb22-11" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<p><strong>Reference:</strong> This specification (MVP error code); <a href="https://www.rfc-editor.org/rfc/rfc9110#section-15.5.2">RFC 9110 Section 15.5.2</a> (HTTP 401), <a href="https://www.rfc-editor.org/rfc/rfc9110#section-15.5.4">Section 15.5.4</a> (HTTP 403)</p>
+<h3 id="411-internal_error">4.11 INTERNAL_ERROR</h3>
+<p><strong>When used:</strong> Server error from target API (HTTP 500+) or unexpected error in the runtime.</p>
+<p><strong>Message format:</strong> <code>Internal error: '{description}'</code></p>
+<p><strong>Details:</strong></p>
+<div class="sourceCode" id="cb23"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb23-1"><a href="#cb23-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb23-2"><a href="#cb23-2" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** HTTP status code from the target API */</span></span>
+<span id="cb23-3"><a href="#cb23-3" aria-hidden="true" tabindex="-1"></a>  http_status<span class="op">?:</span> <span class="dt">number</span><span class="op">;</span></span>
+<span id="cb23-4"><a href="#cb23-4" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** Error message returned by the target API */</span></span>
+<span id="cb23-5"><a href="#cb23-5" aria-hidden="true" tabindex="-1"></a>  upstream_error<span class="op">?:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb23-6"><a href="#cb23-6" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<p><strong>Example:</strong></p>
+<div class="sourceCode" id="cb24"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb24-1"><a href="#cb24-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb24-2"><a href="#cb24-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb24-3"><a href="#cb24-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;error&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb24-4"><a href="#cb24-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;code&quot;</span><span class="fu">:</span> <span class="st">&quot;INTERNAL_ERROR&quot;</span><span class="fu">,</span></span>
+<span id="cb24-5"><a href="#cb24-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;Internal error: GitHub API unavailable&quot;</span><span class="fu">,</span></span>
+<span id="cb24-6"><a href="#cb24-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;details&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb24-7"><a href="#cb24-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;http_status&quot;</span><span class="fu">:</span> <span class="dv">503</span><span class="fu">,</span></span>
+<span id="cb24-8"><a href="#cb24-8" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;upstream_error&quot;</span><span class="fu">:</span> <span class="st">&quot;Service temporarily unavailable&quot;</span></span>
+<span id="cb24-9"><a href="#cb24-9" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb24-10"><a href="#cb24-10" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb24-11"><a href="#cb24-11" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<p><strong>Reference:</strong> This specification (MVP error code); <a href="https://www.rfc-editor.org/rfc/rfc9110#section-15.6">RFC 9110 Section 15.6</a> (HTTP 5xx)</p>
+<hr />
+<h2 id="5-phase-1-robustness-error-codes">5. Phase 1: Robustness Error Codes</h2>
+<p>Phase 1 of MCP-AQL adds robustness features including trust levels, dangerous operation classification, rate limiting, and confirmation tokens. These features introduce 11 additional error codes.</p>
+<h3 id="51-phase-1-error-code-registry">5.1 Phase 1 Error Code Registry</h3>
+<table>
+<thead>
+<tr>
+<th>Code</th>
+<th>Category</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>PERMISSION_TRUST_LEVEL_INSUFFICIENT</code></td>
+<td>Permission</td>
+<td>Adapter trust level too low for operation</td>
+</tr>
+<tr>
+<td><code>PERMISSION_DANGER_LEVEL_DENIED</code></td>
+<td>Permission</td>
+<td>Operation danger level exceeds trust allowance</td>
+</tr>
+<tr>
+<td><code>CONFIRMATION_REQUIRED</code></td>
+<td>Permission</td>
+<td>Dangerous operation requires user confirmation</td>
+</tr>
+<tr>
+<td><code>RATE_LIMIT_EXCEEDED</code></td>
+<td>Rate Limit</td>
+<td>Target API rate limit reached</td>
+</tr>
+<tr>
+<td><code>RATE_LIMIT_QUOTA_PAUSE</code></td>
+<td>Rate Limit</td>
+<td>User quota pause threshold reached</td>
+</tr>
+<tr>
+<td><code>RATE_LIMIT_QUOTA_EXHAUSTED</code></td>
+<td>Rate Limit</td>
+<td>User quota hard stop reached</td>
+</tr>
+<tr>
+<td><code>RATE_LIMIT_QUOTA_WARNING</code></td>
+<td>Rate Limit</td>
+<td>Approaching quota limit (warning)</td>
+</tr>
+<tr>
+<td><code>TOKEN_INVALID</code></td>
+<td>Token</td>
+<td>Confirmation token not found or malformed</td>
+</tr>
+<tr>
+<td><code>TOKEN_EXPIRED</code></td>
+<td>Token</td>
+<td>Confirmation token has expired</td>
+</tr>
+<tr>
+<td><code>TOKEN_ALREADY_USED</code></td>
+<td>Token</td>
+<td>Confirmation token has already been redeemed</td>
+</tr>
+<tr>
+<td><code>TOKEN_SCOPE_MISMATCH</code></td>
+<td>Token</td>
+<td>Token issued for different operation or parameters</td>
+</tr>
+</tbody>
+</table>
+<blockquote>
+<p><strong>Note on <code>CONFIRMATION_REQUIRED</code> categorization:</strong> This code is categorized under "Permission" rather than having its own category because it functions as part of the permission gating flow. The operation is denied pending user confirmation—conceptually similar to other permission denials, but with a recovery path (providing a confirmation token). Clients can treat it as a permission error that includes instructions for resolution.</p>
+</blockquote>
+<h3 id="52-permission_trust_level_insufficient">5.2 PERMISSION_TRUST_LEVEL_INSUFFICIENT</h3>
+<p><strong>When used:</strong> An operation is denied because the adapter's trust level is below the minimum required for the operation's danger level.</p>
+<p><strong>Message format:</strong> <code>Operation '{operation}' requires trust level '{required_trust}', adapter has '{actual_trust}'</code></p>
+<p><strong>Details:</strong></p>
+<div class="sourceCode" id="cb25"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb25-1"><a href="#cb25-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb25-2"><a href="#cb25-2" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** The operation that was attempted */</span></span>
+<span id="cb25-3"><a href="#cb25-3" aria-hidden="true" tabindex="-1"></a>  operation<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb25-4"><a href="#cb25-4" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** Trust level required for this operation */</span></span>
+<span id="cb25-5"><a href="#cb25-5" aria-hidden="true" tabindex="-1"></a>  required_trust<span class="op">:</span> <span class="st">&#39;untested&#39;</span> <span class="op">|</span> <span class="st">&#39;generated&#39;</span> <span class="op">|</span> <span class="st">&#39;validated&#39;</span> <span class="op">|</span> <span class="st">&#39;community_reviewed&#39;</span> <span class="op">|</span> <span class="st">&#39;certified&#39;</span><span class="op">;</span></span>
+<span id="cb25-6"><a href="#cb25-6" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** Adapter&#39;s current trust level */</span></span>
+<span id="cb25-7"><a href="#cb25-7" aria-hidden="true" tabindex="-1"></a>  actual_trust<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb25-8"><a href="#cb25-8" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** The danger level of the operation */</span></span>
+<span id="cb25-9"><a href="#cb25-9" aria-hidden="true" tabindex="-1"></a>  danger_level<span class="op">?:</span> <span class="dt">number</span><span class="op">;</span></span>
+<span id="cb25-10"><a href="#cb25-10" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<p><strong>Example:</strong></p>
+<div class="sourceCode" id="cb26"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb26-1"><a href="#cb26-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb26-2"><a href="#cb26-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb26-3"><a href="#cb26-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;error&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb26-4"><a href="#cb26-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;code&quot;</span><span class="fu">:</span> <span class="st">&quot;PERMISSION_TRUST_LEVEL_INSUFFICIENT&quot;</span><span class="fu">,</span></span>
+<span id="cb26-5"><a href="#cb26-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;Operation &#39;delete_user&#39; requires trust level &#39;community_reviewed&#39;, adapter has &#39;validated&#39;&quot;</span><span class="fu">,</span></span>
+<span id="cb26-6"><a href="#cb26-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;details&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb26-7"><a href="#cb26-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;delete_user&quot;</span><span class="fu">,</span></span>
+<span id="cb26-8"><a href="#cb26-8" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;required_trust&quot;</span><span class="fu">:</span> <span class="st">&quot;community_reviewed&quot;</span><span class="fu">,</span></span>
+<span id="cb26-9"><a href="#cb26-9" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;actual_trust&quot;</span><span class="fu">:</span> <span class="st">&quot;validated&quot;</span><span class="fu">,</span></span>
+<span id="cb26-10"><a href="#cb26-10" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;danger_level&quot;</span><span class="fu">:</span> <span class="dv">2</span></span>
+<span id="cb26-11"><a href="#cb26-11" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb26-12"><a href="#cb26-12" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb26-13"><a href="#cb26-13" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<p><strong>Reference:</strong> <a href="adapter/trust-levels.html">Trust Levels Specification</a></p>
+<h3 id="53-permission_danger_level_denied">5.3 PERMISSION_DANGER_LEVEL_DENIED</h3>
+<p><strong>When used:</strong> An operation is denied because its danger level is too high for the adapter's trust level.</p>
+<p><strong>Message format:</strong> <code>Operation '{operation}' (danger: {danger_level}) denied for adapter trust level '{adapter_trust}'</code></p>
+<p><strong>Details:</strong></p>
+<div class="sourceCode" id="cb27"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb27-1"><a href="#cb27-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb27-2"><a href="#cb27-2" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** The operation that was attempted */</span></span>
+<span id="cb27-3"><a href="#cb27-3" aria-hidden="true" tabindex="-1"></a>  operation<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb27-4"><a href="#cb27-4" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** The danger level of the operation */</span></span>
+<span id="cb27-5"><a href="#cb27-5" aria-hidden="true" tabindex="-1"></a>  danger_level<span class="op">:</span> <span class="st">&#39;safe&#39;</span> <span class="op">|</span> <span class="st">&#39;reversible&#39;</span> <span class="op">|</span> <span class="st">&#39;destructive&#39;</span> <span class="op">|</span> <span class="st">&#39;dangerous&#39;</span> <span class="op">|</span> <span class="st">&#39;forbidden&#39;</span><span class="op">;</span></span>
+<span id="cb27-6"><a href="#cb27-6" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** Adapter&#39;s current trust level */</span></span>
+<span id="cb27-7"><a href="#cb27-7" aria-hidden="true" tabindex="-1"></a>  adapter_trust<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb27-8"><a href="#cb27-8" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** Minimum trust level required */</span></span>
+<span id="cb27-9"><a href="#cb27-9" aria-hidden="true" tabindex="-1"></a>  minimum_trust_required<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb27-10"><a href="#cb27-10" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** Reasons why this operation is dangerous */</span></span>
+<span id="cb27-11"><a href="#cb27-11" aria-hidden="true" tabindex="-1"></a>  reasons<span class="op">?:</span> <span class="dt">string</span>[]<span class="op">;</span></span>
+<span id="cb27-12"><a href="#cb27-12" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<p><strong>Example:</strong></p>
+<div class="sourceCode" id="cb28"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb28-1"><a href="#cb28-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb28-2"><a href="#cb28-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb28-3"><a href="#cb28-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;error&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb28-4"><a href="#cb28-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;code&quot;</span><span class="fu">:</span> <span class="st">&quot;PERMISSION_DANGER_LEVEL_DENIED&quot;</span><span class="fu">,</span></span>
+<span id="cb28-5"><a href="#cb28-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;Operation &#39;bulk_delete&#39; (danger: dangerous) denied for adapter trust level &#39;validated&#39;&quot;</span><span class="fu">,</span></span>
+<span id="cb28-6"><a href="#cb28-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;details&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb28-7"><a href="#cb28-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;bulk_delete&quot;</span><span class="fu">,</span></span>
+<span id="cb28-8"><a href="#cb28-8" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;danger_level&quot;</span><span class="fu">:</span> <span class="st">&quot;dangerous&quot;</span><span class="fu">,</span></span>
+<span id="cb28-9"><a href="#cb28-9" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;adapter_trust&quot;</span><span class="fu">:</span> <span class="st">&quot;validated&quot;</span><span class="fu">,</span></span>
+<span id="cb28-10"><a href="#cb28-10" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;minimum_trust_required&quot;</span><span class="fu">:</span> <span class="st">&quot;community_reviewed&quot;</span><span class="fu">,</span></span>
+<span id="cb28-11"><a href="#cb28-11" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;reasons&quot;</span><span class="fu">:</span> <span class="ot">[</span></span>
+<span id="cb28-12"><a href="#cb28-12" aria-hidden="true" tabindex="-1"></a>        <span class="st">&quot;Affects multiple resources&quot;</span><span class="ot">,</span></span>
+<span id="cb28-13"><a href="#cb28-13" aria-hidden="true" tabindex="-1"></a>        <span class="st">&quot;Cannot be undone&quot;</span></span>
+<span id="cb28-14"><a href="#cb28-14" aria-hidden="true" tabindex="-1"></a>      <span class="ot">]</span></span>
+<span id="cb28-15"><a href="#cb28-15" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb28-16"><a href="#cb28-16" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb28-17"><a href="#cb28-17" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<p><strong>Reference:</strong> <a href="adapter/danger-levels.html">Dangerous Operation Classification</a></p>
+<h3 id="54-confirmation_required">5.4 CONFIRMATION_REQUIRED</h3>
+<p><strong>When used:</strong> A dangerous operation requires explicit user confirmation before execution.</p>
+<blockquote>
+<p><strong>Design note:</strong> This code is categorized under "Permission" in the registry table because it functions as a conditional permission denial—the operation is blocked until the user provides explicit confirmation. Unlike a hard permission denial (<code>PERMISSION_DENIED</code>), this error includes a <code>confirmation_token</code> that enables the client to retry the operation once user consent is obtained. This pattern aligns with the gatekeeper security model where dangerous operations require explicit user approval.</p>
+</blockquote>
+<p><strong>Message format:</strong> <code>This operation requires confirmation</code></p>
+<p><strong>Details:</strong></p>
+<div class="sourceCode" id="cb29"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb29-1"><a href="#cb29-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb29-2"><a href="#cb29-2" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** The operation that requires confirmation */</span></span>
+<span id="cb29-3"><a href="#cb29-3" aria-hidden="true" tabindex="-1"></a>  operation<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb29-4"><a href="#cb29-4" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** The danger level of the operation */</span></span>
+<span id="cb29-5"><a href="#cb29-5" aria-hidden="true" tabindex="-1"></a>  danger_level<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb29-6"><a href="#cb29-6" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** Human-readable reasons for the confirmation requirement */</span></span>
+<span id="cb29-7"><a href="#cb29-7" aria-hidden="true" tabindex="-1"></a>  reasons<span class="op">?:</span> <span class="dt">string</span>[]<span class="op">;</span></span>
+<span id="cb29-8"><a href="#cb29-8" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** Custom confirmation message to display */</span></span>
+<span id="cb29-9"><a href="#cb29-9" aria-hidden="true" tabindex="-1"></a>  confirmation_message<span class="op">?:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb29-10"><a href="#cb29-10" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** Token to include in retry request */</span></span>
+<span id="cb29-11"><a href="#cb29-11" aria-hidden="true" tabindex="-1"></a>  confirmation_token<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb29-12"><a href="#cb29-12" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** When the confirmation token expires */</span></span>
+<span id="cb29-13"><a href="#cb29-13" aria-hidden="true" tabindex="-1"></a>  expires_at<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb29-14"><a href="#cb29-14" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<p><strong>Example:</strong></p>
+<div class="sourceCode" id="cb30"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb30-1"><a href="#cb30-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb30-2"><a href="#cb30-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb30-3"><a href="#cb30-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;error&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb30-4"><a href="#cb30-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;code&quot;</span><span class="fu">:</span> <span class="st">&quot;CONFIRMATION_REQUIRED&quot;</span><span class="fu">,</span></span>
+<span id="cb30-5"><a href="#cb30-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;This operation requires confirmation&quot;</span><span class="fu">,</span></span>
+<span id="cb30-6"><a href="#cb30-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;details&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb30-7"><a href="#cb30-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;delete_repo&quot;</span><span class="fu">,</span></span>
+<span id="cb30-8"><a href="#cb30-8" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;danger_level&quot;</span><span class="fu">:</span> <span class="st">&quot;destructive&quot;</span><span class="fu">,</span></span>
+<span id="cb30-9"><a href="#cb30-9" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;reasons&quot;</span><span class="fu">:</span> <span class="ot">[</span></span>
+<span id="cb30-10"><a href="#cb30-10" aria-hidden="true" tabindex="-1"></a>        <span class="st">&quot;Permanently removes repository and all contents&quot;</span><span class="ot">,</span></span>
+<span id="cb30-11"><a href="#cb30-11" aria-hidden="true" tabindex="-1"></a>        <span class="st">&quot;Cannot be recovered after grace period&quot;</span></span>
+<span id="cb30-12"><a href="#cb30-12" aria-hidden="true" tabindex="-1"></a>      <span class="ot">]</span><span class="fu">,</span></span>
+<span id="cb30-13"><a href="#cb30-13" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;confirmation_message&quot;</span><span class="fu">:</span> <span class="st">&quot;Delete repository &#39;acme/widgets&#39;? This cannot be undone.&quot;</span><span class="fu">,</span></span>
+<span id="cb30-14"><a href="#cb30-14" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;confirmation_token&quot;</span><span class="fu">:</span> <span class="st">&quot;conf_abc123xyz&quot;</span><span class="fu">,</span></span>
+<span id="cb30-15"><a href="#cb30-15" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;expires_at&quot;</span><span class="fu">:</span> <span class="st">&quot;2026-01-28T12:05:00Z&quot;</span></span>
+<span id="cb30-16"><a href="#cb30-16" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb30-17"><a href="#cb30-17" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb30-18"><a href="#cb30-18" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<p><strong>Reference:</strong> <a href="adapter/danger-levels.html">Dangerous Operation Classification</a></p>
+<h3 id="55-rate_limit_exceeded">5.5 RATE_LIMIT_EXCEEDED</h3>
+<p><strong>When used:</strong> The target API rate limit has been reached and requests are blocked until reset.</p>
+<p><strong>Message format:</strong> <code>API rate limit exceeded</code></p>
+<p><strong>Details:</strong></p>
+<div class="sourceCode" id="cb31"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb31-1"><a href="#cb31-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb31-2"><a href="#cb31-2" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** The rate limit that was exceeded */</span></span>
+<span id="cb31-3"><a href="#cb31-3" aria-hidden="true" tabindex="-1"></a>  limit<span class="op">:</span> <span class="dt">number</span><span class="op">;</span></span>
+<span id="cb31-4"><a href="#cb31-4" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** Remaining requests (usually 0) */</span></span>
+<span id="cb31-5"><a href="#cb31-5" aria-hidden="true" tabindex="-1"></a>  remaining<span class="op">:</span> <span class="dt">number</span><span class="op">;</span></span>
+<span id="cb31-6"><a href="#cb31-6" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** Time window of the limit */</span></span>
+<span id="cb31-7"><a href="#cb31-7" aria-hidden="true" tabindex="-1"></a>  window<span class="op">:</span> <span class="st">&#39;second&#39;</span> <span class="op">|</span> <span class="st">&#39;minute&#39;</span> <span class="op">|</span> <span class="st">&#39;hour&#39;</span> <span class="op">|</span> <span class="st">&#39;day&#39;</span><span class="op">;</span></span>
+<span id="cb31-8"><a href="#cb31-8" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** When the rate limit resets */</span></span>
+<span id="cb31-9"><a href="#cb31-9" aria-hidden="true" tabindex="-1"></a>  resets_at<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb31-10"><a href="#cb31-10" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** Seconds until retry is allowed */</span></span>
+<span id="cb31-11"><a href="#cb31-11" aria-hidden="true" tabindex="-1"></a>  retry_after_seconds<span class="op">:</span> <span class="dt">number</span><span class="op">;</span></span>
+<span id="cb31-12"><a href="#cb31-12" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<p><strong>Example:</strong></p>
+<div class="sourceCode" id="cb32"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb32-1"><a href="#cb32-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb32-2"><a href="#cb32-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb32-3"><a href="#cb32-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;error&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb32-4"><a href="#cb32-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;code&quot;</span><span class="fu">:</span> <span class="st">&quot;RATE_LIMIT_EXCEEDED&quot;</span><span class="fu">,</span></span>
+<span id="cb32-5"><a href="#cb32-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;API rate limit exceeded&quot;</span><span class="fu">,</span></span>
+<span id="cb32-6"><a href="#cb32-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;details&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb32-7"><a href="#cb32-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;limit&quot;</span><span class="fu">:</span> <span class="dv">5000</span><span class="fu">,</span></span>
+<span id="cb32-8"><a href="#cb32-8" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;remaining&quot;</span><span class="fu">:</span> <span class="dv">0</span><span class="fu">,</span></span>
+<span id="cb32-9"><a href="#cb32-9" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;window&quot;</span><span class="fu">:</span> <span class="st">&quot;hour&quot;</span><span class="fu">,</span></span>
+<span id="cb32-10"><a href="#cb32-10" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;resets_at&quot;</span><span class="fu">:</span> <span class="st">&quot;2026-01-28T13:00:00Z&quot;</span><span class="fu">,</span></span>
+<span id="cb32-11"><a href="#cb32-11" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;retry_after_seconds&quot;</span><span class="fu">:</span> <span class="dv">1847</span></span>
+<span id="cb32-12"><a href="#cb32-12" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb32-13"><a href="#cb32-13" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb32-14"><a href="#cb32-14" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<p><strong>Reference:</strong> <a href="adapter/rate-limiting.html">Rate Limiting Specification</a></p>
+<h3 id="56-rate_limit_quota_pause">5.6 RATE_LIMIT_QUOTA_PAUSE</h3>
+<p><strong>When used:</strong> A user-configured quota pause threshold has been reached. The user can confirm to continue.</p>
+<p><strong>Message format:</strong> <code>Quota pause threshold reached</code></p>
+<p><strong>Details:</strong></p>
+<div class="sourceCode" id="cb33"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb33-1"><a href="#cb33-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb33-2"><a href="#cb33-2" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** The metric that triggered the pause */</span></span>
+<span id="cb33-3"><a href="#cb33-3" aria-hidden="true" tabindex="-1"></a>  metric<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb33-4"><a href="#cb33-4" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** Current usage */</span></span>
+<span id="cb33-5"><a href="#cb33-5" aria-hidden="true" tabindex="-1"></a>  current<span class="op">:</span> <span class="dt">number</span><span class="op">;</span></span>
+<span id="cb33-6"><a href="#cb33-6" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** The pause threshold */</span></span>
+<span id="cb33-7"><a href="#cb33-7" aria-hidden="true" tabindex="-1"></a>  pause_threshold<span class="op">:</span> <span class="dt">number</span><span class="op">;</span></span>
+<span id="cb33-8"><a href="#cb33-8" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** The hard stop threshold (if configured) */</span></span>
+<span id="cb33-9"><a href="#cb33-9" aria-hidden="true" tabindex="-1"></a>  hard_stop_threshold<span class="op">?:</span> <span class="dt">number</span><span class="op">;</span></span>
+<span id="cb33-10"><a href="#cb33-10" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** Token to continue past the pause */</span></span>
+<span id="cb33-11"><a href="#cb33-11" aria-hidden="true" tabindex="-1"></a>  confirmation_token<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb33-12"><a href="#cb33-12" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** When the confirmation token expires */</span></span>
+<span id="cb33-13"><a href="#cb33-13" aria-hidden="true" tabindex="-1"></a>  expires_at<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb33-14"><a href="#cb33-14" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<p><strong>Example:</strong></p>
+<div class="sourceCode" id="cb34"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb34-1"><a href="#cb34-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb34-2"><a href="#cb34-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb34-3"><a href="#cb34-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;error&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb34-4"><a href="#cb34-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;code&quot;</span><span class="fu">:</span> <span class="st">&quot;RATE_LIMIT_QUOTA_PAUSE&quot;</span><span class="fu">,</span></span>
+<span id="cb34-5"><a href="#cb34-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;Quota pause threshold reached&quot;</span><span class="fu">,</span></span>
+<span id="cb34-6"><a href="#cb34-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;details&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb34-7"><a href="#cb34-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;metric&quot;</span><span class="fu">:</span> <span class="st">&quot;requests_per_hour&quot;</span><span class="fu">,</span></span>
+<span id="cb34-8"><a href="#cb34-8" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;current&quot;</span><span class="fu">:</span> <span class="dv">4850</span><span class="fu">,</span></span>
+<span id="cb34-9"><a href="#cb34-9" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;pause_threshold&quot;</span><span class="fu">:</span> <span class="dv">4800</span><span class="fu">,</span></span>
+<span id="cb34-10"><a href="#cb34-10" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;hard_stop_threshold&quot;</span><span class="fu">:</span> <span class="dv">5000</span><span class="fu">,</span></span>
+<span id="cb34-11"><a href="#cb34-11" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;confirmation_token&quot;</span><span class="fu">:</span> <span class="st">&quot;quota_continue_abc123&quot;</span><span class="fu">,</span></span>
+<span id="cb34-12"><a href="#cb34-12" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;expires_at&quot;</span><span class="fu">:</span> <span class="st">&quot;2026-01-28T12:05:00Z&quot;</span></span>
+<span id="cb34-13"><a href="#cb34-13" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb34-14"><a href="#cb34-14" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb34-15"><a href="#cb34-15" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<p><strong>Reference:</strong> <a href="adapter/rate-limiting.html">Rate Limiting Specification</a></p>
+<h3 id="57-rate_limit_quota_exhausted">5.7 RATE_LIMIT_QUOTA_EXHAUSTED</h3>
+<p><strong>When used:</strong> A user-configured quota hard stop threshold has been reached. All requests are blocked until reset.</p>
+<p><strong>Message format:</strong> <code>Quota exhausted</code></p>
+<p><strong>Details:</strong></p>
+<div class="sourceCode" id="cb35"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb35-1"><a href="#cb35-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb35-2"><a href="#cb35-2" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** The metric that triggered the hard stop */</span></span>
+<span id="cb35-3"><a href="#cb35-3" aria-hidden="true" tabindex="-1"></a>  metric<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb35-4"><a href="#cb35-4" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** Current usage */</span></span>
+<span id="cb35-5"><a href="#cb35-5" aria-hidden="true" tabindex="-1"></a>  current<span class="op">:</span> <span class="dt">number</span><span class="op">;</span></span>
+<span id="cb35-6"><a href="#cb35-6" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** The hard stop threshold */</span></span>
+<span id="cb35-7"><a href="#cb35-7" aria-hidden="true" tabindex="-1"></a>  hard_stop_threshold<span class="op">:</span> <span class="dt">number</span><span class="op">;</span></span>
+<span id="cb35-8"><a href="#cb35-8" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** When the quota resets */</span></span>
+<span id="cb35-9"><a href="#cb35-9" aria-hidden="true" tabindex="-1"></a>  resets_at<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb35-10"><a href="#cb35-10" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<p><strong>Example:</strong></p>
+<div class="sourceCode" id="cb36"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb36-1"><a href="#cb36-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb36-2"><a href="#cb36-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb36-3"><a href="#cb36-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;error&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb36-4"><a href="#cb36-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;code&quot;</span><span class="fu">:</span> <span class="st">&quot;RATE_LIMIT_QUOTA_EXHAUSTED&quot;</span><span class="fu">,</span></span>
+<span id="cb36-5"><a href="#cb36-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;Quota exhausted&quot;</span><span class="fu">,</span></span>
+<span id="cb36-6"><a href="#cb36-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;details&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb36-7"><a href="#cb36-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;metric&quot;</span><span class="fu">:</span> <span class="st">&quot;requests_per_hour&quot;</span><span class="fu">,</span></span>
+<span id="cb36-8"><a href="#cb36-8" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;current&quot;</span><span class="fu">:</span> <span class="dv">5000</span><span class="fu">,</span></span>
+<span id="cb36-9"><a href="#cb36-9" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;hard_stop_threshold&quot;</span><span class="fu">:</span> <span class="dv">5000</span><span class="fu">,</span></span>
+<span id="cb36-10"><a href="#cb36-10" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;resets_at&quot;</span><span class="fu">:</span> <span class="st">&quot;2026-01-28T13:00:00Z&quot;</span></span>
+<span id="cb36-11"><a href="#cb36-11" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb36-12"><a href="#cb36-12" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb36-13"><a href="#cb36-13" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<p><strong>Reference:</strong> <a href="adapter/rate-limiting.html">Rate Limiting Specification</a></p>
+<h3 id="58-rate_limit_quota_warning">5.8 RATE_LIMIT_QUOTA_WARNING</h3>
+<p><strong>When used:</strong> Included in the <code>warnings</code> array of successful responses when approaching a quota limit.</p>
+<blockquote>
+<p><strong>⚠️ IMPORTANT: This is a WARNING code, not an error code.</strong></p>
+<p>Unlike all other codes in this section, <code>RATE_LIMIT_QUOTA_WARNING</code> appears in the <code>warnings</code> array of <strong>successful</strong> responses (<code>success: true</code>), not in the <code>error</code> object. The operation completes normally; this code signals an informational warning about approaching limits.</p>
+<p>See <a href="features/warnings.html">Warnings Specification</a> for details on warning handling.</p>
+</blockquote>
+<p><strong>Message format:</strong> <code>Approaching quota limit</code></p>
+<p><strong>Details:</strong></p>
+<div class="sourceCode" id="cb37"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb37-1"><a href="#cb37-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb37-2"><a href="#cb37-2" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** The metric approaching the limit */</span></span>
+<span id="cb37-3"><a href="#cb37-3" aria-hidden="true" tabindex="-1"></a>  metric<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb37-4"><a href="#cb37-4" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** Current usage */</span></span>
+<span id="cb37-5"><a href="#cb37-5" aria-hidden="true" tabindex="-1"></a>  current<span class="op">:</span> <span class="dt">number</span><span class="op">;</span></span>
+<span id="cb37-6"><a href="#cb37-6" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** The warning threshold */</span></span>
+<span id="cb37-7"><a href="#cb37-7" aria-hidden="true" tabindex="-1"></a>  warn_threshold<span class="op">:</span> <span class="dt">number</span><span class="op">;</span></span>
+<span id="cb37-8"><a href="#cb37-8" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** The pause threshold (next level) */</span></span>
+<span id="cb37-9"><a href="#cb37-9" aria-hidden="true" tabindex="-1"></a>  pause_threshold<span class="op">?:</span> <span class="dt">number</span><span class="op">;</span></span>
+<span id="cb37-10"><a href="#cb37-10" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<p><strong>Example (in successful response):</strong></p>
+<div class="sourceCode" id="cb38"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb38-1"><a href="#cb38-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb38-2"><a href="#cb38-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb38-3"><a href="#cb38-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;data&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;...&quot;</span><span class="fu">:</span> <span class="st">&quot;...&quot;</span> <span class="fu">},</span></span>
+<span id="cb38-4"><a href="#cb38-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;warnings&quot;</span><span class="fu">:</span> <span class="ot">[</span></span>
+<span id="cb38-5"><a href="#cb38-5" aria-hidden="true" tabindex="-1"></a>    <span class="fu">{</span></span>
+<span id="cb38-6"><a href="#cb38-6" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;code&quot;</span><span class="fu">:</span> <span class="st">&quot;RATE_LIMIT_QUOTA_WARNING&quot;</span><span class="fu">,</span></span>
+<span id="cb38-7"><a href="#cb38-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;Approaching quota limit&quot;</span><span class="fu">,</span></span>
+<span id="cb38-8"><a href="#cb38-8" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;details&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb38-9"><a href="#cb38-9" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;metric&quot;</span><span class="fu">:</span> <span class="st">&quot;requests_per_hour&quot;</span><span class="fu">,</span></span>
+<span id="cb38-10"><a href="#cb38-10" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;current&quot;</span><span class="fu">:</span> <span class="dv">4100</span><span class="fu">,</span></span>
+<span id="cb38-11"><a href="#cb38-11" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;warn_threshold&quot;</span><span class="fu">:</span> <span class="dv">4000</span><span class="fu">,</span></span>
+<span id="cb38-12"><a href="#cb38-12" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;pause_threshold&quot;</span><span class="fu">:</span> <span class="dv">4800</span></span>
+<span id="cb38-13"><a href="#cb38-13" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span></span>
+<span id="cb38-14"><a href="#cb38-14" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb38-15"><a href="#cb38-15" aria-hidden="true" tabindex="-1"></a>  <span class="ot">]</span></span>
+<span id="cb38-16"><a href="#cb38-16" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<p><strong>Reference:</strong> <a href="adapter/rate-limiting.html">Rate Limiting Specification</a></p>
+<h3 id="59-token_invalid">5.9 TOKEN_INVALID</h3>
+<p><strong>When used:</strong> A confirmation token was provided but could not be found in the token store or is malformed.</p>
+<p><strong>Message format:</strong> <code>Invalid confirmation token</code></p>
+<p><strong>Details:</strong></p>
+<div class="sourceCode" id="cb39"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb39-1"><a href="#cb39-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb39-2"><a href="#cb39-2" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** The token that was provided */</span></span>
+<span id="cb39-3"><a href="#cb39-3" aria-hidden="true" tabindex="-1"></a>  token<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb39-4"><a href="#cb39-4" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<p><strong>Example:</strong></p>
+<div class="sourceCode" id="cb40"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb40-1"><a href="#cb40-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb40-2"><a href="#cb40-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb40-3"><a href="#cb40-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;error&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb40-4"><a href="#cb40-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;code&quot;</span><span class="fu">:</span> <span class="st">&quot;TOKEN_INVALID&quot;</span><span class="fu">,</span></span>
+<span id="cb40-5"><a href="#cb40-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;Invalid confirmation token&quot;</span><span class="fu">,</span></span>
+<span id="cb40-6"><a href="#cb40-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;details&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb40-7"><a href="#cb40-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;token&quot;</span><span class="fu">:</span> <span class="st">&quot;conf_nonexistent123&quot;</span></span>
+<span id="cb40-8"><a href="#cb40-8" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb40-9"><a href="#cb40-9" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb40-10"><a href="#cb40-10" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<p><strong>Reference:</strong> <a href="security/confirmation-tokens.html">Confirmation Token Specification</a></p>
+<h3 id="510-token_expired">5.10 TOKEN_EXPIRED</h3>
+<p><strong>When used:</strong> A confirmation token was provided but has passed its expiration time.</p>
+<p><strong>Message format:</strong> <code>Confirmation token has expired</code></p>
+<p><strong>Details:</strong></p>
+<div class="sourceCode" id="cb41"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb41-1"><a href="#cb41-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb41-2"><a href="#cb41-2" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** The token that expired */</span></span>
+<span id="cb41-3"><a href="#cb41-3" aria-hidden="true" tabindex="-1"></a>  token<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb41-4"><a href="#cb41-4" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** When the token expired */</span></span>
+<span id="cb41-5"><a href="#cb41-5" aria-hidden="true" tabindex="-1"></a>  expired_at<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb41-6"><a href="#cb41-6" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** Current server time */</span></span>
+<span id="cb41-7"><a href="#cb41-7" aria-hidden="true" tabindex="-1"></a>  current_time<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb41-8"><a href="#cb41-8" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<p><strong>Example:</strong></p>
+<div class="sourceCode" id="cb42"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb42-1"><a href="#cb42-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb42-2"><a href="#cb42-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb42-3"><a href="#cb42-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;error&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb42-4"><a href="#cb42-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;code&quot;</span><span class="fu">:</span> <span class="st">&quot;TOKEN_EXPIRED&quot;</span><span class="fu">,</span></span>
+<span id="cb42-5"><a href="#cb42-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;Confirmation token has expired&quot;</span><span class="fu">,</span></span>
+<span id="cb42-6"><a href="#cb42-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;details&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb42-7"><a href="#cb42-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;token&quot;</span><span class="fu">:</span> <span class="st">&quot;conf_abc123xyz&quot;</span><span class="fu">,</span></span>
+<span id="cb42-8"><a href="#cb42-8" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;expired_at&quot;</span><span class="fu">:</span> <span class="st">&quot;2026-01-28T12:05:00Z&quot;</span><span class="fu">,</span></span>
+<span id="cb42-9"><a href="#cb42-9" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;current_time&quot;</span><span class="fu">:</span> <span class="st">&quot;2026-01-28T12:07:30Z&quot;</span></span>
+<span id="cb42-10"><a href="#cb42-10" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb42-11"><a href="#cb42-11" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb42-12"><a href="#cb42-12" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<p><strong>Reference:</strong> <a href="security/confirmation-tokens.html">Confirmation Token Specification</a></p>
+<h3 id="511-token_already_used">5.11 TOKEN_ALREADY_USED</h3>
+<p><strong>When used:</strong> A confirmation token was provided but has already been redeemed for a previous operation.</p>
+<p><strong>Message format:</strong> <code>Confirmation token has already been used</code></p>
+<p><strong>Details:</strong></p>
+<div class="sourceCode" id="cb43"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb43-1"><a href="#cb43-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb43-2"><a href="#cb43-2" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** The token that was already used */</span></span>
+<span id="cb43-3"><a href="#cb43-3" aria-hidden="true" tabindex="-1"></a>  token<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb43-4"><a href="#cb43-4" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** When the token was consumed */</span></span>
+<span id="cb43-5"><a href="#cb43-5" aria-hidden="true" tabindex="-1"></a>  consumed_at<span class="op">?:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb43-6"><a href="#cb43-6" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<p><strong>Example:</strong></p>
+<div class="sourceCode" id="cb44"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb44-1"><a href="#cb44-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb44-2"><a href="#cb44-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb44-3"><a href="#cb44-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;error&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb44-4"><a href="#cb44-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;code&quot;</span><span class="fu">:</span> <span class="st">&quot;TOKEN_ALREADY_USED&quot;</span><span class="fu">,</span></span>
+<span id="cb44-5"><a href="#cb44-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;Confirmation token has already been used&quot;</span><span class="fu">,</span></span>
+<span id="cb44-6"><a href="#cb44-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;details&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb44-7"><a href="#cb44-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;token&quot;</span><span class="fu">:</span> <span class="st">&quot;conf_abc123xyz&quot;</span><span class="fu">,</span></span>
+<span id="cb44-8"><a href="#cb44-8" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;consumed_at&quot;</span><span class="fu">:</span> <span class="st">&quot;2026-01-28T12:04:15Z&quot;</span></span>
+<span id="cb44-9"><a href="#cb44-9" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb44-10"><a href="#cb44-10" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb44-11"><a href="#cb44-11" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<p><strong>Reference:</strong> <a href="security/confirmation-tokens.html">Confirmation Token Specification</a></p>
+<h3 id="512-token_scope_mismatch">5.12 TOKEN_SCOPE_MISMATCH</h3>
+<p><strong>When used:</strong> A confirmation token was provided but was issued for a different operation or with different parameters.</p>
+<p><strong>Message format:</strong> <code>Confirmation token scope mismatch</code></p>
+<p><strong>Details:</strong></p>
+<div class="sourceCode" id="cb45"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb45-1"><a href="#cb45-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb45-2"><a href="#cb45-2" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** The token that was provided */</span></span>
+<span id="cb45-3"><a href="#cb45-3" aria-hidden="true" tabindex="-1"></a>  token<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb45-4"><a href="#cb45-4" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** Operation the token was issued for */</span></span>
+<span id="cb45-5"><a href="#cb45-5" aria-hidden="true" tabindex="-1"></a>  token_operation<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb45-6"><a href="#cb45-6" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** Operation the client is attempting */</span></span>
+<span id="cb45-7"><a href="#cb45-7" aria-hidden="true" tabindex="-1"></a>  requested_operation<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb45-8"><a href="#cb45-8" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<p><strong>Example:</strong></p>
+<div class="sourceCode" id="cb46"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb46-1"><a href="#cb46-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb46-2"><a href="#cb46-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb46-3"><a href="#cb46-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;error&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb46-4"><a href="#cb46-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;code&quot;</span><span class="fu">:</span> <span class="st">&quot;TOKEN_SCOPE_MISMATCH&quot;</span><span class="fu">,</span></span>
+<span id="cb46-5"><a href="#cb46-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;Confirmation token scope mismatch&quot;</span><span class="fu">,</span></span>
+<span id="cb46-6"><a href="#cb46-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;details&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb46-7"><a href="#cb46-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;token&quot;</span><span class="fu">:</span> <span class="st">&quot;conf_abc123xyz&quot;</span><span class="fu">,</span></span>
+<span id="cb46-8"><a href="#cb46-8" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;token_operation&quot;</span><span class="fu">:</span> <span class="st">&quot;delete_repo&quot;</span><span class="fu">,</span></span>
+<span id="cb46-9"><a href="#cb46-9" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;requested_operation&quot;</span><span class="fu">:</span> <span class="st">&quot;force_push&quot;</span></span>
+<span id="cb46-10"><a href="#cb46-10" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb46-11"><a href="#cb46-11" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb46-12"><a href="#cb46-12" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<p><strong>Reference:</strong> <a href="security/confirmation-tokens.html">Confirmation Token Specification</a></p>
+<hr />
+<h2 id="6-http-status-mapping">6. HTTP Status Mapping</h2>
+<h3 id="61-default-mapping">6.1 Default Mapping</h3>
+<p>The runtime maps HTTP status codes to MCP-AQL error codes:</p>
+<table>
+<thead>
+<tr>
+<th>HTTP Status</th>
+<th>Error Code</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>400</td>
+<td><code>VALIDATION_INVALID_TYPE</code></td>
+<td>Bad request (default for validation errors)</td>
+</tr>
+<tr>
+<td>400</td>
+<td><code>VALIDATION_MISSING_PARAM</code></td>
+<td>Bad request (missing required parameter)</td>
+</tr>
+<tr>
+<td>400</td>
+<td><code>VALIDATION_UNKNOWN_PARAM</code></td>
+<td>Bad request (unknown parameter)</td>
+</tr>
+<tr>
+<td>401</td>
+<td><code>PERMISSION_DENIED</code></td>
+<td>Authentication required</td>
+</tr>
+<tr>
+<td>403</td>
+<td><code>PERMISSION_DENIED</code></td>
+<td>Forbidden</td>
+</tr>
+<tr>
+<td>404</td>
+<td><code>NOT_FOUND_RESOURCE</code></td>
+<td>Not found</td>
+</tr>
+<tr>
+<td>422</td>
+<td><code>VALIDATION_INVALID_TYPE</code></td>
+<td>Unprocessable entity</td>
+</tr>
+<tr>
+<td>500</td>
+<td><code>INTERNAL_ERROR</code></td>
+<td>Internal server error</td>
+</tr>
+<tr>
+<td>502</td>
+<td><code>INTERNAL_ERROR</code></td>
+<td>Bad gateway</td>
+</tr>
+<tr>
+<td>503</td>
+<td><code>INTERNAL_ERROR</code></td>
+<td>Service unavailable</td>
+</tr>
+<tr>
+<td>504</td>
+<td><code>INTERNAL_ERROR</code></td>
+<td>Gateway timeout</td>
+</tr>
+</tbody>
+</table>
+<h3 id="62-mapping-algorithm">6.2 Mapping Algorithm</h3>
+<div class="sourceCode" id="cb47"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb47-1"><a href="#cb47-1" aria-hidden="true" tabindex="-1"></a><span class="kw">function</span> <span class="fu">mapHttpStatusToErrorCode</span>(status<span class="op">:</span> <span class="dt">number</span>)<span class="op">:</span> <span class="dt">string</span> {</span>
+<span id="cb47-2"><a href="#cb47-2" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> (status <span class="op">===</span> <span class="dv">400</span> <span class="op">||</span> status <span class="op">===</span> <span class="dv">422</span>) {</span>
+<span id="cb47-3"><a href="#cb47-3" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> <span class="st">&#39;VALIDATION_INVALID_TYPE&#39;</span><span class="op">;</span></span>
+<span id="cb47-4"><a href="#cb47-4" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb47-5"><a href="#cb47-5" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> (status <span class="op">===</span> <span class="dv">401</span> <span class="op">||</span> status <span class="op">===</span> <span class="dv">403</span>) {</span>
+<span id="cb47-6"><a href="#cb47-6" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> <span class="st">&#39;PERMISSION_DENIED&#39;</span><span class="op">;</span></span>
+<span id="cb47-7"><a href="#cb47-7" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb47-8"><a href="#cb47-8" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> (status <span class="op">===</span> <span class="dv">404</span>) {</span>
+<span id="cb47-9"><a href="#cb47-9" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> <span class="st">&#39;NOT_FOUND_RESOURCE&#39;</span><span class="op">;</span></span>
+<span id="cb47-10"><a href="#cb47-10" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb47-11"><a href="#cb47-11" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> (status <span class="op">&gt;=</span> <span class="dv">500</span>) {</span>
+<span id="cb47-12"><a href="#cb47-12" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> <span class="st">&#39;INTERNAL_ERROR&#39;</span><span class="op">;</span></span>
+<span id="cb47-13"><a href="#cb47-13" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb47-14"><a href="#cb47-14" aria-hidden="true" tabindex="-1"></a>  <span class="co">// Default for other 4xx errors</span></span>
+<span id="cb47-15"><a href="#cb47-15" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> <span class="st">&#39;VALIDATION_INVALID_TYPE&#39;</span><span class="op">;</span></span>
+<span id="cb47-16"><a href="#cb47-16" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<blockquote>
+<p><strong>Note:</strong> HTTP status codes alone cannot distinguish between <code>VALIDATION_MISSING_PARAM</code> and <code>VALIDATION_INVALID_TYPE</code> (both typically return 400 or 422). Adapters SHOULD examine the target API's response body to determine the specific validation error and set the appropriate code. The mapping algorithm above provides a default when response body inspection is not feasible.</p>
+</blockquote>
+<hr />
+<h2 id="7-implementation-requirements">7. Implementation Requirements</h2>
+<h3 id="71-error-generation">7.1 Error Generation</h3>
+<p>Implementations MUST:</p>
+<ol type="1">
+<li>Return structured errors for all failure cases</li>
+<li>Include <code>code</code> and <code>message</code> fields</li>
+<li>Use codes from the MVP registry</li>
+<li>Provide human-readable messages</li>
+</ol>
+<p>Implementations SHOULD:</p>
+<ol type="1">
+<li>Include <code>details</code> with contextual information</li>
+<li>Preserve upstream error messages</li>
+<li>Log full error context for debugging</li>
+</ol>
+<h3 id="72-error-handling">7.2 Error Handling</h3>
+<p>Client implementations SHOULD:</p>
+<ol type="1">
+<li>Check <code>success</code> field first</li>
+<li>Parse the <code>error</code> object to extract <code>code</code> and <code>message</code></li>
+<li>Use <code>code</code> field for programmatic error handling and recovery decisions</li>
+<li>Display <code>message</code> field to users</li>
+</ol>
+<h3 id="73-message-localization">7.3 Message Localization</h3>
+<p>The <code>code</code> field enables localization:</p>
+<div class="sourceCode" id="cb48"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb48-1"><a href="#cb48-1" aria-hidden="true" tabindex="-1"></a><span class="kw">const</span> ERROR_MESSAGES <span class="op">=</span> {</span>
+<span id="cb48-2"><a href="#cb48-2" aria-hidden="true" tabindex="-1"></a>  en<span class="op">:</span> {</span>
+<span id="cb48-3"><a href="#cb48-3" aria-hidden="true" tabindex="-1"></a>    VALIDATION_MISSING_PARAM<span class="op">:</span> <span class="st">&quot;Missing required parameter: &#39;{param_name}&#39;&quot;</span><span class="op">,</span></span>
+<span id="cb48-4"><a href="#cb48-4" aria-hidden="true" tabindex="-1"></a>    NOT_FOUND_RESOURCE<span class="op">:</span> <span class="st">&#39;Resource not found&#39;</span><span class="op">,</span></span>
+<span id="cb48-5"><a href="#cb48-5" aria-hidden="true" tabindex="-1"></a>  }<span class="op">,</span></span>
+<span id="cb48-6"><a href="#cb48-6" aria-hidden="true" tabindex="-1"></a>  es<span class="op">:</span> {</span>
+<span id="cb48-7"><a href="#cb48-7" aria-hidden="true" tabindex="-1"></a>    VALIDATION_MISSING_PARAM<span class="op">:</span> <span class="st">&quot;Falta el parámetro requerido: &#39;{param_name}&#39;&quot;</span><span class="op">,</span></span>
+<span id="cb48-8"><a href="#cb48-8" aria-hidden="true" tabindex="-1"></a>    NOT_FOUND_RESOURCE<span class="op">:</span> <span class="st">&#39;Recurso no encontrado&#39;</span><span class="op">,</span></span>
+<span id="cb48-9"><a href="#cb48-9" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb48-10"><a href="#cb48-10" aria-hidden="true" tabindex="-1"></a>}<span class="op">;</span></span>
+<span id="cb48-11"><a href="#cb48-11" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb48-12"><a href="#cb48-12" aria-hidden="true" tabindex="-1"></a><span class="kw">function</span> <span class="fu">localizeError</span>(error<span class="op">:</span> ErrorDetail<span class="op">,</span> locale<span class="op">:</span> <span class="dt">string</span>)<span class="op">:</span> <span class="dt">string</span> {</span>
+<span id="cb48-13"><a href="#cb48-13" aria-hidden="true" tabindex="-1"></a>  <span class="kw">const</span> template <span class="op">=</span> ERROR_MESSAGES[locale]<span class="op">?.</span>[error<span class="op">.</span><span class="at">code</span>]<span class="op">;</span></span>
+<span id="cb48-14"><a href="#cb48-14" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> (template <span class="op">&amp;&amp;</span> error<span class="op">.</span><span class="at">details</span>) {</span>
+<span id="cb48-15"><a href="#cb48-15" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> <span class="fu">interpolate</span>(template<span class="op">,</span> error<span class="op">.</span><span class="at">details</span>)<span class="op">;</span></span>
+<span id="cb48-16"><a href="#cb48-16" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb48-17"><a href="#cb48-17" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> error<span class="op">.</span><span class="at">message</span><span class="op">;</span></span>
+<span id="cb48-18"><a href="#cb48-18" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<hr />
+<h2 id="8-future-extensions">8. Future Extensions</h2>
+<h3 id="81-additional-error-codes">8.1 Additional Error Codes</h3>
+<p>Future specifications may add:</p>
+<p><strong>Conflict Handling:</strong></p>
+<ul>
+<li><code>CONFLICT_ALREADY_EXISTS</code> - Resource already exists</li>
+<li><code>CONFLICT_VERSION_MISMATCH</code> - Optimistic locking failure (see <a href="versions/v1.0.0-draft.html#93-request-concurrency">Request Concurrency</a>)</li>
+</ul>
+<p><strong>Enhanced Validation:</strong></p>
+<ul>
+<li><code>VALIDATION_INVALID_ENUM</code> - Value not in allowed enum</li>
+<li><code>VALIDATION_OUT_OF_RANGE</code> - Value outside allowed range</li>
+<li><code>VALIDATION_PATTERN_MISMATCH</code> - String doesn't match pattern</li>
+</ul>
+<h3 id="82-error-code-extension-mechanism">8.2 Error Code Extension Mechanism</h3>
+<p>Future versions will define how adapters can register custom error codes:</p>
+<div class="sourceCode" id="cb49"><pre class="sourceCode yaml"><code class="sourceCode yaml"><span id="cb49-1"><a href="#cb49-1" aria-hidden="true" tabindex="-1"></a><span class="co"># In adapter schema</span></span>
+<span id="cb49-2"><a href="#cb49-2" aria-hidden="true" tabindex="-1"></a><span class="fu">error_codes</span><span class="kw">:</span></span>
+<span id="cb49-3"><a href="#cb49-3" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">GITHUB_ABUSE_DETECTED</span><span class="kw">:</span></span>
+<span id="cb49-4"><a href="#cb49-4" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">category</span><span class="kw">:</span><span class="at"> RATE_LIMIT</span></span>
+<span id="cb49-5"><a href="#cb49-5" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">message_template</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;Abuse detection triggered: {reason}&quot;</span></span>
+<span id="cb49-6"><a href="#cb49-6" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">maps_from_http</span><span class="kw">:</span><span class="at"> </span><span class="kw">[</span><span class="dv">403</span><span class="kw">]</span></span>
+<span id="cb49-7"><a href="#cb49-7" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">condition</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;response.body.message contains &#39;abuse&#39;&quot;</span></span></code></pre></div>
+<h3 id="83-per-adapter-error-overrides">8.3 Per-Adapter Error Overrides</h3>
+<p>Future versions will allow adapters to customize HTTP error mapping:</p>
+<div class="sourceCode" id="cb50"><pre class="sourceCode yaml"><code class="sourceCode yaml"><span id="cb50-1"><a href="#cb50-1" aria-hidden="true" tabindex="-1"></a><span class="co"># In adapter schema</span></span>
+<span id="cb50-2"><a href="#cb50-2" aria-hidden="true" tabindex="-1"></a><span class="fu">error_mapping</span><span class="kw">:</span></span>
+<span id="cb50-3"><a href="#cb50-3" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">404</span><span class="kw">:</span></span>
+<span id="cb50-4"><a href="#cb50-4" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">code</span><span class="kw">:</span><span class="at"> NOT_FOUND_REPOSITORY</span></span>
+<span id="cb50-5"><a href="#cb50-5" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">message_template</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;Repository &#39;{owner}/{repo}&#39; not found&quot;</span></span>
+<span id="cb50-6"><a href="#cb50-6" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">403</span><span class="kw">:</span></span>
+<span id="cb50-7"><a href="#cb50-7" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">condition</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;response.body.message contains &#39;rate limit&#39;&quot;</span></span>
+<span id="cb50-8"><a href="#cb50-8" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">code</span><span class="kw">:</span><span class="at"> RATE_LIMIT_EXCEEDED</span></span></code></pre></div>
+<h3 id="84-error-aggregation">8.4 Error Aggregation</h3>
+<p>For batch operations, errors may be aggregated:</p>
+<div class="sourceCode" id="cb51"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb51-1"><a href="#cb51-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb51-2"><a href="#cb51-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb51-3"><a href="#cb51-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;error&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb51-4"><a href="#cb51-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;code&quot;</span><span class="fu">:</span> <span class="st">&quot;BATCH_PARTIAL_FAILURE&quot;</span><span class="fu">,</span></span>
+<span id="cb51-5"><a href="#cb51-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;3 of 5 operations failed&quot;</span><span class="fu">,</span></span>
+<span id="cb51-6"><a href="#cb51-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;details&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb51-7"><a href="#cb51-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;total&quot;</span><span class="fu">:</span> <span class="dv">5</span><span class="fu">,</span></span>
+<span id="cb51-8"><a href="#cb51-8" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;succeeded&quot;</span><span class="fu">:</span> <span class="dv">2</span><span class="fu">,</span></span>
+<span id="cb51-9"><a href="#cb51-9" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;failed&quot;</span><span class="fu">:</span> <span class="dv">3</span><span class="fu">,</span></span>
+<span id="cb51-10"><a href="#cb51-10" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;errors&quot;</span><span class="fu">:</span> <span class="ot">[</span></span>
+<span id="cb51-11"><a href="#cb51-11" aria-hidden="true" tabindex="-1"></a>        <span class="fu">{</span> <span class="dt">&quot;index&quot;</span><span class="fu">:</span> <span class="dv">1</span><span class="fu">,</span> <span class="dt">&quot;code&quot;</span><span class="fu">:</span> <span class="st">&quot;NOT_FOUND_RESOURCE&quot;</span><span class="fu">,</span> <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;...&quot;</span> <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb51-12"><a href="#cb51-12" aria-hidden="true" tabindex="-1"></a>        <span class="fu">{</span> <span class="dt">&quot;index&quot;</span><span class="fu">:</span> <span class="dv">3</span><span class="fu">,</span> <span class="dt">&quot;code&quot;</span><span class="fu">:</span> <span class="st">&quot;PERMISSION_DENIED&quot;</span><span class="fu">,</span> <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;...&quot;</span> <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb51-13"><a href="#cb51-13" aria-hidden="true" tabindex="-1"></a>        <span class="fu">{</span> <span class="dt">&quot;index&quot;</span><span class="fu">:</span> <span class="dv">4</span><span class="fu">,</span> <span class="dt">&quot;code&quot;</span><span class="fu">:</span> <span class="st">&quot;VALIDATION_MISSING_PARAM&quot;</span><span class="fu">,</span> <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;...&quot;</span> <span class="fu">}</span></span>
+<span id="cb51-14"><a href="#cb51-14" aria-hidden="true" tabindex="-1"></a>      <span class="ot">]</span></span>
+<span id="cb51-15"><a href="#cb51-15" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb51-16"><a href="#cb51-16" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb51-17"><a href="#cb51-17" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<hr />
+<h2 id="references">References</h2>
+<ul>
+<li><a href="versions/v1.0.0-draft.html">MCP-AQL Specification</a></li>
+<li><a href="adapter/danger-levels.html">Dangerous Operation Classification</a></li>
+<li><a href="adapter/trust-levels.html">Trust Levels Specification</a></li>
+<li><a href="adapter/rate-limiting.html">Rate Limiting Specification</a></li>
+<li><a href="https://github.com/MCPAQL/mcpaql-adapter/blob/develop/docs/architecture/runtime.md">Universal Adapter Runtime</a> (in mcpaql-adapter repo)</li>
+<li><a href="https://github.com/DollhouseMCP/mcp-server-v2-refactor/issues/298">DollhouseMCP Implementation</a></li>
+<li>GitHub Issue: <a href="https://github.com/MCPAQL/spec/issues/35">#35</a></li>
+</ul>
+
+          </div>
+        </section>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div class="container">
+      <p>&copy; 2026 DollhouseMCP Inc. d/b/a Dollhouse Research. MCP-AQL public draft documentation portal.</p>
+      <div class="footer-links">
+        <a href="../docs/index.html">Docs Library</a>
+        <a href="index.html">Repo-Synced Spec</a>
+        <a href="https://github.com/MCPAQL">MCPAQL Organization</a>
+        <a href="https://dollhouseresearch.com">Dollhouse Research</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../js/search.js"></script>
+</body>
+</html>

--- a/public/spec/error-codes.html
+++ b/public/spec/error-codes.html
@@ -73,6 +73,13 @@
       </aside>
 
       <article class="docs-main">
+        <nav class="breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../index.html">Home</a></li>
+            <li><a href="index.html">Full Spec</a></li>
+            <li><span class="current">Structured Error Codes Specification</span></li>
+          </ol>
+        </nav>
         <section class="hero docs-hero">
           <div class="hero-inner">
             <span class="status-pill">REPO-SYNCED SPEC DOC</span>

--- a/public/spec/error-codes.html
+++ b/public/spec/error-codes.html
@@ -23,7 +23,7 @@
         </ul>
         <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
-          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <input id="site-search-input" data-search-input type="search" placeholder="Search MCP-AQL docs, spec pages, and adapter patterns...">
           <span class="search-count" data-search-count></span>
           <ul class="search-results" data-search-results hidden></ul>
         </form>
@@ -38,7 +38,7 @@
         <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
         <div class="docs-side-group">
   <h3>Core</h3>
-  <ul><li><a href="conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a class="current" href="error-codes.html">Structured Error Codes Specification</a></li><li><a href="introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="mcp-integration.html">MCP Integration Specification</a></li><li><a href="operations.html">MCP-AQL Operations Specification</a></li><li><a href="overview.html">MCP-AQL Protocol Overview</a></li><li><a href="plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="README.html">MCP-AQL Specification Documentation</a></li><li><a href="repo/README.html">MCP-AQL Specification</a></li></ul>
+  <ul><li><a href="conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a class="current" aria-current="page" href="error-codes.html">Structured Error Codes Specification</a></li><li><a href="introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="mcp-integration.html">MCP Integration Specification</a></li><li><a href="operations.html">MCP-AQL Operations Specification</a></li><li><a href="overview.html">MCP-AQL Protocol Overview</a></li><li><a href="plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="README.html">MCP-AQL Specification Documentation</a></li><li><a href="repo/README.html">MCP-AQL Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Versions</h3>
   <ul><li><a href="versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
@@ -1205,6 +1205,16 @@
 
           </div>
         </section>
+        <nav class="page-nav" aria-label="Page navigation">
+  <a class="page-nav-link prev" href="endpoint-modes.html">
+    <span class="page-nav-eyebrow">Previous spec page</span>
+    <strong class="page-nav-label">MCP-AQL Endpoint Modes Specification</strong>
+  </a>
+  <a class="page-nav-link next" href="introspection.html">
+    <span class="page-nav-eyebrow">Next spec page</span>
+    <strong class="page-nav-label">MCP-AQL Introspection Specification</strong>
+  </a>
+</nav>
       </article>
     </div>
   </main>

--- a/public/spec/features/field-selection.html
+++ b/public/spec/features/field-selection.html
@@ -1,0 +1,323 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="This document specifies the optional field selection feature that enables clients to request only specific fields in responses, reducing payload size and token consumption.">
+  <title>MCP-AQL Spec | Field Selection Specification</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../../css/style.css">
+</head>
+<body>
+  <header>
+    <div class="container">
+      <nav>
+        <a class="logo" href="../../index.html"><span class="logo-mark"></span>MCP-AQL</a>
+        <ul class="nav-links">
+          <li><a href="../../index.html">Home</a></li>
+          <li><a href="../../docs/index.html">Docs</a></li>
+          <li><a href="../../launch-checklist.html">Launch Checklist</a></li>
+          <li><a href="../../apis/mcp-server.html">Adapter Patterns</a></li>
+        </ul>
+        <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
+          <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
+          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <span class="search-count" data-search-count></span>
+          <ul class="search-results" data-search-results hidden></ul>
+        </form>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <div class="container docs-shell">
+      <aside class="docs-side">
+        <h2>Repo-Synced Spec</h2>
+        <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
+        <div class="docs-side-group">
+  <h3>Core</h3>
+  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Versions</h3>
+  <ul><li><a href="../versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Adapter</h3>
+  <ul><li><a href="../adapter/danger-levels.html">Dangerous Operation Classification Specification</a></li><li><a href="../adapter/discovery-bundle.html">MCP Server Discovery Bundle</a></li><li><a href="../adapter/element-type.html">Adapter Element Type Specification</a></li><li><a href="../adapter/generator.html">Adapter Generator Specification</a></li><li><a href="../adapter/rate-limiting.html">Rate Limiting and Quota Management Specification</a></li><li><a href="../adapter/trust-levels.html">Trust Levels Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Security</h3>
+  <ul><li><a href="../security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="../security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="../security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Features</h3>
+  <ul><li><a class="current" href="field-selection.html">Field Selection Specification</a></li><li><a href="pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="warnings.html">Warnings Array Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Guides</h3>
+  <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Process</h3>
+  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Architecture</h3>
+  <ul><li><a href="../architecture/README.html">Architecture Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Research</h3>
+  <ul><li><a href="../research/mcp-vs-mcpaql-vs-a2a.html">Protocol Landscape: MCP vs MCP-AQL vs A2A</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Reference</h3>
+  <ul><li><a href="../reference/README.html">Reference Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>ADRs</h3>
+  <ul><li><a href="../adr/ADR-001-crude-pattern.html">ADR-001: CRUDE Pattern (Extending CRUD with Execute)</a></li><li><a href="../adr/ADR-002-graphql-style-input.html">ADR-002: GraphQL-Style Input Objects for Updates</a></li><li><a href="../adr/ADR-003-snake-case-parameters.html">ADR-003: snake_case Parameter Convention</a></li><li><a href="../adr/ADR-004-schema-driven-operations.html">ADR-004: Schema-Driven Operation Definitions</a></li><li><a href="../adr/ADR-005-introspection-system.html">ADR-005: GraphQL-Style Introspection System</a></li><li><a href="../adr/ADR-006-discriminated-responses.html">ADR-006: Discriminated Response Format</a></li><li><a href="../adr/index.html">Architecture Decision Records</a></li><li><a href="../adr/README.html">Architecture Decision Records</a></li></ul>
+</div>
+      </aside>
+
+      <article class="docs-main">
+        <section class="hero docs-hero">
+          <div class="hero-inner">
+            <span class="status-pill">REPO-SYNCED SPEC DOC</span>
+            <h1>Field Selection Specification</h1>
+            <p class="lede">This document specifies the optional field selection feature that enables clients to request only specific fields in responses, reducing payload size and token consumption.</p>
+            <div class="spec-meta"><span class="state-chip live">Support document</span><span class="state-chip pending">Draft</span><span class="state-chip">1.0.0-draft</span><span class="state-chip">2026-01-14</span></div>
+            <p class="spec-source">Source: <a href="https://github.com/MCPAQL/spec/blob/main/docs/features/field-selection.md">spec/docs/features/field-selection.md</a></p>
+            <div class="hero-actions">
+              <a class="btn btn-primary" href="https://github.com/MCPAQL/spec/blob/main/docs/features/field-selection.md">Open Source Markdown</a>
+              <a class="btn btn-secondary" href="../index.html">Browse Full Spec Reference</a>
+            </div>
+          </div>
+        </section>
+
+        <section>
+          <div class="card spec-prose">
+            <p><strong>Version:</strong> 1.0.0-draft <strong>Status:</strong> Draft <strong>Last Updated:</strong> 2026-01-14</p>
+<h2 id="abstract">Abstract</h2>
+<p>This document specifies the optional field selection feature that enables clients to request only specific fields in responses, reducing payload size and token consumption.</p>
+<hr />
+<h2 id="table-of-contents">Table of Contents</h2>
+<ol type="1">
+<li><a href="#1-introduction">Introduction</a></li>
+<li><a href="#2-request-format">Request Format</a></li>
+<li><a href="#3-presets">Presets</a></li>
+<li><a href="#4-response-format">Response Format</a></li>
+<li><a href="#5-implementation-requirements">Implementation Requirements</a></li>
+</ol>
+<hr />
+<h2 id="1-introduction">1. Introduction</h2>
+<h3 id="11-purpose">1.1 Purpose</h3>
+<p>Field selection allows clients to specify which fields to include in responses, providing:</p>
+<ul>
+<li><strong>Token efficiency</strong> - Smaller payloads consume fewer tokens</li>
+<li><strong>Bandwidth savings</strong> - Reduced data transfer</li>
+<li><strong>Client control</strong> - Fetch only what's needed</li>
+<li><strong>Consistent interface</strong> - Same pattern across operations</li>
+</ul>
+<h3 id="12-status">1.2 Status</h3>
+<p>Field selection is an <strong>optional</strong> feature. Adapters MAY implement it for Level 2 conformance.</p>
+<h3 id="13-token-impact">1.3 Token Impact</h3>
+<table>
+<thead>
+<tr>
+<th>Scenario</th>
+<th>Without Selection</th>
+<th>With Selection</th>
+<th>Savings</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>List 10 items (full)</td>
+<td>~2,500 tokens</td>
+<td>~800 tokens</td>
+<td>~68%</td>
+</tr>
+<tr>
+<td>Get single item (full)</td>
+<td>~350 tokens</td>
+<td>~120 tokens</td>
+<td>~65%</td>
+</tr>
+<tr>
+<td>Search results (20 items)</td>
+<td>~4,000 tokens</td>
+<td>~1,200 tokens</td>
+<td>~70%</td>
+</tr>
+</tbody>
+</table>
+<hr />
+<h2 id="2-request-format">2. Request Format</h2>
+<h3 id="21-fields-parameter">2.1 Fields Parameter</h3>
+<p>The <code>fields</code> parameter accepts an array of field names:</p>
+<div class="sourceCode" id="cb1"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb1-2"><a href="#cb1-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;list_users&quot;</span><span class="op">,</span></span>
+<span id="cb1-3"><a href="#cb1-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> {</span>
+<span id="cb1-4"><a href="#cb1-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">fields</span><span class="op">:</span> [<span class="st">&quot;id&quot;</span><span class="op">,</span> <span class="st">&quot;name&quot;</span><span class="op">,</span> <span class="st">&quot;email&quot;</span>]</span>
+<span id="cb1-5"><a href="#cb1-5" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb1-6"><a href="#cb1-6" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<h3 id="22-preset-parameter">2.2 Preset Parameter</h3>
+<p>The <code>preset</code> parameter selects a predefined field set:</p>
+<div class="sourceCode" id="cb2"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb2-2"><a href="#cb2-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;list_users&quot;</span><span class="op">,</span></span>
+<span id="cb2-3"><a href="#cb2-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> {</span>
+<span id="cb2-4"><a href="#cb2-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">preset</span><span class="op">:</span> <span class="st">&quot;minimal&quot;</span></span>
+<span id="cb2-5"><a href="#cb2-5" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb2-6"><a href="#cb2-6" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<h3 id="23-combined-usage">2.3 Combined Usage</h3>
+<p>When both are specified, <code>fields</code> extends the preset:</p>
+<div class="sourceCode" id="cb3"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb3-1"><a href="#cb3-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb3-2"><a href="#cb3-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;list_users&quot;</span><span class="op">,</span></span>
+<span id="cb3-3"><a href="#cb3-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> {</span>
+<span id="cb3-4"><a href="#cb3-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">preset</span><span class="op">:</span> <span class="st">&quot;minimal&quot;</span><span class="op">,</span></span>
+<span id="cb3-5"><a href="#cb3-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">fields</span><span class="op">:</span> [<span class="st">&quot;created_at&quot;</span>]  <span class="co">// Adds to minimal preset</span></span>
+<span id="cb3-6"><a href="#cb3-6" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb3-7"><a href="#cb3-7" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<h3 id="24-nested-fields">2.4 Nested Fields</h3>
+<p>Dot notation accesses nested properties:</p>
+<div class="sourceCode" id="cb4"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb4-1"><a href="#cb4-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb4-2"><a href="#cb4-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;get_user&quot;</span><span class="op">,</span></span>
+<span id="cb4-3"><a href="#cb4-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> {</span>
+<span id="cb4-4"><a href="#cb4-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">fields</span><span class="op">:</span> [<span class="st">&quot;id&quot;</span><span class="op">,</span> <span class="st">&quot;name&quot;</span><span class="op">,</span> <span class="st">&quot;settings.theme&quot;</span><span class="op">,</span> <span class="st">&quot;settings.language&quot;</span>]</span>
+<span id="cb4-5"><a href="#cb4-5" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb4-6"><a href="#cb4-6" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<hr />
+<h2 id="3-presets">3. Presets</h2>
+<h3 id="31-standard-presets">3.1 Standard Presets</h3>
+<p>Adapters implementing field selection SHOULD support these presets:</p>
+<h4 id="311-minimal">3.1.1 Minimal</h4>
+<p>Essential identification fields only.</p>
+<p><strong>Use case:</strong> Quick listings, autocomplete, selection UI.</p>
+<h4 id="312-standard">3.1.2 Standard</h4>
+<p>Common fields for typical use.</p>
+<p><strong>Use case:</strong> Default listing view, basic info display.</p>
+<h4 id="313-full">3.1.3 Full</h4>
+<p>All available fields.</p>
+<p><strong>Use case:</strong> Detailed view, export, debugging.</p>
+<h3 id="32-default-behavior">3.2 Default Behavior</h3>
+<p>When neither <code>fields</code> nor <code>preset</code> is specified:</p>
+<ul>
+<li>Single item operations: Return <code>full</code></li>
+<li>Collection operations: Return <code>standard</code></li>
+<li>Search operations: Return <code>minimal</code></li>
+</ul>
+<h3 id="33-custom-presets">3.3 Custom Presets</h3>
+<p>Adapters MAY define additional presets specific to their domain:</p>
+<div class="sourceCode" id="cb5"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb5-1"><a href="#cb5-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Example custom presets for a user adapter</span></span>
+<span id="cb5-2"><a href="#cb5-2" aria-hidden="true" tabindex="-1"></a><span class="st">&quot;contact&quot;</span><span class="op">:</span> [<span class="st">&quot;id&quot;</span><span class="op">,</span> <span class="st">&quot;name&quot;</span><span class="op">,</span> <span class="st">&quot;email&quot;</span><span class="op">,</span> <span class="st">&quot;phone&quot;</span>]</span>
+<span id="cb5-3"><a href="#cb5-3" aria-hidden="true" tabindex="-1"></a><span class="st">&quot;profile&quot;</span><span class="op">:</span> [<span class="st">&quot;id&quot;</span><span class="op">,</span> <span class="st">&quot;name&quot;</span><span class="op">,</span> <span class="st">&quot;bio&quot;</span><span class="op">,</span> <span class="st">&quot;avatar_url&quot;</span>]</span></code></pre></div>
+<p>Custom presets SHOULD be discoverable via introspection.</p>
+<hr />
+<h2 id="4-response-format">4. Response Format</h2>
+<h3 id="41-filtered-response">4.1 Filtered Response</h3>
+<p>Only requested fields appear in response:</p>
+<p><strong>Request:</strong></p>
+<div class="sourceCode" id="cb6"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb6-1"><a href="#cb6-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb6-2"><a href="#cb6-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;get_user&quot;</span><span class="op">,</span></span>
+<span id="cb6-3"><a href="#cb6-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> {</span>
+<span id="cb6-4"><a href="#cb6-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">user_id</span><span class="op">:</span> <span class="st">&quot;123&quot;</span><span class="op">,</span></span>
+<span id="cb6-5"><a href="#cb6-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">fields</span><span class="op">:</span> [<span class="st">&quot;id&quot;</span><span class="op">,</span> <span class="st">&quot;name&quot;</span>]</span>
+<span id="cb6-6"><a href="#cb6-6" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb6-7"><a href="#cb6-7" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<p><strong>Response:</strong></p>
+<div class="sourceCode" id="cb7"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb7-1"><a href="#cb7-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb7-2"><a href="#cb7-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">success</span><span class="op">:</span> <span class="kw">true</span><span class="op">,</span></span>
+<span id="cb7-3"><a href="#cb7-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">data</span><span class="op">:</span> {</span>
+<span id="cb7-4"><a href="#cb7-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">id</span><span class="op">:</span> <span class="st">&quot;123&quot;</span><span class="op">,</span></span>
+<span id="cb7-5"><a href="#cb7-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;Alice&quot;</span></span>
+<span id="cb7-6"><a href="#cb7-6" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb7-7"><a href="#cb7-7" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<h3 id="42-collection-response">4.2 Collection Response</h3>
+<p>For collections, selection applies to each item:</p>
+<p><strong>Request:</strong></p>
+<div class="sourceCode" id="cb8"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb8-1"><a href="#cb8-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb8-2"><a href="#cb8-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;list_users&quot;</span><span class="op">,</span></span>
+<span id="cb8-3"><a href="#cb8-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> {</span>
+<span id="cb8-4"><a href="#cb8-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">preset</span><span class="op">:</span> <span class="st">&quot;minimal&quot;</span></span>
+<span id="cb8-5"><a href="#cb8-5" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb8-6"><a href="#cb8-6" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<p><strong>Response:</strong></p>
+<div class="sourceCode" id="cb9"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb9-1"><a href="#cb9-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb9-2"><a href="#cb9-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">success</span><span class="op">:</span> <span class="kw">true</span><span class="op">,</span></span>
+<span id="cb9-3"><a href="#cb9-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">data</span><span class="op">:</span> {</span>
+<span id="cb9-4"><a href="#cb9-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">items</span><span class="op">:</span> [</span>
+<span id="cb9-5"><a href="#cb9-5" aria-hidden="true" tabindex="-1"></a>      { <span class="dt">id</span><span class="op">:</span> <span class="st">&quot;1&quot;</span><span class="op">,</span> <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;Alice&quot;</span> }<span class="op">,</span></span>
+<span id="cb9-6"><a href="#cb9-6" aria-hidden="true" tabindex="-1"></a>      { <span class="dt">id</span><span class="op">:</span> <span class="st">&quot;2&quot;</span><span class="op">,</span> <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;Bob&quot;</span> }</span>
+<span id="cb9-7"><a href="#cb9-7" aria-hidden="true" tabindex="-1"></a>    ]<span class="op">,</span></span>
+<span id="cb9-8"><a href="#cb9-8" aria-hidden="true" tabindex="-1"></a>    <span class="dt">pagination</span><span class="op">:</span> { <span class="op">...</span> }  <span class="co">// Pagination not affected by selection</span></span>
+<span id="cb9-9"><a href="#cb9-9" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb9-10"><a href="#cb9-10" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<h3 id="43-missing-fields">4.3 Missing Fields</h3>
+<p>If a requested field doesn't exist on an item:</p>
+<ul>
+<li><strong>Omit the field</strong> - Don't include in response</li>
+<li><strong>No error</strong> - Silently skip</li>
+<li><strong>Consistent behavior</strong> - Same across all items</li>
+</ul>
+<hr />
+<h2 id="5-implementation-requirements">5. Implementation Requirements</h2>
+<h3 id="51-must-requirements">5.1 MUST Requirements</h3>
+<p>Adapters implementing field selection MUST:</p>
+<ol type="1">
+<li>Support the <code>fields</code> parameter on READ operations</li>
+<li>Support the <code>preset</code> parameter</li>
+<li>Handle nested field access via dot notation</li>
+<li>Preserve structure for nested fields</li>
+</ol>
+<h3 id="52-should-requirements">5.2 SHOULD Requirements</h3>
+<p>Adapters implementing field selection SHOULD:</p>
+<ol type="1">
+<li>Implement <code>minimal</code>, <code>standard</code>, and <code>full</code> presets</li>
+<li>Document available fields per resource type</li>
+<li>Support field selection on search results</li>
+<li>Validate field names against known fields</li>
+</ol>
+<h3 id="53-introspection">5.3 Introspection</h3>
+<p>Field selection options SHOULD be discoverable:</p>
+<div class="sourceCode" id="cb10"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb10-1"><a href="#cb10-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb10-2"><a href="#cb10-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;introspect&quot;</span><span class="op">,</span></span>
+<span id="cb10-3"><a href="#cb10-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> { <span class="dt">query</span><span class="op">:</span> <span class="st">&quot;types&quot;</span><span class="op">,</span> <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;FieldSelection&quot;</span> }</span>
+<span id="cb10-4"><a href="#cb10-4" aria-hidden="true" tabindex="-1"></a>}</span>
+<span id="cb10-5"><a href="#cb10-5" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb10-6"><a href="#cb10-6" aria-hidden="true" tabindex="-1"></a><span class="co">// Response:</span></span>
+<span id="cb10-7"><a href="#cb10-7" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb10-8"><a href="#cb10-8" aria-hidden="true" tabindex="-1"></a>  <span class="dt">success</span><span class="op">:</span> <span class="kw">true</span><span class="op">,</span></span>
+<span id="cb10-9"><a href="#cb10-9" aria-hidden="true" tabindex="-1"></a>  <span class="dt">data</span><span class="op">:</span> {</span>
+<span id="cb10-10"><a href="#cb10-10" aria-hidden="true" tabindex="-1"></a>    <span class="dt">type</span><span class="op">:</span> {</span>
+<span id="cb10-11"><a href="#cb10-11" aria-hidden="true" tabindex="-1"></a>      <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;FieldSelection&quot;</span><span class="op">,</span></span>
+<span id="cb10-12"><a href="#cb10-12" aria-hidden="true" tabindex="-1"></a>      <span class="dt">kind</span><span class="op">:</span> <span class="st">&quot;object&quot;</span><span class="op">,</span></span>
+<span id="cb10-13"><a href="#cb10-13" aria-hidden="true" tabindex="-1"></a>      <span class="dt">description</span><span class="op">:</span> <span class="st">&quot;Field selection configuration&quot;</span><span class="op">,</span></span>
+<span id="cb10-14"><a href="#cb10-14" aria-hidden="true" tabindex="-1"></a>      <span class="dt">fields</span><span class="op">:</span> [</span>
+<span id="cb10-15"><a href="#cb10-15" aria-hidden="true" tabindex="-1"></a>        { <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;presets&quot;</span><span class="op">,</span> <span class="dt">type</span><span class="op">:</span> <span class="st">&quot;array&quot;</span><span class="op">,</span> <span class="dt">description</span><span class="op">:</span> <span class="st">&quot;Available presets&quot;</span> }<span class="op">,</span></span>
+<span id="cb10-16"><a href="#cb10-16" aria-hidden="true" tabindex="-1"></a>        { <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;fields&quot;</span><span class="op">,</span> <span class="dt">type</span><span class="op">:</span> <span class="st">&quot;object&quot;</span><span class="op">,</span> <span class="dt">description</span><span class="op">:</span> <span class="st">&quot;Available fields by type&quot;</span> }</span>
+<span id="cb10-17"><a href="#cb10-17" aria-hidden="true" tabindex="-1"></a>      ]</span>
+<span id="cb10-18"><a href="#cb10-18" aria-hidden="true" tabindex="-1"></a>    }</span>
+<span id="cb10-19"><a href="#cb10-19" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb10-20"><a href="#cb10-20" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<hr />
+<h2 id="references">References</h2>
+<ul>
+<li><a href="../versions/v1.0.0-draft.html">MCP-AQL Specification</a></li>
+<li><a href="../operations.html">Operations Guide</a></li>
+<li><a href="../introspection.html">Introspection Specification</a></li>
+</ul>
+
+          </div>
+        </section>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div class="container">
+      <p>&copy; 2026 DollhouseMCP Inc. d/b/a Dollhouse Research. MCP-AQL public draft documentation portal.</p>
+      <div class="footer-links">
+        <a href="../../docs/index.html">Docs Library</a>
+        <a href="../index.html">Repo-Synced Spec</a>
+        <a href="https://github.com/MCPAQL">MCPAQL Organization</a>
+        <a href="https://dollhouseresearch.com">Dollhouse Research</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../../js/search.js"></script>
+</body>
+</html>

--- a/public/spec/features/field-selection.html
+++ b/public/spec/features/field-selection.html
@@ -23,7 +23,7 @@
         </ul>
         <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
-          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <input id="site-search-input" data-search-input type="search" placeholder="Search MCP-AQL docs, spec pages, and adapter patterns...">
           <span class="search-count" data-search-count></span>
           <ul class="search-results" data-search-results hidden></ul>
         </form>
@@ -50,7 +50,7 @@
   <ul><li><a href="../security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="../security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="../security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Features</h3>
-  <ul><li><a class="current" href="field-selection.html">Field Selection Specification</a></li><li><a href="pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="warnings.html">Warnings Array Specification</a></li></ul>
+  <ul><li><a class="current" aria-current="page" href="field-selection.html">Field Selection Specification</a></li><li><a href="pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="warnings.html">Warnings Array Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Guides</h3>
   <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
@@ -309,6 +309,16 @@
 
           </div>
         </section>
+        <nav class="page-nav" aria-label="Page navigation">
+  <a class="page-nav-link prev" href="../security/gatekeeper.html">
+    <span class="page-nav-eyebrow">Previous spec page</span>
+    <strong class="page-nav-label">Security Model: Gatekeeper Specification</strong>
+  </a>
+  <a class="page-nav-link next" href="pagination.html">
+    <span class="page-nav-eyebrow">Next spec page</span>
+    <strong class="page-nav-label">Cursor-Based Pagination Specification</strong>
+  </a>
+</nav>
       </article>
     </div>
   </main>

--- a/public/spec/features/field-selection.html
+++ b/public/spec/features/field-selection.html
@@ -38,7 +38,7 @@
         <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
         <div class="docs-side-group">
   <h3>Core</h3>
-  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li></ul>
+  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li><li><a href="../repo/README.html">MCP-AQL Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Versions</h3>
   <ul><li><a href="../versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
@@ -56,7 +56,7 @@
   <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
-  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li></ul>
+  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li><li><a href="../repo/CHANGELOG.html">Changelog</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Architecture</h3>
   <ul><li><a href="../architecture/README.html">Architecture Documentation</a></li></ul>

--- a/public/spec/features/field-selection.html
+++ b/public/spec/features/field-selection.html
@@ -73,6 +73,13 @@
       </aside>
 
       <article class="docs-main">
+        <nav class="breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../../index.html">Home</a></li>
+            <li><a href="../index.html">Full Spec</a></li>
+            <li><span class="current">Field Selection Specification</span></li>
+          </ol>
+        </nav>
         <section class="hero docs-hero">
           <div class="hero-inner">
             <span class="status-pill">REPO-SYNCED SPEC DOC</span>

--- a/public/spec/features/pagination.html
+++ b/public/spec/features/pagination.html
@@ -73,6 +73,13 @@
       </aside>
 
       <article class="docs-main">
+        <nav class="breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../../index.html">Home</a></li>
+            <li><a href="../index.html">Full Spec</a></li>
+            <li><span class="current">Cursor-Based Pagination Specification</span></li>
+          </ol>
+        </nav>
         <section class="hero docs-hero">
           <div class="hero-inner">
             <span class="status-pill">REPO-SYNCED SPEC DOC</span>

--- a/public/spec/features/pagination.html
+++ b/public/spec/features/pagination.html
@@ -23,7 +23,7 @@
         </ul>
         <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
-          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <input id="site-search-input" data-search-input type="search" placeholder="Search MCP-AQL docs, spec pages, and adapter patterns...">
           <span class="search-count" data-search-count></span>
           <ul class="search-results" data-search-results hidden></ul>
         </form>
@@ -50,7 +50,7 @@
   <ul><li><a href="../security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="../security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="../security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Features</h3>
-  <ul><li><a href="field-selection.html">Field Selection Specification</a></li><li><a class="current" href="pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="warnings.html">Warnings Array Specification</a></li></ul>
+  <ul><li><a href="field-selection.html">Field Selection Specification</a></li><li><a class="current" aria-current="page" href="pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="warnings.html">Warnings Array Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Guides</h3>
   <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
@@ -663,6 +663,16 @@
 
           </div>
         </section>
+        <nav class="page-nav" aria-label="Page navigation">
+  <a class="page-nav-link prev" href="field-selection.html">
+    <span class="page-nav-eyebrow">Previous spec page</span>
+    <strong class="page-nav-label">Field Selection Specification</strong>
+  </a>
+  <a class="page-nav-link next" href="warnings.html">
+    <span class="page-nav-eyebrow">Next spec page</span>
+    <strong class="page-nav-label">Warnings Array Specification</strong>
+  </a>
+</nav>
       </article>
     </div>
   </main>

--- a/public/spec/features/pagination.html
+++ b/public/spec/features/pagination.html
@@ -1,0 +1,677 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="This document defines cursor-based pagination semantics for MCP-AQL operations that return collections. Cursor pagination enables efficient iteration through large datasets while minimizing token usage in LLM context win">
+  <title>MCP-AQL Spec | Cursor-Based Pagination Specification</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../../css/style.css">
+</head>
+<body>
+  <header>
+    <div class="container">
+      <nav>
+        <a class="logo" href="../../index.html"><span class="logo-mark"></span>MCP-AQL</a>
+        <ul class="nav-links">
+          <li><a href="../../index.html">Home</a></li>
+          <li><a href="../../docs/index.html">Docs</a></li>
+          <li><a href="../../launch-checklist.html">Launch Checklist</a></li>
+          <li><a href="../../apis/mcp-server.html">Adapter Patterns</a></li>
+        </ul>
+        <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
+          <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
+          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <span class="search-count" data-search-count></span>
+          <ul class="search-results" data-search-results hidden></ul>
+        </form>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <div class="container docs-shell">
+      <aside class="docs-side">
+        <h2>Repo-Synced Spec</h2>
+        <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
+        <div class="docs-side-group">
+  <h3>Core</h3>
+  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Versions</h3>
+  <ul><li><a href="../versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Adapter</h3>
+  <ul><li><a href="../adapter/danger-levels.html">Dangerous Operation Classification Specification</a></li><li><a href="../adapter/discovery-bundle.html">MCP Server Discovery Bundle</a></li><li><a href="../adapter/element-type.html">Adapter Element Type Specification</a></li><li><a href="../adapter/generator.html">Adapter Generator Specification</a></li><li><a href="../adapter/rate-limiting.html">Rate Limiting and Quota Management Specification</a></li><li><a href="../adapter/trust-levels.html">Trust Levels Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Security</h3>
+  <ul><li><a href="../security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="../security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="../security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Features</h3>
+  <ul><li><a href="field-selection.html">Field Selection Specification</a></li><li><a class="current" href="pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="warnings.html">Warnings Array Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Guides</h3>
+  <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Process</h3>
+  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Architecture</h3>
+  <ul><li><a href="../architecture/README.html">Architecture Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Research</h3>
+  <ul><li><a href="../research/mcp-vs-mcpaql-vs-a2a.html">Protocol Landscape: MCP vs MCP-AQL vs A2A</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Reference</h3>
+  <ul><li><a href="../reference/README.html">Reference Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>ADRs</h3>
+  <ul><li><a href="../adr/ADR-001-crude-pattern.html">ADR-001: CRUDE Pattern (Extending CRUD with Execute)</a></li><li><a href="../adr/ADR-002-graphql-style-input.html">ADR-002: GraphQL-Style Input Objects for Updates</a></li><li><a href="../adr/ADR-003-snake-case-parameters.html">ADR-003: snake_case Parameter Convention</a></li><li><a href="../adr/ADR-004-schema-driven-operations.html">ADR-004: Schema-Driven Operation Definitions</a></li><li><a href="../adr/ADR-005-introspection-system.html">ADR-005: GraphQL-Style Introspection System</a></li><li><a href="../adr/ADR-006-discriminated-responses.html">ADR-006: Discriminated Response Format</a></li><li><a href="../adr/index.html">Architecture Decision Records</a></li><li><a href="../adr/README.html">Architecture Decision Records</a></li></ul>
+</div>
+      </aside>
+
+      <article class="docs-main">
+        <section class="hero docs-hero">
+          <div class="hero-inner">
+            <span class="status-pill">REPO-SYNCED SPEC DOC</span>
+            <h1>Cursor-Based Pagination Specification</h1>
+            <p class="lede">This document defines cursor-based pagination semantics for MCP-AQL operations that return collections. Cursor pagination enables efficient iteration through large datasets while minimizing token usage in LLM context win</p>
+            <div class="spec-meta"><span class="state-chip live">Support document</span><span class="state-chip pending">Draft</span><span class="state-chip">1.0.0-draft</span><span class="state-chip">2026-01-28</span></div>
+            <p class="spec-source">Source: <a href="https://github.com/MCPAQL/spec/blob/main/docs/features/pagination.md">spec/docs/features/pagination.md</a></p>
+            <div class="hero-actions">
+              <a class="btn btn-primary" href="https://github.com/MCPAQL/spec/blob/main/docs/features/pagination.md">Open Source Markdown</a>
+              <a class="btn btn-secondary" href="../index.html">Browse Full Spec Reference</a>
+            </div>
+          </div>
+        </section>
+
+        <section>
+          <div class="card spec-prose">
+            <p><strong>Version:</strong> 1.0.0-draft <strong>Status:</strong> Draft <strong>Last Updated:</strong> 2026-01-28</p>
+<h2 id="abstract">Abstract</h2>
+<p>This document defines cursor-based pagination semantics for MCP-AQL operations that return collections. Cursor pagination enables efficient iteration through large datasets while minimizing token usage in LLM context windows.</p>
+<hr />
+<h2 id="table-of-contents">Table of Contents</h2>
+<ol type="1">
+<li><a href="#1-overview">Overview</a></li>
+<li><a href="#2-pagination-parameters">Pagination Parameters</a></li>
+<li><a href="#3-pageinfo-response">PageInfo Response</a></li>
+<li><a href="#4-connection-style-response">Connection-Style Response</a></li>
+<li><a href="#5-applicable-operations">Applicable Operations</a></li>
+<li><a href="#6-implementation-requirements">Implementation Requirements</a></li>
+<li><a href="#7-future-extensions">Future Extensions</a></li>
+</ol>
+<hr />
+<h2 id="1-overview">1. Overview</h2>
+<h3 id="11-purpose">1.1 Purpose</h3>
+<p>Operations returning complete result sets create several problems:</p>
+<ul>
+<li><strong>Token bloat</strong> - Large collections consume LLM context windows</li>
+<li><strong>Memory pressure</strong> - Servers and clients may struggle with large datasets</li>
+<li><strong>Inefficient re-fetching</strong> - No way to resume interrupted queries</li>
+<li><strong>Poor user experience</strong> - Long wait times for initial results</li>
+</ul>
+<p>Cursor-based pagination addresses these by:</p>
+<ul>
+<li><strong>Bounded responses</strong> - Control result set size per request</li>
+<li><strong>Stable iteration</strong> - Cursors maintain position across requests</li>
+<li><strong>Efficient forward/backward</strong> - Navigate in either direction</li>
+<li><strong>Resumable queries</strong> - Continue from any cursor position</li>
+</ul>
+<h3 id="12-design-principles">1.2 Design Principles</h3>
+<ol type="1">
+<li><strong>Opaque cursors</strong> - Cursor format is implementation-defined</li>
+<li><strong>Stable ordering</strong> - Results maintain consistent order across pages</li>
+<li><strong>Bidirectional</strong> - Support both forward and backward navigation</li>
+<li><strong>Optional totals</strong> - Total count is optional (expensive for some backends)</li>
+</ol>
+<h3 id="13-alignment-with-standards">1.3 Alignment with Standards</h3>
+<p>This specification aligns with:</p>
+<ul>
+<li><strong>GraphQL Relay Cursor Connections</strong> - Primary inspiration for the connection model</li>
+<li><strong>OData pagination</strong> - Parameter naming conventions</li>
+<li><strong>JSON:API pagination</strong> - Link-based navigation patterns</li>
+</ul>
+<hr />
+<h2 id="2-pagination-parameters">2. Pagination Parameters</h2>
+<h3 id="21-parameter-schema">2.1 Parameter Schema</h3>
+<p>Operations supporting pagination accept these parameters:</p>
+<div class="sourceCode" id="cb1"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a><span class="kw">interface</span> PaginationParams {</span>
+<span id="cb1-2"><a href="#cb1-2" aria-hidden="true" tabindex="-1"></a>  <span class="co">/**</span></span>
+<span id="cb1-3"><a href="#cb1-3" aria-hidden="true" tabindex="-1"></a><span class="co">   * Number of items to return from the start</span></span>
+<span id="cb1-4"><a href="#cb1-4" aria-hidden="true" tabindex="-1"></a><span class="co">   * Mutually exclusive with &#39;last&#39;</span></span>
+<span id="cb1-5"><a href="#cb1-5" aria-hidden="true" tabindex="-1"></a><span class="co">   */</span></span>
+<span id="cb1-6"><a href="#cb1-6" aria-hidden="true" tabindex="-1"></a>  first<span class="op">?:</span> <span class="dt">number</span><span class="op">;</span></span>
+<span id="cb1-7"><a href="#cb1-7" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb1-8"><a href="#cb1-8" aria-hidden="true" tabindex="-1"></a>  <span class="co">/**</span></span>
+<span id="cb1-9"><a href="#cb1-9" aria-hidden="true" tabindex="-1"></a><span class="co">   * Cursor to start after (forward pagination)</span></span>
+<span id="cb1-10"><a href="#cb1-10" aria-hidden="true" tabindex="-1"></a><span class="co">   * Used with &#39;first&#39;</span></span>
+<span id="cb1-11"><a href="#cb1-11" aria-hidden="true" tabindex="-1"></a><span class="co">   */</span></span>
+<span id="cb1-12"><a href="#cb1-12" aria-hidden="true" tabindex="-1"></a>  after<span class="op">?:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb1-13"><a href="#cb1-13" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb1-14"><a href="#cb1-14" aria-hidden="true" tabindex="-1"></a>  <span class="co">/**</span></span>
+<span id="cb1-15"><a href="#cb1-15" aria-hidden="true" tabindex="-1"></a><span class="co">   * Number of items to return from the end</span></span>
+<span id="cb1-16"><a href="#cb1-16" aria-hidden="true" tabindex="-1"></a><span class="co">   * Mutually exclusive with &#39;first&#39;</span></span>
+<span id="cb1-17"><a href="#cb1-17" aria-hidden="true" tabindex="-1"></a><span class="co">   */</span></span>
+<span id="cb1-18"><a href="#cb1-18" aria-hidden="true" tabindex="-1"></a>  last<span class="op">?:</span> <span class="dt">number</span><span class="op">;</span></span>
+<span id="cb1-19"><a href="#cb1-19" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb1-20"><a href="#cb1-20" aria-hidden="true" tabindex="-1"></a>  <span class="co">/**</span></span>
+<span id="cb1-21"><a href="#cb1-21" aria-hidden="true" tabindex="-1"></a><span class="co">   * Cursor to start before (backward pagination)</span></span>
+<span id="cb1-22"><a href="#cb1-22" aria-hidden="true" tabindex="-1"></a><span class="co">   * Used with &#39;last&#39;</span></span>
+<span id="cb1-23"><a href="#cb1-23" aria-hidden="true" tabindex="-1"></a><span class="co">   */</span></span>
+<span id="cb1-24"><a href="#cb1-24" aria-hidden="true" tabindex="-1"></a>  before<span class="op">?:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb1-25"><a href="#cb1-25" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<h3 id="22-parameter-combinations">2.2 Parameter Combinations</h3>
+<table>
+<thead>
+<tr>
+<th>Parameters</th>
+<th>Behavior</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>first</code></td>
+<td>First N items from start</td>
+</tr>
+<tr>
+<td><code>first</code> + <code>after</code></td>
+<td>First N items after cursor</td>
+</tr>
+<tr>
+<td><code>last</code></td>
+<td>Last N items from end</td>
+</tr>
+<tr>
+<td><code>last</code> + <code>before</code></td>
+<td>Last N items before cursor</td>
+</tr>
+<tr>
+<td>None</td>
+<td>Default page size from start</td>
+</tr>
+</tbody>
+</table>
+<h3 id="23-invalid-combinations">2.3 Invalid Combinations</h3>
+<p>The following combinations MUST return a validation error:</p>
+<ul>
+<li><code>first</code> + <code>last</code> (ambiguous direction)</li>
+<li><code>after</code> without <code>first</code> (missing page size)</li>
+<li><code>before</code> without <code>last</code> (missing page size)</li>
+<li><code>first</code> + <code>before</code> (mismatched direction)</li>
+<li><code>last</code> + <code>after</code> (mismatched direction)</li>
+</ul>
+<p><strong>Error response:</strong></p>
+<div class="sourceCode" id="cb2"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb2-2"><a href="#cb2-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb2-3"><a href="#cb2-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;error&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb2-4"><a href="#cb2-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;code&quot;</span><span class="fu">:</span> <span class="st">&quot;VALIDATION_INVALID_TYPE&quot;</span><span class="fu">,</span></span>
+<span id="cb2-5"><a href="#cb2-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;Cannot use &#39;first&#39; and &#39;last&#39; together&quot;</span><span class="fu">,</span></span>
+<span id="cb2-6"><a href="#cb2-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;details&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb2-7"><a href="#cb2-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;param_name&quot;</span><span class="fu">:</span> <span class="st">&quot;pagination&quot;</span><span class="fu">,</span></span>
+<span id="cb2-8"><a href="#cb2-8" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;expected_type&quot;</span><span class="fu">:</span> <span class="st">&quot;valid pagination combination&quot;</span><span class="fu">,</span></span>
+<span id="cb2-9"><a href="#cb2-9" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;actual_type&quot;</span><span class="fu">:</span> <span class="st">&quot;conflicting parameters&quot;</span><span class="fu">,</span></span>
+<span id="cb2-10"><a href="#cb2-10" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;provided&quot;</span><span class="fu">:</span> <span class="ot">[</span><span class="st">&quot;first&quot;</span><span class="ot">,</span> <span class="st">&quot;last&quot;</span><span class="ot">]</span><span class="fu">,</span></span>
+<span id="cb2-11"><a href="#cb2-11" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;hint&quot;</span><span class="fu">:</span> <span class="st">&quot;Use &#39;first&#39; for forward pagination or &#39;last&#39; for backward pagination&quot;</span></span>
+<span id="cb2-12"><a href="#cb2-12" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb2-13"><a href="#cb2-13" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb2-14"><a href="#cb2-14" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<blockquote>
+<p><strong>Note:</strong> This uses the existing <code>VALIDATION_INVALID_TYPE</code> error code with pagination-specific context in the <code>details</code> object, following the error-codes.md specification pattern.</p>
+</blockquote>
+<h3 id="24-example-requests">2.4 Example Requests</h3>
+<p><strong>First page:</strong></p>
+<div class="sourceCode" id="cb3"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb3-1"><a href="#cb3-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb3-2"><a href="#cb3-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;list_elements&quot;</span><span class="op">,</span></span>
+<span id="cb3-3"><a href="#cb3-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">element_type</span><span class="op">:</span> <span class="st">&quot;persona&quot;</span><span class="op">,</span></span>
+<span id="cb3-4"><a href="#cb3-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> {</span>
+<span id="cb3-5"><a href="#cb3-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">first</span><span class="op">:</span> <span class="dv">10</span></span>
+<span id="cb3-6"><a href="#cb3-6" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb3-7"><a href="#cb3-7" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<p><strong>Next page:</strong></p>
+<div class="sourceCode" id="cb4"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb4-1"><a href="#cb4-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb4-2"><a href="#cb4-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;list_elements&quot;</span><span class="op">,</span></span>
+<span id="cb4-3"><a href="#cb4-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">element_type</span><span class="op">:</span> <span class="st">&quot;persona&quot;</span><span class="op">,</span></span>
+<span id="cb4-4"><a href="#cb4-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> {</span>
+<span id="cb4-5"><a href="#cb4-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">first</span><span class="op">:</span> <span class="dv">10</span><span class="op">,</span></span>
+<span id="cb4-6"><a href="#cb4-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">after</span><span class="op">:</span> <span class="st">&quot;cursor_xyz789&quot;</span></span>
+<span id="cb4-7"><a href="#cb4-7" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb4-8"><a href="#cb4-8" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<p><strong>Previous page:</strong></p>
+<div class="sourceCode" id="cb5"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb5-1"><a href="#cb5-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb5-2"><a href="#cb5-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;list_elements&quot;</span><span class="op">,</span></span>
+<span id="cb5-3"><a href="#cb5-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">element_type</span><span class="op">:</span> <span class="st">&quot;persona&quot;</span><span class="op">,</span></span>
+<span id="cb5-4"><a href="#cb5-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> {</span>
+<span id="cb5-5"><a href="#cb5-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">last</span><span class="op">:</span> <span class="dv">10</span><span class="op">,</span></span>
+<span id="cb5-6"><a href="#cb5-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">before</span><span class="op">:</span> <span class="st">&quot;cursor_abc123&quot;</span></span>
+<span id="cb5-7"><a href="#cb5-7" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb5-8"><a href="#cb5-8" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<hr />
+<h2 id="3-pageinfo-response">3. PageInfo Response</h2>
+<h3 id="31-pageinfo-schema">3.1 PageInfo Schema</h3>
+<p>All paginated responses MUST include a <code>pageInfo</code> object:</p>
+<div class="sourceCode" id="cb6"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb6-1"><a href="#cb6-1" aria-hidden="true" tabindex="-1"></a><span class="kw">interface</span> PageInfo {</span>
+<span id="cb6-2"><a href="#cb6-2" aria-hidden="true" tabindex="-1"></a>  <span class="co">/**</span></span>
+<span id="cb6-3"><a href="#cb6-3" aria-hidden="true" tabindex="-1"></a><span class="co">   * Whether more items exist after the last item</span></span>
+<span id="cb6-4"><a href="#cb6-4" aria-hidden="true" tabindex="-1"></a><span class="co">   * Required</span></span>
+<span id="cb6-5"><a href="#cb6-5" aria-hidden="true" tabindex="-1"></a><span class="co">   */</span></span>
+<span id="cb6-6"><a href="#cb6-6" aria-hidden="true" tabindex="-1"></a>  hasNextPage<span class="op">:</span> <span class="dt">boolean</span><span class="op">;</span></span>
+<span id="cb6-7"><a href="#cb6-7" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb6-8"><a href="#cb6-8" aria-hidden="true" tabindex="-1"></a>  <span class="co">/**</span></span>
+<span id="cb6-9"><a href="#cb6-9" aria-hidden="true" tabindex="-1"></a><span class="co">   * Whether more items exist before the first item</span></span>
+<span id="cb6-10"><a href="#cb6-10" aria-hidden="true" tabindex="-1"></a><span class="co">   * Required</span></span>
+<span id="cb6-11"><a href="#cb6-11" aria-hidden="true" tabindex="-1"></a><span class="co">   */</span></span>
+<span id="cb6-12"><a href="#cb6-12" aria-hidden="true" tabindex="-1"></a>  hasPreviousPage<span class="op">:</span> <span class="dt">boolean</span><span class="op">;</span></span>
+<span id="cb6-13"><a href="#cb6-13" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb6-14"><a href="#cb6-14" aria-hidden="true" tabindex="-1"></a>  <span class="co">/**</span></span>
+<span id="cb6-15"><a href="#cb6-15" aria-hidden="true" tabindex="-1"></a><span class="co">   * Cursor of the first item in the result set</span></span>
+<span id="cb6-16"><a href="#cb6-16" aria-hidden="true" tabindex="-1"></a><span class="co">   * Required when items are returned</span></span>
+<span id="cb6-17"><a href="#cb6-17" aria-hidden="true" tabindex="-1"></a><span class="co">   */</span></span>
+<span id="cb6-18"><a href="#cb6-18" aria-hidden="true" tabindex="-1"></a>  startCursor<span class="op">?:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb6-19"><a href="#cb6-19" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb6-20"><a href="#cb6-20" aria-hidden="true" tabindex="-1"></a>  <span class="co">/**</span></span>
+<span id="cb6-21"><a href="#cb6-21" aria-hidden="true" tabindex="-1"></a><span class="co">   * Cursor of the last item in the result set</span></span>
+<span id="cb6-22"><a href="#cb6-22" aria-hidden="true" tabindex="-1"></a><span class="co">   * Required when items are returned</span></span>
+<span id="cb6-23"><a href="#cb6-23" aria-hidden="true" tabindex="-1"></a><span class="co">   */</span></span>
+<span id="cb6-24"><a href="#cb6-24" aria-hidden="true" tabindex="-1"></a>  endCursor<span class="op">?:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb6-25"><a href="#cb6-25" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb6-26"><a href="#cb6-26" aria-hidden="true" tabindex="-1"></a>  <span class="co">/**</span></span>
+<span id="cb6-27"><a href="#cb6-27" aria-hidden="true" tabindex="-1"></a><span class="co">   * Total count of items matching the query</span></span>
+<span id="cb6-28"><a href="#cb6-28" aria-hidden="true" tabindex="-1"></a><span class="co">   * Optional - may be omitted if expensive to compute</span></span>
+<span id="cb6-29"><a href="#cb6-29" aria-hidden="true" tabindex="-1"></a><span class="co">   */</span></span>
+<span id="cb6-30"><a href="#cb6-30" aria-hidden="true" tabindex="-1"></a>  totalCount<span class="op">?:</span> <span class="dt">number</span><span class="op">;</span></span>
+<span id="cb6-31"><a href="#cb6-31" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<h3 id="32-pageinfo-requirements">3.2 PageInfo Requirements</h3>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Required</th>
+<th>Notes</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>hasNextPage</code></td>
+<td>Yes</td>
+<td>Always include, even if false</td>
+</tr>
+<tr>
+<td><code>hasPreviousPage</code></td>
+<td>Yes</td>
+<td>Always include, even if false</td>
+</tr>
+<tr>
+<td><code>startCursor</code></td>
+<td>Conditional</td>
+<td>Required when results are returned (<code>items.length &gt; 0</code> or <code>edges.length &gt; 0</code>)</td>
+</tr>
+<tr>
+<td><code>endCursor</code></td>
+<td>Conditional</td>
+<td>Required when results are returned (<code>items.length &gt; 0</code> or <code>edges.length &gt; 0</code>)</td>
+</tr>
+<tr>
+<td><code>totalCount</code></td>
+<td>No</td>
+<td>Include when available without performance impact</td>
+</tr>
+</tbody>
+</table>
+<h3 id="33-example-pageinfo">3.3 Example PageInfo</h3>
+<p><strong>First page of results:</strong></p>
+<div class="sourceCode" id="cb7"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb7-1"><a href="#cb7-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb7-2"><a href="#cb7-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;pageInfo&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb7-3"><a href="#cb7-3" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;hasNextPage&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb7-4"><a href="#cb7-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;hasPreviousPage&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb7-5"><a href="#cb7-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;startCursor&quot;</span><span class="fu">:</span> <span class="st">&quot;cursor_001&quot;</span><span class="fu">,</span></span>
+<span id="cb7-6"><a href="#cb7-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;endCursor&quot;</span><span class="fu">:</span> <span class="st">&quot;cursor_010&quot;</span><span class="fu">,</span></span>
+<span id="cb7-7"><a href="#cb7-7" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;totalCount&quot;</span><span class="fu">:</span> <span class="dv">150</span></span>
+<span id="cb7-8"><a href="#cb7-8" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb7-9"><a href="#cb7-9" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<p><strong>Last page of results:</strong></p>
+<div class="sourceCode" id="cb8"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb8-1"><a href="#cb8-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb8-2"><a href="#cb8-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;pageInfo&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb8-3"><a href="#cb8-3" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;hasNextPage&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb8-4"><a href="#cb8-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;hasPreviousPage&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb8-5"><a href="#cb8-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;startCursor&quot;</span><span class="fu">:</span> <span class="st">&quot;cursor_141&quot;</span><span class="fu">,</span></span>
+<span id="cb8-6"><a href="#cb8-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;endCursor&quot;</span><span class="fu">:</span> <span class="st">&quot;cursor_150&quot;</span></span>
+<span id="cb8-7"><a href="#cb8-7" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb8-8"><a href="#cb8-8" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<p><strong>Empty results:</strong></p>
+<div class="sourceCode" id="cb9"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb9-1"><a href="#cb9-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb9-2"><a href="#cb9-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;pageInfo&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb9-3"><a href="#cb9-3" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;hasNextPage&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb9-4"><a href="#cb9-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;hasPreviousPage&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb9-5"><a href="#cb9-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;totalCount&quot;</span><span class="fu">:</span> <span class="dv">0</span></span>
+<span id="cb9-6"><a href="#cb9-6" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb9-7"><a href="#cb9-7" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<hr />
+<h2 id="4-connection-style-response">4. Connection-Style Response</h2>
+<h3 id="41-response-structure">4.1 Response Structure</h3>
+<p>Paginated operations SHOULD return a connection-style response:</p>
+<div class="sourceCode" id="cb10"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb10-1"><a href="#cb10-1" aria-hidden="true" tabindex="-1"></a><span class="kw">interface</span> Connection<span class="op">&lt;</span>T<span class="op">&gt;</span> {</span>
+<span id="cb10-2"><a href="#cb10-2" aria-hidden="true" tabindex="-1"></a>  <span class="co">/**</span></span>
+<span id="cb10-3"><a href="#cb10-3" aria-hidden="true" tabindex="-1"></a><span class="co">   * The items in this page (mutually exclusive with edges)</span></span>
+<span id="cb10-4"><a href="#cb10-4" aria-hidden="true" tabindex="-1"></a><span class="co">   */</span></span>
+<span id="cb10-5"><a href="#cb10-5" aria-hidden="true" tabindex="-1"></a>  items<span class="op">?:</span> T[]<span class="op">;</span></span>
+<span id="cb10-6"><a href="#cb10-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb10-7"><a href="#cb10-7" aria-hidden="true" tabindex="-1"></a>  <span class="co">/**</span></span>
+<span id="cb10-8"><a href="#cb10-8" aria-hidden="true" tabindex="-1"></a><span class="co">   * Pagination metadata</span></span>
+<span id="cb10-9"><a href="#cb10-9" aria-hidden="true" tabindex="-1"></a><span class="co">   */</span></span>
+<span id="cb10-10"><a href="#cb10-10" aria-hidden="true" tabindex="-1"></a>  pageInfo<span class="op">:</span> PageInfo<span class="op">;</span></span>
+<span id="cb10-11"><a href="#cb10-11" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb10-12"><a href="#cb10-12" aria-hidden="true" tabindex="-1"></a>  <span class="co">/**</span></span>
+<span id="cb10-13"><a href="#cb10-13" aria-hidden="true" tabindex="-1"></a><span class="co">   * Edges with per-item cursors (mutually exclusive with items)</span></span>
+<span id="cb10-14"><a href="#cb10-14" aria-hidden="true" tabindex="-1"></a><span class="co">   * When present, items should be omitted</span></span>
+<span id="cb10-15"><a href="#cb10-15" aria-hidden="true" tabindex="-1"></a><span class="co">   */</span></span>
+<span id="cb10-16"><a href="#cb10-16" aria-hidden="true" tabindex="-1"></a>  edges<span class="op">?:</span> Edge<span class="op">&lt;</span>T<span class="op">&gt;</span>[]<span class="op">;</span></span>
+<span id="cb10-17"><a href="#cb10-17" aria-hidden="true" tabindex="-1"></a>}</span>
+<span id="cb10-18"><a href="#cb10-18" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb10-19"><a href="#cb10-19" aria-hidden="true" tabindex="-1"></a><span class="kw">interface</span> Edge<span class="op">&lt;</span>T<span class="op">&gt;</span> {</span>
+<span id="cb10-20"><a href="#cb10-20" aria-hidden="true" tabindex="-1"></a>  <span class="co">/**</span></span>
+<span id="cb10-21"><a href="#cb10-21" aria-hidden="true" tabindex="-1"></a><span class="co">   * The item</span></span>
+<span id="cb10-22"><a href="#cb10-22" aria-hidden="true" tabindex="-1"></a><span class="co">   */</span></span>
+<span id="cb10-23"><a href="#cb10-23" aria-hidden="true" tabindex="-1"></a>  node<span class="op">:</span> T<span class="op">;</span></span>
+<span id="cb10-24"><a href="#cb10-24" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb10-25"><a href="#cb10-25" aria-hidden="true" tabindex="-1"></a>  <span class="co">/**</span></span>
+<span id="cb10-26"><a href="#cb10-26" aria-hidden="true" tabindex="-1"></a><span class="co">   * Cursor for this specific item</span></span>
+<span id="cb10-27"><a href="#cb10-27" aria-hidden="true" tabindex="-1"></a><span class="co">   */</span></span>
+<span id="cb10-28"><a href="#cb10-28" aria-hidden="true" tabindex="-1"></a>  cursor<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb10-29"><a href="#cb10-29" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<h3 id="42-simple-response-format">4.2 Simple Response Format</h3>
+<p>For most use cases, the simple format is sufficient:</p>
+<div class="sourceCode" id="cb11"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb11-1"><a href="#cb11-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb11-2"><a href="#cb11-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb11-3"><a href="#cb11-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;data&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb11-4"><a href="#cb11-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;items&quot;</span><span class="fu">:</span> <span class="ot">[</span></span>
+<span id="cb11-5"><a href="#cb11-5" aria-hidden="true" tabindex="-1"></a>      <span class="fu">{</span> <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;alice&quot;</span><span class="fu">,</span> <span class="dt">&quot;status&quot;</span><span class="fu">:</span> <span class="st">&quot;active&quot;</span> <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb11-6"><a href="#cb11-6" aria-hidden="true" tabindex="-1"></a>      <span class="fu">{</span> <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;bob&quot;</span><span class="fu">,</span> <span class="dt">&quot;status&quot;</span><span class="fu">:</span> <span class="st">&quot;active&quot;</span> <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb11-7"><a href="#cb11-7" aria-hidden="true" tabindex="-1"></a>      <span class="fu">{</span> <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;charlie&quot;</span><span class="fu">,</span> <span class="dt">&quot;status&quot;</span><span class="fu">:</span> <span class="st">&quot;inactive&quot;</span> <span class="fu">}</span></span>
+<span id="cb11-8"><a href="#cb11-8" aria-hidden="true" tabindex="-1"></a>    <span class="ot">]</span><span class="fu">,</span></span>
+<span id="cb11-9"><a href="#cb11-9" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;pageInfo&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb11-10"><a href="#cb11-10" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;hasNextPage&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb11-11"><a href="#cb11-11" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;hasPreviousPage&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb11-12"><a href="#cb11-12" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;startCursor&quot;</span><span class="fu">:</span> <span class="st">&quot;cursor_001&quot;</span><span class="fu">,</span></span>
+<span id="cb11-13"><a href="#cb11-13" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;endCursor&quot;</span><span class="fu">:</span> <span class="st">&quot;cursor_003&quot;</span><span class="fu">,</span></span>
+<span id="cb11-14"><a href="#cb11-14" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;totalCount&quot;</span><span class="fu">:</span> <span class="dv">25</span></span>
+<span id="cb11-15"><a href="#cb11-15" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb11-16"><a href="#cb11-16" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb11-17"><a href="#cb11-17" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<h3 id="43-edge-response-format">4.3 Edge Response Format</h3>
+<p>When per-item cursors are needed (e.g., for deletion during iteration):</p>
+<div class="sourceCode" id="cb12"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb12-1"><a href="#cb12-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb12-2"><a href="#cb12-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb12-3"><a href="#cb12-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;data&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb12-4"><a href="#cb12-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;edges&quot;</span><span class="fu">:</span> <span class="ot">[</span></span>
+<span id="cb12-5"><a href="#cb12-5" aria-hidden="true" tabindex="-1"></a>      <span class="fu">{</span></span>
+<span id="cb12-6"><a href="#cb12-6" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;node&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;alice&quot;</span><span class="fu">,</span> <span class="dt">&quot;status&quot;</span><span class="fu">:</span> <span class="st">&quot;active&quot;</span> <span class="fu">},</span></span>
+<span id="cb12-7"><a href="#cb12-7" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;cursor&quot;</span><span class="fu">:</span> <span class="st">&quot;cursor_001&quot;</span></span>
+<span id="cb12-8"><a href="#cb12-8" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb12-9"><a href="#cb12-9" aria-hidden="true" tabindex="-1"></a>      <span class="fu">{</span></span>
+<span id="cb12-10"><a href="#cb12-10" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;node&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;bob&quot;</span><span class="fu">,</span> <span class="dt">&quot;status&quot;</span><span class="fu">:</span> <span class="st">&quot;active&quot;</span> <span class="fu">},</span></span>
+<span id="cb12-11"><a href="#cb12-11" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;cursor&quot;</span><span class="fu">:</span> <span class="st">&quot;cursor_002&quot;</span></span>
+<span id="cb12-12"><a href="#cb12-12" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb12-13"><a href="#cb12-13" aria-hidden="true" tabindex="-1"></a>      <span class="fu">{</span></span>
+<span id="cb12-14"><a href="#cb12-14" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;node&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;charlie&quot;</span><span class="fu">,</span> <span class="dt">&quot;status&quot;</span><span class="fu">:</span> <span class="st">&quot;inactive&quot;</span> <span class="fu">},</span></span>
+<span id="cb12-15"><a href="#cb12-15" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;cursor&quot;</span><span class="fu">:</span> <span class="st">&quot;cursor_003&quot;</span></span>
+<span id="cb12-16"><a href="#cb12-16" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span></span>
+<span id="cb12-17"><a href="#cb12-17" aria-hidden="true" tabindex="-1"></a>    <span class="ot">]</span><span class="fu">,</span></span>
+<span id="cb12-18"><a href="#cb12-18" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;pageInfo&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb12-19"><a href="#cb12-19" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;hasNextPage&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb12-20"><a href="#cb12-20" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;hasPreviousPage&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb12-21"><a href="#cb12-21" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;startCursor&quot;</span><span class="fu">:</span> <span class="st">&quot;cursor_001&quot;</span><span class="fu">,</span></span>
+<span id="cb12-22"><a href="#cb12-22" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;endCursor&quot;</span><span class="fu">:</span> <span class="st">&quot;cursor_003&quot;</span></span>
+<span id="cb12-23"><a href="#cb12-23" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb12-24"><a href="#cb12-24" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb12-25"><a href="#cb12-25" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<h3 id="44-choosing-response-format">4.4 Choosing Response Format</h3>
+<table>
+<thead>
+<tr>
+<th>Use Case</th>
+<th>Recommended Format</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Simple listing</td>
+<td><code>items</code> array</td>
+</tr>
+<tr>
+<td>Modify during iteration</td>
+<td><code>edges</code> with cursors</td>
+</tr>
+<tr>
+<td>LLM context (minimize tokens)</td>
+<td><code>items</code> array</td>
+</tr>
+<tr>
+<td>Resume from specific item</td>
+<td><code>edges</code> with cursors</td>
+</tr>
+</tbody>
+</table>
+<hr />
+<h2 id="5-applicable-operations">5. Applicable Operations</h2>
+<h3 id="51-operations-supporting-pagination">5.1 Operations Supporting Pagination</h3>
+<p>The following operation types SHOULD support pagination:</p>
+<table>
+<thead>
+<tr>
+<th>Operation</th>
+<th>Required</th>
+<th>Notes</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>list_elements</code></td>
+<td>Yes</td>
+<td>Core element listing</td>
+</tr>
+<tr>
+<td><code>search_elements</code></td>
+<td>Yes</td>
+<td>Search results</td>
+</tr>
+<tr>
+<td><code>query_elements</code></td>
+<td>Yes</td>
+<td>Complex queries</td>
+</tr>
+<tr>
+<td><code>list_*</code></td>
+<td>Yes</td>
+<td>Any list operation</td>
+</tr>
+<tr>
+<td><code>search_*</code></td>
+<td>Yes</td>
+<td>Any search operation</td>
+</tr>
+</tbody>
+</table>
+<h3 id="52-default-behavior">5.2 Default Behavior</h3>
+<p>When pagination parameters are omitted:</p>
+<table>
+<thead>
+<tr>
+<th>Aspect</th>
+<th>Default</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Page size</td>
+<td>Implementation-defined (RECOMMENDED: 20)</td>
+</tr>
+<tr>
+<td>Direction</td>
+<td>Forward (from start)</td>
+</tr>
+<tr>
+<td>Cursor</td>
+<td>None (first page)</td>
+</tr>
+</tbody>
+</table>
+<h3 id="53-maximum-page-size">5.3 Maximum Page Size</h3>
+<p>Implementations SHOULD enforce a maximum page size:</p>
+<ul>
+<li><strong>RECOMMENDED maximum:</strong> 100 items</li>
+<li><strong>Hard limit:</strong> 1000 items</li>
+</ul>
+<p>Requests exceeding the maximum SHOULD be clamped to the maximum (not rejected).</p>
+<h3 id="54-introspection-of-pagination-support">5.4 Introspection of Pagination Support</h3>
+<p>Operations indicate pagination support in introspection:</p>
+<div class="sourceCode" id="cb13"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb13-1"><a href="#cb13-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb13-2"><a href="#cb13-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;list_elements&quot;</span><span class="fu">,</span></span>
+<span id="cb13-3"><a href="#cb13-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;supports_pagination&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb13-4"><a href="#cb13-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;pagination&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb13-5"><a href="#cb13-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;default_page_size&quot;</span><span class="fu">:</span> <span class="dv">20</span><span class="fu">,</span></span>
+<span id="cb13-6"><a href="#cb13-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;max_page_size&quot;</span><span class="fu">:</span> <span class="dv">100</span><span class="fu">,</span></span>
+<span id="cb13-7"><a href="#cb13-7" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;supports_total_count&quot;</span><span class="fu">:</span> <span class="kw">true</span></span>
+<span id="cb13-8"><a href="#cb13-8" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb13-9"><a href="#cb13-9" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<hr />
+<h2 id="6-implementation-requirements">6. Implementation Requirements</h2>
+<h3 id="61-must-requirements">6.1 MUST Requirements</h3>
+<p>Implementations supporting pagination MUST:</p>
+<ol type="1">
+<li>Accept <code>first</code>, <code>after</code>, <code>last</code>, <code>before</code> parameters</li>
+<li>Return <code>pageInfo</code> with <code>hasNextPage</code> and <code>hasPreviousPage</code></li>
+<li>Return <code>startCursor</code> and <code>endCursor</code> when items are present</li>
+<li>Reject invalid parameter combinations with error code</li>
+<li>Maintain stable ordering within a pagination session</li>
+</ol>
+<h3 id="62-should-requirements">6.2 SHOULD Requirements</h3>
+<p>Implementations supporting pagination SHOULD:</p>
+<ol type="1">
+<li>Return <code>totalCount</code> when available without performance impact</li>
+<li>Enforce maximum page size limits</li>
+<li>Support both forward and backward pagination</li>
+<li>Use opaque, URL-safe cursor format</li>
+<li>Include pagination support in introspection</li>
+</ol>
+<h3 id="63-may-requirements">6.3 MAY Requirements</h3>
+<p>Implementations supporting pagination MAY:</p>
+<ol type="1">
+<li>Include <code>edges</code> with per-item cursors</li>
+<li>Support cursor expiration/TTL</li>
+<li>Implement cursor resumption across sessions</li>
+<li>Support sorting parameters alongside pagination</li>
+</ol>
+<h3 id="64-cursor-format">6.4 Cursor Format</h3>
+<p>Cursors MUST be:</p>
+<ul>
+<li><strong>Opaque</strong> - Clients treat as black box</li>
+<li><strong>URL-safe</strong> - Base64url encoding recommended</li>
+<li><strong>Stable</strong> - Same cursor returns same position</li>
+</ul>
+<p>Cursors SHOULD be:</p>
+<ul>
+<li><strong>Tamper-resistant</strong> - Include validation/signature</li>
+<li><strong>Compact</strong> - Minimize size for LLM context</li>
+<li><strong>Self-contained</strong> - No server-side session state required</li>
+</ul>
+<p><strong>Example cursor encoding:</strong></p>
+<div class="sourceCode" id="cb14"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb14-1"><a href="#cb14-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Encoding</span></span>
+<span id="cb14-2"><a href="#cb14-2" aria-hidden="true" tabindex="-1"></a><span class="kw">const</span> cursor <span class="op">=</span> <span class="fu">btoa</span>(<span class="bu">JSON</span><span class="op">.</span><span class="fu">stringify</span>({</span>
+<span id="cb14-3"><a href="#cb14-3" aria-hidden="true" tabindex="-1"></a>  id<span class="op">:</span> <span class="st">&quot;item_123&quot;</span><span class="op">,</span></span>
+<span id="cb14-4"><a href="#cb14-4" aria-hidden="true" tabindex="-1"></a>  sort_key<span class="op">:</span> <span class="st">&quot;2026-01-28T12:00:00Z&quot;</span></span>
+<span id="cb14-5"><a href="#cb14-5" aria-hidden="true" tabindex="-1"></a>}))<span class="op">;</span></span>
+<span id="cb14-6"><a href="#cb14-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb14-7"><a href="#cb14-7" aria-hidden="true" tabindex="-1"></a><span class="co">// Result: &quot;eyJpZCI6Iml0ZW1fMTIzIiwic29ydF9rZXkiOiIyMDI2LTAxLTI4VDEyOjAwOjAwWiJ9&quot;</span></span></code></pre></div>
+<hr />
+<h2 id="7-future-extensions">7. Future Extensions</h2>
+<h3 id="71-sorting-with-pagination">7.1 Sorting with Pagination</h3>
+<p>Combine sorting and pagination:</p>
+<div class="sourceCode" id="cb15"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb15-1"><a href="#cb15-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb15-2"><a href="#cb15-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;list_elements&quot;</span><span class="op">,</span></span>
+<span id="cb15-3"><a href="#cb15-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">element_type</span><span class="op">:</span> <span class="st">&quot;persona&quot;</span><span class="op">,</span></span>
+<span id="cb15-4"><a href="#cb15-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> {</span>
+<span id="cb15-5"><a href="#cb15-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">first</span><span class="op">:</span> <span class="dv">10</span><span class="op">,</span></span>
+<span id="cb15-6"><a href="#cb15-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">sort_by</span><span class="op">:</span> <span class="st">&quot;created_at&quot;</span><span class="op">,</span></span>
+<span id="cb15-7"><a href="#cb15-7" aria-hidden="true" tabindex="-1"></a>    <span class="dt">sort_order</span><span class="op">:</span> <span class="st">&quot;desc&quot;</span></span>
+<span id="cb15-8"><a href="#cb15-8" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb15-9"><a href="#cb15-9" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<h3 id="72-filtered-pagination">7.2 Filtered Pagination</h3>
+<p>Pagination with filters:</p>
+<div class="sourceCode" id="cb16"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb16-1"><a href="#cb16-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb16-2"><a href="#cb16-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;list_elements&quot;</span><span class="op">,</span></span>
+<span id="cb16-3"><a href="#cb16-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">element_type</span><span class="op">:</span> <span class="st">&quot;persona&quot;</span><span class="op">,</span></span>
+<span id="cb16-4"><a href="#cb16-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> {</span>
+<span id="cb16-5"><a href="#cb16-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">first</span><span class="op">:</span> <span class="dv">10</span><span class="op">,</span></span>
+<span id="cb16-6"><a href="#cb16-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">filter</span><span class="op">:</span> {</span>
+<span id="cb16-7"><a href="#cb16-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">status</span><span class="op">:</span> <span class="st">&quot;active&quot;</span><span class="op">,</span></span>
+<span id="cb16-8"><a href="#cb16-8" aria-hidden="true" tabindex="-1"></a>      <span class="dt">tags</span><span class="op">:</span> { <span class="dt">contains</span><span class="op">:</span> <span class="st">&quot;admin&quot;</span> }</span>
+<span id="cb16-9"><a href="#cb16-9" aria-hidden="true" tabindex="-1"></a>    }</span>
+<span id="cb16-10"><a href="#cb16-10" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb16-11"><a href="#cb16-11" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<h3 id="73-offset-based-pagination">7.3 Offset-Based Pagination</h3>
+<p>For backends requiring offset:</p>
+<div class="sourceCode" id="cb17"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb17-1"><a href="#cb17-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb17-2"><a href="#cb17-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;list_elements&quot;</span><span class="op">,</span></span>
+<span id="cb17-3"><a href="#cb17-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">element_type</span><span class="op">:</span> <span class="st">&quot;persona&quot;</span><span class="op">,</span></span>
+<span id="cb17-4"><a href="#cb17-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> {</span>
+<span id="cb17-5"><a href="#cb17-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">offset</span><span class="op">:</span> <span class="dv">20</span><span class="op">,</span></span>
+<span id="cb17-6"><a href="#cb17-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">limit</span><span class="op">:</span> <span class="dv">10</span></span>
+<span id="cb17-7"><a href="#cb17-7" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb17-8"><a href="#cb17-8" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<h3 id="74-streaming-pagination">7.4 Streaming Pagination</h3>
+<p>For real-time data:</p>
+<div class="sourceCode" id="cb18"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb18-1"><a href="#cb18-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb18-2"><a href="#cb18-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;list_elements&quot;</span><span class="op">,</span></span>
+<span id="cb18-3"><a href="#cb18-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">element_type</span><span class="op">:</span> <span class="st">&quot;persona&quot;</span><span class="op">,</span></span>
+<span id="cb18-4"><a href="#cb18-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> {</span>
+<span id="cb18-5"><a href="#cb18-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">first</span><span class="op">:</span> <span class="dv">10</span><span class="op">,</span></span>
+<span id="cb18-6"><a href="#cb18-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">stream</span><span class="op">:</span> <span class="kw">true</span><span class="op">,</span></span>
+<span id="cb18-7"><a href="#cb18-7" aria-hidden="true" tabindex="-1"></a>    <span class="dt">poll_interval_ms</span><span class="op">:</span> <span class="dv">5000</span></span>
+<span id="cb18-8"><a href="#cb18-8" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb18-9"><a href="#cb18-9" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<h3 id="75-pagination-presets">7.5 Pagination Presets</h3>
+<p>Named pagination configurations:</p>
+<div class="sourceCode" id="cb19"><pre class="sourceCode yaml"><code class="sourceCode yaml"><span id="cb19-1"><a href="#cb19-1" aria-hidden="true" tabindex="-1"></a><span class="co"># In adapter schema</span></span>
+<span id="cb19-2"><a href="#cb19-2" aria-hidden="true" tabindex="-1"></a><span class="fu">pagination_presets</span><span class="kw">:</span></span>
+<span id="cb19-3"><a href="#cb19-3" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">compact</span><span class="kw">:</span></span>
+<span id="cb19-4"><a href="#cb19-4" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">page_size</span><span class="kw">:</span><span class="at"> </span><span class="dv">5</span></span>
+<span id="cb19-5"><a href="#cb19-5" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">include_total</span><span class="kw">:</span><span class="at"> </span><span class="ch">false</span></span>
+<span id="cb19-6"><a href="#cb19-6" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">detailed</span><span class="kw">:</span></span>
+<span id="cb19-7"><a href="#cb19-7" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">page_size</span><span class="kw">:</span><span class="at"> </span><span class="dv">20</span></span>
+<span id="cb19-8"><a href="#cb19-8" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">include_total</span><span class="kw">:</span><span class="at"> </span><span class="ch">true</span></span>
+<span id="cb19-9"><a href="#cb19-9" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">include_edges</span><span class="kw">:</span><span class="at"> </span><span class="ch">true</span></span></code></pre></div>
+<hr />
+<h2 id="references">References</h2>
+<ul>
+<li><a href="../versions/v1.0.0-draft.html">MCP-AQL Specification</a></li>
+<li><a href="https://relay.dev/graphql/connections.htm">GraphQL Relay Cursor Connections</a></li>
+<li><a href="field-selection.html">Field Selection Specification</a></li>
+<li><a href="../operations.html">Operations Reference</a></li>
+<li>GitHub Issue: <a href="https://github.com/MCPAQL/spec/issues/37">#37</a></li>
+<li>DollhouseMCP Implementation: <a href="https://github.com/DollhouseMCP/mcp-server-v2-refactor/issues/299">#299</a></li>
+</ul>
+
+          </div>
+        </section>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div class="container">
+      <p>&copy; 2026 DollhouseMCP Inc. d/b/a Dollhouse Research. MCP-AQL public draft documentation portal.</p>
+      <div class="footer-links">
+        <a href="../../docs/index.html">Docs Library</a>
+        <a href="../index.html">Repo-Synced Spec</a>
+        <a href="https://github.com/MCPAQL">MCPAQL Organization</a>
+        <a href="https://dollhouseresearch.com">Dollhouse Research</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../../js/search.js"></script>
+</body>
+</html>

--- a/public/spec/features/pagination.html
+++ b/public/spec/features/pagination.html
@@ -38,7 +38,7 @@
         <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
         <div class="docs-side-group">
   <h3>Core</h3>
-  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li></ul>
+  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li><li><a href="../repo/README.html">MCP-AQL Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Versions</h3>
   <ul><li><a href="../versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
@@ -56,7 +56,7 @@
   <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
-  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li></ul>
+  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li><li><a href="../repo/CHANGELOG.html">Changelog</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Architecture</h3>
   <ul><li><a href="../architecture/README.html">Architecture Documentation</a></li></ul>

--- a/public/spec/features/warnings.html
+++ b/public/spec/features/warnings.html
@@ -1,0 +1,828 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="This document specifies the warnings array extension to MCP-AQL's discriminated response format. Warnings provide a mechanism to communicate non-fatal conditions to clients within successful responses, enabling proactive">
+  <title>MCP-AQL Spec | Warnings Array Specification</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../../css/style.css">
+</head>
+<body>
+  <header>
+    <div class="container">
+      <nav>
+        <a class="logo" href="../../index.html"><span class="logo-mark"></span>MCP-AQL</a>
+        <ul class="nav-links">
+          <li><a href="../../index.html">Home</a></li>
+          <li><a href="../../docs/index.html">Docs</a></li>
+          <li><a href="../../launch-checklist.html">Launch Checklist</a></li>
+          <li><a href="../../apis/mcp-server.html">Adapter Patterns</a></li>
+        </ul>
+        <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
+          <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
+          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <span class="search-count" data-search-count></span>
+          <ul class="search-results" data-search-results hidden></ul>
+        </form>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <div class="container docs-shell">
+      <aside class="docs-side">
+        <h2>Repo-Synced Spec</h2>
+        <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
+        <div class="docs-side-group">
+  <h3>Core</h3>
+  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Versions</h3>
+  <ul><li><a href="../versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Adapter</h3>
+  <ul><li><a href="../adapter/danger-levels.html">Dangerous Operation Classification Specification</a></li><li><a href="../adapter/discovery-bundle.html">MCP Server Discovery Bundle</a></li><li><a href="../adapter/element-type.html">Adapter Element Type Specification</a></li><li><a href="../adapter/generator.html">Adapter Generator Specification</a></li><li><a href="../adapter/rate-limiting.html">Rate Limiting and Quota Management Specification</a></li><li><a href="../adapter/trust-levels.html">Trust Levels Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Security</h3>
+  <ul><li><a href="../security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="../security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="../security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Features</h3>
+  <ul><li><a href="field-selection.html">Field Selection Specification</a></li><li><a href="pagination.html">Cursor-Based Pagination Specification</a></li><li><a class="current" href="warnings.html">Warnings Array Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Guides</h3>
+  <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Process</h3>
+  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Architecture</h3>
+  <ul><li><a href="../architecture/README.html">Architecture Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Research</h3>
+  <ul><li><a href="../research/mcp-vs-mcpaql-vs-a2a.html">Protocol Landscape: MCP vs MCP-AQL vs A2A</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Reference</h3>
+  <ul><li><a href="../reference/README.html">Reference Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>ADRs</h3>
+  <ul><li><a href="../adr/ADR-001-crude-pattern.html">ADR-001: CRUDE Pattern (Extending CRUD with Execute)</a></li><li><a href="../adr/ADR-002-graphql-style-input.html">ADR-002: GraphQL-Style Input Objects for Updates</a></li><li><a href="../adr/ADR-003-snake-case-parameters.html">ADR-003: snake_case Parameter Convention</a></li><li><a href="../adr/ADR-004-schema-driven-operations.html">ADR-004: Schema-Driven Operation Definitions</a></li><li><a href="../adr/ADR-005-introspection-system.html">ADR-005: GraphQL-Style Introspection System</a></li><li><a href="../adr/ADR-006-discriminated-responses.html">ADR-006: Discriminated Response Format</a></li><li><a href="../adr/index.html">Architecture Decision Records</a></li><li><a href="../adr/README.html">Architecture Decision Records</a></li></ul>
+</div>
+      </aside>
+
+      <article class="docs-main">
+        <section class="hero docs-hero">
+          <div class="hero-inner">
+            <span class="status-pill">REPO-SYNCED SPEC DOC</span>
+            <h1>Warnings Array Specification</h1>
+            <p class="lede">This document specifies the warnings array extension to MCP-AQL's discriminated response format. Warnings provide a mechanism to communicate non-fatal conditions to clients within successful responses, enabling proactive</p>
+            <div class="spec-meta"><span class="state-chip live">Support document</span><span class="state-chip pending">Draft</span><span class="state-chip">1.0.0-draft</span><span class="state-chip">2026-01-28</span></div>
+            <p class="spec-source">Source: <a href="https://github.com/MCPAQL/spec/blob/main/docs/features/warnings.md">spec/docs/features/warnings.md</a></p>
+            <div class="hero-actions">
+              <a class="btn btn-primary" href="https://github.com/MCPAQL/spec/blob/main/docs/features/warnings.md">Open Source Markdown</a>
+              <a class="btn btn-secondary" href="../index.html">Browse Full Spec Reference</a>
+            </div>
+          </div>
+        </section>
+
+        <section>
+          <div class="card spec-prose">
+            <p><strong>Version:</strong> 1.0.0-draft <strong>Status:</strong> Draft <strong>Last Updated:</strong> 2026-01-28</p>
+<h2 id="abstract">Abstract</h2>
+<p>This document specifies the warnings array extension to MCP-AQL's discriminated response format. Warnings provide a mechanism to communicate non-fatal conditions to clients within successful responses, enabling proactive notification without blocking operation execution.</p>
+<hr />
+<h2 id="table-of-contents">Table of Contents</h2>
+<ol type="1">
+<li><a href="#1-overview">Overview</a></li>
+<li><a href="#2-response-format-extension">Response Format Extension</a></li>
+<li><a href="#3-warning-object-schema">Warning Object Schema</a>
+<ul>
+<li><a href="#32-severity-levels">3.2 Severity Levels</a></li>
+</ul></li>
+<li><a href="#4-standard-warning-codes">Standard Warning Codes</a></li>
+<li><a href="#5-client-requirements">Client Requirements</a></li>
+<li><a href="#6-implementation-requirements">Implementation Requirements</a>
+<ul>
+<li><a href="#65-warning-deduplication">6.5 Warning Deduplication</a></li>
+</ul></li>
+</ol>
+<hr />
+<h2 id="1-overview">1. Overview</h2>
+<h3 id="11-purpose">1.1 Purpose</h3>
+<p>Warnings address scenarios where:</p>
+<ul>
+<li>An operation succeeds but a condition warrants attention</li>
+<li>Resource limits are approaching but not exceeded</li>
+<li>Deprecated features are used</li>
+<li>Data quality issues exist but don't prevent operation</li>
+<li>Performance degradation may occur</li>
+</ul>
+<p>Without warnings, these conditions would either:</p>
+<ol type="1">
+<li><strong>Block the operation</strong> (too severe for the condition)</li>
+<li><strong>Go unnoticed</strong> (hidden from the client entirely)</li>
+</ol>
+<h3 id="12-design-principles">1.2 Design Principles</h3>
+<ol type="1">
+<li><strong>Non-blocking</strong> - Warnings never prevent successful operation completion</li>
+<li><strong>Structured</strong> - Same format as error objects for consistency</li>
+<li><strong>Actionable</strong> - Each warning suggests or enables a response</li>
+<li><strong>Combinable</strong> - Multiple warnings can be returned in a single response</li>
+<li><strong>Optional</strong> - Clients MAY ignore warnings without breaking functionality</li>
+</ol>
+<h3 id="13-relationship-to-errors">1.3 Relationship to Errors</h3>
+<table>
+<thead>
+<tr>
+<th>Aspect</th>
+<th>Error</th>
+<th>Warning</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Response success</td>
+<td><code>false</code></td>
+<td><code>true</code></td>
+</tr>
+<tr>
+<td>Operation completed</td>
+<td>No</td>
+<td>Yes</td>
+</tr>
+<tr>
+<td>Client action</td>
+<td>Required</td>
+<td>Optional</td>
+</tr>
+<tr>
+<td>Blocks execution</td>
+<td>Yes</td>
+<td>No</td>
+</tr>
+<tr>
+<td>Schema structure</td>
+<td><code>error</code> object</td>
+<td><code>warnings</code> array</td>
+</tr>
+</tbody>
+</table>
+<hr />
+<h2 id="2-response-format-extension">2. Response Format Extension</h2>
+<h3 id="21-extended-success-response">2.1 Extended Success Response</h3>
+<p>The discriminated response format (see <a href="../adr/ADR-006-discriminated-responses.html">ADR-006</a>) is extended to include an optional <code>warnings</code> array:</p>
+<div class="sourceCode" id="cb1"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a><span class="kw">interface</span> SuccessResponse<span class="op">&lt;</span>T<span class="op">&gt;</span> {</span>
+<span id="cb1-2"><a href="#cb1-2" aria-hidden="true" tabindex="-1"></a>  success<span class="op">:</span> <span class="kw">true</span><span class="op">;</span></span>
+<span id="cb1-3"><a href="#cb1-3" aria-hidden="true" tabindex="-1"></a>  data<span class="op">:</span> T<span class="op">;</span></span>
+<span id="cb1-4"><a href="#cb1-4" aria-hidden="true" tabindex="-1"></a>  warnings<span class="op">?:</span> Warning[]<span class="op">;</span></span>
+<span id="cb1-5"><a href="#cb1-5" aria-hidden="true" tabindex="-1"></a>}</span>
+<span id="cb1-6"><a href="#cb1-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb1-7"><a href="#cb1-7" aria-hidden="true" tabindex="-1"></a><span class="kw">interface</span> ErrorResponse {</span>
+<span id="cb1-8"><a href="#cb1-8" aria-hidden="true" tabindex="-1"></a>  success<span class="op">:</span> <span class="kw">false</span><span class="op">;</span></span>
+<span id="cb1-9"><a href="#cb1-9" aria-hidden="true" tabindex="-1"></a>  error<span class="op">:</span> ErrorDetail<span class="op">;</span></span>
+<span id="cb1-10"><a href="#cb1-10" aria-hidden="true" tabindex="-1"></a>  <span class="co">// Note: warnings are NOT included in error responses</span></span>
+<span id="cb1-11"><a href="#cb1-11" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<h3 id="22-response-examples">2.2 Response Examples</h3>
+<p><strong>Success without warnings:</strong></p>
+<div class="sourceCode" id="cb2"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb2-2"><a href="#cb2-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb2-3"><a href="#cb2-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;data&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb2-4"><a href="#cb2-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;user&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb2-5"><a href="#cb2-5" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;id&quot;</span><span class="fu">:</span> <span class="st">&quot;u123&quot;</span><span class="fu">,</span></span>
+<span id="cb2-6"><a href="#cb2-6" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;Alice&quot;</span></span>
+<span id="cb2-7"><a href="#cb2-7" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb2-8"><a href="#cb2-8" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb2-9"><a href="#cb2-9" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<p><strong>Success with warnings:</strong></p>
+<div class="sourceCode" id="cb3"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb3-1"><a href="#cb3-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb3-2"><a href="#cb3-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb3-3"><a href="#cb3-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;data&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb3-4"><a href="#cb3-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;user&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb3-5"><a href="#cb3-5" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;id&quot;</span><span class="fu">:</span> <span class="st">&quot;u123&quot;</span><span class="fu">,</span></span>
+<span id="cb3-6"><a href="#cb3-6" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;Alice&quot;</span></span>
+<span id="cb3-7"><a href="#cb3-7" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb3-8"><a href="#cb3-8" aria-hidden="true" tabindex="-1"></a>  <span class="fu">},</span></span>
+<span id="cb3-9"><a href="#cb3-9" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;warnings&quot;</span><span class="fu">:</span> <span class="ot">[</span></span>
+<span id="cb3-10"><a href="#cb3-10" aria-hidden="true" tabindex="-1"></a>    <span class="fu">{</span></span>
+<span id="cb3-11"><a href="#cb3-11" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;code&quot;</span><span class="fu">:</span> <span class="st">&quot;RATE_LIMIT_QUOTA_WARNING&quot;</span><span class="fu">,</span></span>
+<span id="cb3-12"><a href="#cb3-12" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;Approaching quota limit&quot;</span><span class="fu">,</span></span>
+<span id="cb3-13"><a href="#cb3-13" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;details&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb3-14"><a href="#cb3-14" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;metric&quot;</span><span class="fu">:</span> <span class="st">&quot;requests_per_hour&quot;</span><span class="fu">,</span></span>
+<span id="cb3-15"><a href="#cb3-15" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;current&quot;</span><span class="fu">:</span> <span class="dv">4100</span><span class="fu">,</span></span>
+<span id="cb3-16"><a href="#cb3-16" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;warn_threshold&quot;</span><span class="fu">:</span> <span class="dv">4000</span></span>
+<span id="cb3-17"><a href="#cb3-17" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span></span>
+<span id="cb3-18"><a href="#cb3-18" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb3-19"><a href="#cb3-19" aria-hidden="true" tabindex="-1"></a>  <span class="ot">]</span></span>
+<span id="cb3-20"><a href="#cb3-20" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<p><strong>Success with multiple warnings:</strong></p>
+<div class="sourceCode" id="cb4"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb4-1"><a href="#cb4-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb4-2"><a href="#cb4-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb4-3"><a href="#cb4-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;data&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb4-4"><a href="#cb4-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;results&quot;</span><span class="fu">:</span> <span class="ot">[</span> <span class="er">/*</span> <span class="er">...</span> <span class="er">*/</span> <span class="ot">]</span></span>
+<span id="cb4-5"><a href="#cb4-5" aria-hidden="true" tabindex="-1"></a>  <span class="fu">},</span></span>
+<span id="cb4-6"><a href="#cb4-6" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;warnings&quot;</span><span class="fu">:</span> <span class="ot">[</span></span>
+<span id="cb4-7"><a href="#cb4-7" aria-hidden="true" tabindex="-1"></a>    <span class="fu">{</span></span>
+<span id="cb4-8"><a href="#cb4-8" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;code&quot;</span><span class="fu">:</span> <span class="st">&quot;RATE_LIMIT_QUOTA_WARNING&quot;</span><span class="fu">,</span></span>
+<span id="cb4-9"><a href="#cb4-9" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;Approaching quota limit&quot;</span><span class="fu">,</span></span>
+<span id="cb4-10"><a href="#cb4-10" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;details&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb4-11"><a href="#cb4-11" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;metric&quot;</span><span class="fu">:</span> <span class="st">&quot;requests_per_hour&quot;</span><span class="fu">,</span></span>
+<span id="cb4-12"><a href="#cb4-12" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;current&quot;</span><span class="fu">:</span> <span class="dv">4100</span><span class="fu">,</span></span>
+<span id="cb4-13"><a href="#cb4-13" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;warn_threshold&quot;</span><span class="fu">:</span> <span class="dv">4000</span></span>
+<span id="cb4-14"><a href="#cb4-14" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span></span>
+<span id="cb4-15"><a href="#cb4-15" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb4-16"><a href="#cb4-16" aria-hidden="true" tabindex="-1"></a>    <span class="fu">{</span></span>
+<span id="cb4-17"><a href="#cb4-17" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;code&quot;</span><span class="fu">:</span> <span class="st">&quot;DEPRECATION_WARNING&quot;</span><span class="fu">,</span></span>
+<span id="cb4-18"><a href="#cb4-18" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;Operation &#39;list_users_v1&#39; is deprecated&quot;</span><span class="fu">,</span></span>
+<span id="cb4-19"><a href="#cb4-19" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;details&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb4-20"><a href="#cb4-20" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;deprecated_operation&quot;</span><span class="fu">:</span> <span class="st">&quot;list_users_v1&quot;</span><span class="fu">,</span></span>
+<span id="cb4-21"><a href="#cb4-21" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;replacement&quot;</span><span class="fu">:</span> <span class="st">&quot;list_users&quot;</span><span class="fu">,</span></span>
+<span id="cb4-22"><a href="#cb4-22" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;removal_date&quot;</span><span class="fu">:</span> <span class="st">&quot;2027-01-01&quot;</span></span>
+<span id="cb4-23"><a href="#cb4-23" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span></span>
+<span id="cb4-24"><a href="#cb4-24" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb4-25"><a href="#cb4-25" aria-hidden="true" tabindex="-1"></a>  <span class="ot">]</span></span>
+<span id="cb4-26"><a href="#cb4-26" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<h3 id="23-warnings-in-error-responses">2.3 Warnings in Error Responses</h3>
+<p>Warnings SHOULD NOT be included in error responses (<code>success: false</code>). The rationale:</p>
+<ol type="1">
+<li><strong>Clarity</strong> - Error responses focus on the failure condition</li>
+<li><strong>Simplicity</strong> - Clients handle one concern at a time</li>
+<li><strong>Semantics</strong> - If the operation failed, pre-operation warnings are moot</li>
+</ol>
+<p>If a warning condition would have applied, it will appear when the operation is retried successfully.</p>
+<hr />
+<h2 id="3-warning-object-schema">3. Warning Object Schema</h2>
+<h3 id="31-schema-definition">3.1 Schema Definition</h3>
+<div class="sourceCode" id="cb5"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb5-1"><a href="#cb5-1" aria-hidden="true" tabindex="-1"></a><span class="kw">interface</span> Warning {</span>
+<span id="cb5-2"><a href="#cb5-2" aria-hidden="true" tabindex="-1"></a>  <span class="co">/**</span></span>
+<span id="cb5-3"><a href="#cb5-3" aria-hidden="true" tabindex="-1"></a><span class="co">   * Machine-readable warning code</span></span>
+<span id="cb5-4"><a href="#cb5-4" aria-hidden="true" tabindex="-1"></a><span class="co">   * Format: CATEGORY_SPECIFIC_WARNING</span></span>
+<span id="cb5-5"><a href="#cb5-5" aria-hidden="true" tabindex="-1"></a><span class="co">   * Uses same format as error codes for consistency</span></span>
+<span id="cb5-6"><a href="#cb5-6" aria-hidden="true" tabindex="-1"></a><span class="co">   */</span></span>
+<span id="cb5-7"><a href="#cb5-7" aria-hidden="true" tabindex="-1"></a>  code<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb5-8"><a href="#cb5-8" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb5-9"><a href="#cb5-9" aria-hidden="true" tabindex="-1"></a>  <span class="co">/**</span></span>
+<span id="cb5-10"><a href="#cb5-10" aria-hidden="true" tabindex="-1"></a><span class="co">   * Human-readable warning message</span></span>
+<span id="cb5-11"><a href="#cb5-11" aria-hidden="true" tabindex="-1"></a><span class="co">   * Should be suitable for display to end users</span></span>
+<span id="cb5-12"><a href="#cb5-12" aria-hidden="true" tabindex="-1"></a><span class="co">   */</span></span>
+<span id="cb5-13"><a href="#cb5-13" aria-hidden="true" tabindex="-1"></a>  message<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb5-14"><a href="#cb5-14" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb5-15"><a href="#cb5-15" aria-hidden="true" tabindex="-1"></a>  <span class="co">/**</span></span>
+<span id="cb5-16"><a href="#cb5-16" aria-hidden="true" tabindex="-1"></a><span class="co">   * Optional structured details about the warning</span></span>
+<span id="cb5-17"><a href="#cb5-17" aria-hidden="true" tabindex="-1"></a><span class="co">   * Content varies by warning code</span></span>
+<span id="cb5-18"><a href="#cb5-18" aria-hidden="true" tabindex="-1"></a><span class="co">   */</span></span>
+<span id="cb5-19"><a href="#cb5-19" aria-hidden="true" tabindex="-1"></a>  details<span class="op">?:</span> <span class="bu">Record</span><span class="op">&lt;</span><span class="dt">string</span><span class="op">,</span> <span class="dt">unknown</span><span class="op">&gt;;</span></span>
+<span id="cb5-20"><a href="#cb5-20" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb5-21"><a href="#cb5-21" aria-hidden="true" tabindex="-1"></a>  <span class="co">/**</span></span>
+<span id="cb5-22"><a href="#cb5-22" aria-hidden="true" tabindex="-1"></a><span class="co">   * Optional severity level for client prioritization</span></span>
+<span id="cb5-23"><a href="#cb5-23" aria-hidden="true" tabindex="-1"></a><span class="co">   * Helps clients decide display ordering and filtering</span></span>
+<span id="cb5-24"><a href="#cb5-24" aria-hidden="true" tabindex="-1"></a><span class="co">   */</span></span>
+<span id="cb5-25"><a href="#cb5-25" aria-hidden="true" tabindex="-1"></a>  severity<span class="op">?:</span> <span class="st">&#39;low&#39;</span> <span class="op">|</span> <span class="st">&#39;medium&#39;</span> <span class="op">|</span> <span class="st">&#39;high&#39;</span><span class="op">;</span></span>
+<span id="cb5-26"><a href="#cb5-26" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<h3 id="32-severity-levels">3.2 Severity Levels</h3>
+<p>The optional <code>severity</code> field helps clients prioritize warnings when multiple are present:</p>
+<table>
+<thead>
+<tr>
+<th>Level</th>
+<th>Description</th>
+<th>Example Use Cases</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>high</code></td>
+<td>Requires immediate attention; may affect operations soon</td>
+<td>Quota nearly exhausted, imminent deprecation removal</td>
+</tr>
+<tr>
+<td><code>medium</code></td>
+<td>Should be addressed but not urgent</td>
+<td>Approaching limits, scheduled deprecation</td>
+</tr>
+<tr>
+<td><code>low</code></td>
+<td>Informational; can be safely deferred or filtered</td>
+<td>Performance hints, soft deprecation notices</td>
+</tr>
+</tbody>
+</table>
+<p><strong>Numeric severity mapping:</strong></p>
+<p>For sorting, filtering, and programmatic comparison, implementations SHOULD use this numeric mapping:</p>
+<table>
+<thead>
+<tr>
+<th>Severity</th>
+<th>Numeric Value</th>
+<th>Sort Order</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>high</code></td>
+<td>0</td>
+<td>First (most urgent)</td>
+</tr>
+<tr>
+<td><code>medium</code></td>
+<td>1</td>
+<td>Second</td>
+</tr>
+<tr>
+<td><code>low</code></td>
+<td>2</td>
+<td>Third (least urgent)</td>
+</tr>
+</tbody>
+</table>
+<p>This mapping ensures:</p>
+<ul>
+<li>Lower numeric values indicate higher urgency (consistent with syslog and common logging frameworks)</li>
+<li>Implementations can store severity in databases as integers</li>
+<li>Threshold-based filtering is consistent (e.g., "show severity ≤ 1" means high and medium)</li>
+<li>Cross-implementation interoperability when comparing severity levels</li>
+</ul>
+<p><strong>Severity guidelines for implementations:</strong></p>
+<ul>
+<li>Implementations MAY omit <code>severity</code> (clients should assume <code>medium</code> as default)</li>
+<li>Implementations SHOULD use <code>high</code> sparingly to avoid alert fatigue</li>
+<li>Implementations SHOULD NOT change a warning's severity between requests for the same condition</li>
+</ul>
+<p><strong>Client handling:</strong></p>
+<div class="sourceCode" id="cb6"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb6-1"><a href="#cb6-1" aria-hidden="true" tabindex="-1"></a><span class="kw">function</span> <span class="fu">sortWarningsBySeverity</span>(warnings<span class="op">:</span> Warning[])<span class="op">:</span> Warning[] {</span>
+<span id="cb6-2"><a href="#cb6-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">const</span> order <span class="op">=</span> { high<span class="op">:</span> <span class="dv">0</span><span class="op">,</span> medium<span class="op">:</span> <span class="dv">1</span><span class="op">,</span> low<span class="op">:</span> <span class="dv">2</span> }<span class="op">;</span></span>
+<span id="cb6-3"><a href="#cb6-3" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> [<span class="op">...</span>warnings]<span class="op">.</span><span class="fu">sort</span>((a<span class="op">,</span> b) <span class="kw">=&gt;</span> {</span>
+<span id="cb6-4"><a href="#cb6-4" aria-hidden="true" tabindex="-1"></a>    <span class="kw">const</span> severityA <span class="op">=</span> a<span class="op">.</span><span class="at">severity</span> <span class="op">??</span> <span class="st">&#39;medium&#39;</span><span class="op">;</span></span>
+<span id="cb6-5"><a href="#cb6-5" aria-hidden="true" tabindex="-1"></a>    <span class="kw">const</span> severityB <span class="op">=</span> b<span class="op">.</span><span class="at">severity</span> <span class="op">??</span> <span class="st">&#39;medium&#39;</span><span class="op">;</span></span>
+<span id="cb6-6"><a href="#cb6-6" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> order[severityA] <span class="op">-</span> order[severityB]<span class="op">;</span></span>
+<span id="cb6-7"><a href="#cb6-7" aria-hidden="true" tabindex="-1"></a>  })<span class="op">;</span></span>
+<span id="cb6-8"><a href="#cb6-8" aria-hidden="true" tabindex="-1"></a>}</span>
+<span id="cb6-9"><a href="#cb6-9" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb6-10"><a href="#cb6-10" aria-hidden="true" tabindex="-1"></a><span class="kw">function</span> <span class="fu">filterByMinimumSeverity</span>(</span>
+<span id="cb6-11"><a href="#cb6-11" aria-hidden="true" tabindex="-1"></a>  warnings<span class="op">:</span> Warning[]<span class="op">,</span></span>
+<span id="cb6-12"><a href="#cb6-12" aria-hidden="true" tabindex="-1"></a>  minimum<span class="op">:</span> <span class="st">&#39;low&#39;</span> <span class="op">|</span> <span class="st">&#39;medium&#39;</span> <span class="op">|</span> <span class="st">&#39;high&#39;</span></span>
+<span id="cb6-13"><a href="#cb6-13" aria-hidden="true" tabindex="-1"></a>)<span class="op">:</span> Warning[] {</span>
+<span id="cb6-14"><a href="#cb6-14" aria-hidden="true" tabindex="-1"></a>  <span class="kw">const</span> threshold <span class="op">=</span> { low<span class="op">:</span> <span class="dv">2</span><span class="op">,</span> medium<span class="op">:</span> <span class="dv">1</span><span class="op">,</span> high<span class="op">:</span> <span class="dv">0</span> }<span class="op">;</span></span>
+<span id="cb6-15"><a href="#cb6-15" aria-hidden="true" tabindex="-1"></a>  <span class="kw">const</span> minLevel <span class="op">=</span> threshold[minimum]<span class="op">;</span></span>
+<span id="cb6-16"><a href="#cb6-16" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> warnings<span class="op">.</span><span class="fu">filter</span>(w <span class="kw">=&gt;</span> {</span>
+<span id="cb6-17"><a href="#cb6-17" aria-hidden="true" tabindex="-1"></a>    <span class="kw">const</span> level <span class="op">=</span> threshold[w<span class="op">.</span><span class="at">severity</span> <span class="op">??</span> <span class="st">&#39;medium&#39;</span>]<span class="op">;</span></span>
+<span id="cb6-18"><a href="#cb6-18" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> level <span class="op">&lt;=</span> minLevel<span class="op">;</span></span>
+<span id="cb6-19"><a href="#cb6-19" aria-hidden="true" tabindex="-1"></a>  })<span class="op">;</span></span>
+<span id="cb6-20"><a href="#cb6-20" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<h3 id="33-code-format">3.3 Code Format</h3>
+<p>Warning codes follow the same naming convention as error codes:</p>
+<pre><code>CATEGORY_SPECIFIC_WARNING</code></pre>
+<p><strong>Rules:</strong></p>
+<ul>
+<li>All uppercase with underscores</li>
+<li>Category prefix identifies warning class</li>
+<li>Specific suffix describes the condition</li>
+<li>Codes may overlap with error codes when the condition can be either (e.g., rate limits)</li>
+</ul>
+<h3 id="34-warning-categories">3.4 Warning Categories</h3>
+<table>
+<thead>
+<tr>
+<th>Category</th>
+<th>Description</th>
+<th>Example</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>RATE_LIMIT_</code></td>
+<td>Approaching rate/quota limits</td>
+<td><code>RATE_LIMIT_QUOTA_WARNING</code></td>
+</tr>
+<tr>
+<td><code>DEPRECATION_</code></td>
+<td>Deprecated feature usage</td>
+<td><code>DEPRECATION_WARNING</code></td>
+</tr>
+<tr>
+<td><code>VALIDATION_</code></td>
+<td>Data quality issues</td>
+<td><code>VALIDATION_TRUNCATED_WARNING</code></td>
+</tr>
+<tr>
+<td><code>PERFORMANCE_</code></td>
+<td>Performance concerns</td>
+<td><code>PERFORMANCE_SLOW_QUERY_WARNING</code></td>
+</tr>
+</tbody>
+</table>
+<hr />
+<h2 id="4-standard-warning-codes">4. Standard Warning Codes</h2>
+<h3 id="41-rate-limit-warnings">4.1 Rate Limit Warnings</h3>
+<h4 id="rate_limit_quota_warning">RATE_LIMIT_QUOTA_WARNING</h4>
+<p><strong>When used:</strong> Usage is approaching a configured quota threshold.</p>
+<p><strong>Message format:</strong> <code>Approaching quota limit</code></p>
+<p><strong>Severity recommendations:</strong></p>
+<table>
+<thead>
+<tr>
+<th>Condition</th>
+<th>Severity</th>
+<th>Rationale</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>&gt;90% of quota consumed</td>
+<td><code>high</code></td>
+<td>Imminent limit, requires immediate attention</td>
+</tr>
+<tr>
+<td>At warn_threshold (default 80%)</td>
+<td><code>medium</code></td>
+<td>Standard warning, action advisable</td>
+</tr>
+</tbody>
+</table>
+<p><strong>Details:</strong></p>
+<div class="sourceCode" id="cb8"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb8-1"><a href="#cb8-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb8-2"><a href="#cb8-2" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** The metric approaching the limit */</span></span>
+<span id="cb8-3"><a href="#cb8-3" aria-hidden="true" tabindex="-1"></a>  metric<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb8-4"><a href="#cb8-4" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** Current usage count */</span></span>
+<span id="cb8-5"><a href="#cb8-5" aria-hidden="true" tabindex="-1"></a>  current<span class="op">:</span> <span class="dt">number</span><span class="op">;</span></span>
+<span id="cb8-6"><a href="#cb8-6" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** The warning threshold */</span></span>
+<span id="cb8-7"><a href="#cb8-7" aria-hidden="true" tabindex="-1"></a>  warn_threshold<span class="op">:</span> <span class="dt">number</span><span class="op">;</span></span>
+<span id="cb8-8"><a href="#cb8-8" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** The next threshold (pause or hard stop) */</span></span>
+<span id="cb8-9"><a href="#cb8-9" aria-hidden="true" tabindex="-1"></a>  pause_threshold<span class="op">?:</span> <span class="dt">number</span><span class="op">;</span></span>
+<span id="cb8-10"><a href="#cb8-10" aria-hidden="true" tabindex="-1"></a>  hard_stop_threshold<span class="op">?:</span> <span class="dt">number</span><span class="op">;</span></span>
+<span id="cb8-11"><a href="#cb8-11" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<p><strong>Example:</strong></p>
+<div class="sourceCode" id="cb9"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb9-1"><a href="#cb9-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb9-2"><a href="#cb9-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;code&quot;</span><span class="fu">:</span> <span class="st">&quot;RATE_LIMIT_QUOTA_WARNING&quot;</span><span class="fu">,</span></span>
+<span id="cb9-3"><a href="#cb9-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;Approaching quota limit&quot;</span><span class="fu">,</span></span>
+<span id="cb9-4"><a href="#cb9-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;details&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb9-5"><a href="#cb9-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;metric&quot;</span><span class="fu">:</span> <span class="st">&quot;requests_per_hour&quot;</span><span class="fu">,</span></span>
+<span id="cb9-6"><a href="#cb9-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;current&quot;</span><span class="fu">:</span> <span class="dv">4100</span><span class="fu">,</span></span>
+<span id="cb9-7"><a href="#cb9-7" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;warn_threshold&quot;</span><span class="fu">:</span> <span class="dv">4000</span><span class="fu">,</span></span>
+<span id="cb9-8"><a href="#cb9-8" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;pause_threshold&quot;</span><span class="fu">:</span> <span class="dv">4800</span></span>
+<span id="cb9-9"><a href="#cb9-9" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb9-10"><a href="#cb9-10" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<p><strong>Reference:</strong> <a href="../adapter/rate-limiting.html">Rate Limiting Specification</a></p>
+<h3 id="42-deprecation-warnings">4.2 Deprecation Warnings</h3>
+<h4 id="deprecation_warning">DEPRECATION_WARNING</h4>
+<p><strong>When used:</strong> A deprecated operation, parameter, or feature was used.</p>
+<p><strong>Message format:</strong> <code>{feature} is deprecated</code></p>
+<p><strong>Severity recommendations:</strong></p>
+<table>
+<thead>
+<tr>
+<th>Condition</th>
+<th>Severity</th>
+<th>Rationale</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Within 30 days of removal_date</td>
+<td><code>high</code></td>
+<td>Urgent migration required</td>
+</tr>
+<tr>
+<td>More than 30 days from removal_date</td>
+<td><code>medium</code></td>
+<td>Migration advisable</td>
+</tr>
+<tr>
+<td>No removal_date set (soft deprecation)</td>
+<td><code>low</code></td>
+<td>Informational, no urgency</td>
+</tr>
+</tbody>
+</table>
+<p><strong>Details:</strong></p>
+<div class="sourceCode" id="cb10"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb10-1"><a href="#cb10-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb10-2"><a href="#cb10-2" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** What is deprecated (operation, parameter, etc.) */</span></span>
+<span id="cb10-3"><a href="#cb10-3" aria-hidden="true" tabindex="-1"></a>  type<span class="op">:</span> <span class="st">&#39;operation&#39;</span> <span class="op">|</span> <span class="st">&#39;parameter&#39;</span> <span class="op">|</span> <span class="st">&#39;feature&#39;</span><span class="op">;</span></span>
+<span id="cb10-4"><a href="#cb10-4" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** Name of the deprecated item */</span></span>
+<span id="cb10-5"><a href="#cb10-5" aria-hidden="true" tabindex="-1"></a>  deprecated_item<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb10-6"><a href="#cb10-6" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** Replacement to use instead */</span></span>
+<span id="cb10-7"><a href="#cb10-7" aria-hidden="true" tabindex="-1"></a>  replacement<span class="op">?:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb10-8"><a href="#cb10-8" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** When the deprecated item will be removed */</span></span>
+<span id="cb10-9"><a href="#cb10-9" aria-hidden="true" tabindex="-1"></a>  removal_date<span class="op">?:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb10-10"><a href="#cb10-10" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** Link to migration documentation */</span></span>
+<span id="cb10-11"><a href="#cb10-11" aria-hidden="true" tabindex="-1"></a>  migration_guide<span class="op">?:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb10-12"><a href="#cb10-12" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<p><strong>Example:</strong></p>
+<div class="sourceCode" id="cb11"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb11-1"><a href="#cb11-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb11-2"><a href="#cb11-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;code&quot;</span><span class="fu">:</span> <span class="st">&quot;DEPRECATION_WARNING&quot;</span><span class="fu">,</span></span>
+<span id="cb11-3"><a href="#cb11-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;Operation &#39;list_users_v1&#39; is deprecated&quot;</span><span class="fu">,</span></span>
+<span id="cb11-4"><a href="#cb11-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;details&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb11-5"><a href="#cb11-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;operation&quot;</span><span class="fu">,</span></span>
+<span id="cb11-6"><a href="#cb11-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;deprecated_item&quot;</span><span class="fu">:</span> <span class="st">&quot;list_users_v1&quot;</span><span class="fu">,</span></span>
+<span id="cb11-7"><a href="#cb11-7" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;replacement&quot;</span><span class="fu">:</span> <span class="st">&quot;list_users&quot;</span><span class="fu">,</span></span>
+<span id="cb11-8"><a href="#cb11-8" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;removal_date&quot;</span><span class="fu">:</span> <span class="st">&quot;2027-01-01&quot;</span></span>
+<span id="cb11-9"><a href="#cb11-9" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb11-10"><a href="#cb11-10" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<h3 id="43-validation-warnings">4.3 Validation Warnings</h3>
+<h4 id="validation_truncated_warning">VALIDATION_TRUNCATED_WARNING</h4>
+<p><strong>When used:</strong> Response data was truncated due to size limits.</p>
+<p><strong>Message format:</strong> <code>Response truncated to {limit} items</code></p>
+<p><strong>Severity recommendations:</strong></p>
+<table>
+<thead>
+<tr>
+<th>Condition</th>
+<th>Severity</th>
+<th>Rationale</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Significant data loss (&gt;50% truncated)</td>
+<td><code>medium</code></td>
+<td>User may miss important data</td>
+</tr>
+<tr>
+<td>Minor truncation (≤50% truncated)</td>
+<td><code>low</code></td>
+<td>Informational, pagination available</td>
+</tr>
+</tbody>
+</table>
+<p><strong>Details:</strong></p>
+<div class="sourceCode" id="cb12"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb12-1"><a href="#cb12-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb12-2"><a href="#cb12-2" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** What was truncated */</span></span>
+<span id="cb12-3"><a href="#cb12-3" aria-hidden="true" tabindex="-1"></a>  field<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb12-4"><a href="#cb12-4" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** Original count before truncation */</span></span>
+<span id="cb12-5"><a href="#cb12-5" aria-hidden="true" tabindex="-1"></a>  original_count<span class="op">:</span> <span class="dt">number</span><span class="op">;</span></span>
+<span id="cb12-6"><a href="#cb12-6" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** Count after truncation */</span></span>
+<span id="cb12-7"><a href="#cb12-7" aria-hidden="true" tabindex="-1"></a>  truncated_count<span class="op">:</span> <span class="dt">number</span><span class="op">;</span></span>
+<span id="cb12-8"><a href="#cb12-8" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** The limit that was applied */</span></span>
+<span id="cb12-9"><a href="#cb12-9" aria-hidden="true" tabindex="-1"></a>  limit<span class="op">:</span> <span class="dt">number</span><span class="op">;</span></span>
+<span id="cb12-10"><a href="#cb12-10" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<p><strong>Example:</strong></p>
+<div class="sourceCode" id="cb13"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb13-1"><a href="#cb13-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb13-2"><a href="#cb13-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;code&quot;</span><span class="fu">:</span> <span class="st">&quot;VALIDATION_TRUNCATED_WARNING&quot;</span><span class="fu">,</span></span>
+<span id="cb13-3"><a href="#cb13-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;Response truncated to 100 items&quot;</span><span class="fu">,</span></span>
+<span id="cb13-4"><a href="#cb13-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;details&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb13-5"><a href="#cb13-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;field&quot;</span><span class="fu">:</span> <span class="st">&quot;results&quot;</span><span class="fu">,</span></span>
+<span id="cb13-6"><a href="#cb13-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;original_count&quot;</span><span class="fu">:</span> <span class="dv">1523</span><span class="fu">,</span></span>
+<span id="cb13-7"><a href="#cb13-7" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;truncated_count&quot;</span><span class="fu">:</span> <span class="dv">100</span><span class="fu">,</span></span>
+<span id="cb13-8"><a href="#cb13-8" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;limit&quot;</span><span class="fu">:</span> <span class="dv">100</span></span>
+<span id="cb13-9"><a href="#cb13-9" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb13-10"><a href="#cb13-10" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<h3 id="44-performance-warnings">4.4 Performance Warnings</h3>
+<h4 id="performance_slow_query_warning">PERFORMANCE_SLOW_QUERY_WARNING</h4>
+<p><strong>When used:</strong> An operation took longer than expected to complete.</p>
+<p><strong>Message format:</strong> <code>Operation took {duration}ms (threshold: {threshold}ms)</code></p>
+<p><strong>Severity recommendations:</strong></p>
+<table>
+<thead>
+<tr>
+<th>Condition</th>
+<th>Severity</th>
+<th>Rationale</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>&gt;10x threshold exceeded</td>
+<td><code>high</code></td>
+<td>Severe degradation, may indicate systemic issue</td>
+</tr>
+<tr>
+<td>2-10x threshold exceeded</td>
+<td><code>medium</code></td>
+<td>Notable slowdown, optimization recommended</td>
+</tr>
+<tr>
+<td>Just above threshold (&lt;2x)</td>
+<td><code>low</code></td>
+<td>Minor performance concern</td>
+</tr>
+</tbody>
+</table>
+<p><strong>Details:</strong></p>
+<div class="sourceCode" id="cb14"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb14-1"><a href="#cb14-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb14-2"><a href="#cb14-2" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** Operation that was slow */</span></span>
+<span id="cb14-3"><a href="#cb14-3" aria-hidden="true" tabindex="-1"></a>  operation<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb14-4"><a href="#cb14-4" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** Actual duration in milliseconds */</span></span>
+<span id="cb14-5"><a href="#cb14-5" aria-hidden="true" tabindex="-1"></a>  duration_ms<span class="op">:</span> <span class="dt">number</span><span class="op">;</span></span>
+<span id="cb14-6"><a href="#cb14-6" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** Threshold that was exceeded */</span></span>
+<span id="cb14-7"><a href="#cb14-7" aria-hidden="true" tabindex="-1"></a>  threshold_ms<span class="op">:</span> <span class="dt">number</span><span class="op">;</span></span>
+<span id="cb14-8"><a href="#cb14-8" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** Suggestions for improvement */</span></span>
+<span id="cb14-9"><a href="#cb14-9" aria-hidden="true" tabindex="-1"></a>  suggestions<span class="op">?:</span> <span class="dt">string</span>[]<span class="op">;</span></span>
+<span id="cb14-10"><a href="#cb14-10" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<p><strong>Example:</strong></p>
+<div class="sourceCode" id="cb15"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb15-1"><a href="#cb15-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb15-2"><a href="#cb15-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;code&quot;</span><span class="fu">:</span> <span class="st">&quot;PERFORMANCE_SLOW_QUERY_WARNING&quot;</span><span class="fu">,</span></span>
+<span id="cb15-3"><a href="#cb15-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;Operation took 5230ms (threshold: 1000ms)&quot;</span><span class="fu">,</span></span>
+<span id="cb15-4"><a href="#cb15-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;details&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb15-5"><a href="#cb15-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;search_all&quot;</span><span class="fu">,</span></span>
+<span id="cb15-6"><a href="#cb15-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;duration_ms&quot;</span><span class="fu">:</span> <span class="dv">5230</span><span class="fu">,</span></span>
+<span id="cb15-7"><a href="#cb15-7" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;threshold_ms&quot;</span><span class="fu">:</span> <span class="dv">1000</span><span class="fu">,</span></span>
+<span id="cb15-8"><a href="#cb15-8" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;suggestions&quot;</span><span class="fu">:</span> <span class="ot">[</span></span>
+<span id="cb15-9"><a href="#cb15-9" aria-hidden="true" tabindex="-1"></a>      <span class="st">&quot;Consider adding filters to narrow results&quot;</span><span class="ot">,</span></span>
+<span id="cb15-10"><a href="#cb15-10" aria-hidden="true" tabindex="-1"></a>      <span class="st">&quot;Use pagination for large result sets&quot;</span></span>
+<span id="cb15-11"><a href="#cb15-11" aria-hidden="true" tabindex="-1"></a>    <span class="ot">]</span></span>
+<span id="cb15-12"><a href="#cb15-12" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb15-13"><a href="#cb15-13" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<hr />
+<h2 id="5-client-requirements">5. Client Requirements</h2>
+<h3 id="51-processing-warnings">5.1 Processing Warnings</h3>
+<p>Clients MUST:</p>
+<ol type="1">
+<li><strong>Accept warnings gracefully</strong> - Responses with warnings are valid successful responses</li>
+<li><strong>Not fail on unknown codes</strong> - New warning codes may be added</li>
+</ol>
+<p>Clients SHOULD:</p>
+<ol type="1">
+<li><strong>Log warnings</strong> - Record warnings for monitoring and debugging</li>
+<li><strong>Display warnings to users</strong> - Make warnings visible when appropriate</li>
+<li><strong>Surface quota warnings</strong> - Rate limit warnings warrant user attention</li>
+</ol>
+<p>Clients MAY:</p>
+<ol type="1">
+<li><strong>Take automated action</strong> - Adjust behavior based on warning codes</li>
+<li><strong>Filter warnings</strong> - Suppress warnings that aren't relevant</li>
+<li><strong>Aggregate warnings</strong> - Combine similar warnings for display</li>
+</ol>
+<h3 id="52-client-handling-algorithm">5.2 Client Handling Algorithm</h3>
+<div class="sourceCode" id="cb16"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb16-1"><a href="#cb16-1" aria-hidden="true" tabindex="-1"></a><span class="kw">function</span> <span class="fu">handleResponse</span><span class="op">&lt;</span>T<span class="op">&gt;</span>(response<span class="op">:</span> SuccessResponse<span class="op">&lt;</span>T<span class="op">&gt;</span> <span class="op">|</span> ErrorResponse)<span class="op">:</span> T {</span>
+<span id="cb16-2"><a href="#cb16-2" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> (<span class="op">!</span>response<span class="op">.</span><span class="at">success</span>) {</span>
+<span id="cb16-3"><a href="#cb16-3" aria-hidden="true" tabindex="-1"></a>    <span class="cf">throw</span> <span class="kw">new</span> <span class="bu">Error</span>(response<span class="op">.</span><span class="at">error</span><span class="op">.</span><span class="at">message</span>)<span class="op">;</span></span>
+<span id="cb16-4"><a href="#cb16-4" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb16-5"><a href="#cb16-5" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb16-6"><a href="#cb16-6" aria-hidden="true" tabindex="-1"></a>  <span class="co">// Process warnings if present</span></span>
+<span id="cb16-7"><a href="#cb16-7" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> (response<span class="op">.</span><span class="at">warnings</span> <span class="op">&amp;&amp;</span> response<span class="op">.</span><span class="at">warnings</span><span class="op">.</span><span class="at">length</span> <span class="op">&gt;</span> <span class="dv">0</span>) {</span>
+<span id="cb16-8"><a href="#cb16-8" aria-hidden="true" tabindex="-1"></a>    <span class="cf">for</span> (<span class="kw">const</span> warning <span class="kw">of</span> response<span class="op">.</span><span class="at">warnings</span>) {</span>
+<span id="cb16-9"><a href="#cb16-9" aria-hidden="true" tabindex="-1"></a>      <span class="co">// Log all warnings</span></span>
+<span id="cb16-10"><a href="#cb16-10" aria-hidden="true" tabindex="-1"></a>      logger<span class="op">.</span><span class="fu">warn</span>(<span class="vs">`[</span><span class="sc">${</span>warning<span class="op">.</span><span class="at">code</span><span class="sc">}</span><span class="vs">] </span><span class="sc">${</span>warning<span class="op">.</span><span class="at">message</span><span class="sc">}</span><span class="vs">`</span><span class="op">,</span> warning<span class="op">.</span><span class="at">details</span>)<span class="op">;</span></span>
+<span id="cb16-11"><a href="#cb16-11" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb16-12"><a href="#cb16-12" aria-hidden="true" tabindex="-1"></a>      <span class="co">// Take action on specific warnings</span></span>
+<span id="cb16-13"><a href="#cb16-13" aria-hidden="true" tabindex="-1"></a>      <span class="cf">if</span> (warning<span class="op">.</span><span class="at">code</span> <span class="op">===</span> <span class="st">&#39;RATE_LIMIT_QUOTA_WARNING&#39;</span>) {</span>
+<span id="cb16-14"><a href="#cb16-14" aria-hidden="true" tabindex="-1"></a>        <span class="fu">displayQuotaWarning</span>(warning)<span class="op">;</span></span>
+<span id="cb16-15"><a href="#cb16-15" aria-hidden="true" tabindex="-1"></a>      }</span>
+<span id="cb16-16"><a href="#cb16-16" aria-hidden="true" tabindex="-1"></a>    }</span>
+<span id="cb16-17"><a href="#cb16-17" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb16-18"><a href="#cb16-18" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb16-19"><a href="#cb16-19" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> response<span class="op">.</span><span class="at">data</span><span class="op">;</span></span>
+<span id="cb16-20"><a href="#cb16-20" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<h3 id="53-display-guidelines">5.3 Display Guidelines</h3>
+<p>When displaying warnings to users:</p>
+<table>
+<thead>
+<tr>
+<th>Warning Category</th>
+<th>Display Recommendation</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>RATE_LIMIT_</code></td>
+<td>Prominent, real-time indicator</td>
+</tr>
+<tr>
+<td><code>DEPRECATION_</code></td>
+<td>One-time notification per session</td>
+</tr>
+<tr>
+<td><code>VALIDATION_</code></td>
+<td>Inline with affected data</td>
+</tr>
+<tr>
+<td><code>PERFORMANCE_</code></td>
+<td>Status bar or background notification</td>
+</tr>
+</tbody>
+</table>
+<hr />
+<h2 id="6-implementation-requirements">6. Implementation Requirements</h2>
+<h3 id="61-must-requirements">6.1 MUST Requirements</h3>
+<p>Implementations supporting warnings MUST:</p>
+<ol type="1">
+<li>Include <code>warnings</code> only in successful responses (<code>success: true</code>)</li>
+<li>Use array format even for single warnings</li>
+<li>Include <code>code</code> and <code>message</code> in all warning objects</li>
+<li>Use consistent warning codes within the adapter</li>
+</ol>
+<h3 id="62-should-requirements">6.2 SHOULD Requirements</h3>
+<p>Implementations supporting warnings SHOULD:</p>
+<ol type="1">
+<li>Include <code>details</code> with contextual information</li>
+<li>Use standard warning codes when applicable</li>
+<li>Limit warnings to actionable conditions</li>
+<li>Aggregate similar warnings rather than repeating</li>
+</ol>
+<h3 id="63-may-requirements">6.3 MAY Requirements</h3>
+<p>Implementations supporting warnings MAY:</p>
+<ol type="1">
+<li>Allow clients to suppress specific warning codes</li>
+<li>Provide warning history via introspection</li>
+<li>Configure warning thresholds</li>
+<li>Include warnings in audit logs</li>
+</ol>
+<h3 id="64-warning-limits">6.4 Warning Limits</h3>
+<p>To prevent response bloat:</p>
+<ul>
+<li>Implementations SHOULD limit warnings to 10 per response</li>
+<li>If more warnings apply, implementations SHOULD include the most important</li>
+<li>Implementations MAY include a meta-warning about suppressed warnings</li>
+</ul>
+<h3 id="65-warning-deduplication">6.5 Warning Deduplication</h3>
+<p>Duplicate warnings (same <code>code</code> and semantically equivalent <code>details</code>) can occur when multiple subsystems generate the same warning or when batch operations trigger repeated conditions.</p>
+<h4 id="server-side-deduplication">Server-Side Deduplication</h4>
+<p>Implementations SHOULD deduplicate warnings before including them in responses:</p>
+<ol type="1">
+<li><strong>Exact duplicates</strong> - Warnings with identical <code>code</code> and <code>details</code> SHOULD be collapsed to a single instance</li>
+<li><strong>Semantic duplicates</strong> - Warnings with the same <code>code</code> but minor variations in <code>details</code> (e.g., same metric at same threshold) MAY be collapsed</li>
+<li><strong>Counting</strong> - When deduplicating, implementations MAY add an <code>occurrence_count</code> field to indicate how many times the warning occurred</li>
+</ol>
+<p><strong>Example with occurrence count:</strong></p>
+<div class="sourceCode" id="cb17"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb17-1"><a href="#cb17-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb17-2"><a href="#cb17-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;code&quot;</span><span class="fu">:</span> <span class="st">&quot;VALIDATION_TRUNCATED_WARNING&quot;</span><span class="fu">,</span></span>
+<span id="cb17-3"><a href="#cb17-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;Response truncated to 100 items&quot;</span><span class="fu">,</span></span>
+<span id="cb17-4"><a href="#cb17-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;details&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb17-5"><a href="#cb17-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;field&quot;</span><span class="fu">:</span> <span class="st">&quot;results&quot;</span><span class="fu">,</span></span>
+<span id="cb17-6"><a href="#cb17-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;truncated_count&quot;</span><span class="fu">:</span> <span class="dv">100</span><span class="fu">,</span></span>
+<span id="cb17-7"><a href="#cb17-7" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;occurrence_count&quot;</span><span class="fu">:</span> <span class="dv">3</span></span>
+<span id="cb17-8"><a href="#cb17-8" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb17-9"><a href="#cb17-9" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<h4 id="client-side-deduplication">Client-Side Deduplication</h4>
+<p>Clients MAY implement additional deduplication when:</p>
+<ol type="1">
+<li><strong>Session-level deduplication</strong> - Suppress warnings already shown in the current session (a session is the lifetime of a single MCP connection; see <a href="../versions/v1.0.0-draft.html#23-session-lifecycle">Section 2.3</a>)</li>
+<li><strong>Time-based deduplication</strong> - Suppress warnings seen within a configurable window (e.g., 5 minutes)</li>
+<li><strong>Code-based filtering</strong> - Allow users to dismiss specific warning codes</li>
+</ol>
+<p><strong>Client deduplication example:</strong></p>
+<div class="sourceCode" id="cb18"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb18-1"><a href="#cb18-1" aria-hidden="true" tabindex="-1"></a><span class="kw">class</span> WarningDeduplicator {</span>
+<span id="cb18-2"><a href="#cb18-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">private</span> seen <span class="op">=</span> <span class="kw">new</span> <span class="bu">Map</span><span class="op">&lt;</span><span class="dt">string</span><span class="op">,</span> <span class="dt">number</span><span class="op">&gt;</span>()<span class="op">;</span> <span class="co">// code -&gt; timestamp</span></span>
+<span id="cb18-3"><a href="#cb18-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">private</span> deduplicationWindowMs <span class="op">=</span> <span class="dv">5</span> <span class="op">*</span> <span class="dv">60</span> <span class="op">*</span> <span class="dv">1000</span><span class="op">;</span> <span class="co">// 5 minutes</span></span>
+<span id="cb18-4"><a href="#cb18-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb18-5"><a href="#cb18-5" aria-hidden="true" tabindex="-1"></a>  <span class="fu">shouldShow</span>(warning<span class="op">:</span> Warning)<span class="op">:</span> <span class="dt">boolean</span> {</span>
+<span id="cb18-6"><a href="#cb18-6" aria-hidden="true" tabindex="-1"></a>    <span class="kw">const</span> key <span class="op">=</span> <span class="vs">`</span><span class="sc">${</span>warning<span class="op">.</span><span class="at">code</span><span class="sc">}</span><span class="vs">:</span><span class="sc">${</span><span class="bu">JSON</span><span class="op">.</span><span class="fu">stringify</span>(warning<span class="op">.</span><span class="at">details</span>)<span class="sc">}</span><span class="vs">`</span><span class="op">;</span></span>
+<span id="cb18-7"><a href="#cb18-7" aria-hidden="true" tabindex="-1"></a>    <span class="kw">const</span> lastSeen <span class="op">=</span> <span class="kw">this</span><span class="op">.</span><span class="at">seen</span><span class="op">.</span><span class="fu">get</span>(key)<span class="op">;</span></span>
+<span id="cb18-8"><a href="#cb18-8" aria-hidden="true" tabindex="-1"></a>    <span class="kw">const</span> now <span class="op">=</span> <span class="bu">Date</span><span class="op">.</span><span class="fu">now</span>()<span class="op">;</span></span>
+<span id="cb18-9"><a href="#cb18-9" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb18-10"><a href="#cb18-10" aria-hidden="true" tabindex="-1"></a>    <span class="cf">if</span> (lastSeen <span class="op">&amp;&amp;</span> now <span class="op">-</span> lastSeen <span class="op">&lt;</span> <span class="kw">this</span><span class="op">.</span><span class="at">deduplicationWindowMs</span>) {</span>
+<span id="cb18-11"><a href="#cb18-11" aria-hidden="true" tabindex="-1"></a>      <span class="cf">return</span> <span class="kw">false</span><span class="op">;</span> <span class="co">// Suppress duplicate</span></span>
+<span id="cb18-12"><a href="#cb18-12" aria-hidden="true" tabindex="-1"></a>    }</span>
+<span id="cb18-13"><a href="#cb18-13" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb18-14"><a href="#cb18-14" aria-hidden="true" tabindex="-1"></a>    <span class="kw">this</span><span class="op">.</span><span class="at">seen</span><span class="op">.</span><span class="fu">set</span>(key<span class="op">,</span> now)<span class="op">;</span></span>
+<span id="cb18-15"><a href="#cb18-15" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> <span class="kw">true</span><span class="op">;</span></span>
+<span id="cb18-16"><a href="#cb18-16" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb18-17"><a href="#cb18-17" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<h4 id="deduplication-recommendations">Deduplication Recommendations</h4>
+<table>
+<thead>
+<tr>
+<th>Context</th>
+<th>Recommendation</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Single request</td>
+<td>Server SHOULD deduplicate identical warnings</td>
+</tr>
+<tr>
+<td>Batch operations</td>
+<td>Server SHOULD collapse per-item warnings into summary</td>
+</tr>
+<tr>
+<td>Client session</td>
+<td>Client MAY deduplicate across requests</td>
+</tr>
+<tr>
+<td>Long-running clients</td>
+<td>Client SHOULD use time-based expiration</td>
+</tr>
+</tbody>
+</table>
+<hr />
+<h2 id="references">References</h2>
+<ul>
+<li><a href="../adr/ADR-006-discriminated-responses.html">ADR-006: Discriminated Response Format</a></li>
+<li><a href="../error-codes.html">Error Codes Specification</a></li>
+<li><a href="../adapter/rate-limiting.html">Rate Limiting Specification</a></li>
+<li>GitHub Issue: <a href="https://github.com/MCPAQL/spec/issues/80">#80</a></li>
+</ul>
+
+          </div>
+        </section>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div class="container">
+      <p>&copy; 2026 DollhouseMCP Inc. d/b/a Dollhouse Research. MCP-AQL public draft documentation portal.</p>
+      <div class="footer-links">
+        <a href="../../docs/index.html">Docs Library</a>
+        <a href="../index.html">Repo-Synced Spec</a>
+        <a href="https://github.com/MCPAQL">MCPAQL Organization</a>
+        <a href="https://dollhouseresearch.com">Dollhouse Research</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../../js/search.js"></script>
+</body>
+</html>

--- a/public/spec/features/warnings.html
+++ b/public/spec/features/warnings.html
@@ -73,6 +73,13 @@
       </aside>
 
       <article class="docs-main">
+        <nav class="breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../../index.html">Home</a></li>
+            <li><a href="../index.html">Full Spec</a></li>
+            <li><span class="current">Warnings Array Specification</span></li>
+          </ol>
+        </nav>
         <section class="hero docs-hero">
           <div class="hero-inner">
             <span class="status-pill">REPO-SYNCED SPEC DOC</span>

--- a/public/spec/features/warnings.html
+++ b/public/spec/features/warnings.html
@@ -23,7 +23,7 @@
         </ul>
         <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
-          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <input id="site-search-input" data-search-input type="search" placeholder="Search MCP-AQL docs, spec pages, and adapter patterns...">
           <span class="search-count" data-search-count></span>
           <ul class="search-results" data-search-results hidden></ul>
         </form>
@@ -50,7 +50,7 @@
   <ul><li><a href="../security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="../security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="../security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Features</h3>
-  <ul><li><a href="field-selection.html">Field Selection Specification</a></li><li><a href="pagination.html">Cursor-Based Pagination Specification</a></li><li><a class="current" href="warnings.html">Warnings Array Specification</a></li></ul>
+  <ul><li><a href="field-selection.html">Field Selection Specification</a></li><li><a href="pagination.html">Cursor-Based Pagination Specification</a></li><li><a class="current" aria-current="page" href="warnings.html">Warnings Array Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Guides</h3>
   <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
@@ -814,6 +814,16 @@
 
           </div>
         </section>
+        <nav class="page-nav" aria-label="Page navigation">
+  <a class="page-nav-link prev" href="pagination.html">
+    <span class="page-nav-eyebrow">Previous spec page</span>
+    <strong class="page-nav-label">Cursor-Based Pagination Specification</strong>
+  </a>
+  <a class="page-nav-link next" href="../guides/protocol-comparison.html">
+    <span class="page-nav-eyebrow">Next spec page</span>
+    <strong class="page-nav-label">Protocol Comparison Guide</strong>
+  </a>
+</nav>
       </article>
     </div>
   </main>

--- a/public/spec/features/warnings.html
+++ b/public/spec/features/warnings.html
@@ -38,7 +38,7 @@
         <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
         <div class="docs-side-group">
   <h3>Core</h3>
-  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li></ul>
+  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li><li><a href="../repo/README.html">MCP-AQL Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Versions</h3>
   <ul><li><a href="../versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
@@ -56,7 +56,7 @@
   <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
-  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li></ul>
+  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li><li><a href="../repo/CHANGELOG.html">Changelog</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Architecture</h3>
   <ul><li><a href="../architecture/README.html">Architecture Documentation</a></li></ul>

--- a/public/spec/guides/README.html
+++ b/public/spec/guides/README.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Step-by-step guides for implementing and using MCP-AQL adapters.">
+  <title>MCP-AQL Spec | Developer Guides</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../../css/style.css">
+</head>
+<body>
+  <header>
+    <div class="container">
+      <nav>
+        <a class="logo" href="../../index.html"><span class="logo-mark"></span>MCP-AQL</a>
+        <ul class="nav-links">
+          <li><a href="../../index.html">Home</a></li>
+          <li><a href="../../docs/index.html">Docs</a></li>
+          <li><a href="../../launch-checklist.html">Launch Checklist</a></li>
+          <li><a href="../../apis/mcp-server.html">Adapter Patterns</a></li>
+        </ul>
+        <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
+          <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
+          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <span class="search-count" data-search-count></span>
+          <ul class="search-results" data-search-results hidden></ul>
+        </form>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <div class="container docs-shell">
+      <aside class="docs-side">
+        <h2>Repo-Synced Spec</h2>
+        <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
+        <div class="docs-side-group">
+  <h3>Core</h3>
+  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Versions</h3>
+  <ul><li><a href="../versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Adapter</h3>
+  <ul><li><a href="../adapter/danger-levels.html">Dangerous Operation Classification Specification</a></li><li><a href="../adapter/discovery-bundle.html">MCP Server Discovery Bundle</a></li><li><a href="../adapter/element-type.html">Adapter Element Type Specification</a></li><li><a href="../adapter/generator.html">Adapter Generator Specification</a></li><li><a href="../adapter/rate-limiting.html">Rate Limiting and Quota Management Specification</a></li><li><a href="../adapter/trust-levels.html">Trust Levels Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Security</h3>
+  <ul><li><a href="../security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="../security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="../security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Features</h3>
+  <ul><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Guides</h3>
+  <ul><li><a href="protocol-comparison.html">Protocol Comparison Guide</a></li><li><a class="current" href="README.html">Developer Guides</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Process</h3>
+  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Architecture</h3>
+  <ul><li><a href="../architecture/README.html">Architecture Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Research</h3>
+  <ul><li><a href="../research/mcp-vs-mcpaql-vs-a2a.html">Protocol Landscape: MCP vs MCP-AQL vs A2A</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Reference</h3>
+  <ul><li><a href="../reference/README.html">Reference Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>ADRs</h3>
+  <ul><li><a href="../adr/ADR-001-crude-pattern.html">ADR-001: CRUDE Pattern (Extending CRUD with Execute)</a></li><li><a href="../adr/ADR-002-graphql-style-input.html">ADR-002: GraphQL-Style Input Objects for Updates</a></li><li><a href="../adr/ADR-003-snake-case-parameters.html">ADR-003: snake_case Parameter Convention</a></li><li><a href="../adr/ADR-004-schema-driven-operations.html">ADR-004: Schema-Driven Operation Definitions</a></li><li><a href="../adr/ADR-005-introspection-system.html">ADR-005: GraphQL-Style Introspection System</a></li><li><a href="../adr/ADR-006-discriminated-responses.html">ADR-006: Discriminated Response Format</a></li><li><a href="../adr/index.html">Architecture Decision Records</a></li><li><a href="../adr/README.html">Architecture Decision Records</a></li></ul>
+</div>
+      </aside>
+
+      <article class="docs-main">
+        <section class="hero docs-hero">
+          <div class="hero-inner">
+            <span class="status-pill">REPO-SYNCED SPEC DOC</span>
+            <h1>Developer Guides</h1>
+            <p class="lede">Step-by-step guides for implementing and using MCP-AQL adapters.</p>
+            <div class="spec-meta"><span class="state-chip live">Support document</span></div>
+            <p class="spec-source">Source: <a href="https://github.com/MCPAQL/spec/blob/main/docs/guides/README.md">spec/docs/guides/README.md</a></p>
+            <div class="hero-actions">
+              <a class="btn btn-primary" href="https://github.com/MCPAQL/spec/blob/main/docs/guides/README.md">Open Source Markdown</a>
+              <a class="btn btn-secondary" href="../index.html">Browse Full Spec Reference</a>
+            </div>
+          </div>
+        </section>
+
+        <section>
+          <div class="card spec-prose">
+            <p>Step-by-step guides for implementing and using MCP-AQL adapters.</p>
+
+          </div>
+        </section>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div class="container">
+      <p>&copy; 2026 DollhouseMCP Inc. d/b/a Dollhouse Research. MCP-AQL public draft documentation portal.</p>
+      <div class="footer-links">
+        <a href="../../docs/index.html">Docs Library</a>
+        <a href="../index.html">Repo-Synced Spec</a>
+        <a href="https://github.com/MCPAQL">MCPAQL Organization</a>
+        <a href="https://dollhouseresearch.com">Dollhouse Research</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../../js/search.js"></script>
+</body>
+</html>

--- a/public/spec/guides/README.html
+++ b/public/spec/guides/README.html
@@ -73,6 +73,13 @@
       </aside>
 
       <article class="docs-main">
+        <nav class="breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../../index.html">Home</a></li>
+            <li><a href="../index.html">Full Spec</a></li>
+            <li><span class="current">Developer Guides</span></li>
+          </ol>
+        </nav>
         <section class="hero docs-hero">
           <div class="hero-inner">
             <span class="status-pill">REPO-SYNCED SPEC DOC</span>

--- a/public/spec/guides/README.html
+++ b/public/spec/guides/README.html
@@ -23,7 +23,7 @@
         </ul>
         <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
-          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <input id="site-search-input" data-search-input type="search" placeholder="Search MCP-AQL docs, spec pages, and adapter patterns...">
           <span class="search-count" data-search-count></span>
           <ul class="search-results" data-search-results hidden></ul>
         </form>
@@ -53,7 +53,7 @@
   <ul><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Guides</h3>
-  <ul><li><a href="protocol-comparison.html">Protocol Comparison Guide</a></li><li><a class="current" href="README.html">Developer Guides</a></li></ul>
+  <ul><li><a href="protocol-comparison.html">Protocol Comparison Guide</a></li><li><a class="current" aria-current="page" href="README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
   <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li><li><a href="../repo/CHANGELOG.html">Changelog</a></li></ul>
@@ -100,6 +100,16 @@
 
           </div>
         </section>
+        <nav class="page-nav" aria-label="Page navigation">
+  <a class="page-nav-link prev" href="protocol-comparison.html">
+    <span class="page-nav-eyebrow">Previous spec page</span>
+    <strong class="page-nav-label">Protocol Comparison Guide</strong>
+  </a>
+  <a class="page-nav-link next" href="../process/breaking-changes.html">
+    <span class="page-nav-eyebrow">Next spec page</span>
+    <strong class="page-nav-label">MCP-AQL Breaking Change Policy</strong>
+  </a>
+</nav>
       </article>
     </div>
   </main>

--- a/public/spec/guides/README.html
+++ b/public/spec/guides/README.html
@@ -38,7 +38,7 @@
         <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
         <div class="docs-side-group">
   <h3>Core</h3>
-  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li></ul>
+  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li><li><a href="../repo/README.html">MCP-AQL Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Versions</h3>
   <ul><li><a href="../versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
@@ -56,7 +56,7 @@
   <ul><li><a href="protocol-comparison.html">Protocol Comparison Guide</a></li><li><a class="current" href="README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
-  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li></ul>
+  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li><li><a href="../repo/CHANGELOG.html">Changelog</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Architecture</h3>
   <ul><li><a href="../architecture/README.html">Architecture Documentation</a></li></ul>

--- a/public/spec/guides/protocol-comparison.html
+++ b/public/spec/guides/protocol-comparison.html
@@ -73,6 +73,13 @@
       </aside>
 
       <article class="docs-main">
+        <nav class="breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../../index.html">Home</a></li>
+            <li><a href="../index.html">Full Spec</a></li>
+            <li><span class="current">Protocol Comparison Guide</span></li>
+          </ol>
+        </nav>
         <section class="hero docs-hero">
           <div class="hero-inner">
             <span class="status-pill">REPO-SYNCED SPEC DOC</span>

--- a/public/spec/guides/protocol-comparison.html
+++ b/public/spec/guides/protocol-comparison.html
@@ -38,7 +38,7 @@
         <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
         <div class="docs-side-group">
   <h3>Core</h3>
-  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li></ul>
+  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li><li><a href="../repo/README.html">MCP-AQL Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Versions</h3>
   <ul><li><a href="../versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
@@ -56,7 +56,7 @@
   <ul><li><a class="current" href="protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
-  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li></ul>
+  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li><li><a href="../repo/CHANGELOG.html">Changelog</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Architecture</h3>
   <ul><li><a href="../architecture/README.html">Architecture Documentation</a></li></ul>

--- a/public/spec/guides/protocol-comparison.html
+++ b/public/spec/guides/protocol-comparison.html
@@ -23,7 +23,7 @@
         </ul>
         <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
-          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <input id="site-search-input" data-search-input type="search" placeholder="Search MCP-AQL docs, spec pages, and adapter patterns...">
           <span class="search-count" data-search-count></span>
           <ul class="search-results" data-search-results hidden></ul>
         </form>
@@ -53,7 +53,7 @@
   <ul><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Guides</h3>
-  <ul><li><a class="current" href="protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="README.html">Developer Guides</a></li></ul>
+  <ul><li><a class="current" aria-current="page" href="protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
   <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li><li><a href="../repo/CHANGELOG.html">Changelog</a></li></ul>
@@ -1587,6 +1587,16 @@ GET /api/swagger.json HTTP/1.1</code></pre>
 
           </div>
         </section>
+        <nav class="page-nav" aria-label="Page navigation">
+  <a class="page-nav-link prev" href="../features/warnings.html">
+    <span class="page-nav-eyebrow">Previous spec page</span>
+    <strong class="page-nav-label">Warnings Array Specification</strong>
+  </a>
+  <a class="page-nav-link next" href="README.html">
+    <span class="page-nav-eyebrow">Next spec page</span>
+    <strong class="page-nav-label">Developer Guides</strong>
+  </a>
+</nav>
       </article>
     </div>
   </main>

--- a/public/spec/guides/protocol-comparison.html
+++ b/public/spec/guides/protocol-comparison.html
@@ -1,0 +1,1601 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="This document helps developers familiar with GraphQL, MongoDB, REST, SQL, or classic MCP understand MCP-AQL by mapping familiar concepts to their MCP-AQL equivalents.">
+  <title>MCP-AQL Spec | Protocol Comparison Guide</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../../css/style.css">
+</head>
+<body>
+  <header>
+    <div class="container">
+      <nav>
+        <a class="logo" href="../../index.html"><span class="logo-mark"></span>MCP-AQL</a>
+        <ul class="nav-links">
+          <li><a href="../../index.html">Home</a></li>
+          <li><a href="../../docs/index.html">Docs</a></li>
+          <li><a href="../../launch-checklist.html">Launch Checklist</a></li>
+          <li><a href="../../apis/mcp-server.html">Adapter Patterns</a></li>
+        </ul>
+        <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
+          <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
+          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <span class="search-count" data-search-count></span>
+          <ul class="search-results" data-search-results hidden></ul>
+        </form>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <div class="container docs-shell">
+      <aside class="docs-side">
+        <h2>Repo-Synced Spec</h2>
+        <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
+        <div class="docs-side-group">
+  <h3>Core</h3>
+  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Versions</h3>
+  <ul><li><a href="../versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Adapter</h3>
+  <ul><li><a href="../adapter/danger-levels.html">Dangerous Operation Classification Specification</a></li><li><a href="../adapter/discovery-bundle.html">MCP Server Discovery Bundle</a></li><li><a href="../adapter/element-type.html">Adapter Element Type Specification</a></li><li><a href="../adapter/generator.html">Adapter Generator Specification</a></li><li><a href="../adapter/rate-limiting.html">Rate Limiting and Quota Management Specification</a></li><li><a href="../adapter/trust-levels.html">Trust Levels Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Security</h3>
+  <ul><li><a href="../security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="../security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="../security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Features</h3>
+  <ul><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Guides</h3>
+  <ul><li><a class="current" href="protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="README.html">Developer Guides</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Process</h3>
+  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Architecture</h3>
+  <ul><li><a href="../architecture/README.html">Architecture Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Research</h3>
+  <ul><li><a href="../research/mcp-vs-mcpaql-vs-a2a.html">Protocol Landscape: MCP vs MCP-AQL vs A2A</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Reference</h3>
+  <ul><li><a href="../reference/README.html">Reference Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>ADRs</h3>
+  <ul><li><a href="../adr/ADR-001-crude-pattern.html">ADR-001: CRUDE Pattern (Extending CRUD with Execute)</a></li><li><a href="../adr/ADR-002-graphql-style-input.html">ADR-002: GraphQL-Style Input Objects for Updates</a></li><li><a href="../adr/ADR-003-snake-case-parameters.html">ADR-003: snake_case Parameter Convention</a></li><li><a href="../adr/ADR-004-schema-driven-operations.html">ADR-004: Schema-Driven Operation Definitions</a></li><li><a href="../adr/ADR-005-introspection-system.html">ADR-005: GraphQL-Style Introspection System</a></li><li><a href="../adr/ADR-006-discriminated-responses.html">ADR-006: Discriminated Response Format</a></li><li><a href="../adr/index.html">Architecture Decision Records</a></li><li><a href="../adr/README.html">Architecture Decision Records</a></li></ul>
+</div>
+      </aside>
+
+      <article class="docs-main">
+        <section class="hero docs-hero">
+          <div class="hero-inner">
+            <span class="status-pill">REPO-SYNCED SPEC DOC</span>
+            <h1>Protocol Comparison Guide</h1>
+            <p class="lede">This document helps developers familiar with GraphQL, MongoDB, REST, SQL, or classic MCP understand MCP-AQL by mapping familiar concepts to their MCP-AQL equivalents.</p>
+            <div class="spec-meta"><span class="state-chip live">Support document</span><span class="state-chip pending">draft</span><span class="state-chip">1.0.0</span></div>
+            <p class="spec-source">Source: <a href="https://github.com/MCPAQL/spec/blob/main/docs/guides/protocol-comparison.md">spec/docs/guides/protocol-comparison.md</a></p>
+            <div class="hero-actions">
+              <a class="btn btn-primary" href="https://github.com/MCPAQL/spec/blob/main/docs/guides/protocol-comparison.md">Open Source Markdown</a>
+              <a class="btn btn-secondary" href="../index.html">Browse Full Spec Reference</a>
+            </div>
+          </div>
+        </section>
+
+        <section>
+          <div class="card spec-prose">
+            <blockquote>
+<p>This document helps developers familiar with GraphQL, MongoDB, REST, SQL, or classic MCP understand MCP-AQL by mapping familiar concepts to their MCP-AQL equivalents.</p>
+</blockquote>
+<h2 id="table-of-contents">Table of Contents</h2>
+<ul>
+<li><a href="#introduction">Introduction</a></li>
+<li><a href="#quick-reference-table">Quick Reference Table</a></li>
+<li><a href="#for-graphql-developers">For GraphQL Developers</a></li>
+<li><a href="#for-mongodb-developers">For MongoDB Developers</a></li>
+<li><a href="#for-rest-api-developers">For REST API Developers</a></li>
+<li><a href="#for-sql-developers">For SQL Developers</a></li>
+<li><a href="#for-classic-mcp-users">For Classic MCP Users</a></li>
+<li><a href="#comprehensive-concept-mapping">Comprehensive Concept Mapping</a></li>
+<li><a href="#code-examples-same-operation-across-protocols">Code Examples: Same Operation Across Protocols</a></li>
+</ul>
+<hr />
+<h2 id="introduction">Introduction</h2>
+<p><strong>MCP-AQL</strong> (Model Context Protocol - Advanced Agent API Adapter Query Language) is a <strong>protocol pattern</strong> for consolidating multiple MCP tools into semantic endpoints. The core ideas are:</p>
+<ul>
+<li><strong>CRUDE Endpoints</strong> - Categorize operations by safety: Create, Read, Update, Delete, Execute</li>
+<li><strong>Operation Routing</strong> - A single <code>operation</code> parameter dispatches to the appropriate handler</li>
+<li><strong>Schema-Driven Dispatch</strong> - Declarative operation definitions with automatic validation</li>
+<li><strong>Introspection</strong> - On-demand discovery replaces upfront schema parsing</li>
+</ul>
+<h3 id="token-efficiency-by-mode">Token Efficiency by Mode</h3>
+<p>MCP-AQL supports multiple endpoint modes with different token trade-offs:</p>
+<table>
+<thead>
+<tr>
+<th>Mode</th>
+<th>Endpoints</th>
+<th>Token Cost</th>
+<th>Reduction</th>
+<th>Use Case</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>Discrete</strong></td>
+<td>Many individual tools</td>
+<td>~30,000</td>
+<td>Baseline</td>
+<td>Traditional MCP</td>
+</tr>
+<tr>
+<td><strong>CRUDE</strong></td>
+<td>5 semantic endpoints</td>
+<td>~4,300</td>
+<td>~85%</td>
+<td>Host-level permission control</td>
+</tr>
+<tr>
+<td><strong>Single</strong></td>
+<td>1 unified endpoint</td>
+<td>~1,100</td>
+<td>~96%</td>
+<td>Maximum token efficiency</td>
+</tr>
+</tbody>
+</table>
+<p><strong>Response Token Savings:</strong> Field selection (<code>fields</code> parameter) provides additional ~73-86% reduction in response tokens. Combined with endpoint consolidation, total savings can exceed 98%.</p>
+<h3 id="why-compare">Why Compare?</h3>
+<p>Developers often approach new protocols through the lens of what they already know. This guide provides mental models for understanding MCP-AQL by drawing parallels to:</p>
+<table>
+<thead>
+<tr>
+<th>Protocol</th>
+<th>Similarity to MCP-AQL</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>GraphQL</strong></td>
+<td>Introspection, typed operations, nested input objects</td>
+</tr>
+<tr>
+<td><strong>MongoDB</strong></td>
+<td>Document-based operations, flexible queries</td>
+</tr>
+<tr>
+<td><strong>REST</strong></td>
+<td>Resource-oriented endpoints, HTTP-like semantics</td>
+</tr>
+<tr>
+<td><strong>SQL</strong></td>
+<td>Structured queries, CRUD operations</td>
+</tr>
+<tr>
+<td><strong>Classic MCP</strong></td>
+<td>Tool-based interface (what MCP-AQL can replace)</td>
+</tr>
+</tbody>
+</table>
+<hr />
+<h2 id="core-design-philosophy">Core Design Philosophy</h2>
+<p>MCP-AQL optimizes for <strong>LLM token efficiency</strong> while maintaining <strong>human readability</strong>:</p>
+<ol type="1">
+<li><strong>Consolidated Endpoints</strong> - Semantic grouping instead of many discrete tools</li>
+<li><strong>On-Demand Discovery</strong> - Introspection replaces upfront schema parsing</li>
+<li><strong>Schema-Driven Dispatch</strong> - Declarative operation definitions with automatic validation</li>
+<li><strong>Flexible Parameter Resolution</strong> - Multiple sources checked for each parameter</li>
+</ol>
+<hr />
+<h2 id="quick-reference-table">Quick Reference Table</h2>
+<table>
+<thead>
+<tr>
+<th>Concept</th>
+<th>GraphQL</th>
+<th>MongoDB</th>
+<th>REST</th>
+<th>SQL</th>
+<th>MCP-AQL</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>Define Operation</strong></td>
+<td><code>mutation createUser</code></td>
+<td><code>db.users.insertOne()</code></td>
+<td><code>POST /users</code></td>
+<td><code>INSERT INTO users</code></td>
+<td><code>{ operation: "..." }</code></td>
+</tr>
+<tr>
+<td><strong>Specify Parameters</strong></td>
+<td><code>variables: { ... }</code></td>
+<td><code>{ filter: { ... } }</code></td>
+<td>Request body / query params</td>
+<td><code>WHERE clause</code></td>
+<td><code>params: { ... }</code></td>
+</tr>
+<tr>
+<td><strong>Target Type</strong></td>
+<td>Type in schema</td>
+<td>Collection name</td>
+<td>URL path</td>
+<td>Table name</td>
+<td>Implementation-defined</td>
+</tr>
+<tr>
+<td><strong>Read One</strong></td>
+<td><code>query { user(id) }</code></td>
+<td><code>findOne({ _id })</code></td>
+<td><code>GET /users/:id</code></td>
+<td><code>SELECT ... WHERE id=</code></td>
+<td>Read operation</td>
+</tr>
+<tr>
+<td><strong>Read Many</strong></td>
+<td><code>query { users }</code></td>
+<td><code>find({})</code></td>
+<td><code>GET /users</code></td>
+<td><code>SELECT * FROM</code></td>
+<td>List operation</td>
+</tr>
+<tr>
+<td><strong>Create</strong></td>
+<td><code>mutation { createUser }</code></td>
+<td><code>insertOne()</code></td>
+<td><code>POST /users</code></td>
+<td><code>INSERT INTO</code></td>
+<td>Create operation</td>
+</tr>
+<tr>
+<td><strong>Update</strong></td>
+<td><code>mutation { updateUser }</code></td>
+<td><code>updateOne()</code></td>
+<td><code>PUT /users/:id</code></td>
+<td><code>UPDATE ... SET</code></td>
+<td>Update operation</td>
+</tr>
+<tr>
+<td><strong>Delete</strong></td>
+<td><code>mutation { deleteUser }</code></td>
+<td><code>deleteOne()</code></td>
+<td><code>DELETE /users/:id</code></td>
+<td><code>DELETE FROM</code></td>
+<td>Delete operation</td>
+</tr>
+<tr>
+<td><strong>Search</strong></td>
+<td><code>query { search(q) }</code></td>
+<td><code>find({ $text })</code></td>
+<td><code>GET /search?q=</code></td>
+<td><code>LIKE '%term%'</code></td>
+<td>Search operation</td>
+</tr>
+<tr>
+<td><strong>Discover Schema</strong></td>
+<td><code>__schema</code> introspection</td>
+<td><code>db.getCollectionInfos()</code></td>
+<td>OpenAPI / Swagger</td>
+<td><code>DESCRIBE table</code></td>
+<td><code>introspect</code></td>
+</tr>
+<tr>
+<td><strong>Field Selection</strong></td>
+<td>Field list in query</td>
+<td>Projection <code>{ field: 1 }</code></td>
+<td><code>?fields=a,b</code></td>
+<td><code>SELECT a, b</code></td>
+<td><code>fields</code> param or preset</td>
+</tr>
+<tr>
+<td><strong>Response Format</strong></td>
+<td><code>{ data, errors }</code></td>
+<td>Document / cursor</td>
+<td>JSON body</td>
+<td>Result set</td>
+<td><code>{ success, data/error }</code></td>
+</tr>
+<tr>
+<td><strong>Error Handling</strong></td>
+<td><code>errors</code> array</td>
+<td>Exception</td>
+<td>HTTP status codes</td>
+<td>SQLSTATE</td>
+<td><code>{ success: false, error }</code></td>
+</tr>
+</tbody>
+</table>
+<hr />
+<h2 id="for-graphql-developers">For GraphQL Developers</h2>
+<p>If you are familiar with GraphQL, MCP-AQL will feel conceptually similar. Both protocols emphasize typed operations, introspection, and structured inputs.</p>
+<h3 id="operations--queriesmutations">Operations = Queries/Mutations</h3>
+<p>GraphQL separates read operations (queries) from write operations (mutations). MCP-AQL takes this further with the <strong>CRUDE pattern</strong> (5 semantic categories):</p>
+<table>
+<thead>
+<tr>
+<th>GraphQL</th>
+<th>MCP-AQL Endpoint</th>
+<th>Purpose</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>query</code></td>
+<td><code>mcp_aql_read</code></td>
+<td>Read-only operations</td>
+</tr>
+<tr>
+<td><code>mutation</code> (create)</td>
+<td><code>mcp_aql_create</code></td>
+<td>Additive operations</td>
+</tr>
+<tr>
+<td><code>mutation</code> (update)</td>
+<td><code>mcp_aql_update</code></td>
+<td>Modifying operations</td>
+</tr>
+<tr>
+<td><code>mutation</code> (delete)</td>
+<td><code>mcp_aql_delete</code></td>
+<td>Destructive operations</td>
+</tr>
+<tr>
+<td><code>subscription</code></td>
+<td><code>mcp_aql_execute</code></td>
+<td>Runtime/stateful operations</td>
+</tr>
+</tbody>
+</table>
+<p><strong>GraphQL:</strong></p>
+<div class="sourceCode" id="cb1"><pre class="sourceCode graphql"><code class="sourceCode graphql"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a><span class="kw">mutation</span> CreateUser(<span class="va">$input</span>: UserInput!) {</span>
+<span id="cb1-2"><a href="#cb1-2" aria-hidden="true" tabindex="-1"></a>  createUser(<span class="kw">input</span>: <span class="va">$input</span>) {</span>
+<span id="cb1-3"><a href="#cb1-3" aria-hidden="true" tabindex="-1"></a>    name</span>
+<span id="cb1-4"><a href="#cb1-4" aria-hidden="true" tabindex="-1"></a>    email</span>
+<span id="cb1-5"><a href="#cb1-5" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb1-6"><a href="#cb1-6" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<p><strong>MCP-AQL:</strong></p>
+<div class="sourceCode" id="cb2"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb2-2"><a href="#cb2-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;create_resource&quot;</span><span class="op">,</span></span>
+<span id="cb2-3"><a href="#cb2-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> {</span>
+<span id="cb2-4"><a href="#cb2-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">resource_type</span><span class="op">:</span> <span class="st">&quot;user&quot;</span><span class="op">,</span></span>
+<span id="cb2-5"><a href="#cb2-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">resource_id</span><span class="op">:</span> <span class="st">&quot;user-123&quot;</span><span class="op">,</span></span>
+<span id="cb2-6"><a href="#cb2-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;Alice&quot;</span><span class="op">,</span></span>
+<span id="cb2-7"><a href="#cb2-7" aria-hidden="true" tabindex="-1"></a>    <span class="dt">email</span><span class="op">:</span> <span class="st">&quot;alice@example.com&quot;</span></span>
+<span id="cb2-8"><a href="#cb2-8" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb2-9"><a href="#cb2-9" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<h3 id="resource-types">Resource Types</h3>
+<p>In GraphQL, you query specific types (<code>User</code>, <code>Post</code>). In MCP-AQL, implementations define their own resource type parameter:</p>
+<table>
+<thead>
+<tr>
+<th>GraphQL</th>
+<th>MCP-AQL Pattern</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>type User</code></td>
+<td><code>resource_type: "user"</code></td>
+</tr>
+<tr>
+<td><code>type Post</code></td>
+<td><code>resource_type: "post"</code></td>
+</tr>
+<tr>
+<td><code>type Comment</code></td>
+<td><code>resource_type: "comment"</code></td>
+</tr>
+</tbody>
+</table>
+<h3 id="introspection-__schema-vs-introspect">Introspection: <code>__schema</code> vs <code>introspect</code></h3>
+<p>Both protocols support self-description. MCP-AQL's introspection is modeled after GraphQL:</p>
+<p><strong>GraphQL:</strong></p>
+<div class="sourceCode" id="cb3"><pre class="sourceCode graphql"><code class="sourceCode graphql"><span id="cb3-1"><a href="#cb3-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb3-2"><a href="#cb3-2" aria-hidden="true" tabindex="-1"></a>  __schema {</span>
+<span id="cb3-3"><a href="#cb3-3" aria-hidden="true" tabindex="-1"></a>    types { name }</span>
+<span id="cb3-4"><a href="#cb3-4" aria-hidden="true" tabindex="-1"></a>    queryType { name }</span>
+<span id="cb3-5"><a href="#cb3-5" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb3-6"><a href="#cb3-6" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<p><strong>MCP-AQL:</strong></p>
+<div class="sourceCode" id="cb4"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb4-1"><a href="#cb4-1" aria-hidden="true" tabindex="-1"></a><span class="co">// List all operations</span></span>
+<span id="cb4-2"><a href="#cb4-2" aria-hidden="true" tabindex="-1"></a>{ <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;introspect&quot;</span><span class="op">,</span> <span class="dt">params</span><span class="op">:</span> { <span class="dt">query</span><span class="op">:</span> <span class="st">&quot;operations&quot;</span> } }</span>
+<span id="cb4-3"><a href="#cb4-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb4-4"><a href="#cb4-4" aria-hidden="true" tabindex="-1"></a><span class="co">// Get specific operation details</span></span>
+<span id="cb4-5"><a href="#cb4-5" aria-hidden="true" tabindex="-1"></a>{ <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;introspect&quot;</span><span class="op">,</span> <span class="dt">params</span><span class="op">:</span> { <span class="dt">query</span><span class="op">:</span> <span class="st">&quot;operations&quot;</span><span class="op">,</span> <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;create_resource&quot;</span> } }</span>
+<span id="cb4-6"><a href="#cb4-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb4-7"><a href="#cb4-7" aria-hidden="true" tabindex="-1"></a><span class="co">// List available types</span></span>
+<span id="cb4-8"><a href="#cb4-8" aria-hidden="true" tabindex="-1"></a>{ <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;introspect&quot;</span><span class="op">,</span> <span class="dt">params</span><span class="op">:</span> { <span class="dt">query</span><span class="op">:</span> <span class="st">&quot;types&quot;</span> } }</span></code></pre></div>
+<h3 id="nested-input-objects-graphql-style-updates">Nested Input Objects (GraphQL-style Updates)</h3>
+<p>MCP-AQL supports GraphQL-style nested <code>input</code> objects for updates. This allows partial updates with deep merging:</p>
+<p><strong>GraphQL:</strong></p>
+<div class="sourceCode" id="cb5"><pre class="sourceCode graphql"><code class="sourceCode graphql"><span id="cb5-1"><a href="#cb5-1" aria-hidden="true" tabindex="-1"></a><span class="kw">mutation</span> UpdateUser(<span class="va">$id</span>: <span class="dt">ID</span>!, <span class="va">$input</span>: UpdateUserInput!) {</span>
+<span id="cb5-2"><a href="#cb5-2" aria-hidden="true" tabindex="-1"></a>  updateUser(id: <span class="va">$id</span>, <span class="kw">input</span>: <span class="va">$input</span>) {</span>
+<span id="cb5-3"><a href="#cb5-3" aria-hidden="true" tabindex="-1"></a>    name</span>
+<span id="cb5-4"><a href="#cb5-4" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb5-5"><a href="#cb5-5" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<p><strong>MCP-AQL:</strong></p>
+<div class="sourceCode" id="cb6"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb6-1"><a href="#cb6-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb6-2"><a href="#cb6-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;update_resource&quot;</span><span class="op">,</span></span>
+<span id="cb6-3"><a href="#cb6-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> {</span>
+<span id="cb6-4"><a href="#cb6-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">resource_id</span><span class="op">:</span> <span class="st">&quot;user-123&quot;</span><span class="op">,</span></span>
+<span id="cb6-5"><a href="#cb6-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">input</span><span class="op">:</span> {                    <span class="co">// Everything in &#39;input&#39; gets deep-merged</span></span>
+<span id="cb6-6"><a href="#cb6-6" aria-hidden="true" tabindex="-1"></a>      <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;Updated Name&quot;</span><span class="op">,</span></span>
+<span id="cb6-7"><a href="#cb6-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">settings</span><span class="op">:</span> { <span class="dt">theme</span><span class="op">:</span> <span class="st">&quot;dark&quot;</span> }</span>
+<span id="cb6-8"><a href="#cb6-8" aria-hidden="true" tabindex="-1"></a>    }</span>
+<span id="cb6-9"><a href="#cb6-9" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb6-10"><a href="#cb6-10" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<h3 id="field-selection-graphql-style">Field Selection (GraphQL-style)</h3>
+<p>MCP-AQL supports GraphQL-style field selection to reduce response token usage. Implementations can support a <code>fields</code> parameter for specific fields or define presets for common use cases.</p>
+<p><strong>MCP-AQL Field Selection:</strong></p>
+<div class="sourceCode" id="cb7"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb7-1"><a href="#cb7-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb7-2"><a href="#cb7-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;list_resources&quot;</span><span class="op">,</span></span>
+<span id="cb7-3"><a href="#cb7-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> {</span>
+<span id="cb7-4"><a href="#cb7-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">resource_type</span><span class="op">:</span> <span class="st">&quot;user&quot;</span><span class="op">,</span></span>
+<span id="cb7-5"><a href="#cb7-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">fields</span><span class="op">:</span> [<span class="st">&quot;name&quot;</span><span class="op">,</span> <span class="st">&quot;description&quot;</span><span class="op">,</span> <span class="st">&quot;metadata.tags&quot;</span>]</span>
+<span id="cb7-6"><a href="#cb7-6" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb7-7"><a href="#cb7-7" aria-hidden="true" tabindex="-1"></a>}</span>
+<span id="cb7-8"><a href="#cb7-8" aria-hidden="true" tabindex="-1"></a><span class="co">// Returns only requested fields, reducing response tokens</span></span></code></pre></div>
+<p><strong>Preset Field Sets:</strong></p>
+<p>Implementations MAY define preset field sets for common use cases:</p>
+<div class="sourceCode" id="cb8"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb8-1"><a href="#cb8-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb8-2"><a href="#cb8-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;get_resource&quot;</span><span class="op">,</span></span>
+<span id="cb8-3"><a href="#cb8-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> {</span>
+<span id="cb8-4"><a href="#cb8-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">resource_id</span><span class="op">:</span> <span class="st">&quot;user-123&quot;</span><span class="op">,</span></span>
+<span id="cb8-5"><a href="#cb8-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">fields</span><span class="op">:</span> <span class="st">&quot;minimal&quot;</span>  <span class="co">// Preset: returns only essential fields</span></span>
+<span id="cb8-6"><a href="#cb8-6" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb8-7"><a href="#cb8-7" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<table>
+<thead>
+<tr>
+<th>Preset</th>
+<th>Description</th>
+<th>Typical Token Savings</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>minimal</code></td>
+<td>Only identifier and description</td>
+<td>~86%</td>
+</tr>
+<tr>
+<td><code>standard</code></td>
+<td>Common fields for most use cases</td>
+<td>~73%</td>
+</tr>
+<tr>
+<td><code>full</code></td>
+<td>All fields (default)</td>
+<td>0%</td>
+</tr>
+</tbody>
+</table>
+<h3 id="key-differences-from-graphql">Key Differences from GraphQL</h3>
+<table>
+<thead>
+<tr>
+<th>Aspect</th>
+<th>GraphQL</th>
+<th>MCP-AQL</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>Field Selection</strong></td>
+<td>Client selects specific fields</td>
+<td><code>fields</code> param or presets</td>
+</tr>
+<tr>
+<td><strong>Subscriptions</strong></td>
+<td>Real-time WebSocket streams</td>
+<td>EXECUTE for stateful lifecycle</td>
+</tr>
+<tr>
+<td><strong>Schema Definition</strong></td>
+<td>SDL files</td>
+<td>Declarative operation schemas</td>
+</tr>
+<tr>
+<td><strong>Fragments/Aliases</strong></td>
+<td>Supported</td>
+<td>Not applicable</td>
+</tr>
+<tr>
+<td><strong>Batching</strong></td>
+<td>DataLoader pattern</td>
+<td>Built-in batch operations</td>
+</tr>
+</tbody>
+</table>
+<hr />
+<h2 id="for-mongodb-developers">For MongoDB Developers</h2>
+<p>If you are familiar with MongoDB, MCP-AQL's document-oriented operations and flexible query patterns will feel natural.</p>
+<h3 id="resource-types-like-collections">Resource Types (like Collections)</h3>
+<p>MongoDB organizes documents into collections. MCP-AQL implementations define resource type parameters:</p>
+<table>
+<thead>
+<tr>
+<th>MongoDB</th>
+<th>MCP-AQL Pattern</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>db.users</code></td>
+<td><code>resource_type: "user"</code></td>
+</tr>
+<tr>
+<td><code>db.posts</code></td>
+<td><code>resource_type: "post"</code></td>
+</tr>
+<tr>
+<td><code>db.comments</code></td>
+<td><code>resource_type: "comment"</code></td>
+</tr>
+<tr>
+<td>Collection name in method</td>
+<td>Passed as parameter</td>
+</tr>
+</tbody>
+</table>
+<h3 id="crud-method-mapping">CRUD Method Mapping</h3>
+<table>
+<thead>
+<tr>
+<th>MongoDB</th>
+<th>MCP-AQL</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>insertOne()</code></td>
+<td><code>create_resource</code></td>
+</tr>
+<tr>
+<td><code>find()</code></td>
+<td><code>list_resources</code></td>
+</tr>
+<tr>
+<td><code>findOne()</code></td>
+<td><code>get_resource</code></td>
+</tr>
+<tr>
+<td><code>updateOne()</code></td>
+<td><code>update_resource</code></td>
+</tr>
+<tr>
+<td><code>deleteOne()</code></td>
+<td><code>delete_resource</code></td>
+</tr>
+<tr>
+<td><code>aggregate()</code></td>
+<td><code>search</code> or <code>query_resources</code></td>
+</tr>
+</tbody>
+</table>
+<p><strong>MongoDB:</strong></p>
+<div class="sourceCode" id="cb9"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb9-1"><a href="#cb9-1" aria-hidden="true" tabindex="-1"></a>db<span class="op">.</span><span class="at">users</span><span class="op">.</span><span class="fu">insertOne</span>({</span>
+<span id="cb9-2"><a href="#cb9-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;Alice&quot;</span><span class="op">,</span></span>
+<span id="cb9-3"><a href="#cb9-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">description</span><span class="op">:</span> <span class="st">&quot;A helpful assistant&quot;</span><span class="op">,</span></span>
+<span id="cb9-4"><a href="#cb9-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">settings</span><span class="op">:</span> { <span class="dt">theme</span><span class="op">:</span> <span class="st">&quot;light&quot;</span> }</span>
+<span id="cb9-5"><a href="#cb9-5" aria-hidden="true" tabindex="-1"></a>})</span></code></pre></div>
+<p><strong>MCP-AQL:</strong></p>
+<div class="sourceCode" id="cb10"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb10-1"><a href="#cb10-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb10-2"><a href="#cb10-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;create_resource&quot;</span><span class="op">,</span></span>
+<span id="cb10-3"><a href="#cb10-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> {</span>
+<span id="cb10-4"><a href="#cb10-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">resource_type</span><span class="op">:</span> <span class="st">&quot;user&quot;</span><span class="op">,</span></span>
+<span id="cb10-5"><a href="#cb10-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">resource_id</span><span class="op">:</span> <span class="st">&quot;alice&quot;</span><span class="op">,</span></span>
+<span id="cb10-6"><a href="#cb10-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">description</span><span class="op">:</span> <span class="st">&quot;A helpful assistant&quot;</span><span class="op">,</span></span>
+<span id="cb10-7"><a href="#cb10-7" aria-hidden="true" tabindex="-1"></a>    <span class="dt">settings</span><span class="op">:</span> { <span class="dt">theme</span><span class="op">:</span> <span class="st">&quot;light&quot;</span> }</span>
+<span id="cb10-8"><a href="#cb10-8" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb10-9"><a href="#cb10-9" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<h3 id="query-patterns">Query Patterns</h3>
+<p><strong>MongoDB Find:</strong></p>
+<div class="sourceCode" id="cb11"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb11-1"><a href="#cb11-1" aria-hidden="true" tabindex="-1"></a>db<span class="op">.</span><span class="at">users</span><span class="op">.</span><span class="fu">find</span>({</span>
+<span id="cb11-2"><a href="#cb11-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">tags</span><span class="op">:</span> { <span class="dt">$in</span><span class="op">:</span> [<span class="st">&quot;creative&quot;</span><span class="op">,</span> <span class="st">&quot;writing&quot;</span>] }</span>
+<span id="cb11-3"><a href="#cb11-3" aria-hidden="true" tabindex="-1"></a>})<span class="op">.</span><span class="fu">limit</span>(<span class="dv">10</span>)</span></code></pre></div>
+<p><strong>MCP-AQL Search:</strong></p>
+<div class="sourceCode" id="cb12"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb12-1"><a href="#cb12-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb12-2"><a href="#cb12-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;search&quot;</span><span class="op">,</span></span>
+<span id="cb12-3"><a href="#cb12-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> {</span>
+<span id="cb12-4"><a href="#cb12-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">query</span><span class="op">:</span> <span class="st">&quot;creative writing&quot;</span><span class="op">,</span></span>
+<span id="cb12-5"><a href="#cb12-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">scope</span><span class="op">:</span> <span class="st">&quot;local&quot;</span><span class="op">,</span></span>
+<span id="cb12-6"><a href="#cb12-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">limit</span><span class="op">:</span> <span class="dv">10</span></span>
+<span id="cb12-7"><a href="#cb12-7" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb12-8"><a href="#cb12-8" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<h3 id="update-patterns">Update Patterns</h3>
+<p>MongoDB's <code>$set</code> operator is similar to MCP-AQL's deep-merge <code>input</code>:</p>
+<p><strong>MongoDB:</strong></p>
+<div class="sourceCode" id="cb13"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb13-1"><a href="#cb13-1" aria-hidden="true" tabindex="-1"></a>db<span class="op">.</span><span class="at">users</span><span class="op">.</span><span class="fu">updateOne</span>(</span>
+<span id="cb13-2"><a href="#cb13-2" aria-hidden="true" tabindex="-1"></a>  { <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;Alice&quot;</span> }<span class="op">,</span></span>
+<span id="cb13-3"><a href="#cb13-3" aria-hidden="true" tabindex="-1"></a>  { <span class="dt">$set</span><span class="op">:</span> {</span>
+<span id="cb13-4"><a href="#cb13-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">description</span><span class="op">:</span> <span class="st">&quot;Updated&quot;</span><span class="op">,</span></span>
+<span id="cb13-5"><a href="#cb13-5" aria-hidden="true" tabindex="-1"></a>    <span class="st">&quot;metadata.triggers&quot;</span><span class="op">:</span> [<span class="st">&quot;helper&quot;</span>]</span>
+<span id="cb13-6"><a href="#cb13-6" aria-hidden="true" tabindex="-1"></a>  }}</span>
+<span id="cb13-7"><a href="#cb13-7" aria-hidden="true" tabindex="-1"></a>)</span></code></pre></div>
+<p><strong>MCP-AQL:</strong></p>
+<div class="sourceCode" id="cb14"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb14-1"><a href="#cb14-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb14-2"><a href="#cb14-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;update_resource&quot;</span><span class="op">,</span></span>
+<span id="cb14-3"><a href="#cb14-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> {</span>
+<span id="cb14-4"><a href="#cb14-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">resource_id</span><span class="op">:</span> <span class="st">&quot;alice&quot;</span><span class="op">,</span></span>
+<span id="cb14-5"><a href="#cb14-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">input</span><span class="op">:</span> {</span>
+<span id="cb14-6"><a href="#cb14-6" aria-hidden="true" tabindex="-1"></a>      <span class="dt">description</span><span class="op">:</span> <span class="st">&quot;Updated&quot;</span><span class="op">,</span></span>
+<span id="cb14-7"><a href="#cb14-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">metadata</span><span class="op">:</span> {</span>
+<span id="cb14-8"><a href="#cb14-8" aria-hidden="true" tabindex="-1"></a>        <span class="dt">triggers</span><span class="op">:</span> [<span class="st">&quot;helper&quot;</span>]</span>
+<span id="cb14-9"><a href="#cb14-9" aria-hidden="true" tabindex="-1"></a>      }</span>
+<span id="cb14-10"><a href="#cb14-10" aria-hidden="true" tabindex="-1"></a>    }</span>
+<span id="cb14-11"><a href="#cb14-11" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb14-12"><a href="#cb14-12" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<h3 id="key-differences-from-mongodb">Key Differences from MongoDB</h3>
+<table>
+<thead>
+<tr>
+<th>Aspect</th>
+<th>MongoDB</th>
+<th>MCP-AQL</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>Query Operators</strong></td>
+<td>Rich ($gt, $in, $regex)</td>
+<td>Simplified search/filter</td>
+</tr>
+<tr>
+<td><strong>Aggregation</strong></td>
+<td>Complex pipelines</td>
+<td>Normalized via <code>search</code> operation</td>
+</tr>
+<tr>
+<td><strong>Indexes</strong></td>
+<td>User-defined</td>
+<td>Managed by server</td>
+</tr>
+<tr>
+<td><strong>Transactions</strong></td>
+<td>Multi-document ACID</td>
+<td>Per-operation atomicity</td>
+</tr>
+<tr>
+<td><strong>Cursors</strong></td>
+<td>Iterable result sets</td>
+<td>Paginated responses</td>
+</tr>
+</tbody>
+</table>
+<hr />
+<h2 id="for-rest-api-developers">For REST API Developers</h2>
+<p>If you are familiar with REST APIs, MCP-AQL maps cleanly to RESTful patterns while adding semantic grouping and introspection.</p>
+<h3 id="http-methods--crude-endpoints">HTTP Methods = CRUDE Endpoints</h3>
+<p>REST uses HTTP methods for semantics. MCP-AQL uses 5 semantic endpoints:</p>
+<table>
+<thead>
+<tr>
+<th>HTTP Method</th>
+<th>MCP-AQL Endpoint</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>POST</code> (create)</td>
+<td><code>mcp_aql_create</code></td>
+<td>Create new resources</td>
+</tr>
+<tr>
+<td><code>GET</code></td>
+<td><code>mcp_aql_read</code></td>
+<td>Read resources</td>
+</tr>
+<tr>
+<td><code>PUT</code> / <code>PATCH</code></td>
+<td><code>mcp_aql_update</code></td>
+<td>Modify resources</td>
+</tr>
+<tr>
+<td><code>DELETE</code></td>
+<td><code>mcp_aql_delete</code></td>
+<td>Remove resources</td>
+</tr>
+<tr>
+<td>N/A</td>
+<td><code>mcp_aql_execute</code></td>
+<td>Runtime operations</td>
+</tr>
+</tbody>
+</table>
+<h3 id="url-paths--operation--resource-parameters">URL Paths = operation + resource parameters</h3>
+<p>REST encodes resources in URLs. MCP-AQL uses <code>operation</code> plus implementation-defined parameters:</p>
+<table>
+<thead>
+<tr>
+<th>REST Pattern</th>
+<th>MCP-AQL Pattern</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>GET /resources</code></td>
+<td><code>{ operation: "list_resources" }</code></td>
+</tr>
+<tr>
+<td><code>GET /resources/:id</code></td>
+<td><code>{ operation: "get_resource", params: { id } }</code></td>
+</tr>
+<tr>
+<td><code>POST /resources</code></td>
+<td><code>{ operation: "create_resource", params: { ... } }</code></td>
+</tr>
+<tr>
+<td><code>PUT /resources/:id</code></td>
+<td><code>{ operation: "update_resource", params: { id, input } }</code></td>
+</tr>
+<tr>
+<td><code>DELETE /resources/:id</code></td>
+<td><code>{ operation: "delete_resource", params: { id } }</code></td>
+</tr>
+</tbody>
+</table>
+<h3 id="requestresponse-patterns">Request/Response Patterns</h3>
+<p><strong>REST:</strong></p>
+<pre class="http"><code>POST /api/users HTTP/1.1
+Content-Type: application/json
+
+{
+  &quot;name&quot;: &quot;Alice&quot;,
+  &quot;description&quot;: &quot;A helpful assistant&quot;,
+  &quot;settings&quot;: { &quot;theme&quot;: &quot;light&quot; }
+}</code></pre>
+<p>Response:</p>
+<div class="sourceCode" id="cb16"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb16-1"><a href="#cb16-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb16-2"><a href="#cb16-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;id&quot;</span><span class="fu">:</span> <span class="st">&quot;123&quot;</span><span class="fu">,</span></span>
+<span id="cb16-3"><a href="#cb16-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;Alice&quot;</span><span class="fu">,</span></span>
+<span id="cb16-4"><a href="#cb16-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;A helpful assistant&quot;</span><span class="fu">,</span></span>
+<span id="cb16-5"><a href="#cb16-5" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;created_at&quot;</span><span class="fu">:</span> <span class="st">&quot;2024-01-15T10:30:00Z&quot;</span></span>
+<span id="cb16-6"><a href="#cb16-6" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<p><strong>MCP-AQL:</strong></p>
+<div class="sourceCode" id="cb17"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb17-1"><a href="#cb17-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Request</span></span>
+<span id="cb17-2"><a href="#cb17-2" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb17-3"><a href="#cb17-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;create_resource&quot;</span><span class="op">,</span></span>
+<span id="cb17-4"><a href="#cb17-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> {</span>
+<span id="cb17-5"><a href="#cb17-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">resource_type</span><span class="op">:</span> <span class="st">&quot;user&quot;</span><span class="op">,</span></span>
+<span id="cb17-6"><a href="#cb17-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">resource_id</span><span class="op">:</span> <span class="st">&quot;alice&quot;</span><span class="op">,</span></span>
+<span id="cb17-7"><a href="#cb17-7" aria-hidden="true" tabindex="-1"></a>    <span class="dt">description</span><span class="op">:</span> <span class="st">&quot;A helpful assistant&quot;</span><span class="op">,</span></span>
+<span id="cb17-8"><a href="#cb17-8" aria-hidden="true" tabindex="-1"></a>    <span class="dt">settings</span><span class="op">:</span> { <span class="dt">theme</span><span class="op">:</span> <span class="st">&quot;light&quot;</span> }</span>
+<span id="cb17-9"><a href="#cb17-9" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb17-10"><a href="#cb17-10" aria-hidden="true" tabindex="-1"></a>}</span>
+<span id="cb17-11"><a href="#cb17-11" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb17-12"><a href="#cb17-12" aria-hidden="true" tabindex="-1"></a><span class="co">// Response</span></span>
+<span id="cb17-13"><a href="#cb17-13" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb17-14"><a href="#cb17-14" aria-hidden="true" tabindex="-1"></a>  <span class="dt">success</span><span class="op">:</span> <span class="kw">true</span><span class="op">,</span></span>
+<span id="cb17-15"><a href="#cb17-15" aria-hidden="true" tabindex="-1"></a>  <span class="dt">data</span><span class="op">:</span> {</span>
+<span id="cb17-16"><a href="#cb17-16" aria-hidden="true" tabindex="-1"></a>    <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;alice&quot;</span><span class="op">,</span></span>
+<span id="cb17-17"><a href="#cb17-17" aria-hidden="true" tabindex="-1"></a>    <span class="dt">type</span><span class="op">:</span> <span class="st">&quot;user&quot;</span><span class="op">,</span></span>
+<span id="cb17-18"><a href="#cb17-18" aria-hidden="true" tabindex="-1"></a>    <span class="dt">description</span><span class="op">:</span> <span class="st">&quot;A helpful assistant&quot;</span><span class="op">,</span></span>
+<span id="cb17-19"><a href="#cb17-19" aria-hidden="true" tabindex="-1"></a>    <span class="co">// ... full resource data</span></span>
+<span id="cb17-20"><a href="#cb17-20" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb17-21"><a href="#cb17-21" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<h3 id="error-handling">Error Handling</h3>
+<table>
+<thead>
+<tr>
+<th>REST</th>
+<th>MCP-AQL</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>HTTP 200 OK</td>
+<td><code>{ success: true, data: ... }</code></td>
+</tr>
+<tr>
+<td>HTTP 400 Bad Request</td>
+<td><code>{ success: false, error: "Invalid parameter..." }</code></td>
+</tr>
+<tr>
+<td>HTTP 404 Not Found</td>
+<td><code>{ success: false, error: "Resource not found..." }</code></td>
+</tr>
+<tr>
+<td>HTTP 500 Internal Error</td>
+<td><code>{ success: false, error: "..." }</code></td>
+</tr>
+</tbody>
+</table>
+<h3 id="api-documentation--introspection">API Documentation = Introspection</h3>
+<p>REST APIs use OpenAPI/Swagger for documentation. MCP-AQL uses introspection:</p>
+<p><strong>OpenAPI (conceptual):</strong></p>
+<div class="sourceCode" id="cb18"><pre class="sourceCode yaml"><code class="sourceCode yaml"><span id="cb18-1"><a href="#cb18-1" aria-hidden="true" tabindex="-1"></a><span class="fu">paths</span><span class="kw">:</span></span>
+<span id="cb18-2"><a href="#cb18-2" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">/users</span><span class="kw">:</span></span>
+<span id="cb18-3"><a href="#cb18-3" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">post</span><span class="kw">:</span></span>
+<span id="cb18-4"><a href="#cb18-4" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">summary</span><span class="kw">:</span><span class="at"> Create a user</span></span>
+<span id="cb18-5"><a href="#cb18-5" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">parameters</span><span class="kw">:</span><span class="at"> </span><span class="kw">[</span><span class="at">...</span><span class="kw">]</span></span></code></pre></div>
+<p><strong>MCP-AQL:</strong></p>
+<div class="sourceCode" id="cb19"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb19-1"><a href="#cb19-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Discover all operations</span></span>
+<span id="cb19-2"><a href="#cb19-2" aria-hidden="true" tabindex="-1"></a>{ <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;introspect&quot;</span><span class="op">,</span> <span class="dt">params</span><span class="op">:</span> { <span class="dt">query</span><span class="op">:</span> <span class="st">&quot;operations&quot;</span> } }</span>
+<span id="cb19-3"><a href="#cb19-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb19-4"><a href="#cb19-4" aria-hidden="true" tabindex="-1"></a><span class="co">// Get specific operation docs</span></span>
+<span id="cb19-5"><a href="#cb19-5" aria-hidden="true" tabindex="-1"></a>{ <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;introspect&quot;</span><span class="op">,</span> <span class="dt">params</span><span class="op">:</span> { <span class="dt">query</span><span class="op">:</span> <span class="st">&quot;operations&quot;</span><span class="op">,</span> <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;create_resource&quot;</span> } }</span>
+<span id="cb19-6"><a href="#cb19-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb19-7"><a href="#cb19-7" aria-hidden="true" tabindex="-1"></a><span class="co">// Returns:</span></span>
+<span id="cb19-8"><a href="#cb19-8" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb19-9"><a href="#cb19-9" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> {</span>
+<span id="cb19-10"><a href="#cb19-10" aria-hidden="true" tabindex="-1"></a>    <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;create_resource&quot;</span><span class="op">,</span></span>
+<span id="cb19-11"><a href="#cb19-11" aria-hidden="true" tabindex="-1"></a>    <span class="dt">endpoint</span><span class="op">:</span> <span class="st">&quot;CREATE&quot;</span><span class="op">,</span></span>
+<span id="cb19-12"><a href="#cb19-12" aria-hidden="true" tabindex="-1"></a>    <span class="dt">mcpTool</span><span class="op">:</span> <span class="st">&quot;mcp_aql_create&quot;</span><span class="op">,</span></span>
+<span id="cb19-13"><a href="#cb19-13" aria-hidden="true" tabindex="-1"></a>    <span class="dt">description</span><span class="op">:</span> <span class="st">&quot;Create a new resource&quot;</span><span class="op">,</span></span>
+<span id="cb19-14"><a href="#cb19-14" aria-hidden="true" tabindex="-1"></a>    <span class="dt">parameters</span><span class="op">:</span> [</span>
+<span id="cb19-15"><a href="#cb19-15" aria-hidden="true" tabindex="-1"></a>      { <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;resource_id&quot;</span><span class="op">,</span> <span class="dt">type</span><span class="op">:</span> <span class="st">&quot;string&quot;</span><span class="op">,</span> <span class="dt">required</span><span class="op">:</span> <span class="kw">true</span><span class="op">,</span> <span class="dt">description</span><span class="op">:</span> <span class="st">&quot;Resource identifier&quot;</span> }<span class="op">,</span></span>
+<span id="cb19-16"><a href="#cb19-16" aria-hidden="true" tabindex="-1"></a>      <span class="co">// ...</span></span>
+<span id="cb19-17"><a href="#cb19-17" aria-hidden="true" tabindex="-1"></a>    ]<span class="op">,</span></span>
+<span id="cb19-18"><a href="#cb19-18" aria-hidden="true" tabindex="-1"></a>    <span class="dt">examples</span><span class="op">:</span> [<span class="op">...</span>]</span>
+<span id="cb19-19"><a href="#cb19-19" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb19-20"><a href="#cb19-20" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<h3 id="key-differences-from-rest">Key Differences from REST</h3>
+<table>
+<thead>
+<tr>
+<th>Aspect</th>
+<th>REST</th>
+<th>MCP-AQL</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>Transport</strong></td>
+<td>HTTP</td>
+<td>MCP (stdio/SSE)</td>
+</tr>
+<tr>
+<td><strong>Versioning</strong></td>
+<td>URL path (<code>/v1/...</code>)</td>
+<td>Schema version in response</td>
+</tr>
+<tr>
+<td><strong>HATEOAS</strong></td>
+<td>Links in responses</td>
+<td>Introspection for discovery</td>
+</tr>
+<tr>
+<td><strong>Caching</strong></td>
+<td>HTTP headers</td>
+<td>Server-managed</td>
+</tr>
+<tr>
+<td><strong>Authentication</strong></td>
+<td>Headers (Bearer, API key)</td>
+<td>MCP session-based</td>
+</tr>
+</tbody>
+</table>
+<hr />
+<h2 id="for-sql-developers">For SQL Developers</h2>
+<p>If you are familiar with SQL, MCP-AQL's structured operations and type system will feel familiar, though the query patterns differ.</p>
+<h3 id="resource-types-like-tables">Resource Types (like Tables)</h3>
+<p>SQL organizes data into tables. MCP-AQL implementations define resource type parameters:</p>
+<table>
+<thead>
+<tr>
+<th>SQL</th>
+<th>MCP-AQL Pattern</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>users</code> table</td>
+<td><code>resource_type: "user"</code></td>
+</tr>
+<tr>
+<td><code>posts</code> table</td>
+<td><code>resource_type: "post"</code></td>
+</tr>
+<tr>
+<td><code>SELECT * FROM users</code></td>
+<td><code>list_resources</code> with <code>resource_type</code></td>
+</tr>
+</tbody>
+</table>
+<h3 id="sql-statement-mapping">SQL Statement Mapping</h3>
+<table>
+<thead>
+<tr>
+<th>SQL</th>
+<th>MCP-AQL Pattern</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>INSERT INTO</code></td>
+<td>Create operation</td>
+</tr>
+<tr>
+<td><code>SELECT * FROM</code></td>
+<td>List operation</td>
+</tr>
+<tr>
+<td><code>SELECT ... WHERE id =</code></td>
+<td>Get operation</td>
+</tr>
+<tr>
+<td><code>UPDATE ... SET</code></td>
+<td>Update operation</td>
+</tr>
+<tr>
+<td><code>DELETE FROM</code></td>
+<td>Delete operation</td>
+</tr>
+<tr>
+<td><code>SELECT ... WHERE ... LIKE</code></td>
+<td>Search operation</td>
+</tr>
+</tbody>
+</table>
+<h3 id="query-examples">Query Examples</h3>
+<p><strong>SQL INSERT:</strong></p>
+<div class="sourceCode" id="cb20"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb20-1"><a href="#cb20-1" aria-hidden="true" tabindex="-1"></a><span class="kw">INSERT</span> <span class="kw">INTO</span> users (name, description, settings)</span>
+<span id="cb20-2"><a href="#cb20-2" aria-hidden="true" tabindex="-1"></a><span class="kw">VALUES</span> (<span class="st">&#39;alice&#39;</span>, <span class="st">&#39;A helpful assistant&#39;</span>, <span class="st">&#39;{&quot;theme&quot;: &quot;light&quot;}&#39;</span>);</span></code></pre></div>
+<p><strong>MCP-AQL:</strong></p>
+<div class="sourceCode" id="cb21"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb21-1"><a href="#cb21-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb21-2"><a href="#cb21-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;create_resource&quot;</span><span class="op">,</span></span>
+<span id="cb21-3"><a href="#cb21-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> {</span>
+<span id="cb21-4"><a href="#cb21-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">resource_type</span><span class="op">:</span> <span class="st">&quot;user&quot;</span><span class="op">,</span></span>
+<span id="cb21-5"><a href="#cb21-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">resource_id</span><span class="op">:</span> <span class="st">&quot;alice&quot;</span><span class="op">,</span></span>
+<span id="cb21-6"><a href="#cb21-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">description</span><span class="op">:</span> <span class="st">&quot;A helpful assistant&quot;</span><span class="op">,</span></span>
+<span id="cb21-7"><a href="#cb21-7" aria-hidden="true" tabindex="-1"></a>    <span class="dt">settings</span><span class="op">:</span> { <span class="dt">theme</span><span class="op">:</span> <span class="st">&quot;light&quot;</span> }</span>
+<span id="cb21-8"><a href="#cb21-8" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb21-9"><a href="#cb21-9" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<p><strong>SQL SELECT:</strong></p>
+<div class="sourceCode" id="cb22"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb22-1"><a href="#cb22-1" aria-hidden="true" tabindex="-1"></a><span class="kw">SELECT</span> <span class="op">*</span> <span class="kw">FROM</span> users <span class="kw">WHERE</span> name <span class="op">=</span> <span class="st">&#39;alice&#39;</span>;</span></code></pre></div>
+<p><strong>MCP-AQL:</strong></p>
+<div class="sourceCode" id="cb23"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb23-1"><a href="#cb23-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb23-2"><a href="#cb23-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;get_resource&quot;</span><span class="op">,</span></span>
+<span id="cb23-3"><a href="#cb23-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> {</span>
+<span id="cb23-4"><a href="#cb23-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">resource_type</span><span class="op">:</span> <span class="st">&quot;user&quot;</span><span class="op">,</span></span>
+<span id="cb23-5"><a href="#cb23-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">resource_id</span><span class="op">:</span> <span class="st">&quot;alice&quot;</span></span>
+<span id="cb23-6"><a href="#cb23-6" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb23-7"><a href="#cb23-7" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<p><strong>SQL UPDATE:</strong></p>
+<div class="sourceCode" id="cb24"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb24-1"><a href="#cb24-1" aria-hidden="true" tabindex="-1"></a><span class="kw">UPDATE</span> users</span>
+<span id="cb24-2"><a href="#cb24-2" aria-hidden="true" tabindex="-1"></a><span class="kw">SET</span> description <span class="op">=</span> <span class="st">&#39;Updated description&#39;</span></span>
+<span id="cb24-3"><a href="#cb24-3" aria-hidden="true" tabindex="-1"></a><span class="kw">WHERE</span> name <span class="op">=</span> <span class="st">&#39;alice&#39;</span>;</span></code></pre></div>
+<p><strong>MCP-AQL:</strong></p>
+<div class="sourceCode" id="cb25"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb25-1"><a href="#cb25-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb25-2"><a href="#cb25-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;update_resource&quot;</span><span class="op">,</span></span>
+<span id="cb25-3"><a href="#cb25-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> {</span>
+<span id="cb25-4"><a href="#cb25-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">resource_id</span><span class="op">:</span> <span class="st">&quot;alice&quot;</span><span class="op">,</span></span>
+<span id="cb25-5"><a href="#cb25-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">input</span><span class="op">:</span> { <span class="dt">description</span><span class="op">:</span> <span class="st">&quot;Updated description&quot;</span> }</span>
+<span id="cb25-6"><a href="#cb25-6" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb25-7"><a href="#cb25-7" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<p><strong>SQL SEARCH:</strong></p>
+<div class="sourceCode" id="cb26"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb26-1"><a href="#cb26-1" aria-hidden="true" tabindex="-1"></a><span class="kw">SELECT</span> <span class="op">*</span> <span class="kw">FROM</span> users</span>
+<span id="cb26-2"><a href="#cb26-2" aria-hidden="true" tabindex="-1"></a><span class="kw">WHERE</span> description <span class="kw">LIKE</span> <span class="st">&#39;%creative%&#39;</span></span>
+<span id="cb26-3"><a href="#cb26-3" aria-hidden="true" tabindex="-1"></a>   <span class="kw">OR</span> settings <span class="kw">LIKE</span> <span class="st">&#39;%creative%&#39;</span></span>
+<span id="cb26-4"><a href="#cb26-4" aria-hidden="true" tabindex="-1"></a><span class="kw">LIMIT</span> <span class="dv">10</span>;</span></code></pre></div>
+<p><strong>MCP-AQL:</strong></p>
+<div class="sourceCode" id="cb27"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb27-1"><a href="#cb27-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb27-2"><a href="#cb27-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;search&quot;</span><span class="op">,</span></span>
+<span id="cb27-3"><a href="#cb27-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> {</span>
+<span id="cb27-4"><a href="#cb27-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">query</span><span class="op">:</span> <span class="st">&quot;creative&quot;</span><span class="op">,</span></span>
+<span id="cb27-5"><a href="#cb27-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">scope</span><span class="op">:</span> <span class="st">&quot;local&quot;</span><span class="op">,</span></span>
+<span id="cb27-6"><a href="#cb27-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">type</span><span class="op">:</span> <span class="st">&quot;user&quot;</span><span class="op">,</span></span>
+<span id="cb27-7"><a href="#cb27-7" aria-hidden="true" tabindex="-1"></a>    <span class="dt">limit</span><span class="op">:</span> <span class="dv">10</span></span>
+<span id="cb27-8"><a href="#cb27-8" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb27-9"><a href="#cb27-9" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<h3 id="schema-discovery">Schema Discovery</h3>
+<table>
+<thead>
+<tr>
+<th>SQL</th>
+<th>MCP-AQL</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>DESCRIBE users</code></td>
+<td><code>introspect</code> with <code>query: "types"</code></td>
+</tr>
+<tr>
+<td><code>SHOW TABLES</code></td>
+<td><code>introspect</code> with <code>query: "operations"</code></td>
+</tr>
+</tbody>
+</table>
+<h3 id="key-differences-from-sql">Key Differences from SQL</h3>
+<table>
+<thead>
+<tr>
+<th>Aspect</th>
+<th>SQL</th>
+<th>MCP-AQL</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>Query Language</strong></td>
+<td>Declarative SQL</td>
+<td>Structured JSON</td>
+</tr>
+<tr>
+<td><strong>Joins</strong></td>
+<td>Complex multi-table joins</td>
+<td>Resource relationships via handlers</td>
+</tr>
+<tr>
+<td><strong>Transactions</strong></td>
+<td>BEGIN/COMMIT/ROLLBACK</td>
+<td>Per-operation atomicity</td>
+</tr>
+<tr>
+<td><strong>Indexes</strong></td>
+<td>User-defined CREATE INDEX</td>
+<td>Managed by server</td>
+</tr>
+<tr>
+<td><strong>Stored Procedures</strong></td>
+<td>User-defined functions</td>
+<td>Agent execution</td>
+</tr>
+</tbody>
+</table>
+<hr />
+<h2 id="for-classic-mcp-users">For Classic MCP Users</h2>
+<p>This section helps developers migrating from discrete MCP tool interfaces to MCP-AQL understand the consolidation benefits.</p>
+<h3 id="before-many-discrete-tools">Before: Many Discrete Tools</h3>
+<p>Traditional MCP servers expose each operation as a separate tool:</p>
+<pre><code>create_user             delete_user             list_users
+create_post             delete_post             list_posts
+create_comment          delete_comment          list_comments
+get_user                edit_user               search_users
+get_post                edit_post               search_posts
+...and more (potentially 40+ tools)</code></pre>
+<p><strong>Token cost:</strong> ~30,000 tokens for tool registrations (depending on tool count)</p>
+<h3 id="after-5-crude-endpoints">After: 5 CRUDE Endpoints</h3>
+<p>MCP-AQL consolidates into 5 semantic endpoints:</p>
+<pre><code>mcp_aql_create  - CREATE operations (create, import, activate, add entry)
+mcp_aql_read    - READ operations (list, get, search, introspect)
+mcp_aql_update  - UPDATE operations (edit)
+mcp_aql_delete  - DELETE operations (delete, clear)
+mcp_aql_execute - EXECUTE operations (execute workflows, update state)</code></pre>
+<p><strong>Token cost by mode:</strong> | Mode | Token Cost | Reduction | |------|------------|-----------| | CRUDE (5 endpoints) | ~4,300 | ~85% | | Single (1 endpoint) | ~1,100 | ~96% |</p>
+<h3 id="migration-examples">Migration Examples</h3>
+<p><strong>Before (Classic MCP):</strong></p>
+<div class="sourceCode" id="cb30"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb30-1"><a href="#cb30-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Tool: create_user</span></span>
+<span id="cb30-2"><a href="#cb30-2" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb30-3"><a href="#cb30-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;alice&quot;</span><span class="op">,</span></span>
+<span id="cb30-4"><a href="#cb30-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">description</span><span class="op">:</span> <span class="st">&quot;A helpful assistant&quot;</span><span class="op">,</span></span>
+<span id="cb30-5"><a href="#cb30-5" aria-hidden="true" tabindex="-1"></a>  <span class="dt">settings</span><span class="op">:</span> { <span class="dt">theme</span><span class="op">:</span> <span class="st">&quot;light&quot;</span> }</span>
+<span id="cb30-6"><a href="#cb30-6" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<p><strong>After (MCP-AQL):</strong></p>
+<div class="sourceCode" id="cb31"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb31-1"><a href="#cb31-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Endpoint: mcp_aql_create</span></span>
+<span id="cb31-2"><a href="#cb31-2" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb31-3"><a href="#cb31-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;create_resource&quot;</span><span class="op">,</span></span>
+<span id="cb31-4"><a href="#cb31-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> {</span>
+<span id="cb31-5"><a href="#cb31-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">resource_type</span><span class="op">:</span> <span class="st">&quot;user&quot;</span><span class="op">,</span></span>
+<span id="cb31-6"><a href="#cb31-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">resource_id</span><span class="op">:</span> <span class="st">&quot;alice&quot;</span><span class="op">,</span></span>
+<span id="cb31-7"><a href="#cb31-7" aria-hidden="true" tabindex="-1"></a>    <span class="dt">description</span><span class="op">:</span> <span class="st">&quot;A helpful assistant&quot;</span><span class="op">,</span></span>
+<span id="cb31-8"><a href="#cb31-8" aria-hidden="true" tabindex="-1"></a>    <span class="dt">settings</span><span class="op">:</span> { <span class="dt">theme</span><span class="op">:</span> <span class="st">&quot;light&quot;</span> }</span>
+<span id="cb31-9"><a href="#cb31-9" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb31-10"><a href="#cb31-10" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<p><strong>Before (Classic MCP):</strong></p>
+<div class="sourceCode" id="cb32"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb32-1"><a href="#cb32-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Tool: list_users</span></span>
+<span id="cb32-2"><a href="#cb32-2" aria-hidden="true" tabindex="-1"></a>{ <span class="dt">page</span><span class="op">:</span> <span class="dv">1</span><span class="op">,</span> <span class="dt">pageSize</span><span class="op">:</span> <span class="dv">10</span> }</span></code></pre></div>
+<p><strong>After (MCP-AQL):</strong></p>
+<div class="sourceCode" id="cb33"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb33-1"><a href="#cb33-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Endpoint: mcp_aql_read</span></span>
+<span id="cb33-2"><a href="#cb33-2" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb33-3"><a href="#cb33-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;list_resources&quot;</span><span class="op">,</span></span>
+<span id="cb33-4"><a href="#cb33-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> {</span>
+<span id="cb33-5"><a href="#cb33-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">resource_type</span><span class="op">:</span> <span class="st">&quot;user&quot;</span><span class="op">,</span></span>
+<span id="cb33-6"><a href="#cb33-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">page</span><span class="op">:</span> <span class="dv">1</span><span class="op">,</span></span>
+<span id="cb33-7"><a href="#cb33-7" aria-hidden="true" tabindex="-1"></a>    <span class="dt">pageSize</span><span class="op">:</span> <span class="dv">10</span></span>
+<span id="cb33-8"><a href="#cb33-8" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb33-9"><a href="#cb33-9" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<h3 id="tool-to-operation-mapping">Tool to Operation Mapping</h3>
+<table>
+<thead>
+<tr>
+<th>Classic Tool Pattern</th>
+<th>MCP-AQL Operation Pattern</th>
+<th>Endpoint</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>create_&lt;type&gt;</code></td>
+<td><code>create_resource</code> + <code>resource_type</code></td>
+<td>CREATE</td>
+</tr>
+<tr>
+<td><code>list_&lt;type&gt;s</code></td>
+<td><code>list_resources</code> + <code>resource_type</code></td>
+<td>READ</td>
+</tr>
+<tr>
+<td><code>get_&lt;type&gt;</code></td>
+<td><code>get_resource</code> + <code>resource_type</code></td>
+<td>READ</td>
+</tr>
+<tr>
+<td><code>edit_&lt;type&gt;</code></td>
+<td><code>update_resource</code> + <code>resource_type</code></td>
+<td>UPDATE</td>
+</tr>
+<tr>
+<td><code>delete_&lt;type&gt;</code></td>
+<td><code>delete_resource</code> + <code>resource_type</code></td>
+<td>DELETE</td>
+</tr>
+<tr>
+<td><code>search_&lt;type&gt;s</code></td>
+<td><code>search</code></td>
+<td>READ</td>
+</tr>
+<tr>
+<td><code>execute_&lt;workflow&gt;</code></td>
+<td><code>execute_workflow</code></td>
+<td>EXECUTE</td>
+</tr>
+</tbody>
+</table>
+<h3 id="permission-model-changes">Permission Model Changes</h3>
+<p><strong>Before:</strong> Each tool had implicit permissions based on naming convention.</p>
+<p><strong>After:</strong> Explicit CRUDE endpoint permissions:</p>
+<table>
+<thead>
+<tr>
+<th>Endpoint</th>
+<th>readOnly</th>
+<th>destructive</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>CREATE</td>
+<td>false</td>
+<td>false</td>
+<td>Additive, non-destructive</td>
+</tr>
+<tr>
+<td>READ</td>
+<td>true</td>
+<td>false</td>
+<td>Safe, read-only</td>
+</tr>
+<tr>
+<td>UPDATE</td>
+<td>false</td>
+<td>true</td>
+<td>Modifying</td>
+</tr>
+<tr>
+<td>DELETE</td>
+<td>false</td>
+<td>true</td>
+<td>Destructive</td>
+</tr>
+<tr>
+<td>EXECUTE</td>
+<td>false</td>
+<td>true</td>
+<td>Potentially destructive, non-idempotent</td>
+</tr>
+</tbody>
+</table>
+<h3 id="discovery-changes">Discovery Changes</h3>
+<p><strong>Before:</strong> LLMs parsed all 40+ tool schemas upfront (~30,000 tokens).</p>
+<p><strong>After:</strong> LLMs use introspection for on-demand discovery:</p>
+<div class="sourceCode" id="cb34"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb34-1"><a href="#cb34-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Step 1: Quick discovery (~50 tokens)</span></span>
+<span id="cb34-2"><a href="#cb34-2" aria-hidden="true" tabindex="-1"></a>{ <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;introspect&quot;</span><span class="op">,</span> <span class="dt">params</span><span class="op">:</span> { <span class="dt">query</span><span class="op">:</span> <span class="st">&quot;operations&quot;</span> } }</span>
+<span id="cb34-3"><a href="#cb34-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb34-4"><a href="#cb34-4" aria-hidden="true" tabindex="-1"></a><span class="co">// Step 2: Get details for relevant operation (~100 tokens)</span></span>
+<span id="cb34-5"><a href="#cb34-5" aria-hidden="true" tabindex="-1"></a>{ <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;introspect&quot;</span><span class="op">,</span> <span class="dt">params</span><span class="op">:</span> { <span class="dt">query</span><span class="op">:</span> <span class="st">&quot;operations&quot;</span><span class="op">,</span> <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;create_resource&quot;</span> } }</span>
+<span id="cb34-6"><a href="#cb34-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb34-7"><a href="#cb34-7" aria-hidden="true" tabindex="-1"></a><span class="co">// Step 3: Use the operation</span></span>
+<span id="cb34-8"><a href="#cb34-8" aria-hidden="true" tabindex="-1"></a>{ <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;create_resource&quot;</span><span class="op">,</span> <span class="op">...</span> }</span></code></pre></div>
+<hr />
+<h2 id="comprehensive-concept-mapping">Comprehensive Concept Mapping</h2>
+<p>This table maps concepts across all compared protocols.</p>
+<table>
+<thead>
+<tr>
+<th>Concept</th>
+<th>GraphQL</th>
+<th>MongoDB</th>
+<th>REST</th>
+<th>SQL</th>
+<th>MCP-AQL</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>Namespace</strong></td>
+<td>Schema</td>
+<td>Database</td>
+<td>Base URL</td>
+<td>Schema</td>
+<td>Implementation-defined</td>
+</tr>
+<tr>
+<td><strong>Type/Entity</strong></td>
+<td>Type</td>
+<td>Collection</td>
+<td>Resource</td>
+<td>Table</td>
+<td>Resource type param</td>
+</tr>
+<tr>
+<td><strong>Instance</strong></td>
+<td>Object</td>
+<td>Document</td>
+<td>Resource instance</td>
+<td>Row</td>
+<td>Resource</td>
+</tr>
+<tr>
+<td><strong>Identifier</strong></td>
+<td>ID field</td>
+<td><code>_id</code></td>
+<td>Path param</td>
+<td>Primary key</td>
+<td>Resource ID</td>
+</tr>
+<tr>
+<td><strong>Create</strong></td>
+<td>Mutation</td>
+<td><code>insertOne</code></td>
+<td>POST</td>
+<td>INSERT</td>
+<td><code>create_*</code> operation</td>
+</tr>
+<tr>
+<td><strong>Read One</strong></td>
+<td>Query</td>
+<td><code>findOne</code></td>
+<td>GET /:id</td>
+<td>SELECT ... WHERE</td>
+<td><code>get_*</code> operation</td>
+</tr>
+<tr>
+<td><strong>Read Many</strong></td>
+<td>Query</td>
+<td><code>find</code></td>
+<td>GET /</td>
+<td>SELECT *</td>
+<td><code>list_*</code> operation</td>
+</tr>
+<tr>
+<td><strong>Update</strong></td>
+<td>Mutation</td>
+<td><code>updateOne</code></td>
+<td>PUT/PATCH</td>
+<td>UPDATE</td>
+<td><code>update_*</code> operation</td>
+</tr>
+<tr>
+<td><strong>Delete</strong></td>
+<td>Mutation</td>
+<td><code>deleteOne</code></td>
+<td>DELETE</td>
+<td>DELETE</td>
+<td><code>delete_*</code> operation</td>
+</tr>
+<tr>
+<td><strong>Search</strong></td>
+<td>Query</td>
+<td><code>find</code>+text</td>
+<td>GET /search</td>
+<td>LIKE/FTS</td>
+<td><code>search</code> operation</td>
+</tr>
+<tr>
+<td><strong>Schema Discovery</strong></td>
+<td><code>__schema</code></td>
+<td><code>getCollectionInfos</code></td>
+<td>OpenAPI</td>
+<td>DESCRIBE</td>
+<td><code>introspect</code></td>
+</tr>
+<tr>
+<td><strong>Parameters</strong></td>
+<td>Variables</td>
+<td>Filter/options</td>
+<td>Query/body</td>
+<td>WHERE/VALUES</td>
+<td><code>params</code> object</td>
+</tr>
+<tr>
+<td><strong>Response</strong></td>
+<td><code>{ data, errors }</code></td>
+<td>Document</td>
+<td>JSON body</td>
+<td>Result set</td>
+<td><code>{ success, data/error }</code></td>
+</tr>
+<tr>
+<td><strong>Error</strong></td>
+<td><code>errors</code> array</td>
+<td>Exception</td>
+<td>HTTP status</td>
+<td>SQLSTATE</td>
+<td><code>{ success: false, error }</code></td>
+</tr>
+<tr>
+<td><strong>Batch</strong></td>
+<td>N/A (single)</td>
+<td><code>insertMany</code></td>
+<td>Bulk endpoint</td>
+<td>Transaction</td>
+<td><code>operations</code> array</td>
+</tr>
+<tr>
+<td><strong>Pagination</strong></td>
+<td><code>first/after</code></td>
+<td><code>skip/limit</code></td>
+<td>Query params</td>
+<td>OFFSET/LIMIT</td>
+<td><code>page/pageSize</code></td>
+</tr>
+</tbody>
+</table>
+<hr />
+<h2 id="code-examples-same-operation-across-protocols">Code Examples: Same Operation Across Protocols</h2>
+<h3 id="example-1-create-a-resource">Example 1: Create a Resource</h3>
+<p><strong>GraphQL:</strong></p>
+<div class="sourceCode" id="cb35"><pre class="sourceCode graphql"><code class="sourceCode graphql"><span id="cb35-1"><a href="#cb35-1" aria-hidden="true" tabindex="-1"></a><span class="kw">mutation</span> CreateUser(<span class="va">$input</span>: UserInput!) {</span>
+<span id="cb35-2"><a href="#cb35-2" aria-hidden="true" tabindex="-1"></a>  createUser(<span class="kw">input</span>: <span class="va">$input</span>) {</span>
+<span id="cb35-3"><a href="#cb35-3" aria-hidden="true" tabindex="-1"></a>    id</span>
+<span id="cb35-4"><a href="#cb35-4" aria-hidden="true" tabindex="-1"></a>    name</span>
+<span id="cb35-5"><a href="#cb35-5" aria-hidden="true" tabindex="-1"></a>    email</span>
+<span id="cb35-6"><a href="#cb35-6" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb35-7"><a href="#cb35-7" aria-hidden="true" tabindex="-1"></a>}</span>
+<span id="cb35-8"><a href="#cb35-8" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb35-9"><a href="#cb35-9" aria-hidden="true" tabindex="-1"></a><span class="co"># Variables</span></span>
+<span id="cb35-10"><a href="#cb35-10" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb35-11"><a href="#cb35-11" aria-hidden="true" tabindex="-1"></a>  <span class="st">&quot;input&quot;</span>: {</span>
+<span id="cb35-12"><a href="#cb35-12" aria-hidden="true" tabindex="-1"></a>    <span class="st">&quot;name&quot;</span>: <span class="st">&quot;CreativeWriter&quot;</span>,</span>
+<span id="cb35-13"><a href="#cb35-13" aria-hidden="true" tabindex="-1"></a>    <span class="st">&quot;email&quot;</span>: <span class="st">&quot;writer@example.com&quot;</span>,</span>
+<span id="cb35-14"><a href="#cb35-14" aria-hidden="true" tabindex="-1"></a>    <span class="st">&quot;bio&quot;</span>: <span class="st">&quot;A creative writing assistant&quot;</span></span>
+<span id="cb35-15"><a href="#cb35-15" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb35-16"><a href="#cb35-16" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<p><strong>MongoDB:</strong></p>
+<div class="sourceCode" id="cb36"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb36-1"><a href="#cb36-1" aria-hidden="true" tabindex="-1"></a>db<span class="op">.</span><span class="at">users</span><span class="op">.</span><span class="fu">insertOne</span>({</span>
+<span id="cb36-2"><a href="#cb36-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;CreativeWriter&quot;</span><span class="op">,</span></span>
+<span id="cb36-3"><a href="#cb36-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">email</span><span class="op">:</span> <span class="st">&quot;writer@example.com&quot;</span><span class="op">,</span></span>
+<span id="cb36-4"><a href="#cb36-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">bio</span><span class="op">:</span> <span class="st">&quot;A creative writing assistant&quot;</span><span class="op">,</span></span>
+<span id="cb36-5"><a href="#cb36-5" aria-hidden="true" tabindex="-1"></a>  <span class="dt">created_at</span><span class="op">:</span> <span class="kw">new</span> <span class="bu">Date</span>()</span>
+<span id="cb36-6"><a href="#cb36-6" aria-hidden="true" tabindex="-1"></a>})<span class="op">;</span></span></code></pre></div>
+<p><strong>REST:</strong></p>
+<pre class="http"><code>POST /api/users HTTP/1.1
+Content-Type: application/json
+
+{
+  &quot;name&quot;: &quot;CreativeWriter&quot;,
+  &quot;description&quot;: &quot;A creative writing assistant&quot;,
+  &quot;settings&quot;: { &quot;expertise&quot;: &quot;storytelling, poetry, imaginative content&quot; }
+}</code></pre>
+<p><strong>SQL:</strong></p>
+<div class="sourceCode" id="cb38"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb38-1"><a href="#cb38-1" aria-hidden="true" tabindex="-1"></a><span class="kw">INSERT</span> <span class="kw">INTO</span> users (name, description, settings, created_at)</span>
+<span id="cb38-2"><a href="#cb38-2" aria-hidden="true" tabindex="-1"></a><span class="kw">VALUES</span> (</span>
+<span id="cb38-3"><a href="#cb38-3" aria-hidden="true" tabindex="-1"></a>  <span class="st">&#39;CreativeWriter&#39;</span>,</span>
+<span id="cb38-4"><a href="#cb38-4" aria-hidden="true" tabindex="-1"></a>  <span class="st">&#39;A creative writing assistant&#39;</span>,</span>
+<span id="cb38-5"><a href="#cb38-5" aria-hidden="true" tabindex="-1"></a>  <span class="st">&#39;{&quot;expertise&quot;: &quot;storytelling, poetry, imaginative content&quot;}&#39;</span>,</span>
+<span id="cb38-6"><a href="#cb38-6" aria-hidden="true" tabindex="-1"></a>  NOW()</span>
+<span id="cb38-7"><a href="#cb38-7" aria-hidden="true" tabindex="-1"></a>);</span></code></pre></div>
+<p><strong>Classic MCP:</strong></p>
+<div class="sourceCode" id="cb39"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb39-1"><a href="#cb39-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Tool: create_user</span></span>
+<span id="cb39-2"><a href="#cb39-2" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb39-3"><a href="#cb39-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;CreativeWriter&quot;</span><span class="op">,</span></span>
+<span id="cb39-4"><a href="#cb39-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">description</span><span class="op">:</span> <span class="st">&quot;A creative writing assistant&quot;</span><span class="op">,</span></span>
+<span id="cb39-5"><a href="#cb39-5" aria-hidden="true" tabindex="-1"></a>  <span class="dt">settings</span><span class="op">:</span> { <span class="dt">expertise</span><span class="op">:</span> <span class="st">&quot;storytelling, poetry, imaginative content&quot;</span> }</span>
+<span id="cb39-6"><a href="#cb39-6" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<p><strong>MCP-AQL:</strong></p>
+<div class="sourceCode" id="cb40"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb40-1"><a href="#cb40-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Endpoint: mcp_aql_create</span></span>
+<span id="cb40-2"><a href="#cb40-2" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb40-3"><a href="#cb40-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;create_resource&quot;</span><span class="op">,</span></span>
+<span id="cb40-4"><a href="#cb40-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> {</span>
+<span id="cb40-5"><a href="#cb40-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">resource_type</span><span class="op">:</span> <span class="st">&quot;user&quot;</span><span class="op">,</span></span>
+<span id="cb40-6"><a href="#cb40-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">resource_id</span><span class="op">:</span> <span class="st">&quot;CreativeWriter&quot;</span><span class="op">,</span></span>
+<span id="cb40-7"><a href="#cb40-7" aria-hidden="true" tabindex="-1"></a>    <span class="dt">description</span><span class="op">:</span> <span class="st">&quot;A creative writing assistant&quot;</span><span class="op">,</span></span>
+<span id="cb40-8"><a href="#cb40-8" aria-hidden="true" tabindex="-1"></a>    <span class="dt">settings</span><span class="op">:</span> { <span class="dt">expertise</span><span class="op">:</span> <span class="st">&quot;storytelling, poetry, imaginative content&quot;</span> }</span>
+<span id="cb40-9"><a href="#cb40-9" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb40-10"><a href="#cb40-10" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<h3 id="example-2-search-for-resources">Example 2: Search for Resources</h3>
+<p><strong>GraphQL:</strong></p>
+<div class="sourceCode" id="cb41"><pre class="sourceCode graphql"><code class="sourceCode graphql"><span id="cb41-1"><a href="#cb41-1" aria-hidden="true" tabindex="-1"></a><span class="kw">query</span> SearchUsers(<span class="va">$query</span>: <span class="dt">String</span>!, <span class="va">$limit</span>: <span class="dt">Int</span>) {</span>
+<span id="cb41-2"><a href="#cb41-2" aria-hidden="true" tabindex="-1"></a>  searchUsers(<span class="kw">query</span>: <span class="va">$query</span>, limit: <span class="va">$limit</span>) {</span>
+<span id="cb41-3"><a href="#cb41-3" aria-hidden="true" tabindex="-1"></a>    results {</span>
+<span id="cb41-4"><a href="#cb41-4" aria-hidden="true" tabindex="-1"></a>      name</span>
+<span id="cb41-5"><a href="#cb41-5" aria-hidden="true" tabindex="-1"></a>      description</span>
+<span id="cb41-6"><a href="#cb41-6" aria-hidden="true" tabindex="-1"></a>    }</span>
+<span id="cb41-7"><a href="#cb41-7" aria-hidden="true" tabindex="-1"></a>    total</span>
+<span id="cb41-8"><a href="#cb41-8" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb41-9"><a href="#cb41-9" aria-hidden="true" tabindex="-1"></a>}</span>
+<span id="cb41-10"><a href="#cb41-10" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb41-11"><a href="#cb41-11" aria-hidden="true" tabindex="-1"></a><span class="co"># Variables</span></span>
+<span id="cb41-12"><a href="#cb41-12" aria-hidden="true" tabindex="-1"></a>{ <span class="st">&quot;query&quot;</span>: <span class="st">&quot;creative writing&quot;</span>, <span class="st">&quot;limit&quot;</span>: <span class="dv">10</span> }</span></code></pre></div>
+<p><strong>MongoDB:</strong></p>
+<div class="sourceCode" id="cb42"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb42-1"><a href="#cb42-1" aria-hidden="true" tabindex="-1"></a>db<span class="op">.</span><span class="at">users</span><span class="op">.</span><span class="fu">find</span>({</span>
+<span id="cb42-2"><a href="#cb42-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">$text</span><span class="op">:</span> { <span class="dt">$search</span><span class="op">:</span> <span class="st">&quot;creative writing&quot;</span> }</span>
+<span id="cb42-3"><a href="#cb42-3" aria-hidden="true" tabindex="-1"></a>})<span class="op">.</span><span class="fu">limit</span>(<span class="dv">10</span>)<span class="op">.</span><span class="fu">toArray</span>()<span class="op">;</span></span></code></pre></div>
+<p><strong>REST:</strong></p>
+<pre class="http"><code>GET /api/users/search?q=creative+writing&amp;limit=10 HTTP/1.1</code></pre>
+<p><strong>SQL:</strong></p>
+<div class="sourceCode" id="cb44"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb44-1"><a href="#cb44-1" aria-hidden="true" tabindex="-1"></a><span class="kw">SELECT</span> <span class="op">*</span> <span class="kw">FROM</span> users</span>
+<span id="cb44-2"><a href="#cb44-2" aria-hidden="true" tabindex="-1"></a><span class="kw">WHERE</span> description <span class="kw">LIKE</span> <span class="st">&#39;%creative%&#39;</span></span>
+<span id="cb44-3"><a href="#cb44-3" aria-hidden="true" tabindex="-1"></a>   <span class="kw">OR</span> description <span class="kw">LIKE</span> <span class="st">&#39;%writing%&#39;</span></span>
+<span id="cb44-4"><a href="#cb44-4" aria-hidden="true" tabindex="-1"></a><span class="kw">LIMIT</span> <span class="dv">10</span>;</span></code></pre></div>
+<p><strong>Classic MCP:</strong></p>
+<div class="sourceCode" id="cb45"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb45-1"><a href="#cb45-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Tool: search_users</span></span>
+<span id="cb45-2"><a href="#cb45-2" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb45-3"><a href="#cb45-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">query</span><span class="op">:</span> <span class="st">&quot;creative writing&quot;</span><span class="op">,</span></span>
+<span id="cb45-4"><a href="#cb45-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">type</span><span class="op">:</span> <span class="st">&quot;user&quot;</span><span class="op">,</span></span>
+<span id="cb45-5"><a href="#cb45-5" aria-hidden="true" tabindex="-1"></a>  <span class="dt">limit</span><span class="op">:</span> <span class="dv">10</span></span>
+<span id="cb45-6"><a href="#cb45-6" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<p><strong>MCP-AQL:</strong></p>
+<div class="sourceCode" id="cb46"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb46-1"><a href="#cb46-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Endpoint: mcp_aql_read</span></span>
+<span id="cb46-2"><a href="#cb46-2" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb46-3"><a href="#cb46-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;search&quot;</span><span class="op">,</span></span>
+<span id="cb46-4"><a href="#cb46-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> {</span>
+<span id="cb46-5"><a href="#cb46-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">query</span><span class="op">:</span> <span class="st">&quot;creative writing&quot;</span><span class="op">,</span></span>
+<span id="cb46-6"><a href="#cb46-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">type</span><span class="op">:</span> <span class="st">&quot;user&quot;</span><span class="op">,</span></span>
+<span id="cb46-7"><a href="#cb46-7" aria-hidden="true" tabindex="-1"></a>    <span class="dt">scope</span><span class="op">:</span> <span class="st">&quot;local&quot;</span><span class="op">,</span></span>
+<span id="cb46-8"><a href="#cb46-8" aria-hidden="true" tabindex="-1"></a>    <span class="dt">limit</span><span class="op">:</span> <span class="dv">10</span></span>
+<span id="cb46-9"><a href="#cb46-9" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb46-10"><a href="#cb46-10" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<h3 id="example-3-update-a-resource">Example 3: Update a Resource</h3>
+<p><strong>GraphQL:</strong></p>
+<div class="sourceCode" id="cb47"><pre class="sourceCode graphql"><code class="sourceCode graphql"><span id="cb47-1"><a href="#cb47-1" aria-hidden="true" tabindex="-1"></a><span class="kw">mutation</span> UpdateUser(<span class="va">$name</span>: <span class="dt">String</span>!, <span class="va">$input</span>: UpdateUserInput!) {</span>
+<span id="cb47-2"><a href="#cb47-2" aria-hidden="true" tabindex="-1"></a>  updateUser(name: <span class="va">$name</span>, <span class="kw">input</span>: <span class="va">$input</span>) {</span>
+<span id="cb47-3"><a href="#cb47-3" aria-hidden="true" tabindex="-1"></a>    name</span>
+<span id="cb47-4"><a href="#cb47-4" aria-hidden="true" tabindex="-1"></a>    description</span>
+<span id="cb47-5"><a href="#cb47-5" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb47-6"><a href="#cb47-6" aria-hidden="true" tabindex="-1"></a>}</span>
+<span id="cb47-7"><a href="#cb47-7" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb47-8"><a href="#cb47-8" aria-hidden="true" tabindex="-1"></a><span class="co"># Variables</span></span>
+<span id="cb47-9"><a href="#cb47-9" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb47-10"><a href="#cb47-10" aria-hidden="true" tabindex="-1"></a>  <span class="st">&quot;name&quot;</span>: <span class="st">&quot;CreativeWriter&quot;</span>,</span>
+<span id="cb47-11"><a href="#cb47-11" aria-hidden="true" tabindex="-1"></a>  <span class="st">&quot;input&quot;</span>: {</span>
+<span id="cb47-12"><a href="#cb47-12" aria-hidden="true" tabindex="-1"></a>    <span class="st">&quot;description&quot;</span>: <span class="st">&quot;An enhanced creative writing assistant with poetry expertise&quot;</span></span>
+<span id="cb47-13"><a href="#cb47-13" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb47-14"><a href="#cb47-14" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<p><strong>MongoDB:</strong></p>
+<div class="sourceCode" id="cb48"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb48-1"><a href="#cb48-1" aria-hidden="true" tabindex="-1"></a>db<span class="op">.</span><span class="at">users</span><span class="op">.</span><span class="fu">updateOne</span>(</span>
+<span id="cb48-2"><a href="#cb48-2" aria-hidden="true" tabindex="-1"></a>  { <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;CreativeWriter&quot;</span> }<span class="op">,</span></span>
+<span id="cb48-3"><a href="#cb48-3" aria-hidden="true" tabindex="-1"></a>  { <span class="dt">$set</span><span class="op">:</span> { <span class="dt">description</span><span class="op">:</span> <span class="st">&quot;An enhanced creative writing assistant with poetry expertise&quot;</span> } }</span>
+<span id="cb48-4"><a href="#cb48-4" aria-hidden="true" tabindex="-1"></a>)<span class="op">;</span></span></code></pre></div>
+<p><strong>REST:</strong></p>
+<pre class="http"><code>PATCH /api/users/CreativeWriter HTTP/1.1
+Content-Type: application/json
+
+{
+  &quot;description&quot;: &quot;An enhanced creative writing assistant with poetry expertise&quot;
+}</code></pre>
+<p><strong>SQL:</strong></p>
+<div class="sourceCode" id="cb50"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb50-1"><a href="#cb50-1" aria-hidden="true" tabindex="-1"></a><span class="kw">UPDATE</span> users</span>
+<span id="cb50-2"><a href="#cb50-2" aria-hidden="true" tabindex="-1"></a><span class="kw">SET</span> description <span class="op">=</span> <span class="st">&#39;An enhanced creative writing assistant with poetry expertise&#39;</span></span>
+<span id="cb50-3"><a href="#cb50-3" aria-hidden="true" tabindex="-1"></a><span class="kw">WHERE</span> name <span class="op">=</span> <span class="st">&#39;CreativeWriter&#39;</span>;</span></code></pre></div>
+<p><strong>Classic MCP:</strong></p>
+<div class="sourceCode" id="cb51"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb51-1"><a href="#cb51-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Tool: edit_user</span></span>
+<span id="cb51-2"><a href="#cb51-2" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb51-3"><a href="#cb51-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;CreativeWriter&quot;</span><span class="op">,</span></span>
+<span id="cb51-4"><a href="#cb51-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">description</span><span class="op">:</span> <span class="st">&quot;An enhanced creative writing assistant with poetry expertise&quot;</span></span>
+<span id="cb51-5"><a href="#cb51-5" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<p><strong>MCP-AQL:</strong></p>
+<div class="sourceCode" id="cb52"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb52-1"><a href="#cb52-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Endpoint: mcp_aql_update</span></span>
+<span id="cb52-2"><a href="#cb52-2" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb52-3"><a href="#cb52-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;update_resource&quot;</span><span class="op">,</span></span>
+<span id="cb52-4"><a href="#cb52-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> {</span>
+<span id="cb52-5"><a href="#cb52-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">resource_id</span><span class="op">:</span> <span class="st">&quot;CreativeWriter&quot;</span><span class="op">,</span></span>
+<span id="cb52-6"><a href="#cb52-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">input</span><span class="op">:</span> {</span>
+<span id="cb52-7"><a href="#cb52-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">description</span><span class="op">:</span> <span class="st">&quot;An enhanced creative writing assistant with poetry expertise&quot;</span></span>
+<span id="cb52-8"><a href="#cb52-8" aria-hidden="true" tabindex="-1"></a>    }</span>
+<span id="cb52-9"><a href="#cb52-9" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb52-10"><a href="#cb52-10" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<h3 id="example-4-discover-available-operations">Example 4: Discover Available Operations</h3>
+<p><strong>GraphQL:</strong></p>
+<div class="sourceCode" id="cb53"><pre class="sourceCode graphql"><code class="sourceCode graphql"><span id="cb53-1"><a href="#cb53-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb53-2"><a href="#cb53-2" aria-hidden="true" tabindex="-1"></a>  __schema {</span>
+<span id="cb53-3"><a href="#cb53-3" aria-hidden="true" tabindex="-1"></a>    mutationType {</span>
+<span id="cb53-4"><a href="#cb53-4" aria-hidden="true" tabindex="-1"></a>      fields {</span>
+<span id="cb53-5"><a href="#cb53-5" aria-hidden="true" tabindex="-1"></a>        name</span>
+<span id="cb53-6"><a href="#cb53-6" aria-hidden="true" tabindex="-1"></a>        description</span>
+<span id="cb53-7"><a href="#cb53-7" aria-hidden="true" tabindex="-1"></a>      }</span>
+<span id="cb53-8"><a href="#cb53-8" aria-hidden="true" tabindex="-1"></a>    }</span>
+<span id="cb53-9"><a href="#cb53-9" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb53-10"><a href="#cb53-10" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<p><strong>MongoDB:</strong></p>
+<div class="sourceCode" id="cb54"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb54-1"><a href="#cb54-1" aria-hidden="true" tabindex="-1"></a><span class="co">// No direct equivalent - typically use documentation</span></span>
+<span id="cb54-2"><a href="#cb54-2" aria-hidden="true" tabindex="-1"></a>db<span class="op">.</span><span class="fu">getCollectionInfos</span>()<span class="op">;</span></span></code></pre></div>
+<p><strong>REST:</strong></p>
+<pre class="http"><code>GET /api/openapi.json HTTP/1.1
+# or
+GET /api/swagger.json HTTP/1.1</code></pre>
+<p><strong>SQL:</strong></p>
+<div class="sourceCode" id="cb56"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb56-1"><a href="#cb56-1" aria-hidden="true" tabindex="-1"></a>SHOW <span class="kw">TABLES</span>;</span>
+<span id="cb56-2"><a href="#cb56-2" aria-hidden="true" tabindex="-1"></a>DESCRIBE users;</span></code></pre></div>
+<p><strong>Classic MCP:</strong></p>
+<pre><code># No dedicated operation - parsed from tool schemas
+# (Consumed ~30,000 tokens for all 40+ tools)</code></pre>
+<p><strong>MCP-AQL:</strong></p>
+<div class="sourceCode" id="cb58"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb58-1"><a href="#cb58-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Endpoint: mcp_aql_read</span></span>
+<span id="cb58-2"><a href="#cb58-2" aria-hidden="true" tabindex="-1"></a><span class="co">// List all operations</span></span>
+<span id="cb58-3"><a href="#cb58-3" aria-hidden="true" tabindex="-1"></a>{ <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;introspect&quot;</span><span class="op">,</span> <span class="dt">params</span><span class="op">:</span> { <span class="dt">query</span><span class="op">:</span> <span class="st">&quot;operations&quot;</span> } }</span>
+<span id="cb58-4"><a href="#cb58-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb58-5"><a href="#cb58-5" aria-hidden="true" tabindex="-1"></a><span class="co">// Get details for specific operation</span></span>
+<span id="cb58-6"><a href="#cb58-6" aria-hidden="true" tabindex="-1"></a>{ <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;introspect&quot;</span><span class="op">,</span> <span class="dt">params</span><span class="op">:</span> { <span class="dt">query</span><span class="op">:</span> <span class="st">&quot;operations&quot;</span><span class="op">,</span> <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;update_resource&quot;</span> } }</span>
+<span id="cb58-7"><a href="#cb58-7" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb58-8"><a href="#cb58-8" aria-hidden="true" tabindex="-1"></a><span class="co">// List available types</span></span>
+<span id="cb58-9"><a href="#cb58-9" aria-hidden="true" tabindex="-1"></a>{ <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;introspect&quot;</span><span class="op">,</span> <span class="dt">params</span><span class="op">:</span> { <span class="dt">query</span><span class="op">:</span> <span class="st">&quot;types&quot;</span> } }</span></code></pre></div>
+<hr />
+<h2 id="summary">Summary</h2>
+<p>MCP-AQL combines the best patterns from established protocols:</p>
+<ul>
+<li><strong>From GraphQL:</strong> Introspection, typed operations, nested input objects, <strong>field selection</strong></li>
+<li><strong>From MongoDB:</strong> Flexible document operations, simple query patterns</li>
+<li><strong>From REST:</strong> Semantic endpoint grouping, clear resource addressing</li>
+<li><strong>From SQL:</strong> Structured CRUD operations, schema awareness</li>
+</ul>
+<p>The result is a protocol optimized for <strong>LLM token efficiency</strong> while remaining <strong>human-readable</strong> and <strong>developer-friendly</strong>.</p>
+<h3 id="token-efficiency-summary">Token Efficiency Summary</h3>
+<table>
+<thead>
+<tr>
+<th>Feature</th>
+<th>Token Savings</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>CRUDE Consolidation</strong></td>
+<td>~85-96%</td>
+<td>Semantic endpoints instead of discrete tools</td>
+</tr>
+<tr>
+<td><strong>On-Demand Introspection</strong></td>
+<td>~95%</td>
+<td>Query schemas as needed vs. upfront parsing</td>
+</tr>
+<tr>
+<td><strong>Field Selection</strong></td>
+<td>~70-90%</td>
+<td>Return only requested fields in responses</td>
+</tr>
+</tbody>
+</table>
+<hr />
+<h2 id="related-documentation">Related Documentation</h2>
+<ul>
+<li><a href="https://github.com/MCPAQL/spec/blob/main/docs/reference/overview.md">Overview</a> - Architecture overview</li>
+<li><a href="https://github.com/MCPAQL/spec/blob/main/docs/reference/operations.md">Operations</a> - Complete operation reference</li>
+<li><a href="https://github.com/MCPAQL/spec/blob/main/docs/reference/introspection.md">Introspection</a> - Discovery system</li>
+<li><a href="https://github.com/MCPAQL/spec/blob/main/docs/reference/design-decisions.md">Design Decisions</a> - Design rationale</li>
+</ul>
+
+          </div>
+        </section>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div class="container">
+      <p>&copy; 2026 DollhouseMCP Inc. d/b/a Dollhouse Research. MCP-AQL public draft documentation portal.</p>
+      <div class="footer-links">
+        <a href="../../docs/index.html">Docs Library</a>
+        <a href="../index.html">Repo-Synced Spec</a>
+        <a href="https://github.com/MCPAQL">MCPAQL Organization</a>
+        <a href="https://dollhouseresearch.com">Dollhouse Research</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../../js/search.js"></script>
+</body>
+</html>

--- a/public/spec/index.html
+++ b/public/spec/index.html
@@ -1,0 +1,503 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Repo-synced full MCP-AQL spec reference generated from the specification repository.">
+  <title>MCP-AQL Spec | Full Reference</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../css/style.css">
+</head>
+<body>
+  <header>
+    <div class="container">
+      <nav>
+        <a class="logo" href="../index.html"><span class="logo-mark"></span>MCP-AQL</a>
+        <ul class="nav-links">
+          <li><a href="../index.html">Home</a></li>
+          <li><a href="../docs/index.html">Docs</a></li>
+          <li><a href="../launch-checklist.html">Launch Checklist</a></li>
+          <li><a href="../apis/mcp-server.html">Adapter Patterns</a></li>
+        </ul>
+        <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
+          <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
+          <input id="site-search-input" data-search-input type="search" placeholder="Search full spec reference...">
+          <span class="search-count" data-search-count></span>
+          <ul class="search-results" data-search-results hidden></ul>
+        </form>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <div class="container">
+      <section class="hero">
+        <div class="hero-inner">
+          <span class="status-pill">REPO-SYNCED SPEC REFERENCE</span>
+          <h1>The deeper protocol docs now live on the website too</h1>
+          <p class="lede">
+            These pages are generated from <code>MCPAQL/spec/docs</code> so the public site can carry the full protocol and adapter material,
+            not just summaries and links back to GitHub.
+          </p>
+          <div class="hero-actions">
+            <a class="btn btn-primary" href="versions/v1.0.0-draft.html">Read The Normative Draft</a>
+            <a class="btn btn-secondary" href="../docs/index.html">Back To Docs Library</a>
+          </div>
+        </div>
+      </section>
+
+      <section>
+        <h2 class="section-title">How To Use This Section</h2>
+        <div class="card">
+          <ul>
+            <li>Use the summary pages in <a href="../docs/index.html">Docs Library</a> for orientation and launch framing.</li>
+            <li>Use this repo-synced reference for the fuller spec text hosted directly on the website.</li>
+            <li>In case of conflict, the versioned draft under <code>versions/</code> remains the normative source.</li>
+          </ul>
+        </div>
+      </section>
+
+      <section>
+  <h2 class="section-title">Core</h2>
+  <div class="grid cols-3 spec-index-grid">
+    <article class="card">
+  <h3>MCP-AQL Conformance Testing Specification</h3>
+  <p>Document Status: This document is an informative conformance framework specification aligned to the normative protocol requirements in docs/versions/v1.0.0-draft.md. Implementation Status: The full mcpaql-conformance run</p>
+  <div class="spec-meta">
+    <span class="state-chip live">Support document</span>
+    <span class="state-chip pending">Draft</span>
+  </div>
+  <a href="conformance-testing.html">Open Page</a>
+</article>
+<article class="card">
+  <h3>MCP-AQL CRUDE Pattern Specification</h3>
+  <p>Document Status: This document is informative. For normative requirements, see MCP-AQL Specification v1.0.0.</p>
+  <div class="spec-meta">
+    <span class="state-chip live">Support document</span>
+    <span class="state-chip pending">Draft</span>
+  </div>
+  <a href="crude-pattern.html">Open Page</a>
+</article>
+<article class="card">
+  <h3>MCP-AQL Endpoint Modes Specification</h3>
+  <p>Document Status: This document is informative. For normative requirements, see MCP-AQL Specification v1.0.0.</p>
+  <div class="spec-meta">
+    <span class="state-chip live">Support document</span>
+    <span class="state-chip pending">Draft</span>
+  </div>
+  <a href="endpoint-modes.html">Open Page</a>
+</article>
+<article class="card">
+  <h3>Structured Error Codes Specification</h3>
+  <p>This document defines the structured error code system for MCP-AQL protocol responses. Structured error codes enable machine-readable error handling, consistent error categorization, and reliable error mapping across ada</p>
+  <div class="spec-meta">
+    <span class="state-chip live">Support document</span>
+    <span class="state-chip pending">Draft (MVP)</span>
+  </div>
+  <a href="error-codes.html">Open Page</a>
+</article>
+<article class="card">
+  <h3>MCP-AQL Introspection Specification</h3>
+  <p>Document Status: This document is informative. For normative requirements, see MCP-AQL Specification v1.0.0.</p>
+  <div class="spec-meta">
+    <span class="state-chip live">Support document</span>
+    <span class="state-chip pending">Draft</span>
+  </div>
+  <a href="introspection.html">Open Page</a>
+</article>
+<article class="card">
+  <h3>MCP-AQL Licensing Options (Working Notes)</h3>
+  <p>This document is a discussion aid for deciding how to license the MCP-AQL ecosystem (spec + schema artifacts + tooling + generated adapters + brand/name), while meeting these goals:</p>
+  <div class="spec-meta">
+    <span class="state-chip live">Support document</span>
+    
+  </div>
+  <a href="licensing-options.html">Open Page</a>
+</article>
+<article class="card">
+  <h3>MCP Integration Specification</h3>
+  <p>This document specifies how MCP-AQL adapters integrate with the Model Context Protocol (MCP). It defines tool registration requirements, input schema composition, error mapping between protocols, progress notification ha</p>
+  <div class="spec-meta">
+    <span class="state-chip live">Support document</span>
+    <span class="state-chip pending">Draft</span>
+  </div>
+  <a href="mcp-integration.html">Open Page</a>
+</article>
+<article class="card">
+  <h3>MCP-AQL Operations Specification</h3>
+  <p>Document Status: This document is informative. For normative requirements, see MCP-AQL Specification v1.0.0.</p>
+  <div class="spec-meta">
+    <span class="state-chip live">Support document</span>
+    <span class="state-chip pending">Draft</span>
+  </div>
+  <a href="operations.html">Open Page</a>
+</article>
+<article class="card">
+  <h3>MCP-AQL Protocol Overview</h3>
+  <p>MCP-AQL (Model Context Protocol - Agent Query Language) is a protocol that consolidates discrete MCP tools into 5 CRUDE endpoints (Create, Read, Update, Delete, Execute), providing significant token reduction while maint</p>
+  <div class="spec-meta">
+    <span class="state-chip live">Support document</span>
+    
+  </div>
+  <a href="overview.html">Open Page</a>
+</article>
+<article class="card">
+  <h3>Plugin Interface Contracts</h3>
+  <p>This document defines the normative plugin interface contracts for the MCP-AQL adapter system. Plugins provide modular, composable functionality for transport, protocol, authentication, and serialization. This specificat</p>
+  <div class="spec-meta">
+    <span class="state-chip live">Support document</span>
+    <span class="state-chip pending">Draft (MVP)</span>
+  </div>
+  <a href="plugin-contracts.html">Open Page</a>
+</article>
+<article class="card">
+  <h3>MCP-AQL Specification Documentation</h3>
+  <p>This directory contains the MCP-AQL specification set:</p>
+  <div class="spec-meta">
+    <span class="state-chip live">Support document</span>
+    
+  </div>
+  <a href="README.html">Open Page</a>
+</article>
+  </div>
+</section>
+<section>
+  <h2 class="section-title">Versions</h2>
+  <div class="grid cols-3 spec-index-grid">
+    <article class="card">
+  <h3>MCP-AQL Specification</h3>
+  <p>MCP-AQL (Model Context Protocol - Advanced Agent API Adapter Query Language) is a protocol specification that consolidates multiple MCP tools into semantic CRUDE endpoints, providing significant token reduction while ena</p>
+  <div class="spec-meta">
+    <span class="state-chip live">Normative source</span>
+    <span class="state-chip pending">Draft</span>
+  </div>
+  <a href="versions/v1.0.0-draft.html">Open Page</a>
+</article>
+  </div>
+</section>
+<section>
+  <h2 class="section-title">Adapter</h2>
+  <div class="grid cols-3 spec-index-grid">
+    <article class="card">
+  <h3>Dangerous Operation Classification Specification</h3>
+  <p>This document defines a standard classification system for dangerous operations in MCP-AQL adapters. Danger levels enable automatic lockdown of high-risk actions, consistent confirmation requirements, and trust-based per</p>
+  <div class="spec-meta">
+    <span class="state-chip live">Support document</span>
+    <span class="state-chip pending">Draft</span>
+  </div>
+  <a href="adapter/danger-levels.html">Open Page</a>
+</article>
+<article class="card">
+  <h3>MCP Server Discovery Bundle</h3>
+  <p>Document Status: This document is informative support text for the current MCP-AQL draft. The normative source of truth remains Specification v1.0.0-draft plus the published schemas in spec/schemas/.</p>
+  <div class="spec-meta">
+    <span class="state-chip live">Support document</span>
+    <span class="state-chip pending">Draft</span>
+  </div>
+  <a href="adapter/discovery-bundle.html">Open Page</a>
+</article>
+<article class="card">
+  <h3>Adapter Element Type Specification</h3>
+  <p>This document defines the Adapter Element Type, a declarative schema format for describing how MCP-AQL CRUDE operations map to target API calls. Adapters are Markdown files with YAML front matter that a universal runtime</p>
+  <div class="spec-meta">
+    <span class="state-chip live">Support document</span>
+    <span class="state-chip pending">Draft (MVP)</span>
+  </div>
+  <a href="adapter/element-type.html">Open Page</a>
+</article>
+<article class="card">
+  <h3>Adapter Generator Specification</h3>
+  <p>This document specifies the requirements and behavior of MCP-AQL adapter generators. An adapter generator takes a schema definition as input and produces compliant adapter code with required licensing artifacts and prove</p>
+  <div class="spec-meta">
+    <span class="state-chip live">Support document</span>
+    <span class="state-chip pending">Draft</span>
+  </div>
+  <a href="adapter/generator.html">Open Page</a>
+</article>
+<article class="card">
+  <h3>Rate Limiting and Quota Management Specification</h3>
+  <p>This document defines the rate limiting and quota management system for MCP-AQL adapters. Rate limits enable systems to respect API constraints, prevent runaway costs, and provide graceful degradation under load.</p>
+  <div class="spec-meta">
+    <span class="state-chip live">Support document</span>
+    <span class="state-chip pending">Draft</span>
+  </div>
+  <a href="adapter/rate-limiting.html">Open Page</a>
+</article>
+<article class="card">
+  <h3>Trust Levels Specification</h3>
+  <p>This document defines the trust level system for MCP-AQL adapters. Trust levels indicate the verification and validation status of an adapter, enabling systems to make informed decisions about which operations to permit </p>
+  <div class="spec-meta">
+    <span class="state-chip live">Support document</span>
+    <span class="state-chip pending">Draft</span>
+  </div>
+  <a href="adapter/trust-levels.html">Open Page</a>
+</article>
+  </div>
+</section>
+<section>
+  <h2 class="section-title">Security</h2>
+  <div class="grid cols-3 spec-index-grid">
+    <article class="card">
+  <h3>Confirmation Token Specification</h3>
+  <p>This document specifies the confirmation token mechanism used by MCP-AQL adapters to gate dangerous operations and quota continuations. Confirmation tokens provide a secure, time-limited method for clients to acknowledge</p>
+  <div class="spec-meta">
+    <span class="state-chip live">Support document</span>
+    <span class="state-chip pending">Draft</span>
+  </div>
+  <a href="security/confirmation-tokens.html">Open Page</a>
+</article>
+<article class="card">
+  <h3>Execution Safety Loop Specification</h3>
+  <p>Informative Document: This is an informative specification that provides detailed guidance for the execution safety loop pattern defined normatively in Section 8.6 of the core specification. In case of conflict, the norm</p>
+  <div class="spec-meta">
+    <span class="state-chip live">Support document</span>
+    <span class="state-chip pending">Draft</span>
+  </div>
+  <a href="security/execution-safety-loop.html">Open Page</a>
+</article>
+<article class="card">
+  <h3>Security Model: Gatekeeper Specification</h3>
+  <p>This document specifies an optional security model for MCP-AQL adapters, providing multi-layer access control, confirmation requirements, and audit capabilities.</p>
+  <div class="spec-meta">
+    <span class="state-chip live">Support document</span>
+    <span class="state-chip pending">Draft</span>
+  </div>
+  <a href="security/gatekeeper.html">Open Page</a>
+</article>
+  </div>
+</section>
+<section>
+  <h2 class="section-title">Features</h2>
+  <div class="grid cols-3 spec-index-grid">
+    <article class="card">
+  <h3>Field Selection Specification</h3>
+  <p>This document specifies the optional field selection feature that enables clients to request only specific fields in responses, reducing payload size and token consumption.</p>
+  <div class="spec-meta">
+    <span class="state-chip live">Support document</span>
+    <span class="state-chip pending">Draft</span>
+  </div>
+  <a href="features/field-selection.html">Open Page</a>
+</article>
+<article class="card">
+  <h3>Cursor-Based Pagination Specification</h3>
+  <p>This document defines cursor-based pagination semantics for MCP-AQL operations that return collections. Cursor pagination enables efficient iteration through large datasets while minimizing token usage in LLM context win</p>
+  <div class="spec-meta">
+    <span class="state-chip live">Support document</span>
+    <span class="state-chip pending">Draft</span>
+  </div>
+  <a href="features/pagination.html">Open Page</a>
+</article>
+<article class="card">
+  <h3>Warnings Array Specification</h3>
+  <p>This document specifies the warnings array extension to MCP-AQL's discriminated response format. Warnings provide a mechanism to communicate non-fatal conditions to clients within successful responses, enabling proactive</p>
+  <div class="spec-meta">
+    <span class="state-chip live">Support document</span>
+    <span class="state-chip pending">Draft</span>
+  </div>
+  <a href="features/warnings.html">Open Page</a>
+</article>
+  </div>
+</section>
+<section>
+  <h2 class="section-title">Guides</h2>
+  <div class="grid cols-3 spec-index-grid">
+    <article class="card">
+  <h3>Protocol Comparison Guide</h3>
+  <p>This document helps developers familiar with GraphQL, MongoDB, REST, SQL, or classic MCP understand MCP-AQL by mapping familiar concepts to their MCP-AQL equivalents.</p>
+  <div class="spec-meta">
+    <span class="state-chip live">Support document</span>
+    <span class="state-chip pending">draft</span>
+  </div>
+  <a href="guides/protocol-comparison.html">Open Page</a>
+</article>
+<article class="card">
+  <h3>Developer Guides</h3>
+  <p>Step-by-step guides for implementing and using MCP-AQL adapters.</p>
+  <div class="spec-meta">
+    <span class="state-chip live">Support document</span>
+    
+  </div>
+  <a href="guides/README.html">Open Page</a>
+</article>
+  </div>
+</section>
+<section>
+  <h2 class="section-title">Process</h2>
+  <div class="grid cols-3 spec-index-grid">
+    <article class="card">
+  <h3>MCP-AQL Breaking Change Policy</h3>
+  <p>This document defines how breaking changes are handled in the MCP-AQL specification, including change classification, deprecation procedures, migration requirements, and communication standards.</p>
+  <div class="spec-meta">
+    <span class="state-chip live">Support document</span>
+    <span class="state-chip pending">Draft</span>
+  </div>
+  <a href="process/breaking-changes.html">Open Page</a>
+</article>
+<article class="card">
+  <h3>Preliminary Public Launch Checklist</h3>
+  <p>This checklist defines the minimum quality bar for a coordinated preliminary public launch of:</p>
+  <div class="spec-meta">
+    <span class="state-chip live">Support document</span>
+    <span class="state-chip pending">Working</span>
+  </div>
+  <a href="process/preliminary-public-launch-checklist.html">Open Page</a>
+</article>
+<article class="card">
+  <h3>RFC Process for MCP-AQL Specification</h3>
+  <p>This document describes the formal process for proposing, reviewing, and accepting changes to the MCP-AQL specification through Requests for Comments (RFCs).</p>
+  <div class="spec-meta">
+    <span class="state-chip live">Support document</span>
+    <span class="state-chip pending">Active</span>
+  </div>
+  <a href="process/rfc-process.html">Open Page</a>
+</article>
+<article class="card">
+  <h3>Versioning Strategy</h3>
+  <p>This document describes the version numbering scheme and release process for the MCPAQL specification.</p>
+  <div class="spec-meta">
+    <span class="state-chip live">Support document</span>
+    <span class="state-chip pending">draft</span>
+  </div>
+  <a href="process/versioning.html">Open Page</a>
+</article>
+  </div>
+</section>
+<section>
+  <h2 class="section-title">Architecture</h2>
+  <div class="grid cols-3 spec-index-grid">
+    <article class="card">
+  <h3>Architecture Documentation</h3>
+  <p>Implementation architecture documentation has moved to the mcpaql-adapter repository.</p>
+  <div class="spec-meta">
+    <span class="state-chip live">Support document</span>
+    
+  </div>
+  <a href="architecture/README.html">Open Page</a>
+</article>
+  </div>
+</section>
+<section>
+  <h2 class="section-title">Research</h2>
+  <div class="grid cols-3 spec-index-grid">
+    <article class="card">
+  <h3>Protocol Landscape: MCP vs MCP-AQL vs A2A</h3>
+  <p>A strategic comparison of three protocols shaping how AI agents interact with the world: where they overlap, where they diverge, and where the gaps are.</p>
+  <div class="spec-meta">
+    <span class="state-chip live">Support document</span>
+    <span class="state-chip pending">research</span>
+  </div>
+  <a href="research/mcp-vs-mcpaql-vs-a2a.html">Open Page</a>
+</article>
+  </div>
+</section>
+<section>
+  <h2 class="section-title">Reference</h2>
+  <div class="grid cols-3 spec-index-grid">
+    <article class="card">
+  <h3>Reference Documentation</h3>
+  <p>Detailed specifications for schemas, formats, and protocol structures.</p>
+  <div class="spec-meta">
+    <span class="state-chip live">Support document</span>
+    
+  </div>
+  <a href="reference/README.html">Open Page</a>
+</article>
+  </div>
+</section>
+<section>
+  <h2 class="section-title">ADRs</h2>
+  <div class="grid cols-3 spec-index-grid">
+    <article class="card">
+  <h3>ADR-001: CRUDE Pattern (Extending CRUD with Execute)</h3>
+  <p>Date: 2026-01-16</p>
+  <div class="spec-meta">
+    <span class="state-chip live">Support document</span>
+    <span class="state-chip pending">Accepted</span>
+  </div>
+  <a href="adr/ADR-001-crude-pattern.html">Open Page</a>
+</article>
+<article class="card">
+  <h3>ADR-002: GraphQL-Style Input Objects for Updates</h3>
+  <p>Date: 2026-01-16</p>
+  <div class="spec-meta">
+    <span class="state-chip live">Support document</span>
+    <span class="state-chip pending">Accepted</span>
+  </div>
+  <a href="adr/ADR-002-graphql-style-input.html">Open Page</a>
+</article>
+<article class="card">
+  <h3>ADR-003: snake_case Parameter Convention</h3>
+  <p>Date: 2026-01-16</p>
+  <div class="spec-meta">
+    <span class="state-chip live">Support document</span>
+    <span class="state-chip pending">Accepted</span>
+  </div>
+  <a href="adr/ADR-003-snake-case-parameters.html">Open Page</a>
+</article>
+<article class="card">
+  <h3>ADR-004: Schema-Driven Operation Definitions</h3>
+  <p>Date: 2026-01-16</p>
+  <div class="spec-meta">
+    <span class="state-chip live">Support document</span>
+    <span class="state-chip pending">Accepted</span>
+  </div>
+  <a href="adr/ADR-004-schema-driven-operations.html">Open Page</a>
+</article>
+<article class="card">
+  <h3>ADR-005: GraphQL-Style Introspection System</h3>
+  <p>Date: 2026-01-16</p>
+  <div class="spec-meta">
+    <span class="state-chip live">Support document</span>
+    <span class="state-chip pending">Accepted</span>
+  </div>
+  <a href="adr/ADR-005-introspection-system.html">Open Page</a>
+</article>
+<article class="card">
+  <h3>ADR-006: Discriminated Response Format</h3>
+  <p>Date: 2026-01-16</p>
+  <div class="spec-meta">
+    <span class="state-chip live">Support document</span>
+    <span class="state-chip pending">Accepted</span>
+  </div>
+  <a href="adr/ADR-006-discriminated-responses.html">Open Page</a>
+</article>
+<article class="card">
+  <h3>Architecture Decision Records</h3>
+  <p>This directory contains Architecture Decision Records (ADRs) documenting significant design decisions in the MCP-AQL protocol specification.</p>
+  <div class="spec-meta">
+    <span class="state-chip live">Support document</span>
+    <span class="state-chip pending">Accepted | Proposed | Deprecated | Superseded</span>
+  </div>
+  <a href="adr/index.html">Open Page</a>
+</article>
+<article class="card">
+  <h3>Architecture Decision Records</h3>
+  <p>See index.md for the complete list of ADRs.</p>
+  <div class="spec-meta">
+    <span class="state-chip live">Support document</span>
+    
+  </div>
+  <a href="adr/README.html">Open Page</a>
+</article>
+  </div>
+</section>
+    </div>
+  </main>
+
+  <footer>
+    <div class="container">
+      <p>&copy; 2026 DollhouseMCP Inc. d/b/a Dollhouse Research. MCP-AQL public draft documentation portal.</p>
+      <div class="footer-links">
+        <a href="../docs/index.html">Docs Library</a>
+        <a href="https://github.com/MCPAQL/spec">Spec Repository</a>
+        <a href="https://github.com/MCPAQL">MCPAQL Organization</a>
+        <a href="https://dollhouseresearch.com">Dollhouse Research</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../js/search.js"></script>
+</body>
+</html>

--- a/public/spec/index.html
+++ b/public/spec/index.html
@@ -33,6 +33,12 @@
 
   <main>
     <div class="container">
+      <nav class="breadcrumbs" aria-label="Breadcrumb">
+        <ol>
+          <li><a href="../index.html">Home</a></li>
+          <li><span class="current">Full Spec</span></li>
+        </ol>
+      </nav>
       <section class="hero">
         <div class="hero-inner">
           <span class="status-pill">REPO-SYNCED SPEC REFERENCE</span>

--- a/public/spec/index.html
+++ b/public/spec/index.html
@@ -23,7 +23,7 @@
         </ul>
         <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
-          <input id="site-search-input" data-search-input type="search" placeholder="Search full spec reference...">
+          <input id="site-search-input" data-search-input type="search" placeholder="Search MCP-AQL docs, spec pages, and adapter patterns...">
           <span class="search-count" data-search-count></span>
           <ul class="search-results" data-search-results hidden></ul>
         </form>

--- a/public/spec/index.html
+++ b/public/spec/index.html
@@ -38,7 +38,7 @@
           <span class="status-pill">REPO-SYNCED SPEC REFERENCE</span>
           <h1>The deeper protocol docs now live on the website too</h1>
           <p class="lede">
-            These pages are generated from <code>MCPAQL/spec/docs</code> so the public site can carry the full protocol and adapter material,
+            These pages are generated from <code>MCPAQL/spec</code> so the public site can carry the full protocol and adapter material,
             not just summaries and links back to GitHub.
           </p>
           <div class="hero-actions">
@@ -63,7 +63,7 @@
   <h2 class="section-title">Core</h2>
   <div class="grid cols-3 spec-index-grid">
     <article class="card">
-  <h3>MCP-AQL Conformance Testing Specification</h3>
+  <h3><a href="conformance-testing.html">MCP-AQL Conformance Testing Specification</a></h3>
   <p>Document Status: This document is an informative conformance framework specification aligned to the normative protocol requirements in docs/versions/v1.0.0-draft.md. Implementation Status: The full mcpaql-conformance run</p>
   <div class="spec-meta">
     <span class="state-chip live">Support document</span>
@@ -72,7 +72,7 @@
   <a href="conformance-testing.html">Open Page</a>
 </article>
 <article class="card">
-  <h3>MCP-AQL CRUDE Pattern Specification</h3>
+  <h3><a href="crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></h3>
   <p>Document Status: This document is informative. For normative requirements, see MCP-AQL Specification v1.0.0.</p>
   <div class="spec-meta">
     <span class="state-chip live">Support document</span>
@@ -81,7 +81,7 @@
   <a href="crude-pattern.html">Open Page</a>
 </article>
 <article class="card">
-  <h3>MCP-AQL Endpoint Modes Specification</h3>
+  <h3><a href="endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></h3>
   <p>Document Status: This document is informative. For normative requirements, see MCP-AQL Specification v1.0.0.</p>
   <div class="spec-meta">
     <span class="state-chip live">Support document</span>
@@ -90,7 +90,7 @@
   <a href="endpoint-modes.html">Open Page</a>
 </article>
 <article class="card">
-  <h3>Structured Error Codes Specification</h3>
+  <h3><a href="error-codes.html">Structured Error Codes Specification</a></h3>
   <p>This document defines the structured error code system for MCP-AQL protocol responses. Structured error codes enable machine-readable error handling, consistent error categorization, and reliable error mapping across ada</p>
   <div class="spec-meta">
     <span class="state-chip live">Support document</span>
@@ -99,7 +99,7 @@
   <a href="error-codes.html">Open Page</a>
 </article>
 <article class="card">
-  <h3>MCP-AQL Introspection Specification</h3>
+  <h3><a href="introspection.html">MCP-AQL Introspection Specification</a></h3>
   <p>Document Status: This document is informative. For normative requirements, see MCP-AQL Specification v1.0.0.</p>
   <div class="spec-meta">
     <span class="state-chip live">Support document</span>
@@ -108,7 +108,7 @@
   <a href="introspection.html">Open Page</a>
 </article>
 <article class="card">
-  <h3>MCP-AQL Licensing Options (Working Notes)</h3>
+  <h3><a href="licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></h3>
   <p>This document is a discussion aid for deciding how to license the MCP-AQL ecosystem (spec + schema artifacts + tooling + generated adapters + brand/name), while meeting these goals:</p>
   <div class="spec-meta">
     <span class="state-chip live">Support document</span>
@@ -117,7 +117,7 @@
   <a href="licensing-options.html">Open Page</a>
 </article>
 <article class="card">
-  <h3>MCP Integration Specification</h3>
+  <h3><a href="mcp-integration.html">MCP Integration Specification</a></h3>
   <p>This document specifies how MCP-AQL adapters integrate with the Model Context Protocol (MCP). It defines tool registration requirements, input schema composition, error mapping between protocols, progress notification ha</p>
   <div class="spec-meta">
     <span class="state-chip live">Support document</span>
@@ -126,7 +126,7 @@
   <a href="mcp-integration.html">Open Page</a>
 </article>
 <article class="card">
-  <h3>MCP-AQL Operations Specification</h3>
+  <h3><a href="operations.html">MCP-AQL Operations Specification</a></h3>
   <p>Document Status: This document is informative. For normative requirements, see MCP-AQL Specification v1.0.0.</p>
   <div class="spec-meta">
     <span class="state-chip live">Support document</span>
@@ -135,7 +135,7 @@
   <a href="operations.html">Open Page</a>
 </article>
 <article class="card">
-  <h3>MCP-AQL Protocol Overview</h3>
+  <h3><a href="overview.html">MCP-AQL Protocol Overview</a></h3>
   <p>MCP-AQL (Model Context Protocol - Agent Query Language) is a protocol that consolidates discrete MCP tools into 5 CRUDE endpoints (Create, Read, Update, Delete, Execute), providing significant token reduction while maint</p>
   <div class="spec-meta">
     <span class="state-chip live">Support document</span>
@@ -144,7 +144,7 @@
   <a href="overview.html">Open Page</a>
 </article>
 <article class="card">
-  <h3>Plugin Interface Contracts</h3>
+  <h3><a href="plugin-contracts.html">Plugin Interface Contracts</a></h3>
   <p>This document defines the normative plugin interface contracts for the MCP-AQL adapter system. Plugins provide modular, composable functionality for transport, protocol, authentication, and serialization. This specificat</p>
   <div class="spec-meta">
     <span class="state-chip live">Support document</span>
@@ -153,7 +153,7 @@
   <a href="plugin-contracts.html">Open Page</a>
 </article>
 <article class="card">
-  <h3>MCP-AQL Specification Documentation</h3>
+  <h3><a href="README.html">MCP-AQL Specification Documentation</a></h3>
   <p>This directory contains the MCP-AQL specification set:</p>
   <div class="spec-meta">
     <span class="state-chip live">Support document</span>
@@ -161,13 +161,22 @@
   </div>
   <a href="README.html">Open Page</a>
 </article>
+<article class="card">
+  <h3><a href="repo/README.html">MCP-AQL Specification</a></h3>
+  <p>Model Context Protocol - Advanced Agent API Adapter Query Language</p>
+  <div class="spec-meta">
+    <span class="state-chip live">Repository source</span>
+    
+  </div>
+  <a href="repo/README.html">Open Page</a>
+</article>
   </div>
 </section>
 <section>
   <h2 class="section-title">Versions</h2>
   <div class="grid cols-3 spec-index-grid">
     <article class="card">
-  <h3>MCP-AQL Specification</h3>
+  <h3><a href="versions/v1.0.0-draft.html">MCP-AQL Specification</a></h3>
   <p>MCP-AQL (Model Context Protocol - Advanced Agent API Adapter Query Language) is a protocol specification that consolidates multiple MCP tools into semantic CRUDE endpoints, providing significant token reduction while ena</p>
   <div class="spec-meta">
     <span class="state-chip live">Normative source</span>
@@ -181,7 +190,7 @@
   <h2 class="section-title">Adapter</h2>
   <div class="grid cols-3 spec-index-grid">
     <article class="card">
-  <h3>Dangerous Operation Classification Specification</h3>
+  <h3><a href="adapter/danger-levels.html">Dangerous Operation Classification Specification</a></h3>
   <p>This document defines a standard classification system for dangerous operations in MCP-AQL adapters. Danger levels enable automatic lockdown of high-risk actions, consistent confirmation requirements, and trust-based per</p>
   <div class="spec-meta">
     <span class="state-chip live">Support document</span>
@@ -190,7 +199,7 @@
   <a href="adapter/danger-levels.html">Open Page</a>
 </article>
 <article class="card">
-  <h3>MCP Server Discovery Bundle</h3>
+  <h3><a href="adapter/discovery-bundle.html">MCP Server Discovery Bundle</a></h3>
   <p>Document Status: This document is informative support text for the current MCP-AQL draft. The normative source of truth remains Specification v1.0.0-draft plus the published schemas in spec/schemas/.</p>
   <div class="spec-meta">
     <span class="state-chip live">Support document</span>
@@ -199,7 +208,7 @@
   <a href="adapter/discovery-bundle.html">Open Page</a>
 </article>
 <article class="card">
-  <h3>Adapter Element Type Specification</h3>
+  <h3><a href="adapter/element-type.html">Adapter Element Type Specification</a></h3>
   <p>This document defines the Adapter Element Type, a declarative schema format for describing how MCP-AQL CRUDE operations map to target API calls. Adapters are Markdown files with YAML front matter that a universal runtime</p>
   <div class="spec-meta">
     <span class="state-chip live">Support document</span>
@@ -208,7 +217,7 @@
   <a href="adapter/element-type.html">Open Page</a>
 </article>
 <article class="card">
-  <h3>Adapter Generator Specification</h3>
+  <h3><a href="adapter/generator.html">Adapter Generator Specification</a></h3>
   <p>This document specifies the requirements and behavior of MCP-AQL adapter generators. An adapter generator takes a schema definition as input and produces compliant adapter code with required licensing artifacts and prove</p>
   <div class="spec-meta">
     <span class="state-chip live">Support document</span>
@@ -217,7 +226,7 @@
   <a href="adapter/generator.html">Open Page</a>
 </article>
 <article class="card">
-  <h3>Rate Limiting and Quota Management Specification</h3>
+  <h3><a href="adapter/rate-limiting.html">Rate Limiting and Quota Management Specification</a></h3>
   <p>This document defines the rate limiting and quota management system for MCP-AQL adapters. Rate limits enable systems to respect API constraints, prevent runaway costs, and provide graceful degradation under load.</p>
   <div class="spec-meta">
     <span class="state-chip live">Support document</span>
@@ -226,7 +235,7 @@
   <a href="adapter/rate-limiting.html">Open Page</a>
 </article>
 <article class="card">
-  <h3>Trust Levels Specification</h3>
+  <h3><a href="adapter/trust-levels.html">Trust Levels Specification</a></h3>
   <p>This document defines the trust level system for MCP-AQL adapters. Trust levels indicate the verification and validation status of an adapter, enabling systems to make informed decisions about which operations to permit </p>
   <div class="spec-meta">
     <span class="state-chip live">Support document</span>
@@ -240,7 +249,7 @@
   <h2 class="section-title">Security</h2>
   <div class="grid cols-3 spec-index-grid">
     <article class="card">
-  <h3>Confirmation Token Specification</h3>
+  <h3><a href="security/confirmation-tokens.html">Confirmation Token Specification</a></h3>
   <p>This document specifies the confirmation token mechanism used by MCP-AQL adapters to gate dangerous operations and quota continuations. Confirmation tokens provide a secure, time-limited method for clients to acknowledge</p>
   <div class="spec-meta">
     <span class="state-chip live">Support document</span>
@@ -249,7 +258,7 @@
   <a href="security/confirmation-tokens.html">Open Page</a>
 </article>
 <article class="card">
-  <h3>Execution Safety Loop Specification</h3>
+  <h3><a href="security/execution-safety-loop.html">Execution Safety Loop Specification</a></h3>
   <p>Informative Document: This is an informative specification that provides detailed guidance for the execution safety loop pattern defined normatively in Section 8.6 of the core specification. In case of conflict, the norm</p>
   <div class="spec-meta">
     <span class="state-chip live">Support document</span>
@@ -258,7 +267,7 @@
   <a href="security/execution-safety-loop.html">Open Page</a>
 </article>
 <article class="card">
-  <h3>Security Model: Gatekeeper Specification</h3>
+  <h3><a href="security/gatekeeper.html">Security Model: Gatekeeper Specification</a></h3>
   <p>This document specifies an optional security model for MCP-AQL adapters, providing multi-layer access control, confirmation requirements, and audit capabilities.</p>
   <div class="spec-meta">
     <span class="state-chip live">Support document</span>
@@ -272,7 +281,7 @@
   <h2 class="section-title">Features</h2>
   <div class="grid cols-3 spec-index-grid">
     <article class="card">
-  <h3>Field Selection Specification</h3>
+  <h3><a href="features/field-selection.html">Field Selection Specification</a></h3>
   <p>This document specifies the optional field selection feature that enables clients to request only specific fields in responses, reducing payload size and token consumption.</p>
   <div class="spec-meta">
     <span class="state-chip live">Support document</span>
@@ -281,7 +290,7 @@
   <a href="features/field-selection.html">Open Page</a>
 </article>
 <article class="card">
-  <h3>Cursor-Based Pagination Specification</h3>
+  <h3><a href="features/pagination.html">Cursor-Based Pagination Specification</a></h3>
   <p>This document defines cursor-based pagination semantics for MCP-AQL operations that return collections. Cursor pagination enables efficient iteration through large datasets while minimizing token usage in LLM context win</p>
   <div class="spec-meta">
     <span class="state-chip live">Support document</span>
@@ -290,7 +299,7 @@
   <a href="features/pagination.html">Open Page</a>
 </article>
 <article class="card">
-  <h3>Warnings Array Specification</h3>
+  <h3><a href="features/warnings.html">Warnings Array Specification</a></h3>
   <p>This document specifies the warnings array extension to MCP-AQL's discriminated response format. Warnings provide a mechanism to communicate non-fatal conditions to clients within successful responses, enabling proactive</p>
   <div class="spec-meta">
     <span class="state-chip live">Support document</span>
@@ -304,7 +313,7 @@
   <h2 class="section-title">Guides</h2>
   <div class="grid cols-3 spec-index-grid">
     <article class="card">
-  <h3>Protocol Comparison Guide</h3>
+  <h3><a href="guides/protocol-comparison.html">Protocol Comparison Guide</a></h3>
   <p>This document helps developers familiar with GraphQL, MongoDB, REST, SQL, or classic MCP understand MCP-AQL by mapping familiar concepts to their MCP-AQL equivalents.</p>
   <div class="spec-meta">
     <span class="state-chip live">Support document</span>
@@ -313,7 +322,7 @@
   <a href="guides/protocol-comparison.html">Open Page</a>
 </article>
 <article class="card">
-  <h3>Developer Guides</h3>
+  <h3><a href="guides/README.html">Developer Guides</a></h3>
   <p>Step-by-step guides for implementing and using MCP-AQL adapters.</p>
   <div class="spec-meta">
     <span class="state-chip live">Support document</span>
@@ -327,7 +336,7 @@
   <h2 class="section-title">Process</h2>
   <div class="grid cols-3 spec-index-grid">
     <article class="card">
-  <h3>MCP-AQL Breaking Change Policy</h3>
+  <h3><a href="process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></h3>
   <p>This document defines how breaking changes are handled in the MCP-AQL specification, including change classification, deprecation procedures, migration requirements, and communication standards.</p>
   <div class="spec-meta">
     <span class="state-chip live">Support document</span>
@@ -336,7 +345,7 @@
   <a href="process/breaking-changes.html">Open Page</a>
 </article>
 <article class="card">
-  <h3>Preliminary Public Launch Checklist</h3>
+  <h3><a href="process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></h3>
   <p>This checklist defines the minimum quality bar for a coordinated preliminary public launch of:</p>
   <div class="spec-meta">
     <span class="state-chip live">Support document</span>
@@ -345,7 +354,7 @@
   <a href="process/preliminary-public-launch-checklist.html">Open Page</a>
 </article>
 <article class="card">
-  <h3>RFC Process for MCP-AQL Specification</h3>
+  <h3><a href="process/rfc-process.html">RFC Process for MCP-AQL Specification</a></h3>
   <p>This document describes the formal process for proposing, reviewing, and accepting changes to the MCP-AQL specification through Requests for Comments (RFCs).</p>
   <div class="spec-meta">
     <span class="state-chip live">Support document</span>
@@ -354,7 +363,7 @@
   <a href="process/rfc-process.html">Open Page</a>
 </article>
 <article class="card">
-  <h3>Versioning Strategy</h3>
+  <h3><a href="process/versioning.html">Versioning Strategy</a></h3>
   <p>This document describes the version numbering scheme and release process for the MCPAQL specification.</p>
   <div class="spec-meta">
     <span class="state-chip live">Support document</span>
@@ -362,13 +371,22 @@
   </div>
   <a href="process/versioning.html">Open Page</a>
 </article>
+<article class="card">
+  <h3><a href="repo/CHANGELOG.html">Changelog</a></h3>
+  <p>All notable changes to the MCP-AQL specification will be documented in this file.</p>
+  <div class="spec-meta">
+    <span class="state-chip live">Repository source</span>
+    
+  </div>
+  <a href="repo/CHANGELOG.html">Open Page</a>
+</article>
   </div>
 </section>
 <section>
   <h2 class="section-title">Architecture</h2>
   <div class="grid cols-3 spec-index-grid">
     <article class="card">
-  <h3>Architecture Documentation</h3>
+  <h3><a href="architecture/README.html">Architecture Documentation</a></h3>
   <p>Implementation architecture documentation has moved to the mcpaql-adapter repository.</p>
   <div class="spec-meta">
     <span class="state-chip live">Support document</span>
@@ -382,7 +400,7 @@
   <h2 class="section-title">Research</h2>
   <div class="grid cols-3 spec-index-grid">
     <article class="card">
-  <h3>Protocol Landscape: MCP vs MCP-AQL vs A2A</h3>
+  <h3><a href="research/mcp-vs-mcpaql-vs-a2a.html">Protocol Landscape: MCP vs MCP-AQL vs A2A</a></h3>
   <p>A strategic comparison of three protocols shaping how AI agents interact with the world: where they overlap, where they diverge, and where the gaps are.</p>
   <div class="spec-meta">
     <span class="state-chip live">Support document</span>
@@ -396,7 +414,7 @@
   <h2 class="section-title">Reference</h2>
   <div class="grid cols-3 spec-index-grid">
     <article class="card">
-  <h3>Reference Documentation</h3>
+  <h3><a href="reference/README.html">Reference Documentation</a></h3>
   <p>Detailed specifications for schemas, formats, and protocol structures.</p>
   <div class="spec-meta">
     <span class="state-chip live">Support document</span>
@@ -410,7 +428,7 @@
   <h2 class="section-title">ADRs</h2>
   <div class="grid cols-3 spec-index-grid">
     <article class="card">
-  <h3>ADR-001: CRUDE Pattern (Extending CRUD with Execute)</h3>
+  <h3><a href="adr/ADR-001-crude-pattern.html">ADR-001: CRUDE Pattern (Extending CRUD with Execute)</a></h3>
   <p>Date: 2026-01-16</p>
   <div class="spec-meta">
     <span class="state-chip live">Support document</span>
@@ -419,7 +437,7 @@
   <a href="adr/ADR-001-crude-pattern.html">Open Page</a>
 </article>
 <article class="card">
-  <h3>ADR-002: GraphQL-Style Input Objects for Updates</h3>
+  <h3><a href="adr/ADR-002-graphql-style-input.html">ADR-002: GraphQL-Style Input Objects for Updates</a></h3>
   <p>Date: 2026-01-16</p>
   <div class="spec-meta">
     <span class="state-chip live">Support document</span>
@@ -428,7 +446,7 @@
   <a href="adr/ADR-002-graphql-style-input.html">Open Page</a>
 </article>
 <article class="card">
-  <h3>ADR-003: snake_case Parameter Convention</h3>
+  <h3><a href="adr/ADR-003-snake-case-parameters.html">ADR-003: snake_case Parameter Convention</a></h3>
   <p>Date: 2026-01-16</p>
   <div class="spec-meta">
     <span class="state-chip live">Support document</span>
@@ -437,7 +455,7 @@
   <a href="adr/ADR-003-snake-case-parameters.html">Open Page</a>
 </article>
 <article class="card">
-  <h3>ADR-004: Schema-Driven Operation Definitions</h3>
+  <h3><a href="adr/ADR-004-schema-driven-operations.html">ADR-004: Schema-Driven Operation Definitions</a></h3>
   <p>Date: 2026-01-16</p>
   <div class="spec-meta">
     <span class="state-chip live">Support document</span>
@@ -446,7 +464,7 @@
   <a href="adr/ADR-004-schema-driven-operations.html">Open Page</a>
 </article>
 <article class="card">
-  <h3>ADR-005: GraphQL-Style Introspection System</h3>
+  <h3><a href="adr/ADR-005-introspection-system.html">ADR-005: GraphQL-Style Introspection System</a></h3>
   <p>Date: 2026-01-16</p>
   <div class="spec-meta">
     <span class="state-chip live">Support document</span>
@@ -455,7 +473,7 @@
   <a href="adr/ADR-005-introspection-system.html">Open Page</a>
 </article>
 <article class="card">
-  <h3>ADR-006: Discriminated Response Format</h3>
+  <h3><a href="adr/ADR-006-discriminated-responses.html">ADR-006: Discriminated Response Format</a></h3>
   <p>Date: 2026-01-16</p>
   <div class="spec-meta">
     <span class="state-chip live">Support document</span>
@@ -464,7 +482,7 @@
   <a href="adr/ADR-006-discriminated-responses.html">Open Page</a>
 </article>
 <article class="card">
-  <h3>Architecture Decision Records</h3>
+  <h3><a href="adr/index.html">Architecture Decision Records</a></h3>
   <p>This directory contains Architecture Decision Records (ADRs) documenting significant design decisions in the MCP-AQL protocol specification.</p>
   <div class="spec-meta">
     <span class="state-chip live">Support document</span>
@@ -473,7 +491,7 @@
   <a href="adr/index.html">Open Page</a>
 </article>
 <article class="card">
-  <h3>Architecture Decision Records</h3>
+  <h3><a href="adr/README.html">Architecture Decision Records</a></h3>
   <p>See index.md for the complete list of ADRs.</p>
   <div class="spec-meta">
     <span class="state-chip live">Support document</span>

--- a/public/spec/introspection.html
+++ b/public/spec/introspection.html
@@ -73,6 +73,13 @@
       </aside>
 
       <article class="docs-main">
+        <nav class="breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../index.html">Home</a></li>
+            <li><a href="index.html">Full Spec</a></li>
+            <li><span class="current">MCP-AQL Introspection Specification</span></li>
+          </ol>
+        </nav>
         <section class="hero docs-hero">
           <div class="hero-inner">
             <span class="status-pill">REPO-SYNCED SPEC DOC</span>

--- a/public/spec/introspection.html
+++ b/public/spec/introspection.html
@@ -1,0 +1,999 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Document Status: This document is informative. For normative requirements, see MCP-AQL Specification v1.0.0.">
+  <title>MCP-AQL Spec | MCP-AQL Introspection Specification</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../css/style.css">
+</head>
+<body>
+  <header>
+    <div class="container">
+      <nav>
+        <a class="logo" href="../index.html"><span class="logo-mark"></span>MCP-AQL</a>
+        <ul class="nav-links">
+          <li><a href="../index.html">Home</a></li>
+          <li><a href="../docs/index.html">Docs</a></li>
+          <li><a href="../launch-checklist.html">Launch Checklist</a></li>
+          <li><a href="../apis/mcp-server.html">Adapter Patterns</a></li>
+        </ul>
+        <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
+          <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
+          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <span class="search-count" data-search-count></span>
+          <ul class="search-results" data-search-results hidden></ul>
+        </form>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <div class="container docs-shell">
+      <aside class="docs-side">
+        <h2>Repo-Synced Spec</h2>
+        <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
+        <div class="docs-side-group">
+  <h3>Core</h3>
+  <ul><li><a href="conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="error-codes.html">Structured Error Codes Specification</a></li><li><a class="current" href="introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="mcp-integration.html">MCP Integration Specification</a></li><li><a href="operations.html">MCP-AQL Operations Specification</a></li><li><a href="overview.html">MCP-AQL Protocol Overview</a></li><li><a href="plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="README.html">MCP-AQL Specification Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Versions</h3>
+  <ul><li><a href="versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Adapter</h3>
+  <ul><li><a href="adapter/danger-levels.html">Dangerous Operation Classification Specification</a></li><li><a href="adapter/discovery-bundle.html">MCP Server Discovery Bundle</a></li><li><a href="adapter/element-type.html">Adapter Element Type Specification</a></li><li><a href="adapter/generator.html">Adapter Generator Specification</a></li><li><a href="adapter/rate-limiting.html">Rate Limiting and Quota Management Specification</a></li><li><a href="adapter/trust-levels.html">Trust Levels Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Security</h3>
+  <ul><li><a href="security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Features</h3>
+  <ul><li><a href="features/field-selection.html">Field Selection Specification</a></li><li><a href="features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="features/warnings.html">Warnings Array Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Guides</h3>
+  <ul><li><a href="guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="guides/README.html">Developer Guides</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Process</h3>
+  <ul><li><a href="process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="process/versioning.html">Versioning Strategy</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Architecture</h3>
+  <ul><li><a href="architecture/README.html">Architecture Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Research</h3>
+  <ul><li><a href="research/mcp-vs-mcpaql-vs-a2a.html">Protocol Landscape: MCP vs MCP-AQL vs A2A</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Reference</h3>
+  <ul><li><a href="reference/README.html">Reference Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>ADRs</h3>
+  <ul><li><a href="adr/ADR-001-crude-pattern.html">ADR-001: CRUDE Pattern (Extending CRUD with Execute)</a></li><li><a href="adr/ADR-002-graphql-style-input.html">ADR-002: GraphQL-Style Input Objects for Updates</a></li><li><a href="adr/ADR-003-snake-case-parameters.html">ADR-003: snake_case Parameter Convention</a></li><li><a href="adr/ADR-004-schema-driven-operations.html">ADR-004: Schema-Driven Operation Definitions</a></li><li><a href="adr/ADR-005-introspection-system.html">ADR-005: GraphQL-Style Introspection System</a></li><li><a href="adr/ADR-006-discriminated-responses.html">ADR-006: Discriminated Response Format</a></li><li><a href="adr/index.html">Architecture Decision Records</a></li><li><a href="adr/README.html">Architecture Decision Records</a></li></ul>
+</div>
+      </aside>
+
+      <article class="docs-main">
+        <section class="hero docs-hero">
+          <div class="hero-inner">
+            <span class="status-pill">REPO-SYNCED SPEC DOC</span>
+            <h1>MCP-AQL Introspection Specification</h1>
+            <p class="lede">Document Status: This document is informative. For normative requirements, see MCP-AQL Specification v1.0.0.</p>
+            <div class="spec-meta"><span class="state-chip live">Support document</span><span class="state-chip pending">Draft</span><span class="state-chip">1.0.0-draft</span><span class="state-chip">2026-01-16</span></div>
+            <p class="spec-source">Source: <a href="https://github.com/MCPAQL/spec/blob/main/docs/introspection.md">spec/docs/introspection.md</a></p>
+            <div class="hero-actions">
+              <a class="btn btn-primary" href="https://github.com/MCPAQL/spec/blob/main/docs/introspection.md">Open Source Markdown</a>
+              <a class="btn btn-secondary" href="index.html">Browse Full Spec Reference</a>
+            </div>
+          </div>
+        </section>
+
+        <section>
+          <div class="card spec-prose">
+            <p><strong>Version:</strong> 1.0.0-draft <strong>Status:</strong> Draft <strong>Last Updated:</strong> 2026-01-16</p>
+<blockquote>
+<p><strong>Document Status:</strong> This document is <strong>informative</strong>. For normative requirements, see <a href="versions/v1.0.0-draft.html">MCP-AQL Specification v1.0.0</a>.</p>
+</blockquote>
+<h2 id="abstract">Abstract</h2>
+<p>This document specifies the MCP-AQL introspection system, which provides GraphQL-style discovery capabilities for operations, parameters, types, and examples at runtime. The introspection system is the only operation that MCP-AQL mandates all adapters implement, enabling AI models to discover capabilities dynamically.</p>
+<h2 id="table-of-contents">Table of Contents</h2>
+<ol type="1">
+<li><a href="#1-introduction">Introduction</a></li>
+<li><a href="#2-introspection-query-types">Introspection Query Types</a></li>
+<li><a href="#3-response-structures">Response Structures</a></li>
+<li><a href="#4-operation-discovery">Operation Discovery</a></li>
+<li><a href="#5-type-discovery">Type Discovery</a></li>
+<li><a href="#6-implementation-guidance">Implementation Guidance</a></li>
+<li><a href="#7-token-efficiency">Token Efficiency</a></li>
+<li><a href="#8-conformance-requirements">Conformance Requirements</a></li>
+</ol>
+<hr />
+<h2 id="1-introduction">1. Introduction</h2>
+<h3 id="11-purpose">1.1 Purpose</h3>
+<p>The introspection system enables AI models to discover available operations at runtime rather than parsing large tool schemas upfront. This provides:</p>
+<ul>
+<li><strong>On-demand discovery</strong> - Query only what is needed</li>
+<li><strong>Self-documenting API</strong> - API describes itself without external documentation</li>
+<li><strong>Token efficiency</strong> - Avoid parsing many tool schemas</li>
+<li><strong>Dynamic capability detection</strong> - Discover adapter-specific operations</li>
+</ul>
+<h3 id="12-design-principles">1.2 Design Principles</h3>
+<ol type="1">
+<li><strong>Progressive disclosure</strong> - Start with summaries, drill into details</li>
+<li><strong>Consistency</strong> - Same response structure for all queries</li>
+<li><strong>Completeness</strong> - Sufficient information to construct valid requests</li>
+<li><strong>Efficiency</strong> - Minimal response size while maintaining usefulness</li>
+</ol>
+<h3 id="13-introspection-flow">1.3 Introspection Flow</h3>
+<p>The following diagram illustrates how an AI model discovers and uses operations:</p>
+<pre class="mermaid"><code>graph TB
+    subgraph &quot;Introspection Flow&quot;
+        LLM[AI Agent]
+        INTRO[introspect operation]
+        RESOLVER[Introspection Handler]
+        SCHEMA[Operation Registry]
+
+        LLM --&gt; |query: operations| INTRO
+        INTRO --&gt; RESOLVER
+        RESOLVER --&gt; |lookup| SCHEMA
+        RESOLVER --&gt; |response| LLM
+    end</code></pre>
+<h3 id="14-adapter-defined-content">1.4 Adapter-Defined Content</h3>
+<p>The introspection system returns information about the adapter's operations and types. Different adapters expose different operations - MCP-AQL defines the introspection mechanism, not the operations themselves.</p>
+<hr />
+<h2 id="2-introspection-query-types">2. Introspection Query Types</h2>
+<h3 id="21-the-introspect-operation">2.1 The <code>introspect</code> Operation</h3>
+<p>All introspection is performed through the <code>introspect</code> operation on the READ endpoint. This is the only operation that MCP-AQL REQUIRES all adapters to implement.</p>
+<p><strong>Request Format:</strong></p>
+<div class="sourceCode" id="cb2"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb2-2"><a href="#cb2-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;introspect&quot;</span><span class="op">,</span></span>
+<span id="cb2-3"><a href="#cb2-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> {</span>
+<span id="cb2-4"><a href="#cb2-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">query</span><span class="op">:</span> <span class="st">&quot;&lt;query_type&gt;&quot;</span><span class="op">,</span></span>
+<span id="cb2-5"><a href="#cb2-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;&lt;optional_specific_name&gt;&quot;</span></span>
+<span id="cb2-6"><a href="#cb2-6" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb2-7"><a href="#cb2-7" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<h3 id="22-query-types">2.2 Query Types</h3>
+<table>
+<thead>
+<tr>
+<th>Query</th>
+<th>Description</th>
+<th>Optional <code>name</code> Parameter</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>operations</code></td>
+<td>List all available operations</td>
+<td>Get details for a specific operation</td>
+</tr>
+<tr>
+<td><code>types</code></td>
+<td>List all available types</td>
+<td>Get details for a specific type</td>
+</tr>
+</tbody>
+</table>
+<h3 id="23-query-behavior">2.3 Query Behavior</h3>
+<p><strong>Without <code>name</code> parameter:</strong> Returns a list of all items of that type with summary information.</p>
+<p><strong>With <code>name</code> parameter:</strong> Returns detailed information for the specific item.</p>
+<h3 id="24-basic-usage-examples">2.4 Basic Usage Examples</h3>
+<div class="sourceCode" id="cb3"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb3-1"><a href="#cb3-1" aria-hidden="true" tabindex="-1"></a><span class="co">// List all operations</span></span>
+<span id="cb3-2"><a href="#cb3-2" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb3-3"><a href="#cb3-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;introspect&quot;</span><span class="op">,</span></span>
+<span id="cb3-4"><a href="#cb3-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> { <span class="dt">query</span><span class="op">:</span> <span class="st">&quot;operations&quot;</span> }</span>
+<span id="cb3-5"><a href="#cb3-5" aria-hidden="true" tabindex="-1"></a>}</span>
+<span id="cb3-6"><a href="#cb3-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb3-7"><a href="#cb3-7" aria-hidden="true" tabindex="-1"></a><span class="co">// Get details for a specific operation</span></span>
+<span id="cb3-8"><a href="#cb3-8" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb3-9"><a href="#cb3-9" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;introspect&quot;</span><span class="op">,</span></span>
+<span id="cb3-10"><a href="#cb3-10" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> { <span class="dt">query</span><span class="op">:</span> <span class="st">&quot;operations&quot;</span><span class="op">,</span> <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;create_entity&quot;</span> }</span>
+<span id="cb3-11"><a href="#cb3-11" aria-hidden="true" tabindex="-1"></a>}</span>
+<span id="cb3-12"><a href="#cb3-12" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb3-13"><a href="#cb3-13" aria-hidden="true" tabindex="-1"></a><span class="co">// List all types</span></span>
+<span id="cb3-14"><a href="#cb3-14" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb3-15"><a href="#cb3-15" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;introspect&quot;</span><span class="op">,</span></span>
+<span id="cb3-16"><a href="#cb3-16" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> { <span class="dt">query</span><span class="op">:</span> <span class="st">&quot;types&quot;</span> }</span>
+<span id="cb3-17"><a href="#cb3-17" aria-hidden="true" tabindex="-1"></a>}</span>
+<span id="cb3-18"><a href="#cb3-18" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb3-19"><a href="#cb3-19" aria-hidden="true" tabindex="-1"></a><span class="co">// Get details for a specific type</span></span>
+<span id="cb3-20"><a href="#cb3-20" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb3-21"><a href="#cb3-21" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;introspect&quot;</span><span class="op">,</span></span>
+<span id="cb3-22"><a href="#cb3-22" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> { <span class="dt">query</span><span class="op">:</span> <span class="st">&quot;types&quot;</span><span class="op">,</span> <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;EntityType&quot;</span> }</span>
+<span id="cb3-23"><a href="#cb3-23" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<hr />
+<h2 id="3-response-structures">3. Response Structures</h2>
+<h3 id="31-standard-response-wrapper">3.1 Standard Response Wrapper</h3>
+<p>All introspection responses MUST follow the standard MCP-AQL discriminated response format:</p>
+<div class="sourceCode" id="cb4"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb4-1"><a href="#cb4-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Success response</span></span>
+<span id="cb4-2"><a href="#cb4-2" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb4-3"><a href="#cb4-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">success</span><span class="op">:</span> <span class="kw">true</span><span class="op">,</span></span>
+<span id="cb4-4"><a href="#cb4-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">data</span><span class="op">:</span> {</span>
+<span id="cb4-5"><a href="#cb4-5" aria-hidden="true" tabindex="-1"></a>    <span class="co">// Introspection-specific payload</span></span>
+<span id="cb4-6"><a href="#cb4-6" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb4-7"><a href="#cb4-7" aria-hidden="true" tabindex="-1"></a>}</span>
+<span id="cb4-8"><a href="#cb4-8" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb4-9"><a href="#cb4-9" aria-hidden="true" tabindex="-1"></a><span class="co">// Failure response</span></span>
+<span id="cb4-10"><a href="#cb4-10" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb4-11"><a href="#cb4-11" aria-hidden="true" tabindex="-1"></a>  <span class="dt">success</span><span class="op">:</span> <span class="kw">false</span><span class="op">,</span></span>
+<span id="cb4-12"><a href="#cb4-12" aria-hidden="true" tabindex="-1"></a>  <span class="dt">error</span><span class="op">:</span> {</span>
+<span id="cb4-13"><a href="#cb4-13" aria-hidden="true" tabindex="-1"></a>    <span class="dt">code</span><span class="op">:</span> <span class="st">&quot;INTROSPECTION_ERROR&quot;</span><span class="op">,</span></span>
+<span id="cb4-14"><a href="#cb4-14" aria-hidden="true" tabindex="-1"></a>    <span class="dt">message</span><span class="op">:</span> <span class="st">&quot;Description of what went wrong&quot;</span></span>
+<span id="cb4-15"><a href="#cb4-15" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb4-16"><a href="#cb4-16" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<h3 id="32-operationinfo-list-item">3.2 OperationInfo (List Item)</h3>
+<p>Summary information for an operation in list responses:</p>
+<div class="sourceCode" id="cb5"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb5-1"><a href="#cb5-1" aria-hidden="true" tabindex="-1"></a><span class="kw">interface</span> OperationInfo {</span>
+<span id="cb5-2"><a href="#cb5-2" aria-hidden="true" tabindex="-1"></a>  name<span class="op">:</span> <span class="dt">string</span><span class="op">;</span>        <span class="co">// Operation identifier (e.g., &quot;create_entity&quot;)</span></span>
+<span id="cb5-3"><a href="#cb5-3" aria-hidden="true" tabindex="-1"></a>  endpoint<span class="op">:</span> <span class="dt">string</span><span class="op">;</span>    <span class="co">// CRUDE endpoint (e.g., &quot;CREATE&quot;)</span></span>
+<span id="cb5-4"><a href="#cb5-4" aria-hidden="true" tabindex="-1"></a>  description<span class="op">:</span> <span class="dt">string</span><span class="op">;</span> <span class="co">// Brief description</span></span>
+<span id="cb5-5"><a href="#cb5-5" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<h3 id="33-operationdetails-detail-response">3.3 OperationDetails (Detail Response)</h3>
+<p>Complete information for a specific operation:</p>
+<div class="sourceCode" id="cb6"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb6-1"><a href="#cb6-1" aria-hidden="true" tabindex="-1"></a><span class="kw">interface</span> OperationDetails {</span>
+<span id="cb6-2"><a href="#cb6-2" aria-hidden="true" tabindex="-1"></a>  name<span class="op">:</span> <span class="dt">string</span><span class="op">;</span>                    <span class="co">// Operation identifier</span></span>
+<span id="cb6-3"><a href="#cb6-3" aria-hidden="true" tabindex="-1"></a>  endpoint<span class="op">:</span> <span class="dt">string</span><span class="op">;</span>                <span class="co">// CRUDE endpoint</span></span>
+<span id="cb6-4"><a href="#cb6-4" aria-hidden="true" tabindex="-1"></a>  mcpTool<span class="op">:</span> <span class="dt">string</span><span class="op">;</span>                 <span class="co">// MCP tool name (e.g., &quot;mcp_aql_create&quot;)</span></span>
+<span id="cb6-5"><a href="#cb6-5" aria-hidden="true" tabindex="-1"></a>  description<span class="op">:</span> <span class="dt">string</span><span class="op">;</span>             <span class="co">// Detailed description</span></span>
+<span id="cb6-6"><a href="#cb6-6" aria-hidden="true" tabindex="-1"></a>  permissions<span class="op">:</span> EndpointPermissions<span class="op">;</span></span>
+<span id="cb6-7"><a href="#cb6-7" aria-hidden="true" tabindex="-1"></a>  parameters<span class="op">:</span> ParameterInfo[]<span class="op">;</span>     <span class="co">// Parameter definitions (see note below)</span></span>
+<span id="cb6-8"><a href="#cb6-8" aria-hidden="true" tabindex="-1"></a>  returns<span class="op">:</span> TypeInfo<span class="op">;</span>               <span class="co">// Return type information</span></span>
+<span id="cb6-9"><a href="#cb6-9" aria-hidden="true" tabindex="-1"></a>  examples<span class="op">:</span> OperationExample[]<span class="op">;</span>    <span class="co">// Example invocations</span></span>
+<span id="cb6-10"><a href="#cb6-10" aria-hidden="true" tabindex="-1"></a>}</span>
+<span id="cb6-11"><a href="#cb6-11" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb6-12"><a href="#cb6-12" aria-hidden="true" tabindex="-1"></a><span class="kw">interface</span> EndpointPermissions {</span>
+<span id="cb6-13"><a href="#cb6-13" aria-hidden="true" tabindex="-1"></a>  readOnly<span class="op">:</span> <span class="dt">boolean</span><span class="op">;</span>    <span class="co">// Whether operation modifies state</span></span>
+<span id="cb6-14"><a href="#cb6-14" aria-hidden="true" tabindex="-1"></a>  destructive<span class="op">:</span> <span class="dt">boolean</span><span class="op">;</span> <span class="co">// Whether operation removes state</span></span>
+<span id="cb6-15"><a href="#cb6-15" aria-hidden="true" tabindex="-1"></a>}</span>
+<span id="cb6-16"><a href="#cb6-16" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb6-17"><a href="#cb6-17" aria-hidden="true" tabindex="-1"></a><span class="kw">interface</span> OperationExample {</span>
+<span id="cb6-18"><a href="#cb6-18" aria-hidden="true" tabindex="-1"></a>  description<span class="op">?:</span> <span class="dt">string</span><span class="op">;</span> <span class="co">// Human-readable description of the example</span></span>
+<span id="cb6-19"><a href="#cb6-19" aria-hidden="true" tabindex="-1"></a>  request<span class="op">:</span> <span class="dt">object</span><span class="op">;</span>      <span class="co">// Example request object</span></span>
+<span id="cb6-20"><a href="#cb6-20" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<blockquote>
+<p><strong>Terminology Note:</strong> The <code>parameters</code> array here describes the definitions of accepted parameters. At request time, callers provide parameter values via the <code>params</code> object (see <a href="versions/v1.0.0-draft.html#41-standard-request-structure">Section 4.1 of the normative spec</a>). The keys of <code>params</code> correspond to the <code>name</code> field of each <code>ParameterInfo</code> entry.</p>
+</blockquote>
+<h3 id="34-parameterinfo">3.4 ParameterInfo</h3>
+<p>Parameter definition with optional constraint metadata:</p>
+<div class="sourceCode" id="cb7"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb7-1"><a href="#cb7-1" aria-hidden="true" tabindex="-1"></a><span class="kw">interface</span> ParameterInfo {</span>
+<span id="cb7-2"><a href="#cb7-2" aria-hidden="true" tabindex="-1"></a>  <span class="co">// Core fields (required)</span></span>
+<span id="cb7-3"><a href="#cb7-3" aria-hidden="true" tabindex="-1"></a>  name<span class="op">:</span> <span class="dt">string</span><span class="op">;</span>        <span class="co">// Parameter name (snake_case recommended)</span></span>
+<span id="cb7-4"><a href="#cb7-4" aria-hidden="true" tabindex="-1"></a>  type<span class="op">:</span> <span class="dt">string</span><span class="op">;</span>        <span class="co">// Type name (e.g., &quot;string&quot;, &quot;number&quot;, &quot;boolean&quot;, &quot;array&quot;, &quot;object&quot;)</span></span>
+<span id="cb7-5"><a href="#cb7-5" aria-hidden="true" tabindex="-1"></a>  required<span class="op">:</span> <span class="dt">boolean</span><span class="op">;</span>   <span class="co">// Whether parameter is required</span></span>
+<span id="cb7-6"><a href="#cb7-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb7-7"><a href="#cb7-7" aria-hidden="true" tabindex="-1"></a>  <span class="co">// Documentation (optional)</span></span>
+<span id="cb7-8"><a href="#cb7-8" aria-hidden="true" tabindex="-1"></a>  description<span class="op">?:</span> <span class="dt">string</span><span class="op">;</span> <span class="co">// Parameter description</span></span>
+<span id="cb7-9"><a href="#cb7-9" aria-hidden="true" tabindex="-1"></a>  <span class="cf">default</span><span class="op">?:</span> <span class="dt">unknown</span><span class="op">;</span>    <span class="co">// Default value if any</span></span>
+<span id="cb7-10"><a href="#cb7-10" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb7-11"><a href="#cb7-11" aria-hidden="true" tabindex="-1"></a>  <span class="co">// Constraint fields (optional) - enable client-side validation and LLM guidance</span></span>
+<span id="cb7-12"><a href="#cb7-12" aria-hidden="true" tabindex="-1"></a>  enum<span class="op">?:</span> <span class="dt">unknown</span>[]<span class="op">;</span>     <span class="co">// Allowed values for this parameter</span></span>
+<span id="cb7-13"><a href="#cb7-13" aria-hidden="true" tabindex="-1"></a>  minimum<span class="op">?:</span> <span class="dt">number</span><span class="op">;</span>     <span class="co">// Minimum value for numeric parameters (inclusive)</span></span>
+<span id="cb7-14"><a href="#cb7-14" aria-hidden="true" tabindex="-1"></a>  maximum<span class="op">?:</span> <span class="dt">number</span><span class="op">;</span>     <span class="co">// Maximum value for numeric parameters (inclusive)</span></span>
+<span id="cb7-15"><a href="#cb7-15" aria-hidden="true" tabindex="-1"></a>  minLength<span class="op">?:</span> <span class="dt">number</span><span class="op">;</span>   <span class="co">// Minimum length for string parameters</span></span>
+<span id="cb7-16"><a href="#cb7-16" aria-hidden="true" tabindex="-1"></a>  maxLength<span class="op">?:</span> <span class="dt">number</span><span class="op">;</span>   <span class="co">// Maximum length for string parameters</span></span>
+<span id="cb7-17"><a href="#cb7-17" aria-hidden="true" tabindex="-1"></a>  pattern<span class="op">?:</span> <span class="dt">string</span><span class="op">;</span>     <span class="co">// Regex pattern for string validation</span></span>
+<span id="cb7-18"><a href="#cb7-18" aria-hidden="true" tabindex="-1"></a>  format<span class="op">?:</span> <span class="dt">string</span><span class="op">;</span>      <span class="co">// Semantic format hint (e.g., &quot;date-time&quot;, &quot;email&quot;, &quot;uri&quot;, &quot;uuid&quot;)</span></span>
+<span id="cb7-19"><a href="#cb7-19" aria-hidden="true" tabindex="-1"></a>  items<span class="op">?:</span> <span class="dt">object</span><span class="op">;</span>       <span class="co">// Schema for array element types (nested ParameterInfo)</span></span>
+<span id="cb7-20"><a href="#cb7-20" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb7-21"><a href="#cb7-21" aria-hidden="true" tabindex="-1"></a>  <span class="co">// Security (optional)</span></span>
+<span id="cb7-22"><a href="#cb7-22" aria-hidden="true" tabindex="-1"></a>  sensitive<span class="op">?:</span> <span class="dt">boolean</span><span class="op">;</span>  <span class="co">// Whether parameter contains sensitive data (passwords, API keys)</span></span>
+<span id="cb7-23"><a href="#cb7-23" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<h4 id="341-constraint-field-usage">3.4.1 Constraint Field Usage</h4>
+<p>Constraint fields are <strong>the highest-value properties in the introspection system</strong> - they prevent LLM hallucination by telling agents exactly what values are valid.</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Type</th>
+<th>Purpose</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>enum</code></td>
+<td>array</td>
+<td>Lists all valid values; LLM can select from these</td>
+</tr>
+<tr>
+<td><code>minimum</code>/<code>maximum</code></td>
+<td>number</td>
+<td>Numeric bounds; LLM can generate values in range</td>
+</tr>
+<tr>
+<td><code>minLength</code>/<code>maxLength</code></td>
+<td>integer</td>
+<td>String length limits</td>
+</tr>
+<tr>
+<td><code>pattern</code></td>
+<td>string</td>
+<td>Regex pattern for validation</td>
+</tr>
+<tr>
+<td><code>format</code></td>
+<td>string</td>
+<td>Semantic format hint (date-time, email, uri, uuid)</td>
+</tr>
+<tr>
+<td><code>items</code></td>
+<td>object</td>
+<td>Element schema for array parameters</td>
+</tr>
+<tr>
+<td><code>sensitive</code></td>
+<td>boolean</td>
+<td>Flag for passwords/API keys; clients SHOULD mask input</td>
+</tr>
+</tbody>
+</table>
+<p><strong>Example with constraints:</strong></p>
+<div class="sourceCode" id="cb8"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb8-1"><a href="#cb8-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb8-2"><a href="#cb8-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;page_size&quot;</span><span class="fu">,</span></span>
+<span id="cb8-3"><a href="#cb8-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;integer&quot;</span><span class="fu">,</span></span>
+<span id="cb8-4"><a href="#cb8-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;required&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb8-5"><a href="#cb8-5" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Number of items per page&quot;</span><span class="fu">,</span></span>
+<span id="cb8-6"><a href="#cb8-6" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;default&quot;</span><span class="fu">:</span> <span class="dv">25</span><span class="fu">,</span></span>
+<span id="cb8-7"><a href="#cb8-7" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;minimum&quot;</span><span class="fu">:</span> <span class="dv">1</span><span class="fu">,</span></span>
+<span id="cb8-8"><a href="#cb8-8" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;maximum&quot;</span><span class="fu">:</span> <span class="dv">100</span></span>
+<span id="cb8-9"><a href="#cb8-9" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<div class="sourceCode" id="cb9"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb9-1"><a href="#cb9-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb9-2"><a href="#cb9-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;status&quot;</span><span class="fu">,</span></span>
+<span id="cb9-3"><a href="#cb9-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;string&quot;</span><span class="fu">,</span></span>
+<span id="cb9-4"><a href="#cb9-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;required&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb9-5"><a href="#cb9-5" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Filter by status&quot;</span><span class="fu">,</span></span>
+<span id="cb9-6"><a href="#cb9-6" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;enum&quot;</span><span class="fu">:</span> <span class="ot">[</span><span class="st">&quot;pending&quot;</span><span class="ot">,</span> <span class="st">&quot;active&quot;</span><span class="ot">,</span> <span class="st">&quot;completed&quot;</span><span class="ot">,</span> <span class="st">&quot;cancelled&quot;</span><span class="ot">]</span></span>
+<span id="cb9-7"><a href="#cb9-7" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<div class="sourceCode" id="cb10"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb10-1"><a href="#cb10-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb10-2"><a href="#cb10-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;api_key&quot;</span><span class="fu">,</span></span>
+<span id="cb10-3"><a href="#cb10-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;string&quot;</span><span class="fu">,</span></span>
+<span id="cb10-4"><a href="#cb10-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;required&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb10-5"><a href="#cb10-5" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;API key for authentication&quot;</span><span class="fu">,</span></span>
+<span id="cb10-6"><a href="#cb10-6" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;sensitive&quot;</span><span class="fu">:</span> <span class="kw">true</span></span>
+<span id="cb10-7"><a href="#cb10-7" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<h3 id="35-typeinfo-list-item">3.5 TypeInfo (List Item)</h3>
+<p>Summary information for a type:</p>
+<div class="sourceCode" id="cb11"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb11-1"><a href="#cb11-1" aria-hidden="true" tabindex="-1"></a><span class="kw">interface</span> TypeInfo {</span>
+<span id="cb11-2"><a href="#cb11-2" aria-hidden="true" tabindex="-1"></a>  name<span class="op">:</span> <span class="dt">string</span><span class="op">;</span>         <span class="co">// Type identifier</span></span>
+<span id="cb11-3"><a href="#cb11-3" aria-hidden="true" tabindex="-1"></a>  kind<span class="op">:</span> TypeKind<span class="op">;</span>       <span class="co">// &quot;enum&quot; | &quot;object&quot; | &quot;scalar&quot; | &quot;union&quot;</span></span>
+<span id="cb11-4"><a href="#cb11-4" aria-hidden="true" tabindex="-1"></a>  description<span class="op">?:</span> <span class="dt">string</span><span class="op">;</span> <span class="co">// Brief description</span></span>
+<span id="cb11-5"><a href="#cb11-5" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<h3 id="36-typedetails-detail-response">3.6 TypeDetails (Detail Response)</h3>
+<p>Complete information for a specific type:</p>
+<div class="sourceCode" id="cb12"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb12-1"><a href="#cb12-1" aria-hidden="true" tabindex="-1"></a><span class="kw">interface</span> TypeDetails <span class="kw">extends</span> TypeInfo {</span>
+<span id="cb12-2"><a href="#cb12-2" aria-hidden="true" tabindex="-1"></a>  values<span class="op">?:</span> <span class="dt">string</span>[]<span class="op">;</span>         <span class="co">// For enum types: allowed values</span></span>
+<span id="cb12-3"><a href="#cb12-3" aria-hidden="true" tabindex="-1"></a>  fields<span class="op">?:</span> ParameterInfo[]<span class="op">;</span>  <span class="co">// For object types: field definitions</span></span>
+<span id="cb12-4"><a href="#cb12-4" aria-hidden="true" tabindex="-1"></a>  members<span class="op">?:</span> <span class="dt">string</span>[]<span class="op">;</span>        <span class="co">// For union types: member type names</span></span>
+<span id="cb12-5"><a href="#cb12-5" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<hr />
+<h2 id="4-operation-discovery">4. Operation Discovery</h2>
+<h3 id="41-listing-all-operations">4.1 Listing All Operations</h3>
+<p><strong>Request:</strong></p>
+<div class="sourceCode" id="cb13"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb13-1"><a href="#cb13-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb13-2"><a href="#cb13-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;introspect&quot;</span><span class="op">,</span></span>
+<span id="cb13-3"><a href="#cb13-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> { <span class="dt">query</span><span class="op">:</span> <span class="st">&quot;operations&quot;</span> }</span>
+<span id="cb13-4"><a href="#cb13-4" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<p><strong>Response (example from a resource management adapter):</strong></p>
+<div class="sourceCode" id="cb14"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb14-1"><a href="#cb14-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb14-2"><a href="#cb14-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb14-3"><a href="#cb14-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;data&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb14-4"><a href="#cb14-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;_protocol&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb14-5"><a href="#cb14-5" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;version&quot;</span><span class="fu">:</span> <span class="st">&quot;1.0.0-alpha.1&quot;</span><span class="fu">,</span></span>
+<span id="cb14-6"><a href="#cb14-6" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;conformance&quot;</span><span class="fu">:</span> <span class="st">&quot;level-1&quot;</span><span class="fu">,</span></span>
+<span id="cb14-7"><a href="#cb14-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;mode&quot;</span><span class="fu">:</span> <span class="st">&quot;crude&quot;</span><span class="fu">,</span></span>
+<span id="cb14-8"><a href="#cb14-8" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;capabilities&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb14-9"><a href="#cb14-9" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;batch&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb14-10"><a href="#cb14-10" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;field_selection&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb14-11"><a href="#cb14-11" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;warnings&quot;</span><span class="fu">:</span> <span class="kw">true</span></span>
+<span id="cb14-12"><a href="#cb14-12" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span></span>
+<span id="cb14-13"><a href="#cb14-13" aria-hidden="true" tabindex="-1"></a>    <span class="fu">},</span></span>
+<span id="cb14-14"><a href="#cb14-14" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;operations&quot;</span><span class="fu">:</span> <span class="ot">[</span></span>
+<span id="cb14-15"><a href="#cb14-15" aria-hidden="true" tabindex="-1"></a>      <span class="fu">{</span></span>
+<span id="cb14-16"><a href="#cb14-16" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;create_entity&quot;</span><span class="fu">,</span></span>
+<span id="cb14-17"><a href="#cb14-17" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;endpoint&quot;</span><span class="fu">:</span> <span class="st">&quot;CREATE&quot;</span><span class="fu">,</span></span>
+<span id="cb14-18"><a href="#cb14-18" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Create a new entity&quot;</span></span>
+<span id="cb14-19"><a href="#cb14-19" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb14-20"><a href="#cb14-20" aria-hidden="true" tabindex="-1"></a>      <span class="fu">{</span></span>
+<span id="cb14-21"><a href="#cb14-21" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;list_entities&quot;</span><span class="fu">,</span></span>
+<span id="cb14-22"><a href="#cb14-22" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;endpoint&quot;</span><span class="fu">:</span> <span class="st">&quot;READ&quot;</span><span class="fu">,</span></span>
+<span id="cb14-23"><a href="#cb14-23" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;List entities with filtering and pagination&quot;</span></span>
+<span id="cb14-24"><a href="#cb14-24" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb14-25"><a href="#cb14-25" aria-hidden="true" tabindex="-1"></a>      <span class="fu">{</span></span>
+<span id="cb14-26"><a href="#cb14-26" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;get_entity&quot;</span><span class="fu">,</span></span>
+<span id="cb14-27"><a href="#cb14-27" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;endpoint&quot;</span><span class="fu">:</span> <span class="st">&quot;READ&quot;</span><span class="fu">,</span></span>
+<span id="cb14-28"><a href="#cb14-28" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Get an entity by identifier&quot;</span></span>
+<span id="cb14-29"><a href="#cb14-29" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb14-30"><a href="#cb14-30" aria-hidden="true" tabindex="-1"></a>      <span class="fu">{</span></span>
+<span id="cb14-31"><a href="#cb14-31" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;update_entity&quot;</span><span class="fu">,</span></span>
+<span id="cb14-32"><a href="#cb14-32" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;endpoint&quot;</span><span class="fu">:</span> <span class="st">&quot;UPDATE&quot;</span><span class="fu">,</span></span>
+<span id="cb14-33"><a href="#cb14-33" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Update entity properties&quot;</span></span>
+<span id="cb14-34"><a href="#cb14-34" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb14-35"><a href="#cb14-35" aria-hidden="true" tabindex="-1"></a>      <span class="fu">{</span></span>
+<span id="cb14-36"><a href="#cb14-36" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;delete_entity&quot;</span><span class="fu">,</span></span>
+<span id="cb14-37"><a href="#cb14-37" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;endpoint&quot;</span><span class="fu">:</span> <span class="st">&quot;DELETE&quot;</span><span class="fu">,</span></span>
+<span id="cb14-38"><a href="#cb14-38" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Delete an entity&quot;</span></span>
+<span id="cb14-39"><a href="#cb14-39" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb14-40"><a href="#cb14-40" aria-hidden="true" tabindex="-1"></a>      <span class="fu">{</span></span>
+<span id="cb14-41"><a href="#cb14-41" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;execute_workflow&quot;</span><span class="fu">,</span></span>
+<span id="cb14-42"><a href="#cb14-42" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;endpoint&quot;</span><span class="fu">:</span> <span class="st">&quot;EXECUTE&quot;</span><span class="fu">,</span></span>
+<span id="cb14-43"><a href="#cb14-43" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Start execution of a workflow&quot;</span></span>
+<span id="cb14-44"><a href="#cb14-44" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb14-45"><a href="#cb14-45" aria-hidden="true" tabindex="-1"></a>      <span class="fu">{</span></span>
+<span id="cb14-46"><a href="#cb14-46" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;introspect&quot;</span><span class="fu">,</span></span>
+<span id="cb14-47"><a href="#cb14-47" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;endpoint&quot;</span><span class="fu">:</span> <span class="st">&quot;READ&quot;</span><span class="fu">,</span></span>
+<span id="cb14-48"><a href="#cb14-48" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Discover available operations and types&quot;</span></span>
+<span id="cb14-49"><a href="#cb14-49" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span></span>
+<span id="cb14-50"><a href="#cb14-50" aria-hidden="true" tabindex="-1"></a>    <span class="ot">]</span></span>
+<span id="cb14-51"><a href="#cb14-51" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb14-52"><a href="#cb14-52" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<h4 id="411-protocol-metadata">4.1.1 Protocol Metadata</h4>
+<p>The <code>_protocol</code> object in operations list responses provides version and capability information:</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Type</th>
+<th>Required</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>version</code></td>
+<td>string</td>
+<td>MUST</td>
+<td>MCP-AQL spec version (semver format)</td>
+</tr>
+<tr>
+<td><code>conformance</code></td>
+<td>string</td>
+<td>SHOULD</td>
+<td>Conformance level ("level-1", "level-2")</td>
+</tr>
+<tr>
+<td><code>mode</code></td>
+<td>string</td>
+<td>SHOULD</td>
+<td>Endpoint mode ("crude", "single", "all")</td>
+</tr>
+<tr>
+<td><code>capabilities</code></td>
+<td>object</td>
+<td>MAY</td>
+<td>Feature flags for optional capabilities</td>
+</tr>
+</tbody>
+</table>
+<p><strong>Capabilities flags:</strong></p>
+<table>
+<thead>
+<tr>
+<th>Capability</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>batch</code></td>
+<td>Supports batch operations</td>
+</tr>
+<tr>
+<td><code>field_selection</code></td>
+<td>Supports field selection in responses</td>
+</tr>
+<tr>
+<td><code>pagination</code></td>
+<td>Supports cursor-based pagination</td>
+</tr>
+<tr>
+<td><code>warnings</code></td>
+<td>Includes warnings array in responses</td>
+</tr>
+<tr>
+<td><code>confirmation</code></td>
+<td>Supports confirmation token flow</td>
+</tr>
+<tr>
+<td><code>dangerous_operations</code></td>
+<td>Has danger level classification</td>
+</tr>
+</tbody>
+</table>
+<p>Clients can use protocol metadata to:</p>
+<ul>
+<li>Adapt behavior to protocol version</li>
+<li>Detect available features before use</li>
+<li>Enable graceful degradation for older adapters</li>
+</ul>
+<h3 id="42-getting-operation-details">4.2 Getting Operation Details</h3>
+<p><strong>Request:</strong></p>
+<div class="sourceCode" id="cb15"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb15-1"><a href="#cb15-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb15-2"><a href="#cb15-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;introspect&quot;</span><span class="op">,</span></span>
+<span id="cb15-3"><a href="#cb15-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> { <span class="dt">query</span><span class="op">:</span> <span class="st">&quot;operations&quot;</span><span class="op">,</span> <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;create_entity&quot;</span> }</span>
+<span id="cb15-4"><a href="#cb15-4" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<p><strong>Response:</strong></p>
+<div class="sourceCode" id="cb16"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb16-1"><a href="#cb16-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb16-2"><a href="#cb16-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb16-3"><a href="#cb16-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;data&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb16-4"><a href="#cb16-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb16-5"><a href="#cb16-5" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;create_entity&quot;</span><span class="fu">,</span></span>
+<span id="cb16-6"><a href="#cb16-6" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;endpoint&quot;</span><span class="fu">:</span> <span class="st">&quot;CREATE&quot;</span><span class="fu">,</span></span>
+<span id="cb16-7"><a href="#cb16-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;mcpTool&quot;</span><span class="fu">:</span> <span class="st">&quot;mcp_aql_create&quot;</span><span class="fu">,</span></span>
+<span id="cb16-8"><a href="#cb16-8" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Create a new entity of any type&quot;</span><span class="fu">,</span></span>
+<span id="cb16-9"><a href="#cb16-9" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;permissions&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb16-10"><a href="#cb16-10" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;readOnly&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb16-11"><a href="#cb16-11" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;destructive&quot;</span><span class="fu">:</span> <span class="kw">false</span></span>
+<span id="cb16-12"><a href="#cb16-12" aria-hidden="true" tabindex="-1"></a>      <span class="fu">},</span></span>
+<span id="cb16-13"><a href="#cb16-13" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;parameters&quot;</span><span class="fu">:</span> <span class="ot">[</span></span>
+<span id="cb16-14"><a href="#cb16-14" aria-hidden="true" tabindex="-1"></a>        <span class="fu">{</span></span>
+<span id="cb16-15"><a href="#cb16-15" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;entity_name&quot;</span><span class="fu">,</span></span>
+<span id="cb16-16"><a href="#cb16-16" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;string&quot;</span><span class="fu">,</span></span>
+<span id="cb16-17"><a href="#cb16-17" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;required&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb16-18"><a href="#cb16-18" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Entity name&quot;</span><span class="fu">,</span></span>
+<span id="cb16-19"><a href="#cb16-19" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;minLength&quot;</span><span class="fu">:</span> <span class="dv">1</span><span class="fu">,</span></span>
+<span id="cb16-20"><a href="#cb16-20" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;maxLength&quot;</span><span class="fu">:</span> <span class="dv">100</span><span class="fu">,</span></span>
+<span id="cb16-21"><a href="#cb16-21" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;pattern&quot;</span><span class="fu">:</span> <span class="st">&quot;^[a-zA-Z][a-zA-Z0-9_-]*$&quot;</span></span>
+<span id="cb16-22"><a href="#cb16-22" aria-hidden="true" tabindex="-1"></a>        <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb16-23"><a href="#cb16-23" aria-hidden="true" tabindex="-1"></a>        <span class="fu">{</span></span>
+<span id="cb16-24"><a href="#cb16-24" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;entity_type&quot;</span><span class="fu">,</span></span>
+<span id="cb16-25"><a href="#cb16-25" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;string&quot;</span><span class="fu">,</span></span>
+<span id="cb16-26"><a href="#cb16-26" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;required&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb16-27"><a href="#cb16-27" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Type of entity to create&quot;</span><span class="fu">,</span></span>
+<span id="cb16-28"><a href="#cb16-28" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;enum&quot;</span><span class="fu">:</span> <span class="ot">[</span><span class="st">&quot;resource&quot;</span><span class="ot">,</span> <span class="st">&quot;item&quot;</span><span class="ot">,</span> <span class="st">&quot;config&quot;</span><span class="ot">,</span> <span class="st">&quot;workflow&quot;</span><span class="ot">]</span></span>
+<span id="cb16-29"><a href="#cb16-29" aria-hidden="true" tabindex="-1"></a>        <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb16-30"><a href="#cb16-30" aria-hidden="true" tabindex="-1"></a>        <span class="fu">{</span></span>
+<span id="cb16-31"><a href="#cb16-31" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;description&quot;</span><span class="fu">,</span></span>
+<span id="cb16-32"><a href="#cb16-32" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;string&quot;</span><span class="fu">,</span></span>
+<span id="cb16-33"><a href="#cb16-33" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;required&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb16-34"><a href="#cb16-34" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Entity description&quot;</span><span class="fu">,</span></span>
+<span id="cb16-35"><a href="#cb16-35" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;maxLength&quot;</span><span class="fu">:</span> <span class="dv">500</span></span>
+<span id="cb16-36"><a href="#cb16-36" aria-hidden="true" tabindex="-1"></a>        <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb16-37"><a href="#cb16-37" aria-hidden="true" tabindex="-1"></a>        <span class="fu">{</span></span>
+<span id="cb16-38"><a href="#cb16-38" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;priority&quot;</span><span class="fu">,</span></span>
+<span id="cb16-39"><a href="#cb16-39" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;integer&quot;</span><span class="fu">,</span></span>
+<span id="cb16-40"><a href="#cb16-40" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;required&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb16-41"><a href="#cb16-41" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Priority level&quot;</span><span class="fu">,</span></span>
+<span id="cb16-42"><a href="#cb16-42" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;default&quot;</span><span class="fu">:</span> <span class="dv">5</span><span class="fu">,</span></span>
+<span id="cb16-43"><a href="#cb16-43" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;minimum&quot;</span><span class="fu">:</span> <span class="dv">1</span><span class="fu">,</span></span>
+<span id="cb16-44"><a href="#cb16-44" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;maximum&quot;</span><span class="fu">:</span> <span class="dv">10</span></span>
+<span id="cb16-45"><a href="#cb16-45" aria-hidden="true" tabindex="-1"></a>        <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb16-46"><a href="#cb16-46" aria-hidden="true" tabindex="-1"></a>        <span class="fu">{</span></span>
+<span id="cb16-47"><a href="#cb16-47" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;metadata&quot;</span><span class="fu">,</span></span>
+<span id="cb16-48"><a href="#cb16-48" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;object&quot;</span><span class="fu">,</span></span>
+<span id="cb16-49"><a href="#cb16-49" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;required&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb16-50"><a href="#cb16-50" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Additional metadata&quot;</span></span>
+<span id="cb16-51"><a href="#cb16-51" aria-hidden="true" tabindex="-1"></a>        <span class="fu">}</span></span>
+<span id="cb16-52"><a href="#cb16-52" aria-hidden="true" tabindex="-1"></a>      <span class="ot">]</span><span class="fu">,</span></span>
+<span id="cb16-53"><a href="#cb16-53" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;returns&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb16-54"><a href="#cb16-54" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;Entity&quot;</span><span class="fu">,</span></span>
+<span id="cb16-55"><a href="#cb16-55" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;kind&quot;</span><span class="fu">:</span> <span class="st">&quot;object&quot;</span><span class="fu">,</span></span>
+<span id="cb16-56"><a href="#cb16-56" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Newly created entity&quot;</span></span>
+<span id="cb16-57"><a href="#cb16-57" aria-hidden="true" tabindex="-1"></a>      <span class="fu">},</span></span>
+<span id="cb16-58"><a href="#cb16-58" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;examples&quot;</span><span class="fu">:</span> <span class="ot">[</span></span>
+<span id="cb16-59"><a href="#cb16-59" aria-hidden="true" tabindex="-1"></a>        <span class="fu">{</span></span>
+<span id="cb16-60"><a href="#cb16-60" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Create a resource entity&quot;</span><span class="fu">,</span></span>
+<span id="cb16-61"><a href="#cb16-61" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;request&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb16-62"><a href="#cb16-62" aria-hidden="true" tabindex="-1"></a>            <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;create_entity&quot;</span><span class="fu">,</span></span>
+<span id="cb16-63"><a href="#cb16-63" aria-hidden="true" tabindex="-1"></a>            <span class="dt">&quot;element_type&quot;</span><span class="fu">:</span> <span class="st">&quot;resource&quot;</span><span class="fu">,</span></span>
+<span id="cb16-64"><a href="#cb16-64" aria-hidden="true" tabindex="-1"></a>            <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb16-65"><a href="#cb16-65" aria-hidden="true" tabindex="-1"></a>              <span class="dt">&quot;entity_name&quot;</span><span class="fu">:</span> <span class="st">&quot;MyResource&quot;</span><span class="fu">,</span></span>
+<span id="cb16-66"><a href="#cb16-66" aria-hidden="true" tabindex="-1"></a>              <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;A sample resource&quot;</span></span>
+<span id="cb16-67"><a href="#cb16-67" aria-hidden="true" tabindex="-1"></a>            <span class="fu">}</span></span>
+<span id="cb16-68"><a href="#cb16-68" aria-hidden="true" tabindex="-1"></a>          <span class="fu">}</span></span>
+<span id="cb16-69"><a href="#cb16-69" aria-hidden="true" tabindex="-1"></a>        <span class="fu">}</span></span>
+<span id="cb16-70"><a href="#cb16-70" aria-hidden="true" tabindex="-1"></a>      <span class="ot">]</span></span>
+<span id="cb16-71"><a href="#cb16-71" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb16-72"><a href="#cb16-72" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb16-73"><a href="#cb16-73" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<h3 id="43-unknown-operation">4.3 Unknown Operation</h3>
+<p>When querying for an operation that does not exist, implementations MUST return a success response with null data:</p>
+<p><strong>Request:</strong></p>
+<div class="sourceCode" id="cb17"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb17-1"><a href="#cb17-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb17-2"><a href="#cb17-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;introspect&quot;</span><span class="op">,</span></span>
+<span id="cb17-3"><a href="#cb17-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> { <span class="dt">query</span><span class="op">:</span> <span class="st">&quot;operations&quot;</span><span class="op">,</span> <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;nonexistent_operation&quot;</span> }</span>
+<span id="cb17-4"><a href="#cb17-4" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<p><strong>Response:</strong></p>
+<div class="sourceCode" id="cb18"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb18-1"><a href="#cb18-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb18-2"><a href="#cb18-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb18-3"><a href="#cb18-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;data&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb18-4"><a href="#cb18-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="kw">null</span></span>
+<span id="cb18-5"><a href="#cb18-5" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb18-6"><a href="#cb18-6" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<hr />
+<h2 id="5-type-discovery">5. Type Discovery</h2>
+<h3 id="51-listing-all-types">5.1 Listing All Types</h3>
+<p><strong>Request:</strong></p>
+<div class="sourceCode" id="cb19"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb19-1"><a href="#cb19-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb19-2"><a href="#cb19-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;introspect&quot;</span><span class="op">,</span></span>
+<span id="cb19-3"><a href="#cb19-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> { <span class="dt">query</span><span class="op">:</span> <span class="st">&quot;types&quot;</span> }</span>
+<span id="cb19-4"><a href="#cb19-4" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<p><strong>Response:</strong></p>
+<div class="sourceCode" id="cb20"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb20-1"><a href="#cb20-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb20-2"><a href="#cb20-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb20-3"><a href="#cb20-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;data&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb20-4"><a href="#cb20-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;types&quot;</span><span class="fu">:</span> <span class="ot">[</span></span>
+<span id="cb20-5"><a href="#cb20-5" aria-hidden="true" tabindex="-1"></a>      <span class="fu">{</span></span>
+<span id="cb20-6"><a href="#cb20-6" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;EntityType&quot;</span><span class="fu">,</span></span>
+<span id="cb20-7"><a href="#cb20-7" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;kind&quot;</span><span class="fu">:</span> <span class="st">&quot;enum&quot;</span><span class="fu">,</span></span>
+<span id="cb20-8"><a href="#cb20-8" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Available entity types&quot;</span></span>
+<span id="cb20-9"><a href="#cb20-9" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb20-10"><a href="#cb20-10" aria-hidden="true" tabindex="-1"></a>      <span class="fu">{</span></span>
+<span id="cb20-11"><a href="#cb20-11" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;CRUDEndpoint&quot;</span><span class="fu">,</span></span>
+<span id="cb20-12"><a href="#cb20-12" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;kind&quot;</span><span class="fu">:</span> <span class="st">&quot;enum&quot;</span><span class="fu">,</span></span>
+<span id="cb20-13"><a href="#cb20-13" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;CRUDE endpoint categories for operation classification&quot;</span></span>
+<span id="cb20-14"><a href="#cb20-14" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb20-15"><a href="#cb20-15" aria-hidden="true" tabindex="-1"></a>      <span class="fu">{</span></span>
+<span id="cb20-16"><a href="#cb20-16" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;OperationInput&quot;</span><span class="fu">,</span></span>
+<span id="cb20-17"><a href="#cb20-17" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;kind&quot;</span><span class="fu">:</span> <span class="st">&quot;object&quot;</span><span class="fu">,</span></span>
+<span id="cb20-18"><a href="#cb20-18" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Standard input structure for all MCP-AQL operations&quot;</span></span>
+<span id="cb20-19"><a href="#cb20-19" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb20-20"><a href="#cb20-20" aria-hidden="true" tabindex="-1"></a>      <span class="fu">{</span></span>
+<span id="cb20-21"><a href="#cb20-21" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;OperationResult&quot;</span><span class="fu">,</span></span>
+<span id="cb20-22"><a href="#cb20-22" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;kind&quot;</span><span class="fu">:</span> <span class="st">&quot;union&quot;</span><span class="fu">,</span></span>
+<span id="cb20-23"><a href="#cb20-23" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Standard result type for all operations&quot;</span></span>
+<span id="cb20-24"><a href="#cb20-24" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb20-25"><a href="#cb20-25" aria-hidden="true" tabindex="-1"></a>      <span class="fu">{</span></span>
+<span id="cb20-26"><a href="#cb20-26" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;OperationSuccess&quot;</span><span class="fu">,</span></span>
+<span id="cb20-27"><a href="#cb20-27" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;kind&quot;</span><span class="fu">:</span> <span class="st">&quot;object&quot;</span><span class="fu">,</span></span>
+<span id="cb20-28"><a href="#cb20-28" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Successful operation result&quot;</span></span>
+<span id="cb20-29"><a href="#cb20-29" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb20-30"><a href="#cb20-30" aria-hidden="true" tabindex="-1"></a>      <span class="fu">{</span></span>
+<span id="cb20-31"><a href="#cb20-31" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;OperationFailure&quot;</span><span class="fu">,</span></span>
+<span id="cb20-32"><a href="#cb20-32" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;kind&quot;</span><span class="fu">:</span> <span class="st">&quot;object&quot;</span><span class="fu">,</span></span>
+<span id="cb20-33"><a href="#cb20-33" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Failed operation result&quot;</span></span>
+<span id="cb20-34"><a href="#cb20-34" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span></span>
+<span id="cb20-35"><a href="#cb20-35" aria-hidden="true" tabindex="-1"></a>    <span class="ot">]</span></span>
+<span id="cb20-36"><a href="#cb20-36" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb20-37"><a href="#cb20-37" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<h3 id="52-getting-type-details">5.2 Getting Type Details</h3>
+<h4 id="521-enum-type">5.2.1 Enum Type</h4>
+<p><strong>Request:</strong></p>
+<div class="sourceCode" id="cb21"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb21-1"><a href="#cb21-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb21-2"><a href="#cb21-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;introspect&quot;</span><span class="op">,</span></span>
+<span id="cb21-3"><a href="#cb21-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> { <span class="dt">query</span><span class="op">:</span> <span class="st">&quot;types&quot;</span><span class="op">,</span> <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;EntityType&quot;</span> }</span>
+<span id="cb21-4"><a href="#cb21-4" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<p><strong>Response:</strong></p>
+<div class="sourceCode" id="cb22"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb22-1"><a href="#cb22-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb22-2"><a href="#cb22-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb22-3"><a href="#cb22-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;data&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb22-4"><a href="#cb22-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb22-5"><a href="#cb22-5" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;EntityType&quot;</span><span class="fu">,</span></span>
+<span id="cb22-6"><a href="#cb22-6" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;kind&quot;</span><span class="fu">:</span> <span class="st">&quot;enum&quot;</span><span class="fu">,</span></span>
+<span id="cb22-7"><a href="#cb22-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Available entity types&quot;</span><span class="fu">,</span></span>
+<span id="cb22-8"><a href="#cb22-8" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;values&quot;</span><span class="fu">:</span> <span class="ot">[</span><span class="st">&quot;resource&quot;</span><span class="ot">,</span> <span class="st">&quot;item&quot;</span><span class="ot">,</span> <span class="st">&quot;config&quot;</span><span class="ot">,</span> <span class="st">&quot;workflow&quot;</span><span class="ot">]</span></span>
+<span id="cb22-9"><a href="#cb22-9" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb22-10"><a href="#cb22-10" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb22-11"><a href="#cb22-11" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<h4 id="522-object-type">5.2.2 Object Type</h4>
+<p><strong>Request:</strong></p>
+<div class="sourceCode" id="cb23"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb23-1"><a href="#cb23-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb23-2"><a href="#cb23-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;introspect&quot;</span><span class="op">,</span></span>
+<span id="cb23-3"><a href="#cb23-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> { <span class="dt">query</span><span class="op">:</span> <span class="st">&quot;types&quot;</span><span class="op">,</span> <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;OperationInput&quot;</span> }</span>
+<span id="cb23-4"><a href="#cb23-4" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<p><strong>Response:</strong></p>
+<div class="sourceCode" id="cb24"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb24-1"><a href="#cb24-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb24-2"><a href="#cb24-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb24-3"><a href="#cb24-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;data&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb24-4"><a href="#cb24-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb24-5"><a href="#cb24-5" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;OperationInput&quot;</span><span class="fu">,</span></span>
+<span id="cb24-6"><a href="#cb24-6" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;kind&quot;</span><span class="fu">:</span> <span class="st">&quot;object&quot;</span><span class="fu">,</span></span>
+<span id="cb24-7"><a href="#cb24-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Standard input structure for all MCP-AQL operations&quot;</span><span class="fu">,</span></span>
+<span id="cb24-8"><a href="#cb24-8" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;fields&quot;</span><span class="fu">:</span> <span class="ot">[</span></span>
+<span id="cb24-9"><a href="#cb24-9" aria-hidden="true" tabindex="-1"></a>        <span class="fu">{</span></span>
+<span id="cb24-10"><a href="#cb24-10" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;operation&quot;</span><span class="fu">,</span></span>
+<span id="cb24-11"><a href="#cb24-11" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;string&quot;</span><span class="fu">,</span></span>
+<span id="cb24-12"><a href="#cb24-12" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;required&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb24-13"><a href="#cb24-13" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;The operation to perform&quot;</span></span>
+<span id="cb24-14"><a href="#cb24-14" aria-hidden="true" tabindex="-1"></a>        <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb24-15"><a href="#cb24-15" aria-hidden="true" tabindex="-1"></a>        <span class="fu">{</span></span>
+<span id="cb24-16"><a href="#cb24-16" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;element_type&quot;</span><span class="fu">,</span></span>
+<span id="cb24-17"><a href="#cb24-17" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;string&quot;</span><span class="fu">,</span></span>
+<span id="cb24-18"><a href="#cb24-18" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;required&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb24-19"><a href="#cb24-19" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Element type for element operations&quot;</span></span>
+<span id="cb24-20"><a href="#cb24-20" aria-hidden="true" tabindex="-1"></a>        <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb24-21"><a href="#cb24-21" aria-hidden="true" tabindex="-1"></a>        <span class="fu">{</span></span>
+<span id="cb24-22"><a href="#cb24-22" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;params&quot;</span><span class="fu">,</span></span>
+<span id="cb24-23"><a href="#cb24-23" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;object&quot;</span><span class="fu">,</span></span>
+<span id="cb24-24"><a href="#cb24-24" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;required&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb24-25"><a href="#cb24-25" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Operation-specific parameters&quot;</span></span>
+<span id="cb24-26"><a href="#cb24-26" aria-hidden="true" tabindex="-1"></a>        <span class="fu">}</span></span>
+<span id="cb24-27"><a href="#cb24-27" aria-hidden="true" tabindex="-1"></a>      <span class="ot">]</span></span>
+<span id="cb24-28"><a href="#cb24-28" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb24-29"><a href="#cb24-29" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb24-30"><a href="#cb24-30" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<h4 id="523-union-type">5.2.3 Union Type</h4>
+<p><strong>Request:</strong></p>
+<div class="sourceCode" id="cb25"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb25-1"><a href="#cb25-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb25-2"><a href="#cb25-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;introspect&quot;</span><span class="op">,</span></span>
+<span id="cb25-3"><a href="#cb25-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> { <span class="dt">query</span><span class="op">:</span> <span class="st">&quot;types&quot;</span><span class="op">,</span> <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;OperationResult&quot;</span> }</span>
+<span id="cb25-4"><a href="#cb25-4" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<p><strong>Response:</strong></p>
+<div class="sourceCode" id="cb26"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb26-1"><a href="#cb26-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb26-2"><a href="#cb26-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb26-3"><a href="#cb26-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;data&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb26-4"><a href="#cb26-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb26-5"><a href="#cb26-5" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;OperationResult&quot;</span><span class="fu">,</span></span>
+<span id="cb26-6"><a href="#cb26-6" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;kind&quot;</span><span class="fu">:</span> <span class="st">&quot;union&quot;</span><span class="fu">,</span></span>
+<span id="cb26-7"><a href="#cb26-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Standard result type for all operations&quot;</span><span class="fu">,</span></span>
+<span id="cb26-8"><a href="#cb26-8" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;members&quot;</span><span class="fu">:</span> <span class="ot">[</span><span class="st">&quot;OperationSuccess&quot;</span><span class="ot">,</span> <span class="st">&quot;OperationFailure&quot;</span><span class="ot">]</span></span>
+<span id="cb26-9"><a href="#cb26-9" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb26-10"><a href="#cb26-10" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb26-11"><a href="#cb26-11" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<h3 id="53-protocol-types">5.3 Protocol Types</h3>
+<p>MCP-AQL defines these protocol-level types that adapters SHOULD include in their type registry:</p>
+<table>
+<thead>
+<tr>
+<th>Type Name</th>
+<th>Kind</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>CRUDEndpoint</code></td>
+<td>enum</td>
+<td>Endpoints: CREATE, READ, UPDATE, DELETE, EXECUTE</td>
+</tr>
+<tr>
+<td><code>OperationInput</code></td>
+<td>object</td>
+<td>Standard input structure</td>
+</tr>
+<tr>
+<td><code>OperationResult</code></td>
+<td>union</td>
+<td>Success or failure result</td>
+</tr>
+<tr>
+<td><code>OperationSuccess</code></td>
+<td>object</td>
+<td>Successful result with data</td>
+</tr>
+<tr>
+<td><code>OperationFailure</code></td>
+<td>object</td>
+<td>Failed result with error</td>
+</tr>
+<tr>
+<td><code>EndpointPermissions</code></td>
+<td>object</td>
+<td>Permission flags for operations</td>
+</tr>
+</tbody>
+</table>
+<p>Adapters define their own domain-specific types in addition to these.</p>
+<hr />
+<h2 id="6-implementation-guidance">6. Implementation Guidance</h2>
+<h3 id="61-schema-driven-architecture">6.1 Schema-Driven Architecture</h3>
+<p>Implementations SHOULD maintain a single source of truth for operation definitions. The introspection system derives its responses from this source:</p>
+<pre class="mermaid"><code>graph LR
+    subgraph &quot;Introspection Source Resolution&quot;
+        OP[Operation Name]
+        SCHEMA[Operation Schema&lt;br/&gt;Single Source of Truth]
+        RESPONSE[Introspection Response]
+
+        OP --&gt; SCHEMA
+        SCHEMA --&gt; RESPONSE
+    end</code></pre>
+<h3 id="62-introspection-handler-architecture">6.2 Introspection Handler Architecture</h3>
+<p>A conforming implementation typically includes these components:</p>
+<pre class="mermaid"><code>classDiagram
+    class IntrospectionHandler {
+        +resolve(params) IntrospectionResult
+        -listOperations() OperationInfo[]
+        -getOperationDetails(name) OperationDetails
+        -listTypes() TypeInfo[]
+        -getTypeDetails(name) TypeDetails
+        +getOperationsByEndpoint() Record
+        +getSummary() string
+    }
+
+    class OperationRegistry {
+        +getOperation(name) OperationSchema
+        +getAllOperations() OperationSchema[]
+        +isValidOperation(name) boolean
+    }
+
+    class TypeRegistry {
+        +getType(name) TypeDefinition
+        +getAllTypes() TypeDefinition[]
+        +isValidType(name) boolean
+    }
+
+    IntrospectionHandler --&gt; OperationRegistry : queries
+    IntrospectionHandler --&gt; TypeRegistry : queries</code></pre>
+<h3 id="63-utility-methods">6.3 Utility Methods</h3>
+<p>Implementations MAY provide utility methods for documentation and tooling:</p>
+<p><strong>Operations by Endpoint:</strong></p>
+<div class="sourceCode" id="cb29"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb29-1"><a href="#cb29-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Returns operations grouped by CRUDE endpoint</span></span>
+<span id="cb29-2"><a href="#cb29-2" aria-hidden="true" tabindex="-1"></a><span class="fu">getOperationsByEndpoint</span>()<span class="op">:</span> <span class="bu">Record</span><span class="op">&lt;</span>CRUDEndpoint<span class="op">,</span> OperationInfo[]<span class="op">&gt;</span></span></code></pre></div>
+<p><strong>Summary Generation:</strong></p>
+<div class="sourceCode" id="cb30"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb30-1"><a href="#cb30-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Returns a human-readable summary of all operations</span></span>
+<span id="cb30-2"><a href="#cb30-2" aria-hidden="true" tabindex="-1"></a><span class="fu">getSummary</span>()<span class="op">:</span> <span class="dt">string</span></span>
+<span id="cb30-3"><a href="#cb30-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb30-4"><a href="#cb30-4" aria-hidden="true" tabindex="-1"></a><span class="co">// Example output:</span></span>
+<span id="cb30-5"><a href="#cb30-5" aria-hidden="true" tabindex="-1"></a><span class="co">// MCP-AQL Operations:</span></span>
+<span id="cb30-6"><a href="#cb30-6" aria-hidden="true" tabindex="-1"></a><span class="co">//   CREATE: create_entity, import_entity</span></span>
+<span id="cb30-7"><a href="#cb30-7" aria-hidden="true" tabindex="-1"></a><span class="co">//   READ: list_entities, get_entity, introspect</span></span>
+<span id="cb30-8"><a href="#cb30-8" aria-hidden="true" tabindex="-1"></a><span class="co">//   UPDATE: update_entity</span></span>
+<span id="cb30-9"><a href="#cb30-9" aria-hidden="true" tabindex="-1"></a><span class="co">//   DELETE: delete_entity</span></span>
+<span id="cb30-10"><a href="#cb30-10" aria-hidden="true" tabindex="-1"></a><span class="co">//   EXECUTE: execute_workflow</span></span>
+<span id="cb30-11"><a href="#cb30-11" aria-hidden="true" tabindex="-1"></a><span class="co">//</span></span>
+<span id="cb30-12"><a href="#cb30-12" aria-hidden="true" tabindex="-1"></a><span class="co">// Types: EntityType, CRUDEndpoint, OperationInput, OperationResult</span></span>
+<span id="cb30-13"><a href="#cb30-13" aria-hidden="true" tabindex="-1"></a><span class="co">//</span></span>
+<span id="cb30-14"><a href="#cb30-14" aria-hidden="true" tabindex="-1"></a><span class="co">// Use introspect with name parameter for details.</span></span></code></pre></div>
+<hr />
+<h2 id="7-token-efficiency">7. Token Efficiency</h2>
+<h3 id="71-discovery-pattern">7.1 Discovery Pattern</h3>
+<p>The introspection system enables a token-efficient discovery pattern:</p>
+<pre><code>Step 1: List operations (~50 tokens response)
+   { operation: &quot;introspect&quot;, params: { query: &quot;operations&quot; } }
+
+Step 2: Get details for relevant operation (~100 tokens response)
+   { operation: &quot;introspect&quot;, params: { query: &quot;operations&quot;, name: &quot;create_entity&quot; } }
+
+Step 3: Execute operation
+   { operation: &quot;create_entity&quot;, params: { ... } }</code></pre>
+<h3 id="72-comparison-with-discrete-tools">7.2 Comparison with Discrete Tools</h3>
+<table>
+<thead>
+<tr>
+<th>Approach</th>
+<th>Upfront Cost</th>
+<th>Per-Operation Cost</th>
+<th>Total (10 ops)</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Discrete tools</td>
+<td>~29,600 tokens</td>
+<td>0</td>
+<td>~29,600</td>
+</tr>
+<tr>
+<td>MCP-AQL + introspect</td>
+<td>~1,100 tokens</td>
+<td>~150 tokens</td>
+<td>~2,600</td>
+</tr>
+</tbody>
+</table>
+<h3 id="73-caching-recommendations">7.3 Caching Recommendations</h3>
+<p>A <strong>session</strong> is the lifetime of a single MCP connection (see <a href="versions/v1.0.0-draft.html#23-session-lifecycle">Section 2.3</a> of the core specification).</p>
+<p>Implementations SHOULD:</p>
+<ul>
+<li>Cache introspection responses for the duration of the MCP connection (session)</li>
+<li>Return consistent results for the same query within a session</li>
+<li>Invalidate all cached introspection data when the session ends</li>
+<li>Invalidate cache mid-session only when server configuration changes</li>
+</ul>
+<hr />
+<h2 id="8-conformance-requirements">8. Conformance Requirements</h2>
+<h3 id="81-must-requirements">8.1 MUST Requirements</h3>
+<p>Conforming implementations MUST:</p>
+<ol type="1">
+<li>Implement the <code>introspect</code> operation on the READ endpoint</li>
+<li>Support both <code>operations</code> and <code>types</code> query types</li>
+<li>Return <code>OperationInfo</code> for all supported operations when listing</li>
+<li>Return <code>OperationDetails</code> when querying a specific operation by name</li>
+<li>Return <code>TypeInfo</code> for all supported types when listing</li>
+<li>Return <code>TypeDetails</code> when querying a specific type by name</li>
+<li>Include accurate parameter information with <code>required</code> flags</li>
+<li>Use consistent type names across all responses</li>
+<li>Return <code>null</code> for the item (not an error) when querying a non-existent operation or type</li>
+<li>Follow the discriminated response format (<code>{ success, data }</code> or <code>{ success, error }</code>)</li>
+<li>Include <code>_protocol</code> object in operations list responses with at least the <code>version</code> field</li>
+</ol>
+<h4 id="811-introspection-accuracy-must">8.1.1 Introspection Accuracy (MUST)</h4>
+<p>Introspection responses MUST accurately reflect the actual parameter names, types, and behaviors accepted by the implementation:</p>
+<ol type="1">
+<li>Parameter names in introspection MUST match the names expected by the operation handler</li>
+<li>Parameter types in introspection MUST match the types accepted by the operation handler</li>
+<li>Required/optional status in introspection MUST match the actual handler behavior</li>
+</ol>
+<h4 id="812-parameter-completeness-must">8.1.2 Parameter Completeness (MUST)</h4>
+<p>For every operation, implementations MUST ensure introspection completeness:</p>
+<ol type="1">
+<li>Every parameter accepted by the handler implementation MUST appear in introspection metadata</li>
+<li>Required parameters MUST appear with <code>required: true</code></li>
+<li>Optional parameters MUST appear with <code>required: false</code></li>
+<li>Feature parameters (e.g., <code>fields</code>, <code>limit</code>, <code>offset</code>) MUST appear with full type information</li>
+</ol>
+<p><strong>Conformance Test:</strong></p>
+<pre><code>FOR EACH operation in introspection:
+  1. Get documented parameters from introspection
+  2. Attempt operation with each documented parameter
+  3. Attempt operation with known cross-cutting parameters (fields, limit, offset)
+  4. Compare accepted vs documented parameters
+
+FAIL IF: Operation accepts parameters not in introspection
+WARN IF: Introspection documents parameters not accepted</code></pre>
+<h4 id="813-error-message-quality-must">8.1.3 Error Message Quality (MUST)</h4>
+<p>Error responses MUST NOT expose internal implementation details:</p>
+<ol type="1">
+<li>Error messages MUST NOT include programming language error messages</li>
+<li>Error messages MUST NOT include stack traces</li>
+<li>Error messages MUST NOT include internal class/object names or file paths</li>
+</ol>
+<h3 id="82-should-requirements">8.2 SHOULD Requirements</h3>
+<p>Conforming implementations SHOULD:</p>
+<ol type="1">
+<li>Include usage examples for all operations</li>
+<li>Provide meaningful descriptions for all parameters</li>
+<li>Document default values in parameter info</li>
+<li>Return operations grouped by endpoint in list responses</li>
+<li>Include the protocol types (<code>CRUDEndpoint</code>, <code>OperationResult</code>, etc.)</li>
+<li>Implement caching for introspection responses</li>
+<li>Include the <code>introspect</code> operation in the operations list</li>
+<li>Derive introspection data from a single source of truth (operation schema)</li>
+</ol>
+<h4 id="821-unknown-parameter-handling-should">8.2.1 Unknown Parameter Handling (SHOULD)</h4>
+<p>Implementations SHOULD handle unrecognized parameters explicitly:</p>
+<ol type="1">
+<li>Accept parameters at documented locations, OR</li>
+<li>Return a warning or error when unrecognized parameters are provided</li>
+<li>Implementations SHOULD NOT silently ignore parameters</li>
+</ol>
+<h4 id="822-element-type-constraints-should">8.2.2 Element-Type Constraints (SHOULD)</h4>
+<p>Introspection responses SHOULD document element-type-specific constraints:</p>
+<ol type="1">
+<li>Read-only or append-only fields SHOULD be documented</li>
+<li>Required nesting (e.g., "tags must be in metadata.tags") SHOULD be documented</li>
+<li>Operations that don't apply to certain element types SHOULD be noted</li>
+</ol>
+<h4 id="823-error-message-guidance-should">8.2.3 Error Message Guidance (SHOULD)</h4>
+<p>Error responses SHOULD include actionable information:</p>
+<ol type="1">
+<li>A clear description of what went wrong</li>
+<li>The correct action the user should take</li>
+<li>Reference to the appropriate operation if applicable</li>
+</ol>
+<p><strong>Recommended Error Message Format:</strong></p>
+<pre><code>Missing required parameter &#39;{paramName}&#39;. Expected: {type} ({description})</code></pre>
+<p><strong>Examples:</strong></p>
+<pre><code>Missing required parameter &#39;name&#39;. Expected: string (the name of the memory to operate on)
+Missing required parameter &#39;source&#39;. Expected: string (URL or file path to import from)</code></pre>
+<h4 id="824-deprecated-parameters-should">8.2.4 Deprecated Parameters (SHOULD)</h4>
+<ol type="1">
+<li>Deprecated parameters SHOULD appear in introspection with a deprecation notice</li>
+<li>Deprecated parameters SHOULD include migration guidance in the description</li>
+</ol>
+<h3 id="83-may-requirements">8.3 MAY Requirements</h3>
+<p>Conforming implementations MAY:</p>
+<ol type="1">
+<li>Define additional custom types</li>
+<li>Include additional metadata in responses</li>
+<li>Support additional query types beyond <code>operations</code> and <code>types</code></li>
+<li>Provide filtering/pagination for large operation lists</li>
+<li>Include utility methods for documentation generation</li>
+<li>Support field selection on introspection responses</li>
+</ol>
+<hr />
+<h2 id="references">References</h2>
+<ul>
+<li><a href="versions/v1.0.0-draft.html">MCP-AQL Specification v1.0.0-draft</a></li>
+<li><a href="crude-pattern.html">CRUDE Pattern Specification</a></li>
+<li><a href="operations.html">Operations Guide</a></li>
+</ul>
+
+          </div>
+        </section>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div class="container">
+      <p>&copy; 2026 DollhouseMCP Inc. d/b/a Dollhouse Research. MCP-AQL public draft documentation portal.</p>
+      <div class="footer-links">
+        <a href="../docs/index.html">Docs Library</a>
+        <a href="index.html">Repo-Synced Spec</a>
+        <a href="https://github.com/MCPAQL">MCPAQL Organization</a>
+        <a href="https://dollhouseresearch.com">Dollhouse Research</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../js/search.js"></script>
+</body>
+</html>

--- a/public/spec/introspection.html
+++ b/public/spec/introspection.html
@@ -38,7 +38,7 @@
         <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
         <div class="docs-side-group">
   <h3>Core</h3>
-  <ul><li><a href="conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="error-codes.html">Structured Error Codes Specification</a></li><li><a class="current" href="introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="mcp-integration.html">MCP Integration Specification</a></li><li><a href="operations.html">MCP-AQL Operations Specification</a></li><li><a href="overview.html">MCP-AQL Protocol Overview</a></li><li><a href="plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="README.html">MCP-AQL Specification Documentation</a></li></ul>
+  <ul><li><a href="conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="error-codes.html">Structured Error Codes Specification</a></li><li><a class="current" href="introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="mcp-integration.html">MCP Integration Specification</a></li><li><a href="operations.html">MCP-AQL Operations Specification</a></li><li><a href="overview.html">MCP-AQL Protocol Overview</a></li><li><a href="plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="README.html">MCP-AQL Specification Documentation</a></li><li><a href="repo/README.html">MCP-AQL Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Versions</h3>
   <ul><li><a href="versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
@@ -56,7 +56,7 @@
   <ul><li><a href="guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
-  <ul><li><a href="process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="process/versioning.html">Versioning Strategy</a></li></ul>
+  <ul><li><a href="process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="process/versioning.html">Versioning Strategy</a></li><li><a href="repo/CHANGELOG.html">Changelog</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Architecture</h3>
   <ul><li><a href="architecture/README.html">Architecture Documentation</a></li></ul>

--- a/public/spec/introspection.html
+++ b/public/spec/introspection.html
@@ -23,7 +23,7 @@
         </ul>
         <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
-          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <input id="site-search-input" data-search-input type="search" placeholder="Search MCP-AQL docs, spec pages, and adapter patterns...">
           <span class="search-count" data-search-count></span>
           <ul class="search-results" data-search-results hidden></ul>
         </form>
@@ -38,7 +38,7 @@
         <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
         <div class="docs-side-group">
   <h3>Core</h3>
-  <ul><li><a href="conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="error-codes.html">Structured Error Codes Specification</a></li><li><a class="current" href="introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="mcp-integration.html">MCP Integration Specification</a></li><li><a href="operations.html">MCP-AQL Operations Specification</a></li><li><a href="overview.html">MCP-AQL Protocol Overview</a></li><li><a href="plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="README.html">MCP-AQL Specification Documentation</a></li><li><a href="repo/README.html">MCP-AQL Specification</a></li></ul>
+  <ul><li><a href="conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="error-codes.html">Structured Error Codes Specification</a></li><li><a class="current" aria-current="page" href="introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="mcp-integration.html">MCP Integration Specification</a></li><li><a href="operations.html">MCP-AQL Operations Specification</a></li><li><a href="overview.html">MCP-AQL Protocol Overview</a></li><li><a href="plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="README.html">MCP-AQL Specification Documentation</a></li><li><a href="repo/README.html">MCP-AQL Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Versions</h3>
   <ul><li><a href="versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
@@ -985,6 +985,16 @@ Missing required parameter &#39;source&#39;. Expected: string (URL or file path 
 
           </div>
         </section>
+        <nav class="page-nav" aria-label="Page navigation">
+  <a class="page-nav-link prev" href="error-codes.html">
+    <span class="page-nav-eyebrow">Previous spec page</span>
+    <strong class="page-nav-label">Structured Error Codes Specification</strong>
+  </a>
+  <a class="page-nav-link next" href="licensing-options.html">
+    <span class="page-nav-eyebrow">Next spec page</span>
+    <strong class="page-nav-label">MCP-AQL Licensing Options (Working Notes)</strong>
+  </a>
+</nav>
       </article>
     </div>
   </main>

--- a/public/spec/licensing-options.html
+++ b/public/spec/licensing-options.html
@@ -38,7 +38,7 @@
         <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
         <div class="docs-side-group">
   <h3>Core</h3>
-  <ul><li><a href="conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="error-codes.html">Structured Error Codes Specification</a></li><li><a href="introspection.html">MCP-AQL Introspection Specification</a></li><li><a class="current" href="licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="mcp-integration.html">MCP Integration Specification</a></li><li><a href="operations.html">MCP-AQL Operations Specification</a></li><li><a href="overview.html">MCP-AQL Protocol Overview</a></li><li><a href="plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="README.html">MCP-AQL Specification Documentation</a></li></ul>
+  <ul><li><a href="conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="error-codes.html">Structured Error Codes Specification</a></li><li><a href="introspection.html">MCP-AQL Introspection Specification</a></li><li><a class="current" href="licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="mcp-integration.html">MCP Integration Specification</a></li><li><a href="operations.html">MCP-AQL Operations Specification</a></li><li><a href="overview.html">MCP-AQL Protocol Overview</a></li><li><a href="plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="README.html">MCP-AQL Specification Documentation</a></li><li><a href="repo/README.html">MCP-AQL Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Versions</h3>
   <ul><li><a href="versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
@@ -56,7 +56,7 @@
   <ul><li><a href="guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
-  <ul><li><a href="process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="process/versioning.html">Versioning Strategy</a></li></ul>
+  <ul><li><a href="process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="process/versioning.html">Versioning Strategy</a></li><li><a href="repo/CHANGELOG.html">Changelog</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Architecture</h3>
   <ul><li><a href="architecture/README.html">Architecture Documentation</a></li></ul>

--- a/public/spec/licensing-options.html
+++ b/public/spec/licensing-options.html
@@ -73,6 +73,13 @@
       </aside>
 
       <article class="docs-main">
+        <nav class="breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../index.html">Home</a></li>
+            <li><a href="index.html">Full Spec</a></li>
+            <li><span class="current">MCP-AQL Licensing Options (Working Notes)</span></li>
+          </ol>
+        </nav>
         <section class="hero docs-hero">
           <div class="hero-inner">
             <span class="status-pill">REPO-SYNCED SPEC DOC</span>

--- a/public/spec/licensing-options.html
+++ b/public/spec/licensing-options.html
@@ -1,0 +1,1035 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="This document is a discussion aid for deciding how to license the MCP-AQL ecosystem (spec + schema artifacts + tooling + generated adapters + brand/name), while meeting these goals:">
+  <title>MCP-AQL Spec | MCP-AQL Licensing Options (Working Notes)</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../css/style.css">
+</head>
+<body>
+  <header>
+    <div class="container">
+      <nav>
+        <a class="logo" href="../index.html"><span class="logo-mark"></span>MCP-AQL</a>
+        <ul class="nav-links">
+          <li><a href="../index.html">Home</a></li>
+          <li><a href="../docs/index.html">Docs</a></li>
+          <li><a href="../launch-checklist.html">Launch Checklist</a></li>
+          <li><a href="../apis/mcp-server.html">Adapter Patterns</a></li>
+        </ul>
+        <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
+          <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
+          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <span class="search-count" data-search-count></span>
+          <ul class="search-results" data-search-results hidden></ul>
+        </form>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <div class="container docs-shell">
+      <aside class="docs-side">
+        <h2>Repo-Synced Spec</h2>
+        <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
+        <div class="docs-side-group">
+  <h3>Core</h3>
+  <ul><li><a href="conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="error-codes.html">Structured Error Codes Specification</a></li><li><a href="introspection.html">MCP-AQL Introspection Specification</a></li><li><a class="current" href="licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="mcp-integration.html">MCP Integration Specification</a></li><li><a href="operations.html">MCP-AQL Operations Specification</a></li><li><a href="overview.html">MCP-AQL Protocol Overview</a></li><li><a href="plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="README.html">MCP-AQL Specification Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Versions</h3>
+  <ul><li><a href="versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Adapter</h3>
+  <ul><li><a href="adapter/danger-levels.html">Dangerous Operation Classification Specification</a></li><li><a href="adapter/discovery-bundle.html">MCP Server Discovery Bundle</a></li><li><a href="adapter/element-type.html">Adapter Element Type Specification</a></li><li><a href="adapter/generator.html">Adapter Generator Specification</a></li><li><a href="adapter/rate-limiting.html">Rate Limiting and Quota Management Specification</a></li><li><a href="adapter/trust-levels.html">Trust Levels Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Security</h3>
+  <ul><li><a href="security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Features</h3>
+  <ul><li><a href="features/field-selection.html">Field Selection Specification</a></li><li><a href="features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="features/warnings.html">Warnings Array Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Guides</h3>
+  <ul><li><a href="guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="guides/README.html">Developer Guides</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Process</h3>
+  <ul><li><a href="process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="process/versioning.html">Versioning Strategy</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Architecture</h3>
+  <ul><li><a href="architecture/README.html">Architecture Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Research</h3>
+  <ul><li><a href="research/mcp-vs-mcpaql-vs-a2a.html">Protocol Landscape: MCP vs MCP-AQL vs A2A</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Reference</h3>
+  <ul><li><a href="reference/README.html">Reference Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>ADRs</h3>
+  <ul><li><a href="adr/ADR-001-crude-pattern.html">ADR-001: CRUDE Pattern (Extending CRUD with Execute)</a></li><li><a href="adr/ADR-002-graphql-style-input.html">ADR-002: GraphQL-Style Input Objects for Updates</a></li><li><a href="adr/ADR-003-snake-case-parameters.html">ADR-003: snake_case Parameter Convention</a></li><li><a href="adr/ADR-004-schema-driven-operations.html">ADR-004: Schema-Driven Operation Definitions</a></li><li><a href="adr/ADR-005-introspection-system.html">ADR-005: GraphQL-Style Introspection System</a></li><li><a href="adr/ADR-006-discriminated-responses.html">ADR-006: Discriminated Response Format</a></li><li><a href="adr/index.html">Architecture Decision Records</a></li><li><a href="adr/README.html">Architecture Decision Records</a></li></ul>
+</div>
+      </aside>
+
+      <article class="docs-main">
+        <section class="hero docs-hero">
+          <div class="hero-inner">
+            <span class="status-pill">REPO-SYNCED SPEC DOC</span>
+            <h1>MCP-AQL Licensing Options (Working Notes)</h1>
+            <p class="lede">This document is a discussion aid for deciding how to license the MCP-AQL ecosystem (spec + schema artifacts + tooling + generated adapters + brand/name), while meeting these goals:</p>
+            <div class="spec-meta"><span class="state-chip live">Support document</span></div>
+            <p class="spec-source">Source: <a href="https://github.com/MCPAQL/spec/blob/main/docs/licensing-options.md">spec/docs/licensing-options.md</a></p>
+            <div class="hero-actions">
+              <a class="btn btn-primary" href="https://github.com/MCPAQL/spec/blob/main/docs/licensing-options.md">Open Source Markdown</a>
+              <a class="btn btn-secondary" href="index.html">Browse Full Spec Reference</a>
+            </div>
+          </div>
+        </section>
+
+        <section>
+          <div class="card spec-prose">
+            <p>This document is a discussion aid for deciding how to license the MCP-AQL ecosystem (spec + schema artifacts + tooling + generated adapters + brand/name), while meeting these goals:</p>
+<ol type="1">
+<li><strong>Attribution is required</strong> (credit matters).</li>
+<li><strong>Improvements flow back</strong> to the ecosystem when people modify/deploy your work.</li>
+<li><strong>Commercial option exists</strong> so organizations that won’t comply can still use MCP‑AQL under negotiated terms (including potentially $0 tiers under a revenue threshold).</li>
+</ol>
+<p>This is not legal advice. It’s a practical “what usually works in open source licensing” map to support a conversation with counsel and collaborators.</p>
+<hr />
+<h2 id="current-mcp-aql-decisions-as-implemented">Current MCP-AQL Decisions (As Implemented)</h2>
+<p>This document contains options and analysis, but MCP-AQL also has <strong>current, implemented choices</strong> in this repo tree. If you are an LLM or contributor implementing policy, treat this section (and Section <strong>17</strong>) as authoritative.</p>
+<ul>
+<li><strong>Spec repository split licensing</strong>:
+<ul>
+<li>Spec docs/prose: <strong>CC BY 4.0</strong> (<code>spec/LICENSE-DOCS</code>) with scope rules in <code>spec/LICENSING.md</code>.</li>
+<li>Artifacts consumed by tooling (schemas/tests/scripts): <strong>AGPL-3.0</strong> (<code>spec/LICENSE</code>).</li>
+<li>Spec version source of truth: <code>spec/SPEC_VERSION</code>.</li>
+<li>Exact path-based split: see <code>spec/LICENSING.md</code>.</li>
+</ul></li>
+<li><strong>Code/tooling repos</strong>: <strong>AGPL-3.0</strong> (<code>LICENSE</code>) with commercial licensing available (<code>COMMERCIAL-LICENSE.md</code>).</li>
+<li><strong>Commercial license policy (documented)</strong>:
+<ul>
+<li>Self-serve free commercial license option for organizations under <strong>$1,000,000 USD annual revenue</strong> via self-certification (<code>COMMERCIAL-LICENSE.md</code>).</li>
+<li>Commercial license terms include restrictions such as <strong>no reverse engineering</strong> and <strong>no competitive re-implementation</strong> (<code>spec/COMMERCIAL-LICENSE-TERMS.md</code>).</li>
+</ul></li>
+<li><strong>Generator output policy (adopted)</strong>:
+<ul>
+<li><strong>No output exception</strong> (see Section <strong>17</strong> and <code>adapter-generator/OUTPUT-POLICY.md</code>).</li>
+<li>Generated adapters must emit provenance and include <code>NOTICE.md</code>, <code>COMMERCIAL-LICENSE.md</code>, and <code>MCPAQL-PROVENANCE.json</code> (Section <strong>17</strong>).</li>
+</ul></li>
+<li><strong>Attribution artifacts (present)</strong>: <code>NOTICE.md</code> and <code>CITATION.cff</code> exist across repos and name <strong>Mick Darling</strong>.</li>
+<li><strong>Trademarks</strong>: <code>spec/TRADEMARKS.md</code> (pointer copies in other repos).</li>
+<li><strong>CLA</strong>: <code>spec/CLA.md</code> (pointer copies in other repos).</li>
+</ul>
+<hr />
+<h2 id="1-what-are-the-things-you-can-licensecontrol">1) What are the “things” you can license/control?</h2>
+<p>You can only enforce terms against things you actually own (copyright/trademark), and only against parties doing acts the law regulates (copying, distributing, making derivatives, public performance/display, etc.).</p>
+<h3 id="high-level-ecosystem-flow-spec--tools--adapters">High-level ecosystem flow (spec → tools → adapters)</h3>
+<pre class="mermaid"><code>flowchart LR
+  subgraph Inputs
+    API[MCP server / API surface]
+    SPEC[&quot;MCP-AQL spec docs + artifacts&quot;]
+  end
+
+  subgraph Tooling[Tooling]
+    I[&quot;Interrogator discover endpoints&quot;]
+    S[&quot;Schema builder encode endpoints as schema&quot;]
+    C[&quot;Compiler / Adapter generator compile schema to adapter&quot;]
+  end
+
+  subgraph Output
+    A[&quot;Generated adapter MCP server + MCP client&quot;]
+    LLM[&quot;LLM / MCP client consumes MCP-AQL endpoints&quot;]
+  end
+
+  API --&gt; I
+  SPEC --&gt; S
+  I --&gt; S
+  S --&gt; C
+  C --&gt; A
+  A --&gt;|serves MCP-AQL| LLM
+  A --&gt;|calls upstream API| API</code></pre>
+<h3 id="assets-in-the-mcpaql-ecosystem">Assets in the MCP‑AQL ecosystem</h3>
+<ul>
+<li><strong>A. Spec documents</strong>: prose + diagrams + examples.</li>
+<li><strong>B. Schema artifacts</strong>: JSON Schema, grammar files, IDLs, test vectors, introspection snapshots.</li>
+<li><strong>C. Tooling code</strong>: interrogator, schema builder, compiler, adapter generator, conformance harness.</li>
+<li><strong>D. Runtime code</strong>: any libraries or shared runtime the adapter uses at execution time.</li>
+<li><strong>E. Generated adapter output</strong>: files produced by the compiler/generator.</li>
+<li><strong>F. The name/brand</strong>: “MCP‑AQL”, logos, compatibility marks (trademark).</li>
+</ul>
+<p>Each category behaves differently under common licenses.</p>
+<hr />
+<h2 id="2-the-three-legal-levers-that-match-your-three-goals">2) The three legal levers that match your three goals</h2>
+<h3 id="goal-attribution-is-required">Goal: “Attribution is required”</h3>
+<p>You can get attribution in a few different ways:</p>
+<ol type="1">
+<li><strong>Copyright notices</strong>: most open source licenses require preservation of copyright and license notices in source and redistributions. This is the baseline.</li>
+<li><strong>Dedicated attribution license for docs</strong>: Creative Commons licenses (e.g., <strong>CC BY 4.0</strong>) are designed for documents and have clear attribution requirements.</li>
+<li><strong>Trademark policy</strong>: this is the strongest tool for “if you claim compatibility / use our name/logo, you must do it correctly and with attribution, and you must not imply endorsement.”</li>
+</ol>
+<p>Practical note: trying to impose “marketing attribution” as a requirement <em>inside</em> AGPL/GPL via extra terms can backfire (risk of being treated as an additional restriction). Trademark is the cleanest way to govern the name; CC BY is the cleanest way to require doc attribution.</p>
+<h3 id="lever-map-which-tool-controls-what">Lever map: which tool controls what?</h3>
+<pre class="mermaid"><code>flowchart TB
+  A[&quot;Attribution / Credit&quot;] --&gt; N[&quot;NOTICE preservation copyright + license notices&quot;]
+  A --&gt; CC[&quot;CC BY for spec/docs explicit attribution&quot;]
+  A --&gt; TM[&quot;Trademark policy name + logo + compatibility claims&quot;]
+
+  B[&quot;Improvements flow back&quot;] --&gt; CP[&quot;Copyleft on code AGPL for tooling/runtime&quot;]
+  B --&gt; OUT[&quot;Generated output strategy output exception vs not&quot;]
+
+  C[&quot;Commercial option&quot;] --&gt; DL[&quot;Dual licensing AGPL + commercial contract&quot;]
+  C --&gt; REV[&quot;Revenue threshold best as contract/policy&quot;]</code></pre>
+<h3 id="goal-improvements-flow-back">Goal: “Improvements flow back”</h3>
+<p>Copyleft only forces sharing when someone uses <strong>your copyrighted work</strong> in a way that creates a derivative work and then distributes or deploys it (AGPL is strong for network deployment).</p>
+<ul>
+<li>Licensing the <strong>spec text</strong> under AGPL does <em>not</em> reliably force open-sourcing of independent implementations that merely follow the spec.</li>
+<li>Licensing the <strong>tooling/runtime code</strong> under <strong>AGPL</strong> is far more effective: if they modify and deploy your tooling/runtime as a network service, AGPL obligations trigger.</li>
+</ul>
+<h3 id="goal-commercial-option-exists">Goal: “Commercial option exists”</h3>
+<p>This is usually done via <strong>dual licensing</strong>:</p>
+<ul>
+<li>Default license: strong copyleft (often AGPL‑3.0).</li>
+<li>Alternative: commercial license with negotiated terms (no source release, private modifications allowed, attribution requirements defined by contract, etc.).</li>
+</ul>
+<p>Important constraint: you generally cannot add a “revenue threshold” restriction to an OSI license like AGPL and still call it AGPL. Revenue thresholds work well as <strong>commercial license policy</strong>, not as modifications to AGPL text.</p>
+<hr />
+<h2 id="3-spec-licensing-creative-commons-vs-agpl-what-each-buys-you">3) Spec licensing: Creative Commons vs AGPL (what each buys you)</h2>
+<h3 id="option-s1-spec-under-cc-by-40-recommended-in-many-standards-ecosystems">Option S1: Spec under <strong>CC BY 4.0</strong> (recommended in many standards ecosystems)</h3>
+<p><strong>What it does well</strong></p>
+<ul>
+<li>Clear, explicit <strong>attribution requirement</strong> for document reuse.</li>
+<li>Common and expected for specifications and docs.</li>
+<li>Encourages adoption while preserving credit.</li>
+</ul>
+<p><strong>What it does not do</strong></p>
+<ul>
+<li>It does not force implementations to be open source.</li>
+<li>It does not impose network copyleft obligations.</li>
+</ul>
+<p><strong>When it fits best</strong></p>
+<ul>
+<li>You care strongly about credit for the <em>spec text</em> itself.</li>
+<li>You expect multiple independent implementations.</li>
+</ul>
+<h3 id="option-s2-spec-under-cc-bysa-40">Option S2: Spec under <strong>CC BY‑SA 4.0</strong></h3>
+<p>Adds a “share-alike” requirement for derivatives of the spec document itself.</p>
+<p><strong>Pros</strong></p>
+<ul>
+<li>Spec improvements to the document must stay open (when redistributed).</li>
+</ul>
+<p><strong>Cons</strong></p>
+<ul>
+<li>Some orgs avoid SA because it can be seen as “viral” for docs.</li>
+</ul>
+<h3 id="option-s3-spec-under-agpl30">Option S3: Spec under <strong>AGPL‑3.0</strong></h3>
+<p><strong>What it does well</strong></p>
+<ul>
+<li>Strong copyleft for software; if the spec repo also contains AGPL code, that code is covered.</li>
+</ul>
+<p><strong>What it does not do well</strong></p>
+<ul>
+<li>Spec‑as‑prose is not the typical AGPL target; attribution requirements beyond notice preservation are awkward.</li>
+<li>Doesn’t reliably force open sourcing of clean-room implementations.</li>
+</ul>
+<p><strong>When it fits best</strong></p>
+<ul>
+<li>The “spec” repo is really a combined <strong>spec + reference code</strong> repo and you want the whole thing copyleft.</li>
+</ul>
+<h3 id="a-common-hybrid-used-by-many-ecosystems">A common hybrid (used by many ecosystems)</h3>
+<ul>
+<li><strong>Spec docs</strong>: CC BY (or CC BY‑SA).</li>
+<li><strong>Reference implementation + tooling</strong>: AGPL (or GPL/LGPL, depending on goals).</li>
+<li><strong>Brand/name</strong>: trademark policy.</li>
+</ul>
+<p>This cleanly separates “credit for the document” from “copyleft for the code.”</p>
+<hr />
+<h2 id="4-toolingruntime-licensing-why-agpl-is-the-strongest-default">4) Tooling/runtime licensing: why AGPL is the strongest default</h2>
+<p>Your architecture includes:</p>
+<ul>
+<li>Interrogator → schema builder → compiler → generated adapter → adapter runs as an MCP server and talks to upstream APIs.</li>
+</ul>
+<p>If your goal is “if you modify/deploy our tooling or runtime, you must contribute back,” then AGPL is usually the strongest mainstream OSI copyleft choice because:</p>
+<ul>
+<li>It’s triggered by <strong>network interaction</strong> (not just distribution).</li>
+<li>It’s widely understood by legal teams (even if disliked).</li>
+<li>It pairs cleanly with <strong>commercial dual licensing</strong>.</li>
+</ul>
+<h3 id="agpl30only-vs-agpl30orlater">“AGPL‑3.0‑only” vs “AGPL‑3.0‑or‑later”</h3>
+<ul>
+<li><strong>AGPL‑3.0‑only</strong>: stable; no automatic upgrades to future versions.</li>
+<li><strong>AGPL‑3.0‑or‑later</strong>: future‑proof, but some adopters dislike uncertainty.</li>
+</ul>
+<p>Many projects pick <strong>only</strong> for clarity, and rely on new releases to change terms if needed.</p>
+<h3 id="deployment-view-wrapper-adapter-vs-native-mcpaql-endpoints">Deployment view: wrapper adapter vs native MCP‑AQL endpoints</h3>
+<pre class="mermaid"><code>flowchart LR
+  LLM[&quot;LLM / MCP client&quot;] --&gt;|MCP-AQL| ADAPTER[&quot;Adapter wrapper MCP server + MCP client&quot;]
+  ADAPTER --&gt;|MCP tools| UPSTREAM[MCP server / other API]
+
+  LLM2[&quot;LLM / MCP client&quot;] --&gt;|MCP-AQL| NATIVE[&quot;Native MCP-AQL server embedded endpoints&quot;]
+  NATIVE --&gt;|internal dispatch| CORE[App / server core]</code></pre>
+<hr />
+<h2 id="5-the-generated-adapter-question-output-licensing--critical-decision">5) The generated adapter question (output licensing) — critical decision</h2>
+<p>The single biggest practical licensing fork in generator ecosystems is:</p>
+<h3 id="option-g1-output-is-not-automatically-copyleft-output-exception">Option G1: “Output is NOT automatically copyleft” (output exception)</h3>
+<p>Some projects explicitly say: the generator is copyleft, but the files it generates are not automatically covered (unless they include substantial copied template code).</p>
+<p><strong>Pros</strong></p>
+<ul>
+<li>Maximizes adoption; people can generate proprietary adapters without buying a commercial license.</li>
+</ul>
+<p><strong>Cons</strong></p>
+<ul>
+<li>Weakens your “closed‑source adopters must pay” lever.</li>
+</ul>
+<h3 id="option-g2-output-is-covered--no-exception-strong-pressure-toward-commercial-licenses">Option G2: “Output IS covered / no exception” (strong pressure toward commercial licenses)</h3>
+<p>If generated output includes substantial copyrighted template/runtime code (or requires linking to an AGPL runtime), then proprietary distribution/deployment becomes harder without:</p>
+<ul>
+<li>releasing source under AGPL, or</li>
+<li>buying a commercial license.</li>
+</ul>
+<p><strong>Pros</strong></p>
+<ul>
+<li>Strong lever to prevent “free‑riding closed source adapters at scale.”</li>
+</ul>
+<p><strong>Cons</strong></p>
+<ul>
+<li>Some organizations will avoid adoption entirely.</li>
+<li>You must be disciplined about what is copied into output vs separated into a runtime library.</li>
+</ul>
+<h3 id="a-practical-pattern">A practical pattern</h3>
+<p>If you want strong leverage:</p>
+<ul>
+<li>Put meaningful code in an <strong>AGPL runtime</strong> the adapter depends on, or</li>
+<li>Generate adapters that embed substantial “core” code (templates) that are clearly yours.</li>
+</ul>
+<p>If you want broad adoption:</p>
+<ul>
+<li>Provide an output exception, or</li>
+<li>Make the runtime permissive/LGPL (but that conflicts with your anti‑free‑rider goal).</li>
+</ul>
+<hr />
+<h2 id="6-schemas-and-test-vectors-what-copyleft-does-and-does-not-enforce">6) Schemas and test vectors: what copyleft does (and does not) enforce</h2>
+<p>Publishing schema files under AGPL (or other copyleft) generally enforces:</p>
+<ul>
+<li>If someone redistributes the schema (modified or not), they must comply for that schema file.</li>
+</ul>
+<p>But it does <strong>not</strong> automatically force:</p>
+<ul>
+<li>an implementation that merely <em>reads</em> the schema as data to be open source.</li>
+</ul>
+<p>If you want “if you use our schema, you must open your implementation,” copyright licenses alone usually won’t achieve that without also requiring use of your AGPL runtime/tooling.</p>
+<hr />
+<h2 id="7-attribution-required-in-practice-what-works-reliably">7) “Attribution required” in practice: what works reliably</h2>
+<p>You said attribution is non‑negotiable. The most reliable stack is:</p>
+<h3 id="a-always-require-preservation-of-legal-notices">A. Always require preservation of legal notices</h3>
+<p>Maintain a <code>NOTICE</code> / <code>NOTICE.md</code> and require it be preserved in redistributions. This is normal and enforceable across many OSS licenses.</p>
+<h3 id="b-use-trademark-to-control-the-name-mcpaql">B. Use trademark to control the name “MCP‑AQL”</h3>
+<p>Add a <code>TRADEMARKS.md</code> policy:</p>
+<ul>
+<li>Allowed: “MCP‑AQL compatible” to describe conformance, with a standard attribution sentence.</li>
+<li>Not allowed without permission: implying endorsement, using logos, naming a fork “MCP‑AQL” in a confusing way, etc.</li>
+</ul>
+<p>This is how many ecosystems ensure credit even when implementations are clean-room.</p>
+<h3 id="c-if-you-want-attribution-in-docsspecs-use-cc-by">C. If you want attribution in docs/specs, use CC BY</h3>
+<p>CC BY has a clear, standard attribution mechanism and is accepted for docs.</p>
+<hr />
+<h2 id="8-revenue-thresholds-where-they-fit-commercial-policy-not-agpl-terms">8) Revenue thresholds: where they fit (commercial policy, not AGPL terms)</h2>
+<p>Your desired rule of thumb:</p>
+<ul>
+<li>If you comply with open terms (including attribution + sharing required code), use is free regardless of revenue.</li>
+<li>If you do <strong>not</strong> comply (no source release where required, or no attribution), you need a commercial license.</li>
+<li>Commercial license price can be <strong>$0 under $1M revenue</strong>, then paid tiers.</li>
+</ul>
+<p>This is best implemented as:</p>
+<ul>
+<li><strong>AGPL</strong> (or CC BY for spec) as the default open license, and</li>
+<li>a <strong>commercial contract</strong> with pricing + revenue threshold + attribution obligations.</li>
+</ul>
+<p>Trying to embed revenue thresholds into the open license itself generally makes it non‑standard and often non‑OSI.</p>
+<hr />
+<h2 id="9-contributor-strategy-so-you-can-keep-dual-licensing-viable">9) Contributor strategy (so you can keep dual licensing viable)</h2>
+<p>If you accept public contributions and want to keep the ability to offer commercial licenses, you usually need one of:</p>
+<ul>
+<li><strong>CLA</strong> (Contributor License Agreement) granting you rights to relicense contributions commercially, or</li>
+<li><strong>copyright assignment</strong>, or</li>
+<li>a tightly controlled contribution process (small trusted group).</li>
+</ul>
+<p>Without this, dual licensing becomes legally complicated because contributors own pieces of the copyright.</p>
+<hr />
+<h2 id="10-recommended-menu-of-coherent-licensing-packages">10) Recommended “menu” of coherent licensing packages</h2>
+<h3 id="package-p1-common--clean-cc-by-spec--agpl-tooling--trademark--commercial">Package P1 (common &amp; clean): CC BY spec + AGPL tooling + trademark + commercial</h3>
+<ul>
+<li>Spec docs: <strong>CC BY 4.0</strong></li>
+<li>Tooling/runtime/compiler/interrogator/conformance: <strong>AGPL‑3.0</strong></li>
+<li>Generated adapters: decide G1 vs G2</li>
+<li>Name/logo: <code>TRADEMARKS.md</code></li>
+<li>Commercial: contract, with your $1M threshold policy</li>
+</ul>
+<p>Best for: maximum clarity + strong attribution + strong copyleft where it matters.</p>
+<h3 id="package-p2-agpl-everywhere-simplest-but-weaker-attribution-control">Package P2: AGPL everywhere (simplest, but weaker attribution control)</h3>
+<ul>
+<li>Spec + tooling: <strong>AGPL‑3.0</strong></li>
+<li>Trademark policy still recommended</li>
+<li>Commercial: contract</li>
+</ul>
+<p>Best for: simple messaging, but attribution is still better handled by trademark/NOTICE than AGPL add‑ons.</p>
+<h3 id="package-p3-more-adoption-less-leverage-cc-by-spec--lgplapache-tooling">Package P3 (more adoption, less leverage): CC BY spec + LGPL/Apache tooling</h3>
+<p>You already dislike permissive licensing; this is listed only as a contrast.</p>
+<hr />
+<h2 id="11-how-these-packages-map-to-your-architecture-scenarios">11) How these packages map to your architecture scenarios</h2>
+<h3 id="scenario-a-clean-room-implementation-of-mcpaql-spec">Scenario A: Clean-room implementation of MCP‑AQL spec</h3>
+<ul>
+<li>Spec license (AGPL or CC BY) does not force their implementation to be open source.</li>
+<li>Trademark policy governs how they can use “MCP‑AQL” in marketing and compatibility claims.</li>
+</ul>
+<pre class="mermaid"><code>flowchart LR
+  SPEC[Spec text] --&gt; IMPL[Independent implementation]
+  SPEC -. &quot;License governs reuse of spec text&quot; .-&gt; REUSE[Redistribute/modify spec]
+  TM[Trademark policy] --&gt; NAME[&quot;Use MCP-AQL name/logo for compatibility claims&quot;]</code></pre>
+<h3 id="scenario-b-they-use-your-interrogatorcompilergenerator-as-part-of-their-product-or-service">Scenario B: They use your interrogator/compiler/generator as part of their product or service</h3>
+<ul>
+<li>If it’s AGPL and they modify/deploy it, AGPL obligations can be triggered.</li>
+<li>If they won’t comply, commercial license covers them.</li>
+</ul>
+<pre class="mermaid"><code>flowchart LR
+  THEIR[Their product/service] --&gt; USE[Uses your AGPL tooling/runtime]
+  USE --&gt;|modify/deploy| TRIGGER[AGPL obligations trigger]
+  TRIGGER --&gt;|comply| OSS[Provide source as required]
+  TRIGGER --&gt;|will not comply| COMM[Commercial license]</code></pre>
+<h3 id="scenario-c-they-generate-an-adapter-using-your-compiler">Scenario C: They generate an adapter using your compiler</h3>
+<p>This depends on G1 vs G2:</p>
+<ul>
+<li>With an output exception (G1): they can often keep the generated adapter proprietary (unless it contains substantial copied code).</li>
+<li>Without an exception / with AGPL runtime dependency (G2): proprietary use likely requires commercial licensing.</li>
+</ul>
+<pre class="mermaid"><code>flowchart TB
+  C[Your compiler/generator] --&gt; A[Generated adapter]
+  A --&gt; DEC{Output policy}
+  DEC --&gt;|G1: output exception| PVT1[&quot;Proprietary adapter possible often&quot;]
+  DEC --&gt;|G2: no exception / AGPL runtime| PVT2[&quot;Proprietary use requires commercial license&quot;]
+  DEC --&gt;|G2 + comply| OSS[&quot;Open-source adapter under AGPL&quot;]</code></pre>
+<h3 id="scenario-d-they-modify-the-spec-text">Scenario D: They modify the spec text</h3>
+<ul>
+<li>Under CC BY‑SA: derivatives of the spec must remain share-alike when redistributed.</li>
+<li>Under AGPL: modifications to the spec repo are under AGPL when distributed (but it’s still “docs under a software license” awkwardness).</li>
+</ul>
+<hr />
+<h2 id="12-practical-repository-artifacts-what-you-can-add">12) Practical repository artifacts (what you can add)</h2>
+<p>For each repo (as applicable):</p>
+<ul>
+<li><code>LICENSE</code> (AGPL‑3.0 text for code repos; CC BY text for doc repos if chosen)</li>
+<li><code>COMMERCIAL-LICENSE.md</code> (commercial off‑ramp; may include self-serve &lt;$1M option)</li>
+<li><code>NOTICE</code> or <code>NOTICE.md</code> (copyright + attribution notice to preserve)</li>
+<li><code>TRADEMARKS.md</code> (name/logo usage policy)</li>
+<li><code>CONTRIBUTING.md</code> + <code>CLA.md</code> (if you want contributions while preserving dual licensing)</li>
+</ul>
+<p>In the current MCP-AQL repos, these artifacts are implemented (see “Current MCP-AQL Decisions (As Implemented)” above).</p>
+<hr />
+<h2 id="13-open-questions-to-resolve-as-a-group">13) Open questions to resolve as a group</h2>
+<ol type="1">
+<li>Should the <strong>spec documents</strong> be CC BY (or CC BY‑SA), or remain AGPL?</li>
+<li>Should generated adapters be:
+<ul>
+<li>permissively usable output (output exception), or</li>
+<li>AGPL‑covered output / require AGPL runtime (strong commercial lever)?</li>
+</ul></li>
+<li>What is the minimal attribution statement you want to enforce via trademark/NOTICE?</li>
+<li>Do you want to allow use of the <strong>name</strong> “MCP‑AQL” for compatibility claims by default, or require registration/permission?</li>
+<li>Do you want a CLA for contributors now, or keep contributions limited until the policy is finalized?</li>
+</ol>
+<hr />
+<h2 id="14-threat-model-big-company-rebrands-it-and-claims-credit">14) Threat model: “big company rebrands it and claims credit”</h2>
+<p>This section focuses on a failure mode you explicitly care about: an organization adopts the <em>idea/architecture</em>, reimplements it under a new brand, and you get little/no credit (even if you published first).</p>
+<h3 id="141-what-open-licenses-can-and-cant-do-here">14.1 What open licenses can and can’t do here</h3>
+<ul>
+<li><strong>Licenses (AGPL/CC) control copying of your expression</strong> (your code, your text, your templates), not the underlying <em>idea</em> (“CRUDE endpoints”, “schema-driven dispatch”, “single endpoint mode”, etc.).</li>
+<li>If a company ships a <strong>clean-room reimplementation</strong> (or at least a non-literal reimplementation) under a new name, <strong>copyright licenses alone may not stop it</strong>.</li>
+<li>Where licenses <em>do</em> help: if they copy your repos, templates, docs, examples, tests, or substantial code structure, you can enforce preservation of notices and license compliance.</li>
+</ul>
+<h3 id="142-patents-are-the-main-tool-for-they-cant-just-reimplement-the-idea">14.2 Patents are the main tool for “they can’t just reimplement the idea”</h3>
+<p>If your primary concern is “they can take the concept and rebrand it”, patents are the lever that targets <strong>functionality/novel method</strong>, not just literal copying.</p>
+<p>Practical notes for a patent strategy (discussion aid, not legal advice):</p>
+<ul>
+<li><strong>File early</strong> (provisional if needed) before public release of key implementation details; treat conference/blog/competition submissions as “public disclosure” unless explicitly confidential.</li>
+<li>Consider claim families around:
+<ul>
+<li>endpoint reduction patterns (CRUDE, single-endpoint routing),</li>
+<li>introspection and schema synthesis from APIs,</li>
+<li>schema-driven dispatch + safety classification enforcement,</li>
+<li>compilation/generation pipeline producing an adapter with constrained operations,</li>
+<li>parameter-resolution and field-selection mechanisms that reduce token usage,</li>
+<li>conformance verification and runtime enforcement mechanisms.</li>
+</ul></li>
+<li>Use <strong>continuations</strong> strategically if you expect the ecosystem to evolve and you want to pursue later claims as competitors reveal implementations.</li>
+<li>Decide whether you want a <strong>patent pledge</strong> for compliant open-source use while reserving enforcement/commercial terms for noncompliant actors. (This can preserve community goodwill while keeping leverage against “credit stripping”.)</li>
+</ul>
+<h3 id="143-contracts-are-how-you-enforce-you-promised-attribution">14.3 Contracts are how you enforce “you promised attribution”</h3>
+<p>Your Claude/competition example is a classic gap: publishing first creates evidence, but it doesn’t force attribution unless there’s an enforceable obligation.</p>
+<p>When attribution is promised (contest, partnership, pilot), try to ensure it is:</p>
+<ul>
+<li>In <strong>written terms</strong> that are signed/click-accepted and specify:
+<ul>
+<li>the exact attribution string,</li>
+<li>where it must appear (docs, UI, marketing, repo),</li>
+<li>duration, and</li>
+<li>remedies for breach.</li>
+</ul></li>
+<li>Not merely in “community guidelines” or informal statements.</li>
+</ul>
+<p>If a contest sponsor says “we will attribute” but the terms are vague, enforcement becomes much harder. The best defense is tightening the terms <em>before</em> submission, or submitting only what you are willing to have copied without credit.</p>
+<h3 id="144-make-provenance-undeniable-for-reputational-and-legal-leverage">14.4 Make provenance undeniable (for reputational and legal leverage)</h3>
+<p>Even when it “didn’t work” to prevent copying, a strong provenance package is still valuable for:</p>
+<ul>
+<li>patent novelty timelines,</li>
+<li>copyright enforcement when literal copying occurs,</li>
+<li>and public credibility when you need to correct the record.</li>
+</ul>
+<p>Concrete steps:</p>
+<ul>
+<li>Add <code>CITATION.cff</code> (canonical “how to cite this”) in the main repos.</li>
+<li>Maintain signed releases/tags and hashes for spec/tooling milestones.</li>
+<li>Keep an internal timeline of disclosures (dates, links, screenshots, submission receipts, emails).</li>
+<li>Keep your copyright notices and a <code>NOTICE</code> file consistent and hard to remove without being obvious.</li>
+</ul>
+<h3 id="145-engineering-choices-that-increase-copying-risk-for-free-riders">14.5 Engineering choices that increase “copying risk” for free riders</h3>
+<p>You can (legitimately) design the ecosystem so that “just copy it and rename it” is harder without either:</p>
+<ul>
+<li>taking your AGPL code (triggering compliance), or</li>
+<li>reimplementing a lot more work (increasing cost).</li>
+</ul>
+<p>Examples:</p>
+<ul>
+<li>Put real value in the <strong>toolchain</strong> (interrogator + compiler + conformance suite + runtime enforcement), not just the high-level concept.</li>
+<li>Keep a clear separation of what is <strong>spec</strong> vs <strong>reference implementation</strong> so that copying the “real thing” is visibly copying your codebase.</li>
+</ul>
+<h3 id="146-what-success-looks-like">14.6 What success looks like</h3>
+<p>Given your threat model, the most realistic “defense-in-depth” target is:</p>
+<ul>
+<li><strong>Patents</strong> cover the key novel mechanisms (so reimplementation carries legal risk).</li>
+<li><strong>AGPL + commercial</strong> covers your toolchain/runtime (so using your code requires compliance or a commercial deal).</li>
+<li><strong>Contracts</strong> cover any “we promise attribution” relationships (so attribution isn’t merely hoped for).</li>
+<li><strong>Provenance + citation</strong> makes public credit correction easy and credible.</li>
+</ul>
+<hr />
+<h2 id="15-make-it-solid-a-practical-enforcement-playbook">15) Make it solid: a practical enforcement playbook</h2>
+<p>This section is a concrete checklist for turning “I can prove I built it first” into leverage that actually works in the real world.</p>
+<h3 id="151-decide-what-youre-enforcing-pick-your-battles">15.1 Decide what you’re enforcing (pick your battles)</h3>
+<p>There are three distinct enforcement targets:</p>
+<ol type="1">
+<li><strong>Literal copying of your code/docs/assets</strong> → copyright + license enforcement + DMCA.</li>
+<li><strong>Breach of a promise</strong> (contest terms, partnership, pilot) → contract enforcement.</li>
+<li><strong>Reimplementation of the method</strong> under a new brand → patents (not copyright).</li>
+</ol>
+<p>Trying to use DMCA for (3) usually fails and can backfire. Build a workflow for each target.</p>
+<h3 id="152-patents-file-first-then-publish-hard">15.2 Patents: file first, then publish hard</h3>
+<p>Since you already plan to patent and have counsel:</p>
+<ul>
+<li>File <strong>provisionals</strong> early for each claim family, then publish aggressively after filing.</li>
+<li>Keep a disclosure log with “filed on X date” so you can safely talk publicly without losing priority.</li>
+<li>Ask counsel about a strategy for <strong>continuations</strong> so you can adapt claims as the market reveals implementation details.</li>
+</ul>
+<h3 id="153-copyright-register-dont-just-timestamp">15.3 Copyright: register, don’t just timestamp</h3>
+<p>If you want fast, credible leverage in the U.S., ask counsel about:</p>
+<ul>
+<li><strong>Copyright registration</strong> for the core repos (tooling/runtime/docs) and major releases.</li>
+<li>Registering before infringement (or within relevant windows) can materially improve remedies and negotiation position.</li>
+</ul>
+<p>Your transcripts/recordings are excellent evidence of authorship, but registration is what often turns “proof” into “actionable.”</p>
+<h3 id="154-build-copying-canaries-that-survive-refactors">15.4 Build “copying canaries” that survive refactors</h3>
+<p>If you expect copying, make it easy to prove:</p>
+<ul>
+<li>Put a few <strong>unique, non-obvious strings</strong> (canaries) in MCP‑AQL places that tend to get copied verbatim:
+<ul>
+<li><strong>adapter generator templates</strong> (headers, default error messages, scaffolding file names),</li>
+<li><strong>spec examples</strong> (sample queries/responses that others paste into docs),</li>
+<li><strong>test vectors</strong> (golden JSON fixtures),</li>
+<li><strong>introspection example outputs</strong> (if you publish them).</li>
+</ul></li>
+<li>Keep them harmless but distinctive (not just “MCP‑AQL”).</li>
+<li>Track them in a private list so you can quickly search for them in suspicious repos.</li>
+</ul>
+<p>If a company copies your code/templates, canaries dramatically reduce debate over “independent creation.”</p>
+<p>Concrete MCP‑AQL examples that map to your architecture:</p>
+<ul>
+<li>A deterministic generated file named something like <code>MCPAQL-PROVENANCE.json</code> containing a stable canary key/value (e.g., <code>"mcpaql_canary":"&lt;opaque-string&gt;"</code>) plus generator metadata.</li>
+<li>A distinctive default error string in the adapter runtime (e.g., <code>"MCPAQL_E_SAFETY_CLASSIFICATION_REQUIRED"</code> or another unique identifier), returned when a request lacks safety metadata.</li>
+<li>A distinctive example query block in the spec docs that’s likely to get copy/pasted.</li>
+</ul>
+<h3 id="155-reduce-the-rename-and-run-surface">15.5 Reduce the “rename-and-run” surface</h3>
+<p>Engineering choices that increase enforceability:</p>
+<ul>
+<li>Concentrate value in an <strong>AGPL runtime</strong> and a <strong>conformance suite</strong> that’s hard to replace.</li>
+<li>Ensure generated adapters include:
+<ul>
+<li><code>LICENSE</code> (for your runtime/templates if included),</li>
+<li><code>NOTICE</code> (attribution/legal notices),</li>
+<li>a machine-readable provenance file (e.g., <code>MCPAQL-PROVENANCE.json</code>) listing generator version + commit hash + schema hash.</li>
+</ul></li>
+</ul>
+<p>This doesn’t stop clean-room reimplementation, but it makes “copy and strip attribution” harder and more obvious.</p>
+<p>Concrete MCP‑AQL enforcement hooks that are hard to “accidentally” recreate:</p>
+<ul>
+<li><strong>Introspection metadata</strong>: include a <code>meta</code> section in introspection responses with <code>mcpaql_spec_version</code>, <code>generator_name</code>, <code>generator_version</code>, <code>generator_commit</code>, and <code>schema_fingerprint</code>.
+<ul>
+<li>If someone ships your code and strips attribution, these fields tend to survive unless they actively remove them.</li>
+<li>If someone reimplements clean-room, they won’t match your fingerprints/canaries unless they copied.</li>
+</ul></li>
+<li><strong>Schema fingerprinting</strong>: hash normalized schema output (stable order + canonical JSON) and embed the hash in both:
+<ul>
+<li>the generated adapter, and</li>
+<li>the schema file itself.</li>
+</ul></li>
+<li><strong>Conformance tests</strong>: make the public conformance suite check for:
+<ul>
+<li>correct CRUDE routing semantics,</li>
+<li>safety classification enforcement behavior,</li>
+<li>introspection completeness,</li>
+<li><em>and</em> presence of provenance metadata fields.</li>
+</ul></li>
+</ul>
+<h3 id="156-monitoring-automate-discovery-instead-of-relying-on-luck">15.6 Monitoring: automate discovery instead of relying on luck</h3>
+<p>Set up continuous discovery for copying signals:</p>
+<ul>
+<li><strong>GitHub code search</strong> for canary strings and MCP‑AQL-specific identifiers you control, such as:
+<ul>
+<li><code>MCPAQL-PROVENANCE.json</code></li>
+<li><code>mcpaql_spec_version</code></li>
+<li><code>schema_fingerprint</code></li>
+<li><code>MCPAQL_E_</code> error identifiers</li>
+</ul></li>
+<li><strong>Search for verbatim spec phrasing</strong> that tends to get copied:
+<ul>
+<li>“CRUDE pattern”</li>
+<li>“single endpoint mode”</li>
+<li>“schema-driven dispatch”</li>
+<li>your token reduction table language/structure</li>
+</ul></li>
+<li><strong>Package registry monitoring</strong> (npm/PyPI/crates) for your canary strings.</li>
+<li><strong>Web alerts</strong> for key phrases from the spec/README.</li>
+</ul>
+<p>The faster you find copying, the easier enforcement is (less diffusion, fewer downstream forks).</p>
+<h3 id="157-dmca-use-it-only-for-expression-copying-and-package-evidence">15.7 DMCA: use it only for expression copying, and package evidence</h3>
+<p>DMCA is effective when they copied your expression. Make a “DMCA evidence pack” template:</p>
+<ul>
+<li>Your canonical source URL + commit hash/tag.</li>
+<li>The infringing URL + commit hash.</li>
+<li>A short table: file → copied section → proof (identical snippet / canary hit).</li>
+<li>Screenshots and timestamps.</li>
+</ul>
+<p>This lets you act quickly without emotional/uncertain claims.</p>
+<p>MCP‑AQL-specific evidence that makes DMCA notices go faster:</p>
+<ul>
+<li>A copied <code>MCPAQL-PROVENANCE.json</code> with your generator commit hashes and canary keys.</li>
+<li>Identical adapter scaffolding files produced by your generator (same structure, same headers, same canary strings).</li>
+<li>Identical portions of your spec docs (tables, examples, phrasing) mirrored into their docs.</li>
+</ul>
+<h3 id="158-license-enforcement-treat-it-like-a-product-process">15.8 License enforcement: treat it like a product process</h3>
+<p>If your repos are AGPL (plus commercial option), have a standard escalation ladder:</p>
+<ol type="1">
+<li>Friendly compliance email (“here are the obligations; we can help”).</li>
+<li>Formal notice from counsel.</li>
+<li>DMCA (if hosted copying is present) and/or litigation decision.</li>
+<li>Offer commercial terms as the off-ramp (including $0 tiers if that’s your policy).</li>
+</ol>
+<p>This is how dual-licensing businesses actually convert “they took it” into either compliance or revenue.</p>
+<h3 id="159-contests-and-we-promise-attribution-protect-yourself-up-front">15.9 Contests and “we promise attribution”: protect yourself up front</h3>
+<p>If you submit to a contest or partner program again:</p>
+<ul>
+<li>Treat it as <strong>hostile by default</strong> unless the terms are explicit and enforceable.</li>
+<li>Require terms to specify:
+<ul>
+<li>attribution text and placement,</li>
+<li>license scope granted to the sponsor (ideally non-exclusive, limited),</li>
+<li>confidentiality window if patent filings are pending,</li>
+<li>what happens to submissions after the contest.</li>
+</ul></li>
+</ul>
+<p>If the sponsor refuses, assume they may copy without credit and submit accordingly (or don’t submit).</p>
+<h3 id="1510-evidence-hardening-for-your-existing-voicecode-catalog">15.10 Evidence hardening for your existing voice/code catalog</h3>
+<p>You already have unusually strong provenance (voice recordings + transcripts + code history). To convert that into “hard to dispute” evidence:</p>
+<ul>
+<li>Generate periodic <strong>cryptographic digests</strong> of:
+<ul>
+<li>repo states (commit hashes are a start, but also include uncommitted work snapshots if relevant),</li>
+<li>the transcript corpus,</li>
+<li>and any key design docs.</li>
+</ul></li>
+<li>Store those digests in at least one <strong>independent timestamped system</strong> (discuss with counsel):
+<ul>
+<li>signed release artifacts,</li>
+<li>a transparency log,</li>
+<li>or any other third-party timestamping mechanism your attorney recommends.</li>
+</ul></li>
+</ul>
+<p>This doesn’t stop copying, but it drastically reduces “we independently invented it” arguments once you’re in a dispute.</p>
+<hr />
+<h2 id="16-practical-implementation-checklist-for-humans--llms">16) Practical implementation checklist (for humans + LLMs)</h2>
+<p>This section is intentionally concrete: it’s a set of repo changes and design hooks that make MCP‑AQL harder to copy-and-erase, easier to detect when copied, and easier to enforce when attribution is stripped.</p>
+<h3 id="161-add-must-preserve-attribution-artifacts-everywhere">16.1 Add “must-preserve” attribution artifacts everywhere</h3>
+<p>Implement in each repo (<code>spec/</code>, <code>adapter-generator/</code>, <code>mcpaql-adapter/</code>, <code>examples/</code>, <code>website/</code>):</p>
+<ul>
+<li>Add <code>NOTICE.md</code> with:
+<ul>
+<li>copyright owner(s),</li>
+<li>a short “Attribution” paragraph (exact wording you want),</li>
+<li>link to the canonical spec site/repo,</li>
+<li>commercial licensing contact (<code>licensing@mcpaql.org</code>).</li>
+</ul></li>
+<li>Add <code>CITATION.cff</code> (so GitHub renders a “Cite this repository” widget).</li>
+<li>Ensure <code>README.md</code> has a “License” section that references:
+<ul>
+<li><code>LICENSE</code>,</li>
+<li><code>COMMERCIAL-LICENSE.md</code>,</li>
+<li>and <code>NOTICE.md</code>.</li>
+</ul></li>
+</ul>
+<p>Do not rely on README attribution alone; make <code>NOTICE.md</code> the canonical thing people must preserve.</p>
+<h3 id="162-treat-removal-of-attribution-as-cmi-stripping-design-for-it">16.2 Treat removal of attribution as CMI stripping (design for it)</h3>
+<p>Goal: if someone copies your runtime/templates and removes attribution, that is not just “license noncompliance” but plausibly “removed Copyright Management Information (CMI)”.</p>
+<p>Implementation:</p>
+<ul>
+<li>Put a short, consistent CMI header block at the top of:
+<ul>
+<li>generator templates,</li>
+<li>runtime source files,</li>
+<li>generated adapter scaffolding.</li>
+</ul></li>
+<li>The CMI header should include:
+<ul>
+<li>project name (MCP‑AQL),</li>
+<li>copyright owner,</li>
+<li>license reference,</li>
+<li>and a canonical URL.</li>
+</ul></li>
+</ul>
+<p>Example header block (adapt wording as desired):</p>
+<pre class="text"><code>MCP-AQL
+Copyright (c) 2025-2026 Mick Darling
+Licensed under AGPL-3.0 (see LICENSE) — commercial licenses available (see COMMERCIAL-LICENSE.md)
+Canonical: https://mcpaql.org</code></pre>
+<h3 id="163-make-adapters-carry-unambiguous-provenance-generated-output">16.3 Make adapters carry unambiguous provenance (generated output)</h3>
+<p>Have the compiler/generator always emit a machine-readable provenance file at the adapter root:</p>
+<ul>
+<li>File: <code>MCPAQL-PROVENANCE.json</code></li>
+<li>Must be included in default <code>.gitignore</code> guidance (i.e., do NOT encourage ignoring it).</li>
+<li>Must be included in packaging/distribution (tarball, container, etc.).</li>
+</ul>
+<p>Suggested shape:</p>
+<div class="sourceCode" id="cb8"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb8-1"><a href="#cb8-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb8-2"><a href="#cb8-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;format&quot;</span><span class="fu">:</span> <span class="st">&quot;mcpaql.provenance.v1&quot;</span><span class="fu">,</span></span>
+<span id="cb8-3"><a href="#cb8-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;generated_at&quot;</span><span class="fu">:</span> <span class="st">&quot;2026-01-13T12:34:56Z&quot;</span><span class="fu">,</span></span>
+<span id="cb8-4"><a href="#cb8-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;mcpaql_spec_version&quot;</span><span class="fu">:</span> <span class="st">&quot;v1.0.0-draft&quot;</span><span class="fu">,</span></span>
+<span id="cb8-5"><a href="#cb8-5" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;generator&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb8-6"><a href="#cb8-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;mcpaql-adapter-generator&quot;</span><span class="fu">,</span></span>
+<span id="cb8-7"><a href="#cb8-7" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;version&quot;</span><span class="fu">:</span> <span class="st">&quot;0.1.0&quot;</span><span class="fu">,</span></span>
+<span id="cb8-8"><a href="#cb8-8" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;commit&quot;</span><span class="fu">:</span> <span class="st">&quot;abcdef1234567890&quot;</span><span class="fu">,</span></span>
+<span id="cb8-9"><a href="#cb8-9" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;source_url&quot;</span><span class="fu">:</span> <span class="st">&quot;https://github.com/MCPAQL/adapter-generator&quot;</span></span>
+<span id="cb8-10"><a href="#cb8-10" aria-hidden="true" tabindex="-1"></a>  <span class="fu">},</span></span>
+<span id="cb8-11"><a href="#cb8-11" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;schema&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb8-12"><a href="#cb8-12" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;fingerprint&quot;</span><span class="fu">:</span> <span class="st">&quot;sha256:...&quot;</span><span class="fu">,</span></span>
+<span id="cb8-13"><a href="#cb8-13" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;source&quot;</span><span class="fu">:</span> <span class="st">&quot;path/or/url/to/schema.json&quot;</span></span>
+<span id="cb8-14"><a href="#cb8-14" aria-hidden="true" tabindex="-1"></a>  <span class="fu">},</span></span>
+<span id="cb8-15"><a href="#cb8-15" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;canary&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb8-16"><a href="#cb8-16" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;id&quot;</span><span class="fu">:</span> <span class="st">&quot;mcpaql_canary_v1&quot;</span><span class="fu">,</span></span>
+<span id="cb8-17"><a href="#cb8-17" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;value&quot;</span><span class="fu">:</span> <span class="st">&quot;&lt;opaque-string&gt;&quot;</span></span>
+<span id="cb8-18"><a href="#cb8-18" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb8-19"><a href="#cb8-19" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<p>Notes:</p>
+<ul>
+<li>The canary value should be stable for a given generator release (or stable per customer build, depending on what you want to detect).</li>
+<li>Keep the canary harmless; its value is evidence, not a security control.</li>
+</ul>
+<h3 id="164-put-provenance-into-runtime-behavior-introspection-metadata">16.4 Put provenance into runtime behavior (introspection metadata)</h3>
+<p>Have the adapter’s <code>introspect</code> response include a <code>meta</code> object with provenance fields.</p>
+<p>Example:</p>
+<div class="sourceCode" id="cb9"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb9-1"><a href="#cb9-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb9-2"><a href="#cb9-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;introspect&quot;</span><span class="fu">,</span></span>
+<span id="cb9-3"><a href="#cb9-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;result&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb9-4"><a href="#cb9-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;meta&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb9-5"><a href="#cb9-5" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;mcpaql_spec_version&quot;</span><span class="fu">:</span> <span class="st">&quot;v1.0.0-draft&quot;</span><span class="fu">,</span></span>
+<span id="cb9-6"><a href="#cb9-6" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;generator_name&quot;</span><span class="fu">:</span> <span class="st">&quot;mcpaql-adapter-generator&quot;</span><span class="fu">,</span></span>
+<span id="cb9-7"><a href="#cb9-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;generator_version&quot;</span><span class="fu">:</span> <span class="st">&quot;0.1.0&quot;</span><span class="fu">,</span></span>
+<span id="cb9-8"><a href="#cb9-8" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;generator_commit&quot;</span><span class="fu">:</span> <span class="st">&quot;abcdef1234567890&quot;</span><span class="fu">,</span></span>
+<span id="cb9-9"><a href="#cb9-9" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;schema_fingerprint&quot;</span><span class="fu">:</span> <span class="st">&quot;sha256:...&quot;</span></span>
+<span id="cb9-10"><a href="#cb9-10" aria-hidden="true" tabindex="-1"></a>    <span class="fu">},</span></span>
+<span id="cb9-11"><a href="#cb9-11" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;operations&quot;</span><span class="fu">:</span> <span class="ot">[</span> <span class="er">/*</span> <span class="er">...</span> <span class="er">*/</span> <span class="ot">]</span></span>
+<span id="cb9-12"><a href="#cb9-12" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb9-13"><a href="#cb9-13" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<p>This gives you three benefits:</p>
+<ul>
+<li>You can detect copying in the wild by searching for these fields/values.</li>
+<li>If someone strips them from your code, it’s a deliberate act, not an accident.</li>
+<li>It’s a conformance surface you can test.</li>
+</ul>
+<h3 id="165-define-a-stable-schema-fingerprint-algorithm-so-its-enforceable">16.5 Define a stable schema fingerprint algorithm (so it’s enforceable)</h3>
+<p>Pick one canonical algorithm and document it (then implement it everywhere):</p>
+<ol type="1">
+<li><strong>Normalize</strong> schema JSON:
+<ul>
+<li>canonical JSON encoding (stable key ordering),</li>
+<li>remove whitespace,</li>
+<li>avoid ephemeral fields (timestamps, local paths) in the hashed material.</li>
+</ul></li>
+<li>Hash with <code>SHA-256</code>.</li>
+<li>Represent as <code>sha256:&lt;hex&gt;</code>.</li>
+</ol>
+<p>If your schemas are not JSON, define the equivalent canonicalization (e.g., normalized AST serialization).</p>
+<h3 id="166-make-conformance-tests-check-provenance--safety-semantics">16.6 Make conformance tests check provenance + safety semantics</h3>
+<p>In <code>spec/tests/</code> (or the appropriate test suite repo), add tests that assert:</p>
+<ul>
+<li>CRUDE routing correctness (already part of spec conformance).</li>
+<li>Safety classification enforcement behaviors (your “red zone” semantics).</li>
+<li>Introspection completeness.</li>
+<li>Presence and correctness of:
+<ul>
+<li><code>result.meta.mcpaql_spec_version</code>,</li>
+<li><code>result.meta.schema_fingerprint</code>,</li>
+<li>and generator identity fields.</li>
+</ul></li>
+</ul>
+<p>This makes it harder for a copy to pass “official conformance” while stripping provenance.</p>
+<h3 id="167-make-copying-signatures-easy-to-search-for">16.7 Make “copying signatures” easy to search for</h3>
+<p>Define and consistently use MCP‑AQL-specific identifiers that are likely to be copied:</p>
+<ul>
+<li>Error code namespace: <code>MCPAQL_E_*</code> (e.g., <code>MCPAQL_E_SAFETY_CLASSIFICATION_REQUIRED</code>).</li>
+<li>Metadata keys: <code>mcpaql_spec_version</code>, <code>schema_fingerprint</code>, <code>generator_commit</code>.</li>
+<li>File name: <code>MCPAQL-PROVENANCE.json</code>.</li>
+</ul>
+<p>Then keep a small internal query list you can run periodically:</p>
+<ul>
+<li>GitHub code search for the identifiers above.</li>
+<li>Package registry search for the same identifiers.</li>
+<li>Web search for distinctive spec phrasing and tables.</li>
+</ul>
+<h3 id="168-decide-the-generated-adapter-licensing-posture-explicitly">16.8 Decide the “generated adapter” licensing posture explicitly</h3>
+<p>The implementation must pick one of these and document it clearly:</p>
+<ul>
+<li><strong>Output exception</strong>: generated adapters can be proprietary by default (max adoption).</li>
+<li><strong>No exception / runtime dependency</strong>: generated adapters are effectively AGPL unless commercially licensed (max leverage).</li>
+</ul>
+<p>If you choose “max leverage”, implement it technically:</p>
+<ul>
+<li>Generated adapters must include or depend on an <strong>AGPL runtime</strong> module that is not trivial to replace without rewriting.</li>
+</ul>
+<h3 id="169-make-the-commercial-off-ramp-real-so-enforcement-converts">16.9 Make the commercial off-ramp real (so enforcement converts)</h3>
+<p>Implementation tasks:</p>
+<ul>
+<li>Put a short “Commercial licensing” section in each <code>README.md</code> pointing to:
+<ul>
+<li><code>COMMERCIAL-LICENSE.md</code>,</li>
+<li>and a single canonical email address (<code>licensing@mcpaql.org</code>).</li>
+</ul></li>
+<li>Consider adding a public “commercial licensing overview” page on <code>website/</code> (even if pricing is “contact us”), because it helps support “reasonable royalty” arguments and shortens sales cycles.</li>
+</ul>
+<h3 id="1610-keep-the-specdocs-license-separate-from-the-code-license">16.10 Keep the spec/docs license separate from the code license</h3>
+<p>If you decide to use CC BY for the spec text:</p>
+<ul>
+<li>Make it explicit in <code>spec/</code>:
+<ul>
+<li><code>LICENSE</code> for the repo’s code (if any),</li>
+<li>a separate <code>LICENSE-DOCS</code> (or similar) for spec prose,</li>
+<li>and clear labeling in <code>spec/README.md</code>.</li>
+</ul></li>
+</ul>
+<p>This avoids accidentally mixing a doc license into the toolchain/code.</p>
+<hr />
+<h2 id="17-policy-to-implement-toolchain--generated-adapter-licensing-llm-ready">17) Policy to implement: toolchain + generated adapter licensing (LLM-ready)</h2>
+<p>This section is a <strong>normative policy spec</strong> for the MCP‑AQL toolchain and generated adapters. It is written so another LLM can implement it directly in the generator/compiler and related repos.</p>
+<h3 id="171-goals-what-this-policy-must-accomplish">17.1 Goals (what this policy must accomplish)</h3>
+<ol type="1">
+<li><strong>Default path</strong>: anyone can use MCP‑AQL tooling under open terms (AGPL for code; CC BY for spec docs as applicable).</li>
+<li><strong>Closed-source path</strong>: organizations that do not want to comply with AGPL obligations should be able to obtain a <strong>commercial license easily</strong> (low-friction, “email us / simple form”).</li>
+<li><strong>Deterrence</strong>: the easiest way to ship adapters is to use the official toolchain; bypassing it (clean-room reimplementation) should be meaningfully more work.</li>
+<li><strong>Attribution stickiness</strong>: when the toolchain is used, generated output must carry clear, durable attribution/notice artifacts and machine-readable provenance that is hard to remove “by accident”.</li>
+</ol>
+<h3 id="172-definitions">17.2 Definitions</h3>
+<ul>
+<li><strong>Toolchain</strong>: interrogator + schema builder + compiler/adapter generator + any runtime libraries required by generated adapters.</li>
+<li><strong>Generated adapter</strong>: the multi-file wrapper produced by the compiler/generator that runs as an MCP server (MCP‑AQL endpoints) and as an MCP client (upstream API binding).</li>
+<li><strong>Output exception</strong>: a license statement that grants permission to use generated output under terms other than the generator’s copyleft.</li>
+</ul>
+<h3 id="173-license-posture-explicit-decisions">17.3 License posture (explicit decisions)</h3>
+<ol type="1">
+<li>Toolchain code is licensed under <strong>AGPL-3.0</strong> (see <code>LICENSE</code>).</li>
+<li><strong>No output exception is granted.</strong>
+<ul>
+<li>The project will not publish an “output exception” that automatically permits proprietary use of generated adapters.</li>
+</ul></li>
+<li>Commercial licenses are available as the off‑ramp for closed-source use (see <code>COMMERCIAL-LICENSE.md</code> and contact <code>licensing@mcpaql.org</code>).</li>
+</ol>
+<p>Notes:</p>
+<ul>
+<li>This policy does <strong>not</strong> attempt to modify AGPL terms (no revenue thresholds inside open licensing text).</li>
+<li>Any revenue thresholds or “free commercial license under $X revenue” rules belong in the <strong>commercial contract</strong> and can be described (non-binding) in <code>COMMERCIAL-LICENSE.md</code>.
+<ul>
+<li>Current intent: a self-serve free commercial license option for organizations under $1,000,000 USD in annual revenue via self-certification.</li>
+</ul></li>
+</ul>
+<h3 id="174-technical-requirements-what-the-generator-must-emit">17.4 Technical requirements (what the generator must emit)</h3>
+<p>When the toolchain generates an adapter, the output <strong>MUST</strong> include the following files at the adapter root (or a documented equivalent path):</p>
+<ol type="1">
+<li><code>LICENSE</code>:
+<ul>
+<li>If the generated adapter includes or vendors MCP‑AQL runtime/template code, this file MUST contain the applicable open license text (AGPL-3.0) for that included code.</li>
+</ul></li>
+<li><code>NOTICE.md</code>:
+<ul>
+<li>MUST include an attribution statement and canonical links (see template below).</li>
+<li>MUST state that commercial licensing is available and point to the contact address.</li>
+</ul></li>
+<li><code>COMMERCIAL-LICENSE.md</code>:
+<ul>
+<li>MUST be included as a short pointer (not full terms) so downstream users can immediately find the off‑ramp.</li>
+</ul></li>
+<li><code>MCPAQL-PROVENANCE.json</code>:
+<ul>
+<li>MUST include generator identity and build metadata (commit hash, version, source URL).</li>
+<li>MUST include a stable <code>schema_fingerprint</code>.</li>
+<li>MUST include a <code>canary</code> section (see below).</li>
+</ul></li>
+</ol>
+<p>Generator identity defaults (so implementations are consistent):</p>
+<ul>
+<li><code>generator.name</code>: <code>mcpaql-adapter-generator</code></li>
+<li><code>generator.source_url</code>: <code>https://github.com/MCPAQL/adapter-generator</code></li>
+<li><code>generator.commit</code>: git commit of the generator used for the build.</li>
+<li><code>generator.version</code>: prefer a semver tag if present, else <code>0.0.0+&lt;short-commit&gt;</code>.</li>
+</ul>
+<p>Spec version source of truth:</p>
+<ul>
+<li>Read the current spec version from <code>spec/SPEC_VERSION</code> in the <code>spec</code> repo (example value: <code>v1.0.0-draft</code>).</li>
+<li>Use that value for:
+<ul>
+<li><code>mcpaql_spec_version</code> in <code>MCPAQL-PROVENANCE.json</code>, and</li>
+<li><code>result.meta.mcpaql_spec_version</code> in introspection.</li>
+</ul></li>
+</ul>
+<p>The generator <strong>SHOULD</strong> also:</p>
+<ul>
+<li>include <code>CITATION.cff</code> in generated output (optional but helpful), and</li>
+<li>include a <code>LICENSING.md</code> (short human-friendly summary of what’s included and why).</li>
+</ul>
+<h3 id="175-runtime-dependency-requirement-what-makes-this-enforceable">17.5 Runtime dependency requirement (what makes this enforceable)</h3>
+<p>To achieve the desired “use our toolchain or pay/comply” outcome, generated adapters MUST, by default, be built in a way that they:</p>
+<ul>
+<li><strong>depend on an MCP‑AQL runtime module</strong> that is part of the toolchain and is licensed under AGPL-3.0, OR</li>
+<li>embed substantial MCP‑AQL template/runtime code that is clearly copyrighted by the project.</li>
+</ul>
+<p>Implementation guidance:</p>
+<ul>
+<li>Prefer a runtime module import/dependency (cleaner engineering) over copying large template blobs into every file.</li>
+<li>The runtime should implement core behaviors that are hard to “stub out” without rewriting:
+<ul>
+<li>CRUDE routing,</li>
+<li>safety classification enforcement (your “red zone” semantics),</li>
+<li>introspection meta emission,</li>
+<li>schema fingerprint verification.</li>
+</ul></li>
+</ul>
+<h3 id="176-required-behavior-surfaces-what-the-adapter-must-expose">17.6 Required behavior surfaces (what the adapter must expose)</h3>
+<p>To make copying detectable and attribution durable, adapters produced by the toolchain MUST:</p>
+<ol type="1">
+<li>Expose provenance in introspection:
+<ul>
+<li><code>introspect</code> responses MUST include a <code>meta</code> object with:
+<ul>
+<li><code>mcpaql_spec_version</code></li>
+<li><code>generator_name</code></li>
+<li><code>generator_version</code></li>
+<li><code>generator_commit</code></li>
+<li><code>schema_fingerprint</code></li>
+</ul></li>
+</ul></li>
+<li>Use a stable error namespace:
+<ul>
+<li>Safety and policy-related errors SHOULD use <code>MCPAQL_E_*</code> identifiers.</li>
+</ul></li>
+</ol>
+<h3 id="177-canary-policy-copy-detection-not-security">17.7 Canary policy (copy detection, not security)</h3>
+<p>The generator MUST include a <code>canary</code> in <code>MCPAQL-PROVENANCE.json</code>.</p>
+<p>Policy:</p>
+<ul>
+<li>Canary value MUST be non-obvious and stable for a given generator release (or stable per “distribution channel”).</li>
+<li>Canary value MUST NOT be a secret credential; it is only an identifier for copy detection.</li>
+<li>The project should keep an internal mapping of canary values to generator releases for later verification.</li>
+</ul>
+<h3 id="178-templates-drop-in-text-for-generated-artifacts">17.8 Templates (drop-in text for generated artifacts)</h3>
+<p><code>NOTICE.md</code> template (generated adapter):</p>
+<div class="sourceCode" id="cb10"><pre class="sourceCode markdown"><code class="sourceCode markdown"><span id="cb10-1"><a href="#cb10-1" aria-hidden="true" tabindex="-1"></a><span class="fu"># NOTICE</span></span>
+<span id="cb10-2"><a href="#cb10-2" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb10-3"><a href="#cb10-3" aria-hidden="true" tabindex="-1"></a>This adapter was generated by the MCP-AQL toolchain.</span>
+<span id="cb10-4"><a href="#cb10-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb10-5"><a href="#cb10-5" aria-hidden="true" tabindex="-1"></a>MCP-AQL (Model Context Protocol – Advanced Agent API Adapter Query Language)</span>
+<span id="cb10-6"><a href="#cb10-6" aria-hidden="true" tabindex="-1"></a>Copyright (c) 2025-2026 Mick Darling.</span>
+<span id="cb10-7"><a href="#cb10-7" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb10-8"><a href="#cb10-8" aria-hidden="true" tabindex="-1"></a>You must preserve this notice and other copyright and license notices in any redistribution.</span>
+<span id="cb10-9"><a href="#cb10-9" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb10-10"><a href="#cb10-10" aria-hidden="true" tabindex="-1"></a>Canonical: https://mcpaql.org</span>
+<span id="cb10-11"><a href="#cb10-11" aria-hidden="true" tabindex="-1"></a>Toolchain source: https://github.com/MCPAQL</span>
+<span id="cb10-12"><a href="#cb10-12" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb10-13"><a href="#cb10-13" aria-hidden="true" tabindex="-1"></a>Commercial licenses are available: licensing@mcpaql.org (see COMMERCIAL-LICENSE.md).</span></code></pre></div>
+<p><code>COMMERCIAL-LICENSE.md</code> template (generated adapter):</p>
+<div class="sourceCode" id="cb11"><pre class="sourceCode markdown"><code class="sourceCode markdown"><span id="cb11-1"><a href="#cb11-1" aria-hidden="true" tabindex="-1"></a><span class="fu"># Commercial Licensing</span></span>
+<span id="cb11-2"><a href="#cb11-2" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb11-3"><a href="#cb11-3" aria-hidden="true" tabindex="-1"></a>This adapter includes MCP-AQL toolchain/runtime components licensed under AGPL-3.0. See LICENSE.</span>
+<span id="cb11-4"><a href="#cb11-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb11-5"><a href="#cb11-5" aria-hidden="true" tabindex="-1"></a>Commercial licenses are available for organizations that want to use, modify, or distribute this adapter without AGPL obligations.</span>
+<span id="cb11-6"><a href="#cb11-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb11-7"><a href="#cb11-7" aria-hidden="true" tabindex="-1"></a>If your organization has less than $1,000,000 USD in annual revenue, you may use the self-serve free commercial license option by self-certifying in writing in your own records (no correspondence required).</span>
+<span id="cb11-8"><a href="#cb11-8" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb11-9"><a href="#cb11-9" aria-hidden="true" tabindex="-1"></a>Contact: licensing@mcpaql.org</span></code></pre></div>
+<h3 id="179-non-goals-what-this-policy-is-not-trying-to-do">17.9 Non-goals (what this policy is not trying to do)</h3>
+<ul>
+<li>This policy cannot prevent a true clean-room reimplementation of the idea under a new brand.</li>
+<li>This policy is designed to:
+<ul>
+<li>make copying your actual toolchain/runtime/templates easy to detect and enforce, and</li>
+<li>make the commercial-license off‑ramp obvious and low friction.</li>
+</ul></li>
+</ul>
+<h3 id="1710-schema-fingerprinting-canonical-definition-to-implement">17.10 Schema fingerprinting (canonical definition to implement)</h3>
+<p>The <code>schema_fingerprint</code> MUST be computed using a stable canonicalization so that:</p>
+<ul>
+<li>the same schema content yields the same fingerprint across platforms/languages, and</li>
+<li>the fingerprint does not change due to whitespace, key ordering, or formatting differences.</li>
+</ul>
+<p>Definition:</p>
+<ol type="1">
+<li>Let <code>schema</code> be the schema document in JSON form.</li>
+<li>Remove any explicitly non-semantic, build-specific fields (if present), such as:
+<ul>
+<li><code>generated_at</code>, <code>generator</code>, <code>provenance</code>, or similar build metadata fields embedded inside the schema document.</li>
+</ul></li>
+<li>Canonicalize the JSON using the JSON Canonicalization Scheme (JCS, RFC 8785) or an equivalent stable canonical JSON serializer:
+<ul>
+<li>stable key ordering,</li>
+<li>UTF-8 encoding,</li>
+<li>no insignificant whitespace differences.</li>
+</ul></li>
+<li>Compute SHA-256 over the canonicalized UTF-8 bytes.</li>
+<li>Represent the fingerprint as <code>sha256:&lt;hex&gt;</code>.</li>
+</ol>
+<p>The canonicalization requirement is the important part; the exact library used can vary by language as long as it produces the same canonical bytes.</p>
+
+          </div>
+        </section>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div class="container">
+      <p>&copy; 2026 DollhouseMCP Inc. d/b/a Dollhouse Research. MCP-AQL public draft documentation portal.</p>
+      <div class="footer-links">
+        <a href="../docs/index.html">Docs Library</a>
+        <a href="index.html">Repo-Synced Spec</a>
+        <a href="https://github.com/MCPAQL">MCPAQL Organization</a>
+        <a href="https://dollhouseresearch.com">Dollhouse Research</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../js/search.js"></script>
+</body>
+</html>

--- a/public/spec/licensing-options.html
+++ b/public/spec/licensing-options.html
@@ -23,7 +23,7 @@
         </ul>
         <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
-          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <input id="site-search-input" data-search-input type="search" placeholder="Search MCP-AQL docs, spec pages, and adapter patterns...">
           <span class="search-count" data-search-count></span>
           <ul class="search-results" data-search-results hidden></ul>
         </form>
@@ -38,7 +38,7 @@
         <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
         <div class="docs-side-group">
   <h3>Core</h3>
-  <ul><li><a href="conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="error-codes.html">Structured Error Codes Specification</a></li><li><a href="introspection.html">MCP-AQL Introspection Specification</a></li><li><a class="current" href="licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="mcp-integration.html">MCP Integration Specification</a></li><li><a href="operations.html">MCP-AQL Operations Specification</a></li><li><a href="overview.html">MCP-AQL Protocol Overview</a></li><li><a href="plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="README.html">MCP-AQL Specification Documentation</a></li><li><a href="repo/README.html">MCP-AQL Specification</a></li></ul>
+  <ul><li><a href="conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="error-codes.html">Structured Error Codes Specification</a></li><li><a href="introspection.html">MCP-AQL Introspection Specification</a></li><li><a class="current" aria-current="page" href="licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="mcp-integration.html">MCP Integration Specification</a></li><li><a href="operations.html">MCP-AQL Operations Specification</a></li><li><a href="overview.html">MCP-AQL Protocol Overview</a></li><li><a href="plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="README.html">MCP-AQL Specification Documentation</a></li><li><a href="repo/README.html">MCP-AQL Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Versions</h3>
   <ul><li><a href="versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
@@ -1021,6 +1021,16 @@ Canonical: https://mcpaql.org</code></pre>
 
           </div>
         </section>
+        <nav class="page-nav" aria-label="Page navigation">
+  <a class="page-nav-link prev" href="introspection.html">
+    <span class="page-nav-eyebrow">Previous spec page</span>
+    <strong class="page-nav-label">MCP-AQL Introspection Specification</strong>
+  </a>
+  <a class="page-nav-link next" href="mcp-integration.html">
+    <span class="page-nav-eyebrow">Next spec page</span>
+    <strong class="page-nav-label">MCP Integration Specification</strong>
+  </a>
+</nav>
       </article>
     </div>
   </main>

--- a/public/spec/mcp-integration.html
+++ b/public/spec/mcp-integration.html
@@ -23,7 +23,7 @@
         </ul>
         <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
-          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <input id="site-search-input" data-search-input type="search" placeholder="Search MCP-AQL docs, spec pages, and adapter patterns...">
           <span class="search-count" data-search-count></span>
           <ul class="search-results" data-search-results hidden></ul>
         </form>
@@ -38,7 +38,7 @@
         <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
         <div class="docs-side-group">
   <h3>Core</h3>
-  <ul><li><a href="conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="error-codes.html">Structured Error Codes Specification</a></li><li><a href="introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a class="current" href="mcp-integration.html">MCP Integration Specification</a></li><li><a href="operations.html">MCP-AQL Operations Specification</a></li><li><a href="overview.html">MCP-AQL Protocol Overview</a></li><li><a href="plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="README.html">MCP-AQL Specification Documentation</a></li><li><a href="repo/README.html">MCP-AQL Specification</a></li></ul>
+  <ul><li><a href="conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="error-codes.html">Structured Error Codes Specification</a></li><li><a href="introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a class="current" aria-current="page" href="mcp-integration.html">MCP Integration Specification</a></li><li><a href="operations.html">MCP-AQL Operations Specification</a></li><li><a href="overview.html">MCP-AQL Protocol Overview</a></li><li><a href="plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="README.html">MCP-AQL Specification Documentation</a></li><li><a href="repo/README.html">MCP-AQL Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Versions</h3>
   <ul><li><a href="versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
@@ -735,6 +735,16 @@ github_mcp_aql_execute</code></pre>
 
           </div>
         </section>
+        <nav class="page-nav" aria-label="Page navigation">
+  <a class="page-nav-link prev" href="licensing-options.html">
+    <span class="page-nav-eyebrow">Previous spec page</span>
+    <strong class="page-nav-label">MCP-AQL Licensing Options (Working Notes)</strong>
+  </a>
+  <a class="page-nav-link next" href="operations.html">
+    <span class="page-nav-eyebrow">Next spec page</span>
+    <strong class="page-nav-label">MCP-AQL Operations Specification</strong>
+  </a>
+</nav>
       </article>
     </div>
   </main>

--- a/public/spec/mcp-integration.html
+++ b/public/spec/mcp-integration.html
@@ -38,7 +38,7 @@
         <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
         <div class="docs-side-group">
   <h3>Core</h3>
-  <ul><li><a href="conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="error-codes.html">Structured Error Codes Specification</a></li><li><a href="introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a class="current" href="mcp-integration.html">MCP Integration Specification</a></li><li><a href="operations.html">MCP-AQL Operations Specification</a></li><li><a href="overview.html">MCP-AQL Protocol Overview</a></li><li><a href="plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="README.html">MCP-AQL Specification Documentation</a></li></ul>
+  <ul><li><a href="conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="error-codes.html">Structured Error Codes Specification</a></li><li><a href="introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a class="current" href="mcp-integration.html">MCP Integration Specification</a></li><li><a href="operations.html">MCP-AQL Operations Specification</a></li><li><a href="overview.html">MCP-AQL Protocol Overview</a></li><li><a href="plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="README.html">MCP-AQL Specification Documentation</a></li><li><a href="repo/README.html">MCP-AQL Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Versions</h3>
   <ul><li><a href="versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
@@ -56,7 +56,7 @@
   <ul><li><a href="guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
-  <ul><li><a href="process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="process/versioning.html">Versioning Strategy</a></li></ul>
+  <ul><li><a href="process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="process/versioning.html">Versioning Strategy</a></li><li><a href="repo/CHANGELOG.html">Changelog</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Architecture</h3>
   <ul><li><a href="architecture/README.html">Architecture Documentation</a></li></ul>

--- a/public/spec/mcp-integration.html
+++ b/public/spec/mcp-integration.html
@@ -1,0 +1,749 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="This document specifies how MCP-AQL adapters integrate with the Model Context Protocol (MCP). It defines tool registration requirements, input schema composition, error mapping between protocols, progress notification ha">
+  <title>MCP-AQL Spec | MCP Integration Specification</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../css/style.css">
+</head>
+<body>
+  <header>
+    <div class="container">
+      <nav>
+        <a class="logo" href="../index.html"><span class="logo-mark"></span>MCP-AQL</a>
+        <ul class="nav-links">
+          <li><a href="../index.html">Home</a></li>
+          <li><a href="../docs/index.html">Docs</a></li>
+          <li><a href="../launch-checklist.html">Launch Checklist</a></li>
+          <li><a href="../apis/mcp-server.html">Adapter Patterns</a></li>
+        </ul>
+        <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
+          <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
+          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <span class="search-count" data-search-count></span>
+          <ul class="search-results" data-search-results hidden></ul>
+        </form>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <div class="container docs-shell">
+      <aside class="docs-side">
+        <h2>Repo-Synced Spec</h2>
+        <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
+        <div class="docs-side-group">
+  <h3>Core</h3>
+  <ul><li><a href="conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="error-codes.html">Structured Error Codes Specification</a></li><li><a href="introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a class="current" href="mcp-integration.html">MCP Integration Specification</a></li><li><a href="operations.html">MCP-AQL Operations Specification</a></li><li><a href="overview.html">MCP-AQL Protocol Overview</a></li><li><a href="plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="README.html">MCP-AQL Specification Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Versions</h3>
+  <ul><li><a href="versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Adapter</h3>
+  <ul><li><a href="adapter/danger-levels.html">Dangerous Operation Classification Specification</a></li><li><a href="adapter/discovery-bundle.html">MCP Server Discovery Bundle</a></li><li><a href="adapter/element-type.html">Adapter Element Type Specification</a></li><li><a href="adapter/generator.html">Adapter Generator Specification</a></li><li><a href="adapter/rate-limiting.html">Rate Limiting and Quota Management Specification</a></li><li><a href="adapter/trust-levels.html">Trust Levels Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Security</h3>
+  <ul><li><a href="security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Features</h3>
+  <ul><li><a href="features/field-selection.html">Field Selection Specification</a></li><li><a href="features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="features/warnings.html">Warnings Array Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Guides</h3>
+  <ul><li><a href="guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="guides/README.html">Developer Guides</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Process</h3>
+  <ul><li><a href="process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="process/versioning.html">Versioning Strategy</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Architecture</h3>
+  <ul><li><a href="architecture/README.html">Architecture Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Research</h3>
+  <ul><li><a href="research/mcp-vs-mcpaql-vs-a2a.html">Protocol Landscape: MCP vs MCP-AQL vs A2A</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Reference</h3>
+  <ul><li><a href="reference/README.html">Reference Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>ADRs</h3>
+  <ul><li><a href="adr/ADR-001-crude-pattern.html">ADR-001: CRUDE Pattern (Extending CRUD with Execute)</a></li><li><a href="adr/ADR-002-graphql-style-input.html">ADR-002: GraphQL-Style Input Objects for Updates</a></li><li><a href="adr/ADR-003-snake-case-parameters.html">ADR-003: snake_case Parameter Convention</a></li><li><a href="adr/ADR-004-schema-driven-operations.html">ADR-004: Schema-Driven Operation Definitions</a></li><li><a href="adr/ADR-005-introspection-system.html">ADR-005: GraphQL-Style Introspection System</a></li><li><a href="adr/ADR-006-discriminated-responses.html">ADR-006: Discriminated Response Format</a></li><li><a href="adr/index.html">Architecture Decision Records</a></li><li><a href="adr/README.html">Architecture Decision Records</a></li></ul>
+</div>
+      </aside>
+
+      <article class="docs-main">
+        <section class="hero docs-hero">
+          <div class="hero-inner">
+            <span class="status-pill">REPO-SYNCED SPEC DOC</span>
+            <h1>MCP Integration Specification</h1>
+            <p class="lede">This document specifies how MCP-AQL adapters integrate with the Model Context Protocol (MCP). It defines tool registration requirements, input schema composition, error mapping between protocols, progress notification ha</p>
+            <div class="spec-meta"><span class="state-chip live">Support document</span><span class="state-chip pending">Draft</span><span class="state-chip">1.0.0-draft</span><span class="state-chip">2026-01-30</span></div>
+            <p class="spec-source">Source: <a href="https://github.com/MCPAQL/spec/blob/main/docs/mcp-integration.md">spec/docs/mcp-integration.md</a></p>
+            <div class="hero-actions">
+              <a class="btn btn-primary" href="https://github.com/MCPAQL/spec/blob/main/docs/mcp-integration.md">Open Source Markdown</a>
+              <a class="btn btn-secondary" href="index.html">Browse Full Spec Reference</a>
+            </div>
+          </div>
+        </section>
+
+        <section>
+          <div class="card spec-prose">
+            <p><strong>Version:</strong> 1.0.0-draft <strong>Status:</strong> Draft <strong>Last Updated:</strong> 2026-01-30</p>
+<h2 id="abstract">Abstract</h2>
+<p>This document specifies how MCP-AQL adapters integrate with the Model Context Protocol (MCP). It defines tool registration requirements, input schema composition, error mapping between protocols, progress notification handling, and multi-adapter deployment patterns.</p>
+<hr />
+<h2 id="table-of-contents">Table of Contents</h2>
+<ol type="1">
+<li><a href="#1-introduction">Introduction</a></li>
+<li><a href="#2-tool-registration">Tool Registration</a></li>
+<li><a href="#3-input-schema-composition">Input Schema Composition</a></li>
+<li><a href="#4-error-mapping">Error Mapping</a></li>
+<li><a href="#5-progress-notifications">Progress Notifications</a></li>
+<li><a href="#6-multi-adapter-deployment">Multi-Adapter Deployment</a></li>
+<li><a href="#7-conformance-requirements">Conformance Requirements</a></li>
+</ol>
+<hr />
+<h2 id="1-introduction">1. Introduction</h2>
+<h3 id="11-purpose">1.1 Purpose</h3>
+<p>MCP-AQL is a protocol layer that sits atop the Model Context Protocol. This specification defines the integration semantics between the two protocols, ensuring that:</p>
+<ul>
+<li>Clients can discover MCP-AQL operations through standard MCP tool registration</li>
+<li>Error handling is consistent across both protocol layers</li>
+<li>Multiple MCP-AQL adapters can coexist in a single MCP session</li>
+</ul>
+<h3 id="12-the-bootstrap-problem">1.2 The Bootstrap Problem</h3>
+<p>MCP-AQL uses introspection for operation discovery, but an agent can only know that <code>introspect</code> exists if the MCP tool description explicitly advertises it. This creates a bootstrap dependency that this specification resolves through normative tool description requirements.</p>
+<h3 id="13-scope">1.3 Scope</h3>
+<p>This specification covers:</p>
+<ul>
+<li>MCP tool description templates</li>
+<li>Input schema composition rules</li>
+<li>Error code mapping between MCP-AQL and MCP</li>
+<li>Progress notification integration for EXECUTE operations</li>
+<li>Multi-adapter deployment patterns</li>
+</ul>
+<h3 id="14-relationship-to-mcp">1.4 Relationship to MCP</h3>
+<p>MCP-AQL adapters are MCP servers that expose operations through the CRUDE endpoint pattern. All MCP transport and lifecycle requirements apply. This specification defines additional requirements specific to MCP-AQL tool registration and error handling.</p>
+<hr />
+<h2 id="2-tool-registration">2. Tool Registration</h2>
+<h3 id="21-tool-description-requirements">2.1 Tool Description Requirements</h3>
+<p>MCP-AQL adapters MUST include the <code>introspect</code> operation in their tool descriptions. This solves the bootstrap problem by ensuring agents know how to discover available operations.</p>
+<h4 id="211-crude-mode-tool-descriptions">2.1.1 CRUDE Mode Tool Descriptions</h4>
+<p>In CRUDE mode, each endpoint registers as a separate MCP tool. Tool descriptions MUST follow this template:</p>
+<p><strong>CREATE Endpoint:</strong></p>
+<pre><code>[Semantic category description].
+
+Supported operations: [operation_list]
+
+[Element types if applicable]
+
+These operations add new data without removing or overwriting existing content.
+
+Quick start examples:
+{ operation: &quot;[example_op]&quot;, params: { [example_params] } }
+
+Discover required parameters:
+{ operation: &quot;introspect&quot;, params: { query: &quot;operations&quot;, name: &quot;[operation_name]&quot; } }</code></pre>
+<p><strong>READ Endpoint:</strong></p>
+<pre><code>Safe, read-only operations.
+
+Supported operations: [operation_list]
+
+[Element types if applicable]
+
+These queries only read data and never modify server state.
+
+Quick start examples:
+{ operation: &quot;list_elements&quot;, element_type: &quot;[type]&quot; }
+{ operation: &quot;get_active_elements&quot;, element_type: &quot;[type]&quot; }
+{ operation: &quot;search_elements&quot;, params: { query: &quot;[search_term]&quot; } }
+
+Discover all operations and parameters:
+{ operation: &quot;introspect&quot;, params: { query: &quot;operations&quot; } }</code></pre>
+<p><strong>UPDATE Endpoint:</strong></p>
+<pre><code>Modifying operations that overwrite data.
+
+Supported operations: [operation_list]
+
+[Element types if applicable]
+
+These operations modify existing data, potentially overwriting previous values.
+
+Quick start example:
+{ operation: &quot;[example_op]&quot;, params: { [example_params] } }
+
+Discover required parameters:
+{ operation: &quot;introspect&quot;, params: { query: &quot;operations&quot;, name: &quot;[operation_name]&quot; } }</code></pre>
+<p><strong>DELETE Endpoint:</strong></p>
+<pre><code>Destructive operations that remove data.
+
+Supported operations: [operation_list]
+
+[Element types if applicable]
+
+These operations remove data. Use with caution.
+
+Quick start examples:
+{ operation: &quot;[example_op]&quot;, params: { [example_params] } }
+
+Discover required parameters:
+{ operation: &quot;introspect&quot;, params: { query: &quot;operations&quot;, name: &quot;[operation_name]&quot; } }</code></pre>
+<p><strong>EXECUTE Endpoint:</strong></p>
+<pre><code>Execution lifecycle operations for [executable element types].
+
+Supported operations: [operation_list]
+
+These operations manage runtime execution state. Unlike CRUD operations (which manage definitions), Execute operations handle the execution lifecycle:
+- [operation]: [description]
+
+IMPORTANT: Execute operations are potentially destructive and non-idempotent.
+
+Quick start examples:
+{ operation: &quot;[example_op]&quot;, params: { [example_params] } }
+
+Discover required parameters:
+{ operation: &quot;introspect&quot;, params: { query: &quot;operations&quot;, name: &quot;[operation_name]&quot; } }</code></pre>
+<h4 id="212-single-mode-tool-description">2.1.2 Single Mode Tool Description</h4>
+<p>In Single mode, a single MCP tool is registered with this template:</p>
+<pre><code>MCP-AQL [domain] adapter. All operations through unified entry point.
+
+Operations are automatically routed based on their semantic category (Create, Read, Update, Delete, Execute).
+
+Supported operation categories:
+- Create: [brief list]
+- Read: [brief list]
+- Update: [brief list]
+- Delete: [brief list]
+- Execute: [brief list]
+
+Quick start:
+{ operation: &quot;introspect&quot;, params: { query: &quot;operations&quot; } }
+
+Use introspection to discover all available operations and their parameters.</code></pre>
+<h3 id="22-tool-naming">2.2 Tool Naming</h3>
+<h4 id="221-standard-tool-names">2.2.1 Standard Tool Names</h4>
+<p>Implementations SHOULD use these standard tool names:</p>
+<p><strong>CRUDE Mode:</strong> | Tool Name | Purpose | |-----------|---------| | <code>mcp_aql_create</code> | CREATE operations | | <code>mcp_aql_read</code> | READ operations | | <code>mcp_aql_update</code> | UPDATE operations | | <code>mcp_aql_delete</code> | DELETE operations | | <code>mcp_aql_execute</code> | EXECUTE operations |</p>
+<p><strong>Single Mode:</strong> | Tool Name | Purpose | |-----------|---------| | <code>mcp_aql</code> | All operations |</p>
+<h4 id="222-custom-tool-name-prefixes">2.2.2 Custom Tool Name Prefixes</h4>
+<p>When multiple MCP-AQL adapters are deployed in a single session, tool names MUST be disambiguated. See <a href="#6-multi-adapter-deployment">Section 6</a> for details.</p>
+<h3 id="23-mcp-tool-annotations">2.3 MCP Tool Annotations</h3>
+<p>Adapters SHOULD include MCP tool annotations to provide permission hints:</p>
+<p><strong>CRUDE Mode Annotations:</strong></p>
+<div class="sourceCode" id="cb7"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb7-1"><a href="#cb7-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb7-2"><a href="#cb7-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;mcp_aql_read&quot;</span><span class="fu">,</span></span>
+<span id="cb7-3"><a href="#cb7-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;annotations&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb7-4"><a href="#cb7-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;readOnlyHint&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb7-5"><a href="#cb7-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;destructiveHint&quot;</span><span class="fu">:</span> <span class="kw">false</span></span>
+<span id="cb7-6"><a href="#cb7-6" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb7-7"><a href="#cb7-7" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span>
+<span id="cb7-8"><a href="#cb7-8" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb7-9"><a href="#cb7-9" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb7-10"><a href="#cb7-10" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;mcp_aql_create&quot;</span><span class="fu">,</span></span>
+<span id="cb7-11"><a href="#cb7-11" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;annotations&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb7-12"><a href="#cb7-12" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;readOnlyHint&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb7-13"><a href="#cb7-13" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;destructiveHint&quot;</span><span class="fu">:</span> <span class="kw">false</span></span>
+<span id="cb7-14"><a href="#cb7-14" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb7-15"><a href="#cb7-15" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span>
+<span id="cb7-16"><a href="#cb7-16" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb7-17"><a href="#cb7-17" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb7-18"><a href="#cb7-18" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;mcp_aql_update&quot;</span><span class="fu">,</span></span>
+<span id="cb7-19"><a href="#cb7-19" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;annotations&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb7-20"><a href="#cb7-20" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;readOnlyHint&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb7-21"><a href="#cb7-21" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;destructiveHint&quot;</span><span class="fu">:</span> <span class="kw">true</span></span>
+<span id="cb7-22"><a href="#cb7-22" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb7-23"><a href="#cb7-23" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span>
+<span id="cb7-24"><a href="#cb7-24" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb7-25"><a href="#cb7-25" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb7-26"><a href="#cb7-26" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;mcp_aql_delete&quot;</span><span class="fu">,</span></span>
+<span id="cb7-27"><a href="#cb7-27" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;annotations&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb7-28"><a href="#cb7-28" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;readOnlyHint&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb7-29"><a href="#cb7-29" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;destructiveHint&quot;</span><span class="fu">:</span> <span class="kw">true</span></span>
+<span id="cb7-30"><a href="#cb7-30" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb7-31"><a href="#cb7-31" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span>
+<span id="cb7-32"><a href="#cb7-32" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb7-33"><a href="#cb7-33" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb7-34"><a href="#cb7-34" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;mcp_aql_execute&quot;</span><span class="fu">,</span></span>
+<span id="cb7-35"><a href="#cb7-35" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;annotations&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb7-36"><a href="#cb7-36" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;readOnlyHint&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb7-37"><a href="#cb7-37" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;destructiveHint&quot;</span><span class="fu">:</span> <span class="kw">true</span></span>
+<span id="cb7-38"><a href="#cb7-38" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb7-39"><a href="#cb7-39" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<p><strong>Single Mode Annotations:</strong></p>
+<div class="sourceCode" id="cb8"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb8-1"><a href="#cb8-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb8-2"><a href="#cb8-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;mcp_aql&quot;</span><span class="fu">,</span></span>
+<span id="cb8-3"><a href="#cb8-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;annotations&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb8-4"><a href="#cb8-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;readOnlyHint&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb8-5"><a href="#cb8-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;destructiveHint&quot;</span><span class="fu">:</span> <span class="kw">true</span></span>
+<span id="cb8-6"><a href="#cb8-6" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb8-7"><a href="#cb8-7" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<blockquote>
+<p><strong>Note:</strong> Single mode uses <code>destructiveHint: true</code> because the unified endpoint can route to destructive operations. Clients cannot determine safety from the endpoint alone.</p>
+</blockquote>
+<hr />
+<h2 id="3-input-schema-composition">3. Input Schema Composition</h2>
+<h3 id="31-standard-input-schema">3.1 Standard Input Schema</h3>
+<p>All MCP-AQL tools MUST use this base input schema:</p>
+<div class="sourceCode" id="cb9"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb9-1"><a href="#cb9-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb9-2"><a href="#cb9-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;object&quot;</span><span class="fu">,</span></span>
+<span id="cb9-3"><a href="#cb9-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;properties&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb9-4"><a href="#cb9-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb9-5"><a href="#cb9-5" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;string&quot;</span><span class="fu">,</span></span>
+<span id="cb9-6"><a href="#cb9-6" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Operation name to execute&quot;</span></span>
+<span id="cb9-7"><a href="#cb9-7" aria-hidden="true" tabindex="-1"></a>    <span class="fu">},</span></span>
+<span id="cb9-8"><a href="#cb9-8" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb9-9"><a href="#cb9-9" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;object&quot;</span><span class="fu">,</span></span>
+<span id="cb9-10"><a href="#cb9-10" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Operation parameters&quot;</span><span class="fu">,</span></span>
+<span id="cb9-11"><a href="#cb9-11" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;additionalProperties&quot;</span><span class="fu">:</span> <span class="kw">true</span></span>
+<span id="cb9-12"><a href="#cb9-12" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb9-13"><a href="#cb9-13" aria-hidden="true" tabindex="-1"></a>  <span class="fu">},</span></span>
+<span id="cb9-14"><a href="#cb9-14" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;required&quot;</span><span class="fu">:</span> <span class="ot">[</span><span class="st">&quot;operation&quot;</span><span class="ot">]</span></span>
+<span id="cb9-15"><a href="#cb9-15" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<h3 id="32-extended-input-schema">3.2 Extended Input Schema</h3>
+<p>Adapters MAY extend the base schema with additional top-level properties for common cross-cutting concerns:</p>
+<div class="sourceCode" id="cb10"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb10-1"><a href="#cb10-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb10-2"><a href="#cb10-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;object&quot;</span><span class="fu">,</span></span>
+<span id="cb10-3"><a href="#cb10-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;properties&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb10-4"><a href="#cb10-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb10-5"><a href="#cb10-5" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;string&quot;</span><span class="fu">,</span></span>
+<span id="cb10-6"><a href="#cb10-6" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Operation name to execute&quot;</span></span>
+<span id="cb10-7"><a href="#cb10-7" aria-hidden="true" tabindex="-1"></a>    <span class="fu">},</span></span>
+<span id="cb10-8"><a href="#cb10-8" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;element_type&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb10-9"><a href="#cb10-9" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;string&quot;</span><span class="fu">,</span></span>
+<span id="cb10-10"><a href="#cb10-10" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Target element type (optional)&quot;</span></span>
+<span id="cb10-11"><a href="#cb10-11" aria-hidden="true" tabindex="-1"></a>    <span class="fu">},</span></span>
+<span id="cb10-12"><a href="#cb10-12" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb10-13"><a href="#cb10-13" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;object&quot;</span><span class="fu">,</span></span>
+<span id="cb10-14"><a href="#cb10-14" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Operation parameters&quot;</span><span class="fu">,</span></span>
+<span id="cb10-15"><a href="#cb10-15" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;additionalProperties&quot;</span><span class="fu">:</span> <span class="kw">true</span></span>
+<span id="cb10-16"><a href="#cb10-16" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb10-17"><a href="#cb10-17" aria-hidden="true" tabindex="-1"></a>  <span class="fu">},</span></span>
+<span id="cb10-18"><a href="#cb10-18" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;required&quot;</span><span class="fu">:</span> <span class="ot">[</span><span class="st">&quot;operation&quot;</span><span class="ot">]</span></span>
+<span id="cb10-19"><a href="#cb10-19" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<h3 id="33-dynamic-operation-enumeration">3.3 Dynamic Operation Enumeration</h3>
+<p>Adapters MAY use dynamic <code>enum</code> generation for the <code>operation</code> property to provide client-side validation and autocompletion:</p>
+<div class="sourceCode" id="cb11"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb11-1"><a href="#cb11-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb11-2"><a href="#cb11-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;object&quot;</span><span class="fu">,</span></span>
+<span id="cb11-3"><a href="#cb11-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;properties&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb11-4"><a href="#cb11-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb11-5"><a href="#cb11-5" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;string&quot;</span><span class="fu">,</span></span>
+<span id="cb11-6"><a href="#cb11-6" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Operation name to execute&quot;</span><span class="fu">,</span></span>
+<span id="cb11-7"><a href="#cb11-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;enum&quot;</span><span class="fu">:</span> <span class="ot">[</span><span class="st">&quot;list_elements&quot;</span><span class="ot">,</span> <span class="st">&quot;get_element&quot;</span><span class="ot">,</span> <span class="st">&quot;search_elements&quot;</span><span class="ot">,</span> <span class="st">&quot;introspect&quot;</span><span class="ot">]</span></span>
+<span id="cb11-8"><a href="#cb11-8" aria-hidden="true" tabindex="-1"></a>    <span class="fu">},</span></span>
+<span id="cb11-9"><a href="#cb11-9" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb11-10"><a href="#cb11-10" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;object&quot;</span><span class="fu">,</span></span>
+<span id="cb11-11"><a href="#cb11-11" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Operation parameters&quot;</span></span>
+<span id="cb11-12"><a href="#cb11-12" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb11-13"><a href="#cb11-13" aria-hidden="true" tabindex="-1"></a>  <span class="fu">},</span></span>
+<span id="cb11-14"><a href="#cb11-14" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;required&quot;</span><span class="fu">:</span> <span class="ot">[</span><span class="st">&quot;operation&quot;</span><span class="ot">]</span></span>
+<span id="cb11-15"><a href="#cb11-15" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<blockquote>
+<p><strong>Note:</strong> Dynamic enumeration increases tool registration token cost. Implementations SHOULD consider the trade-off between discoverability and token efficiency. For large operation sets, prefer introspection over enumeration.</p>
+</blockquote>
+<h3 id="34-crude-mode-schema-composition">3.4 CRUDE Mode Schema Composition</h3>
+<p>In CRUDE mode, each endpoint MAY have a schema that enumerates only operations valid for that endpoint:</p>
+<div class="sourceCode" id="cb12"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb12-1"><a href="#cb12-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb12-2"><a href="#cb12-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;mcp_aql_read&quot;</span><span class="fu">,</span></span>
+<span id="cb12-3"><a href="#cb12-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;inputSchema&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb12-4"><a href="#cb12-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;object&quot;</span><span class="fu">,</span></span>
+<span id="cb12-5"><a href="#cb12-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;properties&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb12-6"><a href="#cb12-6" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb12-7"><a href="#cb12-7" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;string&quot;</span><span class="fu">,</span></span>
+<span id="cb12-8"><a href="#cb12-8" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;READ operation to execute&quot;</span><span class="fu">,</span></span>
+<span id="cb12-9"><a href="#cb12-9" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;enum&quot;</span><span class="fu">:</span> <span class="ot">[</span><span class="st">&quot;list_elements&quot;</span><span class="ot">,</span> <span class="st">&quot;get_element&quot;</span><span class="ot">,</span> <span class="st">&quot;search_elements&quot;</span><span class="ot">,</span> <span class="st">&quot;introspect&quot;</span><span class="ot">]</span></span>
+<span id="cb12-10"><a href="#cb12-10" aria-hidden="true" tabindex="-1"></a>      <span class="fu">},</span></span>
+<span id="cb12-11"><a href="#cb12-11" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb12-12"><a href="#cb12-12" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;object&quot;</span></span>
+<span id="cb12-13"><a href="#cb12-13" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span></span>
+<span id="cb12-14"><a href="#cb12-14" aria-hidden="true" tabindex="-1"></a>    <span class="fu">},</span></span>
+<span id="cb12-15"><a href="#cb12-15" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;required&quot;</span><span class="fu">:</span> <span class="ot">[</span><span class="st">&quot;operation&quot;</span><span class="ot">]</span></span>
+<span id="cb12-16"><a href="#cb12-16" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb12-17"><a href="#cb12-17" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<p>This approach:</p>
+<ul>
+<li>Prevents clients from sending operations to wrong endpoints</li>
+<li>Provides endpoint-specific autocompletion</li>
+<li>Increases token cost proportionally to operation count</li>
+</ul>
+<hr />
+<h2 id="4-error-mapping">4. Error Mapping</h2>
+<h3 id="41-mcp-aql-to-mcp-error-mapping">4.1 MCP-AQL to MCP Error Mapping</h3>
+<p>MCP-AQL errors are returned as <code>CallToolResult</code> content, not as MCP JSON-RPC errors. The <code>isError</code> flag on <code>CallToolResult</code> indicates whether the client should treat the response as an error condition.</p>
+<h4 id="411-mapping-table">4.1.1 Mapping Table</h4>
+<table>
+<thead>
+<tr>
+<th>MCP-AQL Response</th>
+<th>MCP <code>isError</code></th>
+<th>Rationale</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>success: true</code></td>
+<td><code>false</code></td>
+<td>Normal success</td>
+</tr>
+<tr>
+<td><code>success: false</code>, recoverable error</td>
+<td><code>false</code></td>
+<td>Domain-level error; agent should interpret and recover</td>
+</tr>
+<tr>
+<td><code>success: false</code>, unrecoverable error</td>
+<td><code>true</code></td>
+<td>Protocol failure; agent cannot recover without intervention</td>
+</tr>
+</tbody>
+</table>
+<h4 id="412-recoverable-vs-unrecoverable-errors">4.1.2 Recoverable vs Unrecoverable Errors</h4>
+<p><strong>Recoverable errors</strong> (<code>isError: false</code>):</p>
+<ul>
+<li><code>NOT_FOUND_RESOURCE</code> - Resource doesn't exist; agent can try different resource</li>
+<li><code>NOT_FOUND_OPERATION</code> - Operation doesn't exist; agent can use introspect</li>
+<li><code>VALIDATION_MISSING_PARAM</code> - Missing parameter; agent can add parameter</li>
+<li><code>VALIDATION_INVALID_TYPE</code> - Wrong type; agent can fix type</li>
+<li><code>PERMISSION_DENIED</code> - Access denied; agent can inform user or try alternative</li>
+<li><code>RATE_LIMIT_EXCEEDED</code> - Rate limited; agent can wait and retry</li>
+<li><code>CONFIRMATION_REQUIRED</code> - Needs confirmation; agent can request user confirmation</li>
+</ul>
+<p><strong>Unrecoverable errors</strong> (<code>isError: true</code>):</p>
+<ul>
+<li>Schema validation failures before dispatch</li>
+<li>Unknown operations with no recovery path</li>
+<li>Internal server errors</li>
+<li>Transport failures</li>
+</ul>
+<h4 id="413-implementation-guidance">4.1.3 Implementation Guidance</h4>
+<div class="sourceCode" id="cb13"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb13-1"><a href="#cb13-1" aria-hidden="true" tabindex="-1"></a><span class="kw">function</span> <span class="fu">toCallToolResult</span>(response<span class="op">:</span> OperationResult)<span class="op">:</span> CallToolResult {</span>
+<span id="cb13-2"><a href="#cb13-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">const</span> content <span class="op">=</span> [{</span>
+<span id="cb13-3"><a href="#cb13-3" aria-hidden="true" tabindex="-1"></a>    type<span class="op">:</span> <span class="st">&quot;text&quot;</span><span class="op">,</span></span>
+<span id="cb13-4"><a href="#cb13-4" aria-hidden="true" tabindex="-1"></a>    text<span class="op">:</span> <span class="bu">JSON</span><span class="op">.</span><span class="fu">stringify</span>(response)</span>
+<span id="cb13-5"><a href="#cb13-5" aria-hidden="true" tabindex="-1"></a>  }]<span class="op">;</span></span>
+<span id="cb13-6"><a href="#cb13-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb13-7"><a href="#cb13-7" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> (response<span class="op">.</span><span class="at">success</span>) {</span>
+<span id="cb13-8"><a href="#cb13-8" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> { content<span class="op">,</span> isError<span class="op">:</span> <span class="kw">false</span> }<span class="op">;</span></span>
+<span id="cb13-9"><a href="#cb13-9" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb13-10"><a href="#cb13-10" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb13-11"><a href="#cb13-11" aria-hidden="true" tabindex="-1"></a>  <span class="co">// Determine if error is recoverable</span></span>
+<span id="cb13-12"><a href="#cb13-12" aria-hidden="true" tabindex="-1"></a>  <span class="kw">const</span> recoverableErrors <span class="op">=</span> [</span>
+<span id="cb13-13"><a href="#cb13-13" aria-hidden="true" tabindex="-1"></a>    <span class="st">&quot;NOT_FOUND_RESOURCE&quot;</span><span class="op">,</span></span>
+<span id="cb13-14"><a href="#cb13-14" aria-hidden="true" tabindex="-1"></a>    <span class="st">&quot;NOT_FOUND_OPERATION&quot;</span><span class="op">,</span></span>
+<span id="cb13-15"><a href="#cb13-15" aria-hidden="true" tabindex="-1"></a>    <span class="st">&quot;VALIDATION_MISSING_PARAM&quot;</span><span class="op">,</span></span>
+<span id="cb13-16"><a href="#cb13-16" aria-hidden="true" tabindex="-1"></a>    <span class="st">&quot;VALIDATION_INVALID_TYPE&quot;</span><span class="op">,</span></span>
+<span id="cb13-17"><a href="#cb13-17" aria-hidden="true" tabindex="-1"></a>    <span class="st">&quot;VALIDATION_INVALID_VALUE&quot;</span><span class="op">,</span></span>
+<span id="cb13-18"><a href="#cb13-18" aria-hidden="true" tabindex="-1"></a>    <span class="st">&quot;PERMISSION_DENIED&quot;</span><span class="op">,</span></span>
+<span id="cb13-19"><a href="#cb13-19" aria-hidden="true" tabindex="-1"></a>    <span class="st">&quot;RATE_LIMIT_EXCEEDED&quot;</span><span class="op">,</span></span>
+<span id="cb13-20"><a href="#cb13-20" aria-hidden="true" tabindex="-1"></a>    <span class="st">&quot;RATE_LIMIT_QUOTA_PAUSE&quot;</span><span class="op">,</span></span>
+<span id="cb13-21"><a href="#cb13-21" aria-hidden="true" tabindex="-1"></a>    <span class="st">&quot;CONFIRMATION_REQUIRED&quot;</span></span>
+<span id="cb13-22"><a href="#cb13-22" aria-hidden="true" tabindex="-1"></a>  ]<span class="op">;</span></span>
+<span id="cb13-23"><a href="#cb13-23" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb13-24"><a href="#cb13-24" aria-hidden="true" tabindex="-1"></a>  <span class="kw">const</span> isRecoverable <span class="op">=</span> recoverableErrors<span class="op">.</span><span class="fu">includes</span>(response<span class="op">.</span><span class="at">error</span><span class="op">.</span><span class="at">code</span>)<span class="op">;</span></span>
+<span id="cb13-25"><a href="#cb13-25" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb13-26"><a href="#cb13-26" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> {</span>
+<span id="cb13-27"><a href="#cb13-27" aria-hidden="true" tabindex="-1"></a>    content<span class="op">,</span></span>
+<span id="cb13-28"><a href="#cb13-28" aria-hidden="true" tabindex="-1"></a>    isError<span class="op">:</span> <span class="op">!</span>isRecoverable</span>
+<span id="cb13-29"><a href="#cb13-29" aria-hidden="true" tabindex="-1"></a>  }<span class="op">;</span></span>
+<span id="cb13-30"><a href="#cb13-30" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<h3 id="42-mcp-json-rpc-error-codes">4.2 MCP JSON-RPC Error Codes</h3>
+<p>MCP JSON-RPC errors (-32600 to -32603) are reserved for transport and protocol-level failures. MCP-AQL adapters MUST NOT use these codes for domain-level errors.</p>
+<table>
+<thead>
+<tr>
+<th>JSON-RPC Code</th>
+<th>Description</th>
+<th>When Used</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>-32600</td>
+<td>Invalid Request</td>
+<td>Malformed JSON-RPC request</td>
+</tr>
+<tr>
+<td>-32601</td>
+<td>Method not found</td>
+<td>Unknown MCP method</td>
+</tr>
+<tr>
+<td>-32602</td>
+<td>Invalid params</td>
+<td>Invalid MCP method parameters</td>
+</tr>
+<tr>
+<td>-32603</td>
+<td>Internal error</td>
+<td>MCP server internal error</td>
+</tr>
+</tbody>
+</table>
+<p>Domain-level errors (validation, not found, permission) MUST be returned as <code>CallToolResult</code> with <code>success: false</code>, not as JSON-RPC errors.</p>
+<h3 id="43-http-status-to-mcp-aql-error-mapping">4.3 HTTP Status to MCP-AQL Error Mapping</h3>
+<p>When adapters wrap HTTP APIs, HTTP status codes SHOULD be mapped to MCP-AQL error codes:</p>
+<table>
+<thead>
+<tr>
+<th>HTTP Status</th>
+<th>MCP-AQL Error Code</th>
+<th>Notes</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>400</td>
+<td><code>VALIDATION_INVALID_TYPE</code></td>
+<td>Bad request</td>
+</tr>
+<tr>
+<td>401</td>
+<td><code>PERMISSION_DENIED</code></td>
+<td>Authentication required</td>
+</tr>
+<tr>
+<td>403</td>
+<td><code>PERMISSION_DENIED</code></td>
+<td>Forbidden</td>
+</tr>
+<tr>
+<td>404</td>
+<td><code>NOT_FOUND_RESOURCE</code></td>
+<td>Not found</td>
+</tr>
+<tr>
+<td>409</td>
+<td><code>CONFLICT_ALREADY_EXISTS</code></td>
+<td>Conflict</td>
+</tr>
+<tr>
+<td>422</td>
+<td><code>VALIDATION_INVALID_TYPE</code></td>
+<td>Unprocessable entity</td>
+</tr>
+<tr>
+<td>429</td>
+<td><code>RATE_LIMIT_EXCEEDED</code></td>
+<td>Rate limited</td>
+</tr>
+<tr>
+<td>500+</td>
+<td><code>INTERNAL_ERROR</code></td>
+<td>Server errors</td>
+</tr>
+</tbody>
+</table>
+<p>See <a href="error-codes.html">Structured Error Codes Specification</a> for the complete error code taxonomy.</p>
+<hr />
+<h2 id="5-progress-notifications">5. Progress Notifications</h2>
+<h3 id="51-mcp-progress-protocol">5.1 MCP Progress Protocol</h3>
+<p>MCP supports progress notifications for long-running operations via the <code>notifications/progress</code> method. MCP-AQL EXECUTE operations SHOULD emit progress notifications when:</p>
+<ul>
+<li>The operation will take significant time (&gt; 1 second)</li>
+<li>The operation has measurable progress stages</li>
+<li>The client provided a progress token</li>
+</ul>
+<h3 id="52-progress-token-handling">5.2 Progress Token Handling</h3>
+<p>Clients MAY include a <code>_meta.progressToken</code> in requests to receive progress updates:</p>
+<div class="sourceCode" id="cb14"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb14-1"><a href="#cb14-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb14-2"><a href="#cb14-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;execute_agent&quot;</span><span class="fu">,</span></span>
+<span id="cb14-3"><a href="#cb14-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb14-4"><a href="#cb14-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;element_name&quot;</span><span class="fu">:</span> <span class="st">&quot;MyAgent&quot;</span><span class="fu">,</span></span>
+<span id="cb14-5"><a href="#cb14-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;parameters&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;goal&quot;</span><span class="fu">:</span> <span class="st">&quot;Review code&quot;</span> <span class="fu">}</span></span>
+<span id="cb14-6"><a href="#cb14-6" aria-hidden="true" tabindex="-1"></a>  <span class="fu">},</span></span>
+<span id="cb14-7"><a href="#cb14-7" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;_meta&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb14-8"><a href="#cb14-8" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;progressToken&quot;</span><span class="fu">:</span> <span class="st">&quot;progress_abc123&quot;</span></span>
+<span id="cb14-9"><a href="#cb14-9" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb14-10"><a href="#cb14-10" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<p>Adapters receiving a progress token SHOULD emit progress notifications during EXECUTE operations.</p>
+<h3 id="53-progress-notification-format">5.3 Progress Notification Format</h3>
+<p>Progress notifications MUST follow the MCP progress notification format:</p>
+<div class="sourceCode" id="cb15"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb15-1"><a href="#cb15-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb15-2"><a href="#cb15-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;jsonrpc&quot;</span><span class="fu">:</span> <span class="st">&quot;2.0&quot;</span><span class="fu">,</span></span>
+<span id="cb15-3"><a href="#cb15-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;method&quot;</span><span class="fu">:</span> <span class="st">&quot;notifications/progress&quot;</span><span class="fu">,</span></span>
+<span id="cb15-4"><a href="#cb15-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb15-5"><a href="#cb15-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;progressToken&quot;</span><span class="fu">:</span> <span class="st">&quot;progress_abc123&quot;</span><span class="fu">,</span></span>
+<span id="cb15-6"><a href="#cb15-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;progress&quot;</span><span class="fu">:</span> <span class="dv">50</span><span class="fu">,</span></span>
+<span id="cb15-7"><a href="#cb15-7" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;total&quot;</span><span class="fu">:</span> <span class="dv">100</span><span class="fu">,</span></span>
+<span id="cb15-8"><a href="#cb15-8" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;Processing step 5 of 10&quot;</span></span>
+<span id="cb15-9"><a href="#cb15-9" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb15-10"><a href="#cb15-10" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<h3 id="54-execute-operation-progress-mapping">5.4 EXECUTE Operation Progress Mapping</h3>
+<p>For EXECUTE operations with defined state machines, map states to progress:</p>
+<table>
+<thead>
+<tr>
+<th>EXECUTE State</th>
+<th>Progress Range</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Initializing</td>
+<td>0-10%</td>
+<td>Setting up execution context</td>
+</tr>
+<tr>
+<td>Running</td>
+<td>10-90%</td>
+<td>Main execution phase</td>
+</tr>
+<tr>
+<td>Completing</td>
+<td>90-100%</td>
+<td>Finalizing and cleaning up</td>
+</tr>
+</tbody>
+</table>
+<p><strong>Example mapping:</strong></p>
+<div class="sourceCode" id="cb16"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb16-1"><a href="#cb16-1" aria-hidden="true" tabindex="-1"></a><span class="kw">function</span> <span class="fu">mapExecutionStateToProgress</span>(state<span class="op">:</span> ExecutionState)<span class="op">:</span> <span class="dt">number</span> {</span>
+<span id="cb16-2"><a href="#cb16-2" aria-hidden="true" tabindex="-1"></a>  <span class="cf">switch</span> (state<span class="op">.</span><span class="at">status</span>) {</span>
+<span id="cb16-3"><a href="#cb16-3" aria-hidden="true" tabindex="-1"></a>    <span class="cf">case</span> <span class="st">&quot;pending&quot;</span><span class="op">:</span> <span class="cf">return</span> <span class="dv">0</span><span class="op">;</span></span>
+<span id="cb16-4"><a href="#cb16-4" aria-hidden="true" tabindex="-1"></a>    <span class="cf">case</span> <span class="st">&quot;initializing&quot;</span><span class="op">:</span> <span class="cf">return</span> <span class="dv">5</span><span class="op">;</span></span>
+<span id="cb16-5"><a href="#cb16-5" aria-hidden="true" tabindex="-1"></a>    <span class="cf">case</span> <span class="st">&quot;running&quot;</span><span class="op">:</span></span>
+<span id="cb16-6"><a href="#cb16-6" aria-hidden="true" tabindex="-1"></a>      <span class="co">// Calculate progress within running phase</span></span>
+<span id="cb16-7"><a href="#cb16-7" aria-hidden="true" tabindex="-1"></a>      <span class="kw">const</span> runningProgress <span class="op">=</span> state<span class="op">.</span><span class="at">stepsCompleted</span> <span class="op">/</span> state<span class="op">.</span><span class="at">totalSteps</span><span class="op">;</span></span>
+<span id="cb16-8"><a href="#cb16-8" aria-hidden="true" tabindex="-1"></a>      <span class="cf">return</span> <span class="dv">10</span> <span class="op">+</span> (runningProgress <span class="op">*</span> <span class="dv">80</span>)<span class="op">;</span></span>
+<span id="cb16-9"><a href="#cb16-9" aria-hidden="true" tabindex="-1"></a>    <span class="cf">case</span> <span class="st">&quot;completing&quot;</span><span class="op">:</span> <span class="cf">return</span> <span class="dv">95</span><span class="op">;</span></span>
+<span id="cb16-10"><a href="#cb16-10" aria-hidden="true" tabindex="-1"></a>    <span class="cf">case</span> <span class="st">&quot;completed&quot;</span><span class="op">:</span> <span class="cf">return</span> <span class="dv">100</span><span class="op">;</span></span>
+<span id="cb16-11"><a href="#cb16-11" aria-hidden="true" tabindex="-1"></a>    <span class="cf">default</span><span class="op">:</span> <span class="cf">return</span> <span class="dv">0</span><span class="op">;</span></span>
+<span id="cb16-12"><a href="#cb16-12" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb16-13"><a href="#cb16-13" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<h3 id="55-progress-for-non-execute-operations">5.5 Progress for Non-EXECUTE Operations</h3>
+<p>READ, CREATE, UPDATE, and DELETE operations MAY emit progress notifications for long-running operations such as:</p>
+<ul>
+<li>Bulk imports (CREATE)</li>
+<li>Large search queries (READ)</li>
+<li>Batch updates (UPDATE)</li>
+<li>Bulk deletions (DELETE)</li>
+</ul>
+<hr />
+<h2 id="6-multi-adapter-deployment">6. Multi-Adapter Deployment</h2>
+<h3 id="61-the-collision-problem">6.1 The Collision Problem</h3>
+<p>When multiple MCP-AQL adapters are deployed in a single MCP session, tool names may collide. Two adapters both registering <code>mcp_aql_read</code> creates ambiguity.</p>
+<h3 id="62-tool-name-prefixing">6.2 Tool Name Prefixing</h3>
+<p>Implementations SHOULD support a tool name prefix for disambiguation:</p>
+<p><strong>Environment Variable:</strong></p>
+<pre><code>MCP_AQL_TOOL_PREFIX=github_</code></pre>
+<p><strong>Result:</strong></p>
+<pre><code>github_mcp_aql_create
+github_mcp_aql_read
+github_mcp_aql_update
+github_mcp_aql_delete
+github_mcp_aql_execute</code></pre>
+<h3 id="63-configuration-methods">6.3 Configuration Methods</h3>
+<p>Adapters SHOULD support prefix configuration via:</p>
+<ol type="1">
+<li>Environment variable: <code>MCP_AQL_TOOL_PREFIX</code></li>
+<li>Configuration file</li>
+<li>Programmatic API</li>
+</ol>
+<p><strong>Priority order:</strong> Environment variable &gt; Configuration file &gt; Default (no prefix)</p>
+<h3 id="64-prefix-format-requirements">6.4 Prefix Format Requirements</h3>
+<p>Tool name prefixes:</p>
+<ul>
+<li>MUST contain only lowercase letters, numbers, and underscores</li>
+<li>MUST end with an underscore</li>
+<li>SHOULD be short (&lt; 20 characters)</li>
+<li>SHOULD be descriptive of the adapter's domain</li>
+</ul>
+<p><strong>Examples:</strong></p>
+<ul>
+<li><code>github_</code> for GitHub API adapter</li>
+<li><code>jira_</code> for Jira adapter</li>
+<li><code>slack_</code> for Slack adapter</li>
+<li><code>db_</code> for database adapter</li>
+</ul>
+<h3 id="65-client-side-disambiguation">6.5 Client-Side Disambiguation</h3>
+<p>When multiple MCP-AQL adapters are present, clients SHOULD:</p>
+<ol type="1">
+<li>Group tools by prefix to identify adapter boundaries</li>
+<li>Use introspection on each adapter to discover operations</li>
+<li>Present operations with adapter context to users</li>
+</ol>
+<p><strong>Example client logic:</strong></p>
+<div class="sourceCode" id="cb19"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb19-1"><a href="#cb19-1" aria-hidden="true" tabindex="-1"></a><span class="kw">function</span> <span class="fu">groupAdapterTools</span>(tools<span class="op">:</span> Tool[])<span class="op">:</span> <span class="bu">Map</span><span class="op">&lt;</span><span class="dt">string</span><span class="op">,</span> Tool[]<span class="op">&gt;</span> {</span>
+<span id="cb19-2"><a href="#cb19-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">const</span> groups <span class="op">=</span> <span class="kw">new</span> <span class="bu">Map</span><span class="op">&lt;</span><span class="dt">string</span><span class="op">,</span> Tool[]<span class="op">&gt;</span>()<span class="op">;</span></span>
+<span id="cb19-3"><a href="#cb19-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb19-4"><a href="#cb19-4" aria-hidden="true" tabindex="-1"></a>  <span class="cf">for</span> (<span class="kw">const</span> tool <span class="kw">of</span> tools) {</span>
+<span id="cb19-5"><a href="#cb19-5" aria-hidden="true" tabindex="-1"></a>    <span class="co">// Extract prefix from tool name</span></span>
+<span id="cb19-6"><a href="#cb19-6" aria-hidden="true" tabindex="-1"></a>    <span class="kw">const</span> match <span class="op">=</span> tool<span class="op">.</span><span class="at">name</span><span class="op">.</span><span class="fu">match</span>(<span class="ss">/</span><span class="sc">^(</span><span class="ss">.</span><span class="sc">+</span><span class="ss">_</span><span class="sc">)</span><span class="ss">mcp_aql_</span><span class="sc">(</span><span class="ss">create</span><span class="sc">|</span><span class="ss">read</span><span class="sc">|</span><span class="ss">update</span><span class="sc">|</span><span class="ss">delete</span><span class="sc">|</span><span class="ss">execute</span><span class="sc">)$</span><span class="ss">/</span>)<span class="op">;</span></span>
+<span id="cb19-7"><a href="#cb19-7" aria-hidden="true" tabindex="-1"></a>    <span class="kw">const</span> prefix <span class="op">=</span> match <span class="op">?</span> match[<span class="dv">1</span>] <span class="op">:</span> <span class="st">&quot;&quot;</span><span class="op">;</span></span>
+<span id="cb19-8"><a href="#cb19-8" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb19-9"><a href="#cb19-9" aria-hidden="true" tabindex="-1"></a>    <span class="cf">if</span> (<span class="op">!</span>groups<span class="op">.</span><span class="fu">has</span>(prefix)) {</span>
+<span id="cb19-10"><a href="#cb19-10" aria-hidden="true" tabindex="-1"></a>      groups<span class="op">.</span><span class="fu">set</span>(prefix<span class="op">,</span> [])<span class="op">;</span></span>
+<span id="cb19-11"><a href="#cb19-11" aria-hidden="true" tabindex="-1"></a>    }</span>
+<span id="cb19-12"><a href="#cb19-12" aria-hidden="true" tabindex="-1"></a>    groups<span class="op">.</span><span class="fu">get</span>(prefix)<span class="op">!.</span><span class="fu">push</span>(tool)<span class="op">;</span></span>
+<span id="cb19-13"><a href="#cb19-13" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb19-14"><a href="#cb19-14" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb19-15"><a href="#cb19-15" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> groups<span class="op">;</span></span>
+<span id="cb19-16"><a href="#cb19-16" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<h3 id="66-introspection-disambiguation">6.6 Introspection Disambiguation</h3>
+<p>Each adapter's introspection returns only its own operations. Clients discover the full operation space by querying each adapter:</p>
+<div class="sourceCode" id="cb20"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb20-1"><a href="#cb20-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Query GitHub adapter</span></span>
+<span id="cb20-2"><a href="#cb20-2" aria-hidden="true" tabindex="-1"></a>{ <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;introspect&quot;</span><span class="op">,</span> <span class="dt">params</span><span class="op">:</span> { <span class="dt">query</span><span class="op">:</span> <span class="st">&quot;operations&quot;</span> } }</span>
+<span id="cb20-3"><a href="#cb20-3" aria-hidden="true" tabindex="-1"></a><span class="co">// Returns: list_repos, get_repo, create_issue, etc.</span></span>
+<span id="cb20-4"><a href="#cb20-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb20-5"><a href="#cb20-5" aria-hidden="true" tabindex="-1"></a><span class="co">// Query Jira adapter</span></span>
+<span id="cb20-6"><a href="#cb20-6" aria-hidden="true" tabindex="-1"></a>{ <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;introspect&quot;</span><span class="op">,</span> <span class="dt">params</span><span class="op">:</span> { <span class="dt">query</span><span class="op">:</span> <span class="st">&quot;operations&quot;</span> } }</span>
+<span id="cb20-7"><a href="#cb20-7" aria-hidden="true" tabindex="-1"></a><span class="co">// Returns: list_projects, get_issue, create_ticket, etc.</span></span></code></pre></div>
+<hr />
+<h2 id="7-conformance-requirements">7. Conformance Requirements</h2>
+<h3 id="71-must-requirements">7.1 MUST Requirements</h3>
+<p>Conforming implementations MUST:</p>
+<ol type="1">
+<li>Include <code>introspect</code> operation reference in tool descriptions</li>
+<li>Use the standard input schema structure (<code>operation</code>, <code>params</code>)</li>
+<li>Return domain errors as <code>CallToolResult</code> content, not JSON-RPC errors</li>
+<li>Map <code>success: false</code> responses to <code>CallToolResult</code> with appropriate <code>isError</code> flag</li>
+<li>Use unique tool names when multiple adapters are deployed</li>
+</ol>
+<h3 id="72-should-requirements">7.2 SHOULD Requirements</h3>
+<p>Conforming implementations SHOULD:</p>
+<ol type="1">
+<li>Use the standard tool names (<code>mcp_aql_create</code>, etc.)</li>
+<li>Include MCP tool annotations for permission hints</li>
+<li>Support the <code>MCP_AQL_TOOL_PREFIX</code> environment variable</li>
+<li>Emit progress notifications for long-running EXECUTE operations</li>
+<li>Map HTTP errors to MCP-AQL error codes consistently</li>
+</ol>
+<h3 id="73-may-requirements">7.3 MAY Requirements</h3>
+<p>Conforming implementations MAY:</p>
+<ol type="1">
+<li>Use dynamic <code>enum</code> generation for operation names</li>
+<li>Extend the input schema with additional top-level properties</li>
+<li>Emit progress notifications for non-EXECUTE operations</li>
+<li>Support additional prefix configuration methods</li>
+</ol>
+<hr />
+<h2 id="references">References</h2>
+<ul>
+<li><a href="versions/v1.0.0-draft.html">MCP-AQL Specification v1.0.0-draft</a></li>
+<li><a href="endpoint-modes.html">Endpoint Modes Specification</a></li>
+<li><a href="operations.html">Operations Specification</a></li>
+<li><a href="error-codes.html">Structured Error Codes Specification</a></li>
+<li><a href="https://spec.modelcontextprotocol.io/">Model Context Protocol Specification</a></li>
+</ul>
+
+          </div>
+        </section>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div class="container">
+      <p>&copy; 2026 DollhouseMCP Inc. d/b/a Dollhouse Research. MCP-AQL public draft documentation portal.</p>
+      <div class="footer-links">
+        <a href="../docs/index.html">Docs Library</a>
+        <a href="index.html">Repo-Synced Spec</a>
+        <a href="https://github.com/MCPAQL">MCPAQL Organization</a>
+        <a href="https://dollhouseresearch.com">Dollhouse Research</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../js/search.js"></script>
+</body>
+</html>

--- a/public/spec/mcp-integration.html
+++ b/public/spec/mcp-integration.html
@@ -73,6 +73,13 @@
       </aside>
 
       <article class="docs-main">
+        <nav class="breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../index.html">Home</a></li>
+            <li><a href="index.html">Full Spec</a></li>
+            <li><span class="current">MCP Integration Specification</span></li>
+          </ol>
+        </nav>
         <section class="hero docs-hero">
           <div class="hero-inner">
             <span class="status-pill">REPO-SYNCED SPEC DOC</span>

--- a/public/spec/operations.html
+++ b/public/spec/operations.html
@@ -73,6 +73,13 @@
       </aside>
 
       <article class="docs-main">
+        <nav class="breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../index.html">Home</a></li>
+            <li><a href="index.html">Full Spec</a></li>
+            <li><span class="current">MCP-AQL Operations Specification</span></li>
+          </ol>
+        </nav>
         <section class="hero docs-hero">
           <div class="hero-inner">
             <span class="status-pill">REPO-SYNCED SPEC DOC</span>

--- a/public/spec/operations.html
+++ b/public/spec/operations.html
@@ -38,7 +38,7 @@
         <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
         <div class="docs-side-group">
   <h3>Core</h3>
-  <ul><li><a href="conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="error-codes.html">Structured Error Codes Specification</a></li><li><a href="introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="mcp-integration.html">MCP Integration Specification</a></li><li><a class="current" href="operations.html">MCP-AQL Operations Specification</a></li><li><a href="overview.html">MCP-AQL Protocol Overview</a></li><li><a href="plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="README.html">MCP-AQL Specification Documentation</a></li></ul>
+  <ul><li><a href="conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="error-codes.html">Structured Error Codes Specification</a></li><li><a href="introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="mcp-integration.html">MCP Integration Specification</a></li><li><a class="current" href="operations.html">MCP-AQL Operations Specification</a></li><li><a href="overview.html">MCP-AQL Protocol Overview</a></li><li><a href="plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="README.html">MCP-AQL Specification Documentation</a></li><li><a href="repo/README.html">MCP-AQL Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Versions</h3>
   <ul><li><a href="versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
@@ -56,7 +56,7 @@
   <ul><li><a href="guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
-  <ul><li><a href="process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="process/versioning.html">Versioning Strategy</a></li></ul>
+  <ul><li><a href="process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="process/versioning.html">Versioning Strategy</a></li><li><a href="repo/CHANGELOG.html">Changelog</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Architecture</h3>
   <ul><li><a href="architecture/README.html">Architecture Documentation</a></li></ul>

--- a/public/spec/operations.html
+++ b/public/spec/operations.html
@@ -1,0 +1,1141 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Document Status: This document is informative. For normative requirements, see MCP-AQL Specification v1.0.0.">
+  <title>MCP-AQL Spec | MCP-AQL Operations Specification</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../css/style.css">
+</head>
+<body>
+  <header>
+    <div class="container">
+      <nav>
+        <a class="logo" href="../index.html"><span class="logo-mark"></span>MCP-AQL</a>
+        <ul class="nav-links">
+          <li><a href="../index.html">Home</a></li>
+          <li><a href="../docs/index.html">Docs</a></li>
+          <li><a href="../launch-checklist.html">Launch Checklist</a></li>
+          <li><a href="../apis/mcp-server.html">Adapter Patterns</a></li>
+        </ul>
+        <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
+          <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
+          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <span class="search-count" data-search-count></span>
+          <ul class="search-results" data-search-results hidden></ul>
+        </form>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <div class="container docs-shell">
+      <aside class="docs-side">
+        <h2>Repo-Synced Spec</h2>
+        <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
+        <div class="docs-side-group">
+  <h3>Core</h3>
+  <ul><li><a href="conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="error-codes.html">Structured Error Codes Specification</a></li><li><a href="introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="mcp-integration.html">MCP Integration Specification</a></li><li><a class="current" href="operations.html">MCP-AQL Operations Specification</a></li><li><a href="overview.html">MCP-AQL Protocol Overview</a></li><li><a href="plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="README.html">MCP-AQL Specification Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Versions</h3>
+  <ul><li><a href="versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Adapter</h3>
+  <ul><li><a href="adapter/danger-levels.html">Dangerous Operation Classification Specification</a></li><li><a href="adapter/discovery-bundle.html">MCP Server Discovery Bundle</a></li><li><a href="adapter/element-type.html">Adapter Element Type Specification</a></li><li><a href="adapter/generator.html">Adapter Generator Specification</a></li><li><a href="adapter/rate-limiting.html">Rate Limiting and Quota Management Specification</a></li><li><a href="adapter/trust-levels.html">Trust Levels Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Security</h3>
+  <ul><li><a href="security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Features</h3>
+  <ul><li><a href="features/field-selection.html">Field Selection Specification</a></li><li><a href="features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="features/warnings.html">Warnings Array Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Guides</h3>
+  <ul><li><a href="guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="guides/README.html">Developer Guides</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Process</h3>
+  <ul><li><a href="process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="process/versioning.html">Versioning Strategy</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Architecture</h3>
+  <ul><li><a href="architecture/README.html">Architecture Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Research</h3>
+  <ul><li><a href="research/mcp-vs-mcpaql-vs-a2a.html">Protocol Landscape: MCP vs MCP-AQL vs A2A</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Reference</h3>
+  <ul><li><a href="reference/README.html">Reference Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>ADRs</h3>
+  <ul><li><a href="adr/ADR-001-crude-pattern.html">ADR-001: CRUDE Pattern (Extending CRUD with Execute)</a></li><li><a href="adr/ADR-002-graphql-style-input.html">ADR-002: GraphQL-Style Input Objects for Updates</a></li><li><a href="adr/ADR-003-snake-case-parameters.html">ADR-003: snake_case Parameter Convention</a></li><li><a href="adr/ADR-004-schema-driven-operations.html">ADR-004: Schema-Driven Operation Definitions</a></li><li><a href="adr/ADR-005-introspection-system.html">ADR-005: GraphQL-Style Introspection System</a></li><li><a href="adr/ADR-006-discriminated-responses.html">ADR-006: Discriminated Response Format</a></li><li><a href="adr/index.html">Architecture Decision Records</a></li><li><a href="adr/README.html">Architecture Decision Records</a></li></ul>
+</div>
+      </aside>
+
+      <article class="docs-main">
+        <section class="hero docs-hero">
+          <div class="hero-inner">
+            <span class="status-pill">REPO-SYNCED SPEC DOC</span>
+            <h1>MCP-AQL Operations Specification</h1>
+            <p class="lede">Document Status: This document is informative. For normative requirements, see MCP-AQL Specification v1.0.0.</p>
+            <div class="spec-meta"><span class="state-chip live">Support document</span><span class="state-chip pending">Draft</span><span class="state-chip">1.0.0-draft</span><span class="state-chip">2026-01-16</span></div>
+            <p class="spec-source">Source: <a href="https://github.com/MCPAQL/spec/blob/main/docs/operations.md">spec/docs/operations.md</a></p>
+            <div class="hero-actions">
+              <a class="btn btn-primary" href="https://github.com/MCPAQL/spec/blob/main/docs/operations.md">Open Source Markdown</a>
+              <a class="btn btn-secondary" href="index.html">Browse Full Spec Reference</a>
+            </div>
+          </div>
+        </section>
+
+        <section>
+          <div class="card spec-prose">
+            <p><strong>Version:</strong> 1.0.0-draft <strong>Status:</strong> Draft <strong>Last Updated:</strong> 2026-01-16</p>
+<blockquote>
+<p><strong>Document Status:</strong> This document is <strong>informative</strong>. For normative requirements, see <a href="versions/v1.0.0-draft.html">MCP-AQL Specification v1.0.0</a>.</p>
+</blockquote>
+<h2 id="abstract">Abstract</h2>
+<p>This document specifies how operations are defined, documented, and invoked in MCP-AQL adapters. It covers the operation input format, response format, parameter conventions, operation schemas, batch operations, and error handling patterns.</p>
+<hr />
+<h2 id="table-of-contents">Table of Contents</h2>
+<ol type="1">
+<li><a href="#1-conformance-requirements">Conformance Requirements</a></li>
+<li><a href="#2-operation-input-format">Operation Input Format</a></li>
+<li><a href="#3-response-format">Response Format</a></li>
+<li><a href="#4-parameter-conventions">Parameter Conventions</a></li>
+<li><a href="#5-operation-schema-definition">Operation Schema Definition</a></li>
+<li><a href="#6-crude-endpoint-assignment">CRUDE Endpoint Assignment</a></li>
+<li><a href="#7-batch-operations">Batch Operations</a></li>
+<li><a href="#8-error-handling">Error Handling</a></li>
+<li><a href="#9-the-introspect-operation">The introspect Operation</a></li>
+</ol>
+<hr />
+<h2 id="1-conformance-requirements">1. Conformance Requirements</h2>
+<p>The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in <a href="https://www.rfc-editor.org/rfc/rfc2119">RFC 2119</a>.</p>
+<p>An MCP-AQL adapter is conformant if it implements:</p>
+<ol type="1">
+<li>The operation input format as specified in Section 2</li>
+<li>The discriminated response format as specified in Section 3</li>
+<li>The <code>introspect</code> operation as specified in Section 9</li>
+<li>Correct endpoint routing based on operation semantics (Section 6)</li>
+</ol>
+<hr />
+<h2 id="2-operation-input-format">2. Operation Input Format</h2>
+<h3 id="21-standard-input-structure">2.1 Standard Input Structure</h3>
+<p>All operations MUST follow a consistent input structure:</p>
+<div class="sourceCode" id="cb1"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb1-2"><a href="#cb1-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;&lt;operation_name&gt;&quot;</span><span class="fu">,</span></span>
+<span id="cb1-3"><a href="#cb1-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb1-4"><a href="#cb1-4" aria-hidden="true" tabindex="-1"></a>    <span class="er">//</span> <span class="er">Operation-specific</span> <span class="er">parameters</span></span>
+<span id="cb1-5"><a href="#cb1-5" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb1-6"><a href="#cb1-6" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<h3 id="22-required-fields">2.2 Required Fields</h3>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Type</th>
+<th>Required</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>operation</code></td>
+<td>string</td>
+<td>REQUIRED</td>
+<td>The operation to perform</td>
+</tr>
+<tr>
+<td><code>params</code></td>
+<td>object</td>
+<td>OPTIONAL</td>
+<td>Operation-specific parameters</td>
+</tr>
+</tbody>
+</table>
+<p>The <code>operation</code> field MUST be a non-empty string matching a defined operation name.</p>
+<blockquote>
+<p><strong>Terminology Note:</strong> The request field <code>params</code> (an object) carries runtime parameter values. The introspection field <code>parameters</code> (an array of <code>ParameterInfo</code>) describes the accepted parameter definitions. The keys of <code>params</code> correspond to the <code>name</code> field of each <code>ParameterInfo</code> entry. See <a href="introspection.html#33-operationdetails-detail-response">Introspection — OperationDetails</a>.</p>
+</blockquote>
+<h3 id="23-parameter-resolution">2.3 Parameter Resolution</h3>
+<p>Adapters MAY support parameter resolution from multiple locations. The RECOMMENDED resolution order is:</p>
+<ol type="1">
+<li><code>params.&lt;parameter_name&gt;</code> (preferred)</li>
+<li>Top-level <code>&lt;parameter_name&gt;</code> (convenience)</li>
+</ol>
+<p>When the same parameter appears at multiple levels, the value in <code>params</code> takes precedence.</p>
+<p><strong>Example - Equivalent Requests:</strong></p>
+<div class="sourceCode" id="cb2"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Parameters in params object (RECOMMENDED)</span></span>
+<span id="cb2-2"><a href="#cb2-2" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb2-3"><a href="#cb2-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;get_item&quot;</span><span class="op">,</span></span>
+<span id="cb2-4"><a href="#cb2-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> { <span class="dt">item_id</span><span class="op">:</span> <span class="st">&quot;123&quot;</span> }</span>
+<span id="cb2-5"><a href="#cb2-5" aria-hidden="true" tabindex="-1"></a>}</span>
+<span id="cb2-6"><a href="#cb2-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb2-7"><a href="#cb2-7" aria-hidden="true" tabindex="-1"></a><span class="co">// Parameters at top level (also valid)</span></span>
+<span id="cb2-8"><a href="#cb2-8" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb2-9"><a href="#cb2-9" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;get_item&quot;</span><span class="op">,</span></span>
+<span id="cb2-10"><a href="#cb2-10" aria-hidden="true" tabindex="-1"></a>  <span class="dt">item_id</span><span class="op">:</span> <span class="st">&quot;123&quot;</span></span>
+<span id="cb2-11"><a href="#cb2-11" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<h3 id="24-case-sensitivity">2.4 Case Sensitivity</h3>
+<p>Operation names MUST be case-sensitive. Operation names MUST use snake_case (a lowercase letter followed by lowercase letters, digits, and underscores), matching the schema pattern <code>^[a-z][a-z0-9_]*$</code>.</p>
+<hr />
+<h2 id="3-response-format">3. Response Format</h2>
+<h3 id="31-discriminated-union-result">3.1 Discriminated Union Result</h3>
+<p>All operations MUST return a discriminated union response. The <code>success</code> field serves as the discriminator.</p>
+<div class="sourceCode" id="cb3"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb3-1"><a href="#cb3-1" aria-hidden="true" tabindex="-1"></a><span class="kw">type</span> OperationResult <span class="op">=</span> OperationSuccess <span class="op">|</span> OperationFailure<span class="op">;</span></span>
+<span id="cb3-2"><a href="#cb3-2" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb3-3"><a href="#cb3-3" aria-hidden="true" tabindex="-1"></a><span class="kw">interface</span> OperationSuccess {</span>
+<span id="cb3-4"><a href="#cb3-4" aria-hidden="true" tabindex="-1"></a>  success<span class="op">:</span> <span class="kw">true</span><span class="op">;</span></span>
+<span id="cb3-5"><a href="#cb3-5" aria-hidden="true" tabindex="-1"></a>  data<span class="op">:</span> <span class="dt">unknown</span><span class="op">;</span>   <span class="co">// Operation-specific payload</span></span>
+<span id="cb3-6"><a href="#cb3-6" aria-hidden="true" tabindex="-1"></a>  error<span class="op">?:</span> <span class="dt">never</span><span class="op">;</span>   <span class="co">// MUST NOT be present</span></span>
+<span id="cb3-7"><a href="#cb3-7" aria-hidden="true" tabindex="-1"></a>}</span>
+<span id="cb3-8"><a href="#cb3-8" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb3-9"><a href="#cb3-9" aria-hidden="true" tabindex="-1"></a><span class="kw">interface</span> OperationFailure {</span>
+<span id="cb3-10"><a href="#cb3-10" aria-hidden="true" tabindex="-1"></a>  success<span class="op">:</span> <span class="kw">false</span><span class="op">;</span></span>
+<span id="cb3-11"><a href="#cb3-11" aria-hidden="true" tabindex="-1"></a>  error<span class="op">:</span> ErrorDetail<span class="op">;</span>  <span class="co">// Structured error information</span></span>
+<span id="cb3-12"><a href="#cb3-12" aria-hidden="true" tabindex="-1"></a>  data<span class="op">?:</span> <span class="dt">never</span><span class="op">;</span>        <span class="co">// MUST NOT be present</span></span>
+<span id="cb3-13"><a href="#cb3-13" aria-hidden="true" tabindex="-1"></a>}</span>
+<span id="cb3-14"><a href="#cb3-14" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb3-15"><a href="#cb3-15" aria-hidden="true" tabindex="-1"></a><span class="kw">interface</span> ErrorDetail {</span>
+<span id="cb3-16"><a href="#cb3-16" aria-hidden="true" tabindex="-1"></a>  code<span class="op">:</span> <span class="dt">string</span><span class="op">;</span>     <span class="co">// Machine-readable error code (e.g., &quot;NOT_FOUND_RESOURCE&quot;)</span></span>
+<span id="cb3-17"><a href="#cb3-17" aria-hidden="true" tabindex="-1"></a>  message<span class="op">:</span> <span class="dt">string</span><span class="op">;</span>  <span class="co">// Human-readable error message</span></span>
+<span id="cb3-18"><a href="#cb3-18" aria-hidden="true" tabindex="-1"></a>  details<span class="op">?:</span> <span class="bu">Record</span><span class="op">&lt;</span><span class="dt">string</span><span class="op">,</span> <span class="dt">unknown</span><span class="op">&gt;;</span>  <span class="co">// Optional contextual information</span></span>
+<span id="cb3-19"><a href="#cb3-19" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<blockquote>
+<p><strong>Note:</strong> See <a href="error-codes.html">Structured Error Codes Specification</a> for the complete error code taxonomy.</p>
+</blockquote>
+<h3 id="32-success-response">3.2 Success Response</h3>
+<p>A successful operation MUST return:</p>
+<ul>
+<li><code>success</code>: The boolean value <code>true</code></li>
+<li><code>data</code>: The operation result (type varies by operation)</li>
+</ul>
+<div class="sourceCode" id="cb4"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb4-1"><a href="#cb4-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb4-2"><a href="#cb4-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb4-3"><a href="#cb4-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;data&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb4-4"><a href="#cb4-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;id&quot;</span><span class="fu">:</span> <span class="st">&quot;item_123&quot;</span><span class="fu">,</span></span>
+<span id="cb4-5"><a href="#cb4-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;Example Item&quot;</span><span class="fu">,</span></span>
+<span id="cb4-6"><a href="#cb4-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;created_at&quot;</span><span class="fu">:</span> <span class="st">&quot;2024-01-15T10:30:00Z&quot;</span></span>
+<span id="cb4-7"><a href="#cb4-7" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb4-8"><a href="#cb4-8" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<h3 id="33-failure-response">3.3 Failure Response</h3>
+<p>A failed operation MUST return:</p>
+<ul>
+<li><code>success</code>: The boolean value <code>false</code></li>
+<li><code>error</code>: A structured error object with <code>code</code> and <code>message</code></li>
+</ul>
+<div class="sourceCode" id="cb5"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb5-1"><a href="#cb5-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb5-2"><a href="#cb5-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb5-3"><a href="#cb5-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;error&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb5-4"><a href="#cb5-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;code&quot;</span><span class="fu">:</span> <span class="st">&quot;NOT_FOUND_RESOURCE&quot;</span><span class="fu">,</span></span>
+<span id="cb5-5"><a href="#cb5-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;Item with ID &#39;item_999&#39; not found&quot;</span><span class="fu">,</span></span>
+<span id="cb5-6"><a href="#cb5-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;details&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb5-7"><a href="#cb5-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;resource_type&quot;</span><span class="fu">:</span> <span class="st">&quot;item&quot;</span><span class="fu">,</span></span>
+<span id="cb5-8"><a href="#cb5-8" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;resource_id&quot;</span><span class="fu">:</span> <span class="st">&quot;item_999&quot;</span></span>
+<span id="cb5-9"><a href="#cb5-9" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb5-10"><a href="#cb5-10" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb5-11"><a href="#cb5-11" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<h3 id="34-response-metadata">3.4 Response Metadata</h3>
+<p>Implementations MAY include metadata in responses:</p>
+<div class="sourceCode" id="cb6"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb6-1"><a href="#cb6-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb6-2"><a href="#cb6-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb6-3"><a href="#cb6-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;data&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="er">...</span> <span class="fu">},</span></span>
+<span id="cb6-4"><a href="#cb6-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;_meta&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb6-5"><a href="#cb6-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;requestId&quot;</span><span class="fu">:</span> <span class="st">&quot;req_abc123&quot;</span><span class="fu">,</span></span>
+<span id="cb6-6"><a href="#cb6-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;duration_ms&quot;</span><span class="fu">:</span> <span class="dv">42</span></span>
+<span id="cb6-7"><a href="#cb6-7" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb6-8"><a href="#cb6-8" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<p>Metadata fields MUST be prefixed with underscore (<code>_</code>) to distinguish them from the operation payload.</p>
+<hr />
+<h2 id="4-parameter-conventions">4. Parameter Conventions</h2>
+<h3 id="41-naming-convention">4.1 Naming Convention</h3>
+<p>All public-facing parameter names MUST use <strong>snake_case</strong> (matching the pattern <code>^[a-z][a-z0-9_]*$</code>):</p>
+<div class="sourceCode" id="cb7"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb7-1"><a href="#cb7-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Correct</span></span>
+<span id="cb7-2"><a href="#cb7-2" aria-hidden="true" tabindex="-1"></a>{ <span class="dt">item_id</span><span class="op">:</span> <span class="st">&quot;123&quot;</span><span class="op">,</span> <span class="dt">created_after</span><span class="op">:</span> <span class="st">&quot;2024-01-01&quot;</span> }</span>
+<span id="cb7-3"><a href="#cb7-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb7-4"><a href="#cb7-4" aria-hidden="true" tabindex="-1"></a><span class="co">// Non-conforming</span></span>
+<span id="cb7-5"><a href="#cb7-5" aria-hidden="true" tabindex="-1"></a>{ <span class="dt">itemId</span><span class="op">:</span> <span class="st">&quot;123&quot;</span><span class="op">,</span> <span class="dt">createdAfter</span><span class="op">:</span> <span class="st">&quot;2024-01-01&quot;</span> }</span></code></pre></div>
+<p>For backward compatibility, adapters MAY accept camelCase variants as aliases and normalize them to snake_case internally, but the canonical parameter names MUST be snake_case.</p>
+<h3 id="42-common-parameter-patterns">4.2 Common Parameter Patterns</h3>
+<p>Adapters SHOULD use consistent patterns for common functionality:</p>
+<p><strong>Pagination (offset-based):</strong></p>
+<div class="sourceCode" id="cb8"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb8-1"><a href="#cb8-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb8-2"><a href="#cb8-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">page</span><span class="op">:</span> <span class="dv">1</span><span class="op">,</span>           <span class="co">// Page number (1-indexed)</span></span>
+<span id="cb8-3"><a href="#cb8-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">page_size</span><span class="op">:</span> <span class="dv">25</span>      <span class="co">// Items per page</span></span>
+<span id="cb8-4"><a href="#cb8-4" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<p><strong>Pagination (cursor-based):</strong></p>
+<div class="sourceCode" id="cb9"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb9-1"><a href="#cb9-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb9-2"><a href="#cb9-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">cursor</span><span class="op">:</span> <span class="st">&quot;abc123&quot;</span><span class="op">,</span>  <span class="co">// Opaque cursor from previous response</span></span>
+<span id="cb9-3"><a href="#cb9-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">limit</span><span class="op">:</span> <span class="dv">25</span>          <span class="co">// Maximum items to return</span></span>
+<span id="cb9-4"><a href="#cb9-4" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<p><strong>Filtering:</strong></p>
+<div class="sourceCode" id="cb10"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb10-1"><a href="#cb10-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb10-2"><a href="#cb10-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">filter</span><span class="op">:</span> {</span>
+<span id="cb10-3"><a href="#cb10-3" aria-hidden="true" tabindex="-1"></a>    <span class="dt">status</span><span class="op">:</span> <span class="st">&quot;active&quot;</span><span class="op">,</span></span>
+<span id="cb10-4"><a href="#cb10-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">created_after</span><span class="op">:</span> <span class="st">&quot;2024-01-01&quot;</span></span>
+<span id="cb10-5"><a href="#cb10-5" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb10-6"><a href="#cb10-6" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<p><strong>Sorting:</strong></p>
+<div class="sourceCode" id="cb11"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb11-1"><a href="#cb11-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb11-2"><a href="#cb11-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">sort</span><span class="op">:</span> {</span>
+<span id="cb11-3"><a href="#cb11-3" aria-hidden="true" tabindex="-1"></a>    <span class="dt">field</span><span class="op">:</span> <span class="st">&quot;created_at&quot;</span><span class="op">,</span></span>
+<span id="cb11-4"><a href="#cb11-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">order</span><span class="op">:</span> <span class="st">&quot;desc&quot;</span>  <span class="co">// &quot;asc&quot; or &quot;desc&quot;</span></span>
+<span id="cb11-5"><a href="#cb11-5" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb11-6"><a href="#cb11-6" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<p><strong>Field Selection:</strong></p>
+<div class="sourceCode" id="cb12"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb12-1"><a href="#cb12-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb12-2"><a href="#cb12-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">fields</span><span class="op">:</span> [<span class="st">&quot;id&quot;</span><span class="op">,</span> <span class="st">&quot;name&quot;</span><span class="op">,</span> <span class="st">&quot;email&quot;</span>]  <span class="co">// Only return these fields</span></span>
+<span id="cb12-3"><a href="#cb12-3" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<h3 id="43-required-vs-optional-parameters">4.3 Required vs Optional Parameters</h3>
+<p>Each parameter MUST be documented as either required or optional. The operation schema (Section 5) specifies this via the <code>required</code> attribute.</p>
+<h3 id="44-cross-cutting-parameters">4.4 Cross-Cutting Parameters</h3>
+<p>Cross-cutting parameters are parameters that apply across multiple operations. To ensure consistent discoverability, implementations SHOULD define these parameters once and reference them consistently.</p>
+<h4 id="441-standard-cross-cutting-parameters">4.4.1 Standard Cross-Cutting Parameters</h4>
+<table>
+<thead>
+<tr>
+<th>Parameter</th>
+<th>Type</th>
+<th>Operations</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>fields</code></td>
+<td><code>string | string[]</code></td>
+<td>All READ operations returning data</td>
+<td>Field selection: preset name or array of field paths</td>
+</tr>
+<tr>
+<td><code>limit</code></td>
+<td><code>number</code></td>
+<td>List/search operations</td>
+<td>Maximum results to return</td>
+</tr>
+<tr>
+<td><code>offset</code></td>
+<td><code>number</code></td>
+<td>List/search operations</td>
+<td>Number of results to skip</td>
+</tr>
+<tr>
+<td><code>page</code></td>
+<td><code>number</code></td>
+<td>List/search operations</td>
+<td>Page number (1-indexed)</td>
+</tr>
+<tr>
+<td><code>page_size</code></td>
+<td><code>number</code></td>
+<td>List/search operations</td>
+<td>Items per page</td>
+</tr>
+<tr>
+<td><code>sort</code></td>
+<td><code>string</code></td>
+<td>List/search operations</td>
+<td>Sort field name</td>
+</tr>
+<tr>
+<td><code>order</code></td>
+<td><code>string</code></td>
+<td>List/search operations</td>
+<td>Sort order: "asc" or "desc"</td>
+</tr>
+<tr>
+<td><code>dry_run</code></td>
+<td><code>boolean</code></td>
+<td>All mutating operations</td>
+<td>Preview without executing</td>
+</tr>
+</tbody>
+</table>
+<h4 id="442-shared-parameter-definitions">4.4.2 Shared Parameter Definitions</h4>
+<p>Implementations SHOULD use a shared definition mechanism to ensure consistency:</p>
+<div class="sourceCode" id="cb13"><pre class="sourceCode yaml"><code class="sourceCode yaml"><span id="cb13-1"><a href="#cb13-1" aria-hidden="true" tabindex="-1"></a><span class="fu">shared_parameters</span><span class="kw">:</span></span>
+<span id="cb13-2"><a href="#cb13-2" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">fields</span><span class="kw">:</span></span>
+<span id="cb13-3"><a href="#cb13-3" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">name</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;fields&quot;</span></span>
+<span id="cb13-4"><a href="#cb13-4" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">type</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;string | string[]&quot;</span></span>
+<span id="cb13-5"><a href="#cb13-5" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">required</span><span class="kw">:</span><span class="at"> </span><span class="ch">false</span></span>
+<span id="cb13-6"><a href="#cb13-6" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">description</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;Field selection: preset (&#39;minimal&#39;, &#39;standard&#39;, &#39;full&#39;) or array of field names&quot;</span></span>
+<span id="cb13-7"><a href="#cb13-7" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb13-8"><a href="#cb13-8" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">pagination</span><span class="kw">:</span></span>
+<span id="cb13-9"><a href="#cb13-9" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="kw">-</span><span class="at"> </span><span class="fu">name</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;limit&quot;</span></span>
+<span id="cb13-10"><a href="#cb13-10" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">type</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;number&quot;</span></span>
+<span id="cb13-11"><a href="#cb13-11" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">required</span><span class="kw">:</span><span class="at"> </span><span class="ch">false</span></span>
+<span id="cb13-12"><a href="#cb13-12" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">description</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;Maximum results to return&quot;</span></span>
+<span id="cb13-13"><a href="#cb13-13" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">default</span><span class="kw">:</span><span class="at"> </span><span class="dv">25</span></span>
+<span id="cb13-14"><a href="#cb13-14" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="kw">-</span><span class="at"> </span><span class="fu">name</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;offset&quot;</span></span>
+<span id="cb13-15"><a href="#cb13-15" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">type</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;number&quot;</span></span>
+<span id="cb13-16"><a href="#cb13-16" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">required</span><span class="kw">:</span><span class="at"> </span><span class="ch">false</span></span>
+<span id="cb13-17"><a href="#cb13-17" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">description</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;Number of results to skip&quot;</span></span>
+<span id="cb13-18"><a href="#cb13-18" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">default</span><span class="kw">:</span><span class="at"> </span><span class="dv">0</span></span>
+<span id="cb13-19"><a href="#cb13-19" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb13-20"><a href="#cb13-20" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">sorting</span><span class="kw">:</span></span>
+<span id="cb13-21"><a href="#cb13-21" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="kw">-</span><span class="at"> </span><span class="fu">name</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;sort&quot;</span></span>
+<span id="cb13-22"><a href="#cb13-22" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">type</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;string&quot;</span></span>
+<span id="cb13-23"><a href="#cb13-23" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">required</span><span class="kw">:</span><span class="at"> </span><span class="ch">false</span></span>
+<span id="cb13-24"><a href="#cb13-24" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">description</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;Field to sort by&quot;</span></span>
+<span id="cb13-25"><a href="#cb13-25" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="kw">-</span><span class="at"> </span><span class="fu">name</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;order&quot;</span></span>
+<span id="cb13-26"><a href="#cb13-26" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">type</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;string&quot;</span></span>
+<span id="cb13-27"><a href="#cb13-27" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">required</span><span class="kw">:</span><span class="at"> </span><span class="ch">false</span></span>
+<span id="cb13-28"><a href="#cb13-28" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">enum</span><span class="kw">:</span><span class="at"> </span><span class="kw">[</span><span class="st">&quot;asc&quot;</span><span class="kw">,</span><span class="at"> </span><span class="st">&quot;desc&quot;</span><span class="kw">]</span></span>
+<span id="cb13-29"><a href="#cb13-29" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">description</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;Sort order&quot;</span></span>
+<span id="cb13-30"><a href="#cb13-30" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">default</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;asc&quot;</span></span></code></pre></div>
+<h4 id="443-cross-cutting-parameter-consistency-should">4.4.3 Cross-Cutting Parameter Consistency (SHOULD)</h4>
+<p>When a parameter applies to multiple operations:</p>
+<ol type="1">
+<li>The parameter name SHOULD be identical across operations</li>
+<li>The parameter type SHOULD be identical across operations</li>
+<li>The parameter description SHOULD be semantically equivalent</li>
+<li>Default values SHOULD be consistent where applicable</li>
+</ol>
+<h4 id="444-introspection-integration">4.4.4 Introspection Integration</h4>
+<p>When introspection is queried, shared parameters SHOULD be expanded inline with their full definitions. This ensures LLMs see consistent documentation regardless of which operation they query.</p>
+<p><strong>Example - Operations referencing shared parameters:</strong></p>
+<div class="sourceCode" id="cb14"><pre class="sourceCode yaml"><code class="sourceCode yaml"><span id="cb14-1"><a href="#cb14-1" aria-hidden="true" tabindex="-1"></a><span class="fu">operations</span><span class="kw">:</span></span>
+<span id="cb14-2"><a href="#cb14-2" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">list_items</span><span class="kw">:</span></span>
+<span id="cb14-3"><a href="#cb14-3" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">params</span><span class="kw">:</span></span>
+<span id="cb14-4"><a href="#cb14-4" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="kw">-</span><span class="at"> </span><span class="fu">$ref</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;#/shared_parameters/fields&quot;</span></span>
+<span id="cb14-5"><a href="#cb14-5" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="kw">-</span><span class="at"> </span><span class="fu">$ref</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;#/shared_parameters/pagination&quot;</span></span>
+<span id="cb14-6"><a href="#cb14-6" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="kw">-</span><span class="at"> </span><span class="fu">name</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;category&quot;</span></span>
+<span id="cb14-7"><a href="#cb14-7" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">type</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;string&quot;</span></span>
+<span id="cb14-8"><a href="#cb14-8" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">required</span><span class="kw">:</span><span class="at"> </span><span class="ch">false</span></span>
+<span id="cb14-9"><a href="#cb14-9" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">description</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;Filter by category&quot;</span></span>
+<span id="cb14-10"><a href="#cb14-10" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb14-11"><a href="#cb14-11" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">search_items</span><span class="kw">:</span></span>
+<span id="cb14-12"><a href="#cb14-12" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">params</span><span class="kw">:</span></span>
+<span id="cb14-13"><a href="#cb14-13" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="kw">-</span><span class="at"> </span><span class="fu">$ref</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;#/shared_parameters/fields&quot;</span></span>
+<span id="cb14-14"><a href="#cb14-14" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="kw">-</span><span class="at"> </span><span class="fu">$ref</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;#/shared_parameters/pagination&quot;</span></span>
+<span id="cb14-15"><a href="#cb14-15" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="kw">-</span><span class="at"> </span><span class="fu">$ref</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;#/shared_parameters/sorting&quot;</span></span>
+<span id="cb14-16"><a href="#cb14-16" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="kw">-</span><span class="at"> </span><span class="fu">name</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;query&quot;</span></span>
+<span id="cb14-17"><a href="#cb14-17" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">type</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;string&quot;</span></span>
+<span id="cb14-18"><a href="#cb14-18" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">required</span><span class="kw">:</span><span class="at"> </span><span class="ch">true</span></span>
+<span id="cb14-19"><a href="#cb14-19" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">description</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;Search query&quot;</span></span></code></pre></div>
+<h3 id="45-update-input-pattern">4.5 UPDATE Input Pattern</h3>
+<p>UPDATE operations SHOULD use a nested <code>input</code> object to separate identifier parameters from updateable fields. See <a href="versions/v1.0.0-draft.html#45-update-input-pattern">MCP-AQL Specification Section 4.5</a> for normative requirements including deep-merge semantics and field removal. See <a href="adr/ADR-002-graphql-style-input.html">ADR-002</a> for design rationale.</p>
+<hr />
+<h2 id="5-operation-schema-definition">5. Operation Schema Definition</h2>
+<h3 id="51-schema-structure">5.1 Schema Structure</h3>
+<p>Each operation MUST be defined by a schema that specifies its behavior, parameters, and routing. Conformant adapters MUST validate requests against operation schemas before execution.</p>
+<p><strong>Schema Properties:</strong></p>
+<table>
+<thead>
+<tr>
+<th>Property</th>
+<th>Type</th>
+<th>Required</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>endpoint</code></td>
+<td>string</td>
+<td>REQUIRED</td>
+<td>CRUDE endpoint: CREATE, READ, UPDATE, DELETE, or EXECUTE</td>
+</tr>
+<tr>
+<td><code>description</code></td>
+<td>string</td>
+<td>REQUIRED</td>
+<td>Human-readable description</td>
+</tr>
+<tr>
+<td><code>params</code></td>
+<td>object</td>
+<td>OPTIONAL</td>
+<td>Parameter definitions</td>
+</tr>
+<tr>
+<td><code>handler</code></td>
+<td>string</td>
+<td>OPTIONAL</td>
+<td>Internal handler reference</td>
+</tr>
+<tr>
+<td><code>dangerous</code></td>
+<td>boolean</td>
+<td>OPTIONAL</td>
+<td>If true, operation has significant side effects</td>
+</tr>
+</tbody>
+</table>
+<h3 id="52-parameter-schema">5.2 Parameter Schema</h3>
+<p>Each parameter in the <code>params</code> object MUST include:</p>
+<table>
+<thead>
+<tr>
+<th>Property</th>
+<th>Type</th>
+<th>Required</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>type</code></td>
+<td>string</td>
+<td>REQUIRED</td>
+<td>Data type: "string", "number", "boolean", "object", "array"</td>
+</tr>
+<tr>
+<td><code>required</code></td>
+<td>boolean</td>
+<td>OPTIONAL</td>
+<td>Whether parameter is required (default: false)</td>
+</tr>
+<tr>
+<td><code>description</code></td>
+<td>string</td>
+<td>OPTIONAL</td>
+<td>Human-readable description</td>
+</tr>
+<tr>
+<td><code>default</code></td>
+<td>any</td>
+<td>OPTIONAL</td>
+<td>Default value if not provided</td>
+</tr>
+</tbody>
+</table>
+<p>Additional properties MAY be included:</p>
+<table>
+<thead>
+<tr>
+<th>Property</th>
+<th>Type</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>mapTo</code></td>
+<td>string</td>
+<td>Internal parameter name mapping</td>
+</tr>
+<tr>
+<td><code>sources</code></td>
+<td>array</td>
+<td>Ordered list of resolution paths</td>
+</tr>
+<tr>
+<td><code>enum</code></td>
+<td>array</td>
+<td>Allowed values for string parameters</td>
+</tr>
+<tr>
+<td><code>minimum</code></td>
+<td>number</td>
+<td>Minimum value for numeric parameters</td>
+</tr>
+<tr>
+<td><code>maximum</code></td>
+<td>number</td>
+<td>Maximum value for numeric parameters</td>
+</tr>
+<tr>
+<td><code>pattern</code></td>
+<td>string</td>
+<td>Regex pattern for string validation</td>
+</tr>
+</tbody>
+</table>
+<h3 id="53-example-schema-definition">5.3 Example Schema Definition</h3>
+<div class="sourceCode" id="cb15"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb15-1"><a href="#cb15-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Schema for a create operation</span></span>
+<span id="cb15-2"><a href="#cb15-2" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb15-3"><a href="#cb15-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">create_item</span><span class="op">:</span> {</span>
+<span id="cb15-4"><a href="#cb15-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">endpoint</span><span class="op">:</span> <span class="st">&quot;CREATE&quot;</span><span class="op">,</span></span>
+<span id="cb15-5"><a href="#cb15-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">description</span><span class="op">:</span> <span class="st">&quot;Create a new item in the system&quot;</span><span class="op">,</span></span>
+<span id="cb15-6"><a href="#cb15-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">params</span><span class="op">:</span> {</span>
+<span id="cb15-7"><a href="#cb15-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">name</span><span class="op">:</span> {</span>
+<span id="cb15-8"><a href="#cb15-8" aria-hidden="true" tabindex="-1"></a>        <span class="dt">type</span><span class="op">:</span> <span class="st">&quot;string&quot;</span><span class="op">,</span></span>
+<span id="cb15-9"><a href="#cb15-9" aria-hidden="true" tabindex="-1"></a>        <span class="dt">required</span><span class="op">:</span> <span class="kw">true</span><span class="op">,</span></span>
+<span id="cb15-10"><a href="#cb15-10" aria-hidden="true" tabindex="-1"></a>        <span class="dt">description</span><span class="op">:</span> <span class="st">&quot;Item name&quot;</span></span>
+<span id="cb15-11"><a href="#cb15-11" aria-hidden="true" tabindex="-1"></a>      }<span class="op">,</span></span>
+<span id="cb15-12"><a href="#cb15-12" aria-hidden="true" tabindex="-1"></a>      <span class="dt">category</span><span class="op">:</span> {</span>
+<span id="cb15-13"><a href="#cb15-13" aria-hidden="true" tabindex="-1"></a>        <span class="dt">type</span><span class="op">:</span> <span class="st">&quot;string&quot;</span><span class="op">,</span></span>
+<span id="cb15-14"><a href="#cb15-14" aria-hidden="true" tabindex="-1"></a>        <span class="dt">required</span><span class="op">:</span> <span class="kw">true</span><span class="op">,</span></span>
+<span id="cb15-15"><a href="#cb15-15" aria-hidden="true" tabindex="-1"></a>        <span class="dt">description</span><span class="op">:</span> <span class="st">&quot;Item category&quot;</span><span class="op">,</span></span>
+<span id="cb15-16"><a href="#cb15-16" aria-hidden="true" tabindex="-1"></a>        <span class="dt">enum</span><span class="op">:</span> [<span class="st">&quot;product&quot;</span><span class="op">,</span> <span class="st">&quot;service&quot;</span><span class="op">,</span> <span class="st">&quot;subscription&quot;</span>]</span>
+<span id="cb15-17"><a href="#cb15-17" aria-hidden="true" tabindex="-1"></a>      }<span class="op">,</span></span>
+<span id="cb15-18"><a href="#cb15-18" aria-hidden="true" tabindex="-1"></a>      <span class="dt">price</span><span class="op">:</span> {</span>
+<span id="cb15-19"><a href="#cb15-19" aria-hidden="true" tabindex="-1"></a>        <span class="dt">type</span><span class="op">:</span> <span class="st">&quot;number&quot;</span><span class="op">,</span></span>
+<span id="cb15-20"><a href="#cb15-20" aria-hidden="true" tabindex="-1"></a>        <span class="dt">required</span><span class="op">:</span> <span class="kw">false</span><span class="op">,</span></span>
+<span id="cb15-21"><a href="#cb15-21" aria-hidden="true" tabindex="-1"></a>        <span class="dt">minimum</span><span class="op">:</span> <span class="dv">0</span><span class="op">,</span></span>
+<span id="cb15-22"><a href="#cb15-22" aria-hidden="true" tabindex="-1"></a>        <span class="dt">description</span><span class="op">:</span> <span class="st">&quot;Item price in cents&quot;</span></span>
+<span id="cb15-23"><a href="#cb15-23" aria-hidden="true" tabindex="-1"></a>      }<span class="op">,</span></span>
+<span id="cb15-24"><a href="#cb15-24" aria-hidden="true" tabindex="-1"></a>      <span class="dt">metadata</span><span class="op">:</span> {</span>
+<span id="cb15-25"><a href="#cb15-25" aria-hidden="true" tabindex="-1"></a>        <span class="dt">type</span><span class="op">:</span> <span class="st">&quot;object&quot;</span><span class="op">,</span></span>
+<span id="cb15-26"><a href="#cb15-26" aria-hidden="true" tabindex="-1"></a>        <span class="dt">required</span><span class="op">:</span> <span class="kw">false</span><span class="op">,</span></span>
+<span id="cb15-27"><a href="#cb15-27" aria-hidden="true" tabindex="-1"></a>        <span class="dt">description</span><span class="op">:</span> <span class="st">&quot;Additional item metadata&quot;</span></span>
+<span id="cb15-28"><a href="#cb15-28" aria-hidden="true" tabindex="-1"></a>      }</span>
+<span id="cb15-29"><a href="#cb15-29" aria-hidden="true" tabindex="-1"></a>    }</span>
+<span id="cb15-30"><a href="#cb15-30" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb15-31"><a href="#cb15-31" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<h3 id="54-parameter-validation">5.4 Parameter Validation</h3>
+<p>Before executing an operation, adapters MUST:</p>
+<ol type="1">
+<li>Verify all required parameters are present</li>
+<li>Validate parameter types match the schema</li>
+<li>Reject unknown parameters not defined in the operation schema (see <a href="versions/v1.0.0-draft.html#46-unknown-parameter-handling">MCP-AQL Specification Section 4.6</a>)</li>
+<li>Apply any constraints (enum, minimum, maximum, pattern)</li>
+<li>Apply default values for missing optional parameters</li>
+</ol>
+<blockquote>
+<p><strong>Note:</strong> Unknown parameter rejection (step 3) occurs before applying defaults (step 5) to ensure that typos or hallucinated parameters are caught early, before any processing occurs.</p>
+</blockquote>
+<p>Validation failures MUST return an error response (not throw exceptions).</p>
+<hr />
+<h2 id="6-crude-endpoint-assignment">6. CRUDE Endpoint Assignment</h2>
+<h3 id="61-endpoint-semantics">6.1 Endpoint Semantics</h3>
+<p>Operations MUST be assigned to endpoints based on their semantics:</p>
+<table>
+<thead>
+<tr>
+<th>Endpoint</th>
+<th>Semantics</th>
+<th>Characteristics</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>CREATE</strong></td>
+<td>Additive, non-destructive</td>
+<td>Creates new resources; idempotent if duplicate detection enabled</td>
+</tr>
+<tr>
+<td><strong>READ</strong></td>
+<td>Safe, read-only</td>
+<td>No side effects; cacheable; always safe to retry</td>
+</tr>
+<tr>
+<td><strong>UPDATE</strong></td>
+<td>Modifying</td>
+<td>Changes existing resources; may be partially idempotent</td>
+</tr>
+<tr>
+<td><strong>DELETE</strong></td>
+<td>Destructive</td>
+<td>Removes resources; potentially irreversible</td>
+</tr>
+<tr>
+<td><strong>EXECUTE</strong></td>
+<td>Lifecycle, non-idempotent</td>
+<td>Triggers actions; manages runtime state</td>
+</tr>
+</tbody>
+</table>
+<h3 id="62-common-verbs-by-endpoint">6.2 Common Verbs by Endpoint</h3>
+<p>Each endpoint has canonical verbs (shown in bold) that SHOULD be used for standard operations, plus additional verbs for domain-specific semantics. See <a href="versions/v1.0.0-draft.html#85-operation-naming-grammar">Section 8.5</a> of the normative specification for naming requirements.</p>
+<table>
+<thead>
+<tr>
+<th>Endpoint</th>
+<th>Canonical</th>
+<th>Additional Verbs</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>CREATE</td>
+<td><strong>create</strong></td>
+<td>add, upload, register, import, insert</td>
+</tr>
+<tr>
+<td>READ</td>
+<td><strong>get</strong>, <strong>list</strong></td>
+<td>search, find, export, count</td>
+</tr>
+<tr>
+<td>UPDATE</td>
+<td><strong>update</strong></td>
+<td>edit, set, rename, move, patch, merge</td>
+</tr>
+<tr>
+<td>DELETE</td>
+<td><strong>delete</strong></td>
+<td>remove, purge, unregister, clear, drop</td>
+</tr>
+<tr>
+<td>EXECUTE</td>
+<td><strong>execute</strong>, <strong>cancel</strong></td>
+<td>run, start, stop, resume, trigger, invoke</td>
+</tr>
+</tbody>
+</table>
+<blockquote>
+<p><strong>Note:</strong> The <code>introspect</code> operation is a reserved protocol operation and is not listed as a common verb. See <a href="versions/v1.0.0-draft.html#854-reserved-operations">Section 8.5.4</a> of the normative specification.</p>
+</blockquote>
+<h3 id="63-endpoint-routing-enforcement">6.3 Endpoint Routing Enforcement</h3>
+<p>Adapters MUST validate that operations are invoked via their designated endpoint. An operation assigned to CREATE MUST NOT execute when called via the DELETE endpoint.</p>
+<p>When an operation is routed to the wrong endpoint, adapters SHOULD return an error:</p>
+<div class="sourceCode" id="cb16"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb16-1"><a href="#cb16-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb16-2"><a href="#cb16-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb16-3"><a href="#cb16-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;error&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb16-4"><a href="#cb16-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;code&quot;</span><span class="fu">:</span> <span class="st">&quot;VALIDATION_ENDPOINT_MISMATCH&quot;</span><span class="fu">,</span></span>
+<span id="cb16-5"><a href="#cb16-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;Operation &#39;create_item&#39; must use CREATE endpoint, not DELETE&quot;</span><span class="fu">,</span></span>
+<span id="cb16-6"><a href="#cb16-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;details&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb16-7"><a href="#cb16-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;create_item&quot;</span><span class="fu">,</span></span>
+<span id="cb16-8"><a href="#cb16-8" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;expected_endpoint&quot;</span><span class="fu">:</span> <span class="st">&quot;CREATE&quot;</span><span class="fu">,</span></span>
+<span id="cb16-9"><a href="#cb16-9" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;actual_endpoint&quot;</span><span class="fu">:</span> <span class="st">&quot;DELETE&quot;</span></span>
+<span id="cb16-10"><a href="#cb16-10" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb16-11"><a href="#cb16-11" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb16-12"><a href="#cb16-12" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<h3 id="64-dangerous-operation-classification">6.4 Dangerous Operation Classification</h3>
+<p>Operations with significant consequences SHOULD be marked with <code>dangerous: true</code> in their schema. This enables clients to:</p>
+<ul>
+<li>Display confirmation prompts</li>
+<li>Log operations with enhanced audit trails</li>
+<li>Apply additional authorization checks</li>
+</ul>
+<p>Examples of dangerous operations:</p>
+<ul>
+<li>Bulk deletions</li>
+<li>Data truncation</li>
+<li>Irreversible state changes</li>
+<li>Operations affecting production data</li>
+</ul>
+<hr />
+<h2 id="7-batch-operations">7. Batch Operations</h2>
+<h3 id="71-batch-request-format">7.1 Batch Request Format</h3>
+<p>Adapters MAY support batch operations. When supported, the format MUST be:</p>
+<div class="sourceCode" id="cb17"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb17-1"><a href="#cb17-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb17-2"><a href="#cb17-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;operations&quot;</span><span class="fu">:</span> <span class="ot">[</span></span>
+<span id="cb17-3"><a href="#cb17-3" aria-hidden="true" tabindex="-1"></a>    <span class="fu">{</span> <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;create_item&quot;</span><span class="fu">,</span> <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;Item A&quot;</span><span class="fu">,</span> <span class="dt">&quot;category&quot;</span><span class="fu">:</span> <span class="st">&quot;product&quot;</span> <span class="fu">}</span> <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb17-4"><a href="#cb17-4" aria-hidden="true" tabindex="-1"></a>    <span class="fu">{</span> <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;create_item&quot;</span><span class="fu">,</span> <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;Item B&quot;</span><span class="fu">,</span> <span class="dt">&quot;category&quot;</span><span class="fu">:</span> <span class="st">&quot;service&quot;</span> <span class="fu">}</span> <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb17-5"><a href="#cb17-5" aria-hidden="true" tabindex="-1"></a>    <span class="fu">{</span> <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;create_item&quot;</span><span class="fu">,</span> <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;Item C&quot;</span><span class="fu">,</span> <span class="dt">&quot;category&quot;</span><span class="fu">:</span> <span class="st">&quot;product&quot;</span> <span class="fu">}</span> <span class="fu">}</span></span>
+<span id="cb17-6"><a href="#cb17-6" aria-hidden="true" tabindex="-1"></a>  <span class="ot">]</span></span>
+<span id="cb17-7"><a href="#cb17-7" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<h3 id="72-batch-response-format">7.2 Batch Response Format</h3>
+<p>Batch responses MUST include individual results for each operation:</p>
+<div class="sourceCode" id="cb18"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb18-1"><a href="#cb18-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb18-2"><a href="#cb18-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb18-3"><a href="#cb18-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;data&quot;</span><span class="fu">:</span> <span class="kw">null</span><span class="fu">,</span></span>
+<span id="cb18-4"><a href="#cb18-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;results&quot;</span><span class="fu">:</span> <span class="ot">[</span></span>
+<span id="cb18-5"><a href="#cb18-5" aria-hidden="true" tabindex="-1"></a>    <span class="fu">{</span> <span class="dt">&quot;index&quot;</span><span class="fu">:</span> <span class="dv">0</span><span class="fu">,</span> <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;create_item&quot;</span><span class="fu">,</span> <span class="dt">&quot;result&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span> <span class="dt">&quot;data&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;id&quot;</span><span class="fu">:</span> <span class="st">&quot;item_1&quot;</span> <span class="fu">}</span> <span class="fu">}</span> <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb18-6"><a href="#cb18-6" aria-hidden="true" tabindex="-1"></a>    <span class="fu">{</span> <span class="dt">&quot;index&quot;</span><span class="fu">:</span> <span class="dv">1</span><span class="fu">,</span> <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;create_item&quot;</span><span class="fu">,</span> <span class="dt">&quot;result&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span> <span class="dt">&quot;data&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;id&quot;</span><span class="fu">:</span> <span class="st">&quot;item_2&quot;</span> <span class="fu">}</span> <span class="fu">}</span> <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb18-7"><a href="#cb18-7" aria-hidden="true" tabindex="-1"></a>    <span class="fu">{</span> <span class="dt">&quot;index&quot;</span><span class="fu">:</span> <span class="dv">2</span><span class="fu">,</span> <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;create_item&quot;</span><span class="fu">,</span> <span class="dt">&quot;result&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span> <span class="dt">&quot;error&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;code&quot;</span><span class="fu">:</span> <span class="st">&quot;CONFLICT_ALREADY_EXISTS&quot;</span><span class="fu">,</span> <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;Item with name &#39;Item C&#39; already exists&quot;</span> <span class="fu">}</span> <span class="fu">}</span> <span class="fu">}</span></span>
+<span id="cb18-8"><a href="#cb18-8" aria-hidden="true" tabindex="-1"></a>  <span class="ot">]</span><span class="fu">,</span></span>
+<span id="cb18-9"><a href="#cb18-9" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;summary&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb18-10"><a href="#cb18-10" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;total&quot;</span><span class="fu">:</span> <span class="dv">3</span><span class="fu">,</span></span>
+<span id="cb18-11"><a href="#cb18-11" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;succeeded&quot;</span><span class="fu">:</span> <span class="dv">2</span><span class="fu">,</span></span>
+<span id="cb18-12"><a href="#cb18-12" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;failed&quot;</span><span class="fu">:</span> <span class="dv">1</span></span>
+<span id="cb18-13"><a href="#cb18-13" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb18-14"><a href="#cb18-14" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<h3 id="73-batch-execution-semantics">7.3 Batch Execution Semantics</h3>
+<p>Conformant batch implementations MUST follow these semantics:</p>
+<ol type="1">
+<li>Operations execute in array order</li>
+<li>Failure of one operation MUST NOT prevent subsequent operations from executing</li>
+<li>Each operation result is independent</li>
+<li>The overall <code>success</code> is <code>true</code> if the batch completed processing (even with individual failures)</li>
+<li>The overall <code>success</code> is <code>false</code> only for batch-level errors (malformed request, authentication failure)</li>
+</ol>
+<h3 id="74-cross-endpoint-batching">7.4 Cross-Endpoint Batching</h3>
+<p>When using CRUDE mode (separate endpoints), batch operations SHOULD be constrained to a single endpoint:</p>
+<ul>
+<li>All CREATE operations together in one batch to the CREATE endpoint</li>
+<li>All READ operations together in one batch to the READ endpoint</li>
+</ul>
+<p>Mixing operations across endpoints in a single batch is NOT RECOMMENDED. Implementations MAY reject mixed batches or MAY process them with explicit endpoint routing per operation.</p>
+<h3 id="75-confirmation-gated-batch-operations">7.5 Confirmation-Gated Batch Operations</h3>
+<p>When a batch operation encounters a <code>CONFIRMATION_REQUIRED</code> response, special handling is needed to maintain state consistency.</p>
+<h4 id="751-the-problem">7.5.1 The Problem</h4>
+<p>Consider a batch where operations depend on each other:</p>
+<div class="sourceCode" id="cb19"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb19-1"><a href="#cb19-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb19-2"><a href="#cb19-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;operations&quot;</span><span class="fu">:</span> <span class="ot">[</span></span>
+<span id="cb19-3"><a href="#cb19-3" aria-hidden="true" tabindex="-1"></a>    <span class="fu">{</span> <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;delete_user&quot;</span><span class="fu">,</span> <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;user_id&quot;</span><span class="fu">:</span> <span class="st">&quot;alice&quot;</span> <span class="fu">}</span> <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb19-4"><a href="#cb19-4" aria-hidden="true" tabindex="-1"></a>    <span class="fu">{</span> <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;send_notification&quot;</span><span class="fu">,</span> <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;user_id&quot;</span><span class="fu">:</span> <span class="st">&quot;alice&quot;</span><span class="fu">,</span> <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;Account deleted&quot;</span> <span class="fu">}</span> <span class="fu">}</span></span>
+<span id="cb19-5"><a href="#cb19-5" aria-hidden="true" tabindex="-1"></a>  <span class="ot">]</span></span>
+<span id="cb19-6"><a href="#cb19-6" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<p>If <code>delete_user</code> requires confirmation, executing <code>send_notification</code> anyway would create inconsistent state (notification sent, but user not deleted).</p>
+<h4 id="752-batch-halting-recommended">7.5.2 Batch Halting (RECOMMENDED)</h4>
+<p>When an operation returns <code>CONFIRMATION_REQUIRED</code>, the batch SHOULD halt:</p>
+<ol type="1">
+<li>Operations before the gated operation execute normally</li>
+<li>The gated operation returns <code>CONFIRMATION_REQUIRED</code> with a confirmation token</li>
+<li>Subsequent operations do NOT execute</li>
+<li>Response includes partial results and continuation information</li>
+</ol>
+<div class="sourceCode" id="cb20"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb20-1"><a href="#cb20-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb20-2"><a href="#cb20-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb20-3"><a href="#cb20-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;data&quot;</span><span class="fu">:</span> <span class="kw">null</span><span class="fu">,</span></span>
+<span id="cb20-4"><a href="#cb20-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;results&quot;</span><span class="fu">:</span> <span class="ot">[</span></span>
+<span id="cb20-5"><a href="#cb20-5" aria-hidden="true" tabindex="-1"></a>    <span class="fu">{</span> <span class="dt">&quot;index&quot;</span><span class="fu">:</span> <span class="dv">0</span><span class="fu">,</span> <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;update_user&quot;</span><span class="fu">,</span> <span class="dt">&quot;result&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span> <span class="dt">&quot;data&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;id&quot;</span><span class="fu">:</span> <span class="st">&quot;alice&quot;</span> <span class="fu">}</span> <span class="fu">}</span> <span class="fu">}</span></span>
+<span id="cb20-6"><a href="#cb20-6" aria-hidden="true" tabindex="-1"></a>  <span class="ot">]</span><span class="fu">,</span></span>
+<span id="cb20-7"><a href="#cb20-7" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;halted_at&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb20-8"><a href="#cb20-8" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;index&quot;</span><span class="fu">:</span> <span class="dv">1</span><span class="fu">,</span></span>
+<span id="cb20-9"><a href="#cb20-9" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;delete_user&quot;</span><span class="fu">,</span></span>
+<span id="cb20-10"><a href="#cb20-10" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;result&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb20-11"><a href="#cb20-11" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb20-12"><a href="#cb20-12" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;error&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb20-13"><a href="#cb20-13" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;code&quot;</span><span class="fu">:</span> <span class="st">&quot;CONFIRMATION_REQUIRED&quot;</span><span class="fu">,</span></span>
+<span id="cb20-14"><a href="#cb20-14" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;This operation requires confirmation&quot;</span><span class="fu">,</span></span>
+<span id="cb20-15"><a href="#cb20-15" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;details&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb20-16"><a href="#cb20-16" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;delete_user&quot;</span><span class="fu">,</span></span>
+<span id="cb20-17"><a href="#cb20-17" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;danger_level&quot;</span><span class="fu">:</span> <span class="st">&quot;destructive&quot;</span><span class="fu">,</span></span>
+<span id="cb20-18"><a href="#cb20-18" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;reasons&quot;</span><span class="fu">:</span> <span class="ot">[</span><span class="st">&quot;Permanently deletes user account and associated data&quot;</span><span class="ot">]</span><span class="fu">,</span></span>
+<span id="cb20-19"><a href="#cb20-19" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;confirmation_token&quot;</span><span class="fu">:</span> <span class="st">&quot;conf_abc123&quot;</span><span class="fu">,</span></span>
+<span id="cb20-20"><a href="#cb20-20" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;expires_at&quot;</span><span class="fu">:</span> <span class="st">&quot;2026-02-04T12:05:00Z&quot;</span></span>
+<span id="cb20-21"><a href="#cb20-21" aria-hidden="true" tabindex="-1"></a>        <span class="fu">}</span></span>
+<span id="cb20-22"><a href="#cb20-22" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span></span>
+<span id="cb20-23"><a href="#cb20-23" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb20-24"><a href="#cb20-24" aria-hidden="true" tabindex="-1"></a>  <span class="fu">},</span></span>
+<span id="cb20-25"><a href="#cb20-25" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;pending_operations&quot;</span><span class="fu">:</span> <span class="ot">[</span></span>
+<span id="cb20-26"><a href="#cb20-26" aria-hidden="true" tabindex="-1"></a>    <span class="fu">{</span> <span class="dt">&quot;index&quot;</span><span class="fu">:</span> <span class="dv">2</span><span class="fu">,</span> <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;send_notification&quot;</span><span class="fu">,</span> <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;user_id&quot;</span><span class="fu">:</span> <span class="st">&quot;alice&quot;</span><span class="fu">,</span> <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;Account deleted&quot;</span> <span class="fu">}</span> <span class="fu">}</span></span>
+<span id="cb20-27"><a href="#cb20-27" aria-hidden="true" tabindex="-1"></a>  <span class="ot">]</span><span class="fu">,</span></span>
+<span id="cb20-28"><a href="#cb20-28" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;summary&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb20-29"><a href="#cb20-29" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;total&quot;</span><span class="fu">:</span> <span class="dv">3</span><span class="fu">,</span></span>
+<span id="cb20-30"><a href="#cb20-30" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;succeeded&quot;</span><span class="fu">:</span> <span class="dv">1</span><span class="fu">,</span></span>
+<span id="cb20-31"><a href="#cb20-31" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;failed&quot;</span><span class="fu">:</span> <span class="dv">0</span><span class="fu">,</span></span>
+<span id="cb20-32"><a href="#cb20-32" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;halted&quot;</span><span class="fu">:</span> <span class="dv">1</span><span class="fu">,</span></span>
+<span id="cb20-33"><a href="#cb20-33" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;pending&quot;</span><span class="fu">:</span> <span class="dv">1</span></span>
+<span id="cb20-34"><a href="#cb20-34" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb20-35"><a href="#cb20-35" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<h4 id="753-continuation-after-confirmation">7.5.3 Continuation After Confirmation</h4>
+<p>To continue after the user confirms, submit a new batch starting from the halted operation with the confirmation token:</p>
+<div class="sourceCode" id="cb21"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb21-1"><a href="#cb21-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb21-2"><a href="#cb21-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;operations&quot;</span><span class="fu">:</span> <span class="ot">[</span></span>
+<span id="cb21-3"><a href="#cb21-3" aria-hidden="true" tabindex="-1"></a>    <span class="fu">{</span></span>
+<span id="cb21-4"><a href="#cb21-4" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;delete_user&quot;</span><span class="fu">,</span></span>
+<span id="cb21-5"><a href="#cb21-5" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb21-6"><a href="#cb21-6" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;user_id&quot;</span><span class="fu">:</span> <span class="st">&quot;alice&quot;</span><span class="fu">,</span></span>
+<span id="cb21-7"><a href="#cb21-7" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;confirmation_token&quot;</span><span class="fu">:</span> <span class="st">&quot;conf_abc123&quot;</span></span>
+<span id="cb21-8"><a href="#cb21-8" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span></span>
+<span id="cb21-9"><a href="#cb21-9" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb21-10"><a href="#cb21-10" aria-hidden="true" tabindex="-1"></a>    <span class="fu">{</span></span>
+<span id="cb21-11"><a href="#cb21-11" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;send_notification&quot;</span><span class="fu">,</span></span>
+<span id="cb21-12"><a href="#cb21-12" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;user_id&quot;</span><span class="fu">:</span> <span class="st">&quot;alice&quot;</span><span class="fu">,</span> <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;Account deleted&quot;</span> <span class="fu">}</span></span>
+<span id="cb21-13"><a href="#cb21-13" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb21-14"><a href="#cb21-14" aria-hidden="true" tabindex="-1"></a>  <span class="ot">]</span></span>
+<span id="cb21-15"><a href="#cb21-15" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<p>Clients MAY use the <code>pending_operations</code> array from the halted response to construct the continuation batch.</p>
+<h4 id="754-alternative-skip-and-continue-may">7.5.4 Alternative: Skip and Continue (MAY)</h4>
+<p>Adapters MAY implement skip-and-continue behavior, where the gated operation is skipped and subsequent operations execute.</p>
+<blockquote>
+<p><strong>Mode Selection:</strong> Whether an adapter uses halt-and-wait (recommended) or skip-and-continue is an adapter configuration decision, not a per-request option. Clients can detect which mode is in use by examining the response:</p>
+<ul>
+<li><strong>Halt mode:</strong> Response includes <code>halted_at</code> and <code>pending_operations</code></li>
+<li><strong>Skip mode:</strong> Response includes results for all operations, with <code>status: "pending_confirmation"</code> on gated operations</li>
+</ul>
+</blockquote>
+<div class="sourceCode" id="cb22"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb22-1"><a href="#cb22-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb22-2"><a href="#cb22-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb22-3"><a href="#cb22-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;data&quot;</span><span class="fu">:</span> <span class="kw">null</span><span class="fu">,</span></span>
+<span id="cb22-4"><a href="#cb22-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;results&quot;</span><span class="fu">:</span> <span class="ot">[</span></span>
+<span id="cb22-5"><a href="#cb22-5" aria-hidden="true" tabindex="-1"></a>    <span class="fu">{</span> <span class="dt">&quot;index&quot;</span><span class="fu">:</span> <span class="dv">0</span><span class="fu">,</span> <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;update_user&quot;</span><span class="fu">,</span> <span class="dt">&quot;result&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span> <span class="dt">&quot;data&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;id&quot;</span><span class="fu">:</span> <span class="st">&quot;alice&quot;</span> <span class="fu">}</span> <span class="fu">}</span> <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb22-6"><a href="#cb22-6" aria-hidden="true" tabindex="-1"></a>    <span class="fu">{</span> <span class="dt">&quot;index&quot;</span><span class="fu">:</span> <span class="dv">1</span><span class="fu">,</span> <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;delete_user&quot;</span><span class="fu">,</span> <span class="dt">&quot;result&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span> <span class="dt">&quot;error&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;code&quot;</span><span class="fu">:</span> <span class="st">&quot;CONFIRMATION_REQUIRED&quot;</span><span class="fu">,</span> <span class="er">...</span> <span class="fu">}</span> <span class="fu">},</span> <span class="dt">&quot;status&quot;</span><span class="fu">:</span> <span class="st">&quot;pending_confirmation&quot;</span> <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb22-7"><a href="#cb22-7" aria-hidden="true" tabindex="-1"></a>    <span class="fu">{</span> <span class="dt">&quot;index&quot;</span><span class="fu">:</span> <span class="dv">2</span><span class="fu">,</span> <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;send_notification&quot;</span><span class="fu">,</span> <span class="dt">&quot;result&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span> <span class="dt">&quot;data&quot;</span><span class="fu">:</span> <span class="fu">{}</span> <span class="fu">}</span> <span class="fu">}</span></span>
+<span id="cb22-8"><a href="#cb22-8" aria-hidden="true" tabindex="-1"></a>  <span class="ot">]</span><span class="fu">,</span></span>
+<span id="cb22-9"><a href="#cb22-9" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;summary&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;total&quot;</span><span class="fu">:</span> <span class="dv">3</span><span class="fu">,</span> <span class="dt">&quot;succeeded&quot;</span><span class="fu">:</span> <span class="dv">2</span><span class="fu">,</span> <span class="dt">&quot;failed&quot;</span><span class="fu">:</span> <span class="dv">0</span><span class="fu">,</span> <span class="dt">&quot;pending_confirmation&quot;</span><span class="fu">:</span> <span class="dv">1</span> <span class="fu">}</span></span>
+<span id="cb22-10"><a href="#cb22-10" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<blockquote>
+<p><strong>Warning:</strong> Skip-and-continue risks inconsistent state when operations depend on each other. This approach is NOT RECOMMENDED unless operations are known to be independent.</p>
+</blockquote>
+<h4 id="755-semantics">7.5.5 Semantics</h4>
+<p>For batch processing purposes:</p>
+<ul>
+<li><code>CONFIRMATION_REQUIRED</code> is NOT a failure — it is a halting condition</li>
+<li>The batch overall <code>success</code> is <code>true</code> (batch processing succeeded; an operation requires confirmation)</li>
+<li>Halted batches include <code>halted_at</code> and <code>pending_operations</code> for continuation</li>
+<li>The <code>summary.halted</code> count indicates operations that triggered halting</li>
+<li>The <code>summary.pending</code> count indicates operations that did not execute</li>
+</ul>
+<p>See <a href="security/confirmation-tokens.html">Confirmation Token Specification</a> for token lifecycle details and <a href="error-codes.html#54-confirmation_required">CONFIRMATION_REQUIRED Error Code</a> for the complete response format.</p>
+<hr />
+<h2 id="8-error-handling">8. Error Handling</h2>
+<h3 id="81-error-categories">8.1 Error Categories</h3>
+<p>Adapters MUST categorize errors using structured error codes. The table below shows error categories and their corresponding codes:</p>
+<table>
+<thead>
+<tr>
+<th>Category</th>
+<th>Error Code</th>
+<th>Example Message</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Missing Parameter</td>
+<td><code>VALIDATION_MISSING_PARAM</code></td>
+<td>"Missing required parameter 'name'"</td>
+</tr>
+<tr>
+<td>Invalid Type</td>
+<td><code>VALIDATION_INVALID_TYPE</code></td>
+<td>"Parameter 'price' expected 'number', got 'string'"</td>
+</tr>
+<tr>
+<td>Resource Not Found</td>
+<td><code>NOT_FOUND_RESOURCE</code></td>
+<td>"Item 'item_999' not found"</td>
+</tr>
+<tr>
+<td>Unknown Operation</td>
+<td><code>NOT_FOUND_OPERATION</code></td>
+<td>"Unknown operation: 'create_widget'"</td>
+</tr>
+<tr>
+<td>Permission Denied</td>
+<td><code>PERMISSION_DENIED</code></td>
+<td>"Permission denied: requires 'admin' scope"</td>
+</tr>
+<tr>
+<td>Rate Limited</td>
+<td><code>RATE_LIMIT_EXCEEDED</code></td>
+<td>"API rate limit exceeded"</td>
+</tr>
+<tr>
+<td>Internal Error</td>
+<td><code>INTERNAL_ERROR</code></td>
+<td>"Internal error: database connection failed"</td>
+</tr>
+</tbody>
+</table>
+<p>See <a href="error-codes.html">Structured Error Codes Specification</a> for detailed error code definitions and usage.</p>
+<h3 id="82-error-response-structure">8.2 Error Response Structure</h3>
+<p>All error responses MUST use structured error objects:</p>
+<div class="sourceCode" id="cb23"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb23-1"><a href="#cb23-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb23-2"><a href="#cb23-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb23-3"><a href="#cb23-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;error&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb23-4"><a href="#cb23-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;code&quot;</span><span class="fu">:</span> <span class="st">&quot;NOT_FOUND_RESOURCE&quot;</span><span class="fu">,</span></span>
+<span id="cb23-5"><a href="#cb23-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;Item &#39;item_999&#39; not found&quot;</span><span class="fu">,</span></span>
+<span id="cb23-6"><a href="#cb23-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;details&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb23-7"><a href="#cb23-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;resource_type&quot;</span><span class="fu">:</span> <span class="st">&quot;item&quot;</span><span class="fu">,</span></span>
+<span id="cb23-8"><a href="#cb23-8" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;resource_id&quot;</span><span class="fu">:</span> <span class="st">&quot;item_999&quot;</span></span>
+<span id="cb23-9"><a href="#cb23-9" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb23-10"><a href="#cb23-10" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb23-11"><a href="#cb23-11" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<p>The <code>error</code> object:</p>
+<ul>
+<li>MUST include <code>code</code> - A machine-readable error code from the <a href="error-codes.html">error code taxonomy</a></li>
+<li>MUST include <code>message</code> - A human-readable error message</li>
+<li>MAY include <code>details</code> - Additional contextual information for debugging</li>
+</ul>
+<p>See <a href="error-codes.html">Structured Error Codes Specification</a> for the complete error code registry and usage guidelines.</p>
+<h3 id="83-standard-error-codes">8.3 Standard Error Codes</h3>
+<p>Adapters MUST use standardized error codes for programmatic handling. Common codes include:</p>
+<table>
+<thead>
+<tr>
+<th>Code</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>VALIDATION_MISSING_PARAM</code></td>
+<td>Required parameter not provided</td>
+</tr>
+<tr>
+<td><code>VALIDATION_INVALID_TYPE</code></td>
+<td>Parameter type mismatch</td>
+</tr>
+<tr>
+<td><code>NOT_FOUND_OPERATION</code></td>
+<td>Operation name not recognized</td>
+</tr>
+<tr>
+<td><code>NOT_FOUND_RESOURCE</code></td>
+<td>Resource not found</td>
+</tr>
+<tr>
+<td><code>PERMISSION_DENIED</code></td>
+<td>Operation not permitted</td>
+</tr>
+<tr>
+<td><code>RATE_LIMIT_EXCEEDED</code></td>
+<td>Too many requests</td>
+</tr>
+<tr>
+<td><code>INTERNAL_ERROR</code></td>
+<td>Server error</td>
+</tr>
+</tbody>
+</table>
+<p>See <a href="error-codes.html">Structured Error Codes Specification</a> for the complete error code registry including Phase 1 robustness codes.</p>
+<h3 id="84-error-message-guidelines">8.4 Error Message Guidelines</h3>
+<p>Error messages SHOULD be:</p>
+<ol type="1">
+<li><strong>Actionable</strong>: Tell the user what to do to fix the problem</li>
+<li><strong>Specific</strong>: Include relevant identifiers and values</li>
+<li><strong>Safe</strong>: Never expose sensitive information (passwords, tokens, internal paths)</li>
+</ol>
+<hr />
+<h2 id="9-the-introspect-operation">9. The introspect Operation</h2>
+<h3 id="91-required-implementation">9.1 Required Implementation</h3>
+<p>Every MCP-AQL adapter MUST implement the <code>introspect</code> operation on the READ endpoint. This operation enables runtime discovery of available operations and types.</p>
+<h3 id="92-operation-schema">9.2 Operation Schema</h3>
+<div class="sourceCode" id="cb24"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb24-1"><a href="#cb24-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb24-2"><a href="#cb24-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">introspect</span><span class="op">:</span> {</span>
+<span id="cb24-3"><a href="#cb24-3" aria-hidden="true" tabindex="-1"></a>    <span class="dt">endpoint</span><span class="op">:</span> <span class="st">&quot;READ&quot;</span><span class="op">,</span></span>
+<span id="cb24-4"><a href="#cb24-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">description</span><span class="op">:</span> <span class="st">&quot;Discover available operations and types&quot;</span><span class="op">,</span></span>
+<span id="cb24-5"><a href="#cb24-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">params</span><span class="op">:</span> {</span>
+<span id="cb24-6"><a href="#cb24-6" aria-hidden="true" tabindex="-1"></a>      <span class="dt">query</span><span class="op">:</span> {</span>
+<span id="cb24-7"><a href="#cb24-7" aria-hidden="true" tabindex="-1"></a>        <span class="dt">type</span><span class="op">:</span> <span class="st">&quot;string&quot;</span><span class="op">,</span></span>
+<span id="cb24-8"><a href="#cb24-8" aria-hidden="true" tabindex="-1"></a>        <span class="dt">required</span><span class="op">:</span> <span class="kw">true</span><span class="op">,</span></span>
+<span id="cb24-9"><a href="#cb24-9" aria-hidden="true" tabindex="-1"></a>        <span class="dt">enum</span><span class="op">:</span> [<span class="st">&quot;operations&quot;</span><span class="op">,</span> <span class="st">&quot;types&quot;</span>]<span class="op">,</span></span>
+<span id="cb24-10"><a href="#cb24-10" aria-hidden="true" tabindex="-1"></a>        <span class="dt">description</span><span class="op">:</span> <span class="st">&quot;What to introspect&quot;</span></span>
+<span id="cb24-11"><a href="#cb24-11" aria-hidden="true" tabindex="-1"></a>      }<span class="op">,</span></span>
+<span id="cb24-12"><a href="#cb24-12" aria-hidden="true" tabindex="-1"></a>      <span class="dt">name</span><span class="op">:</span> {</span>
+<span id="cb24-13"><a href="#cb24-13" aria-hidden="true" tabindex="-1"></a>        <span class="dt">type</span><span class="op">:</span> <span class="st">&quot;string&quot;</span><span class="op">,</span></span>
+<span id="cb24-14"><a href="#cb24-14" aria-hidden="true" tabindex="-1"></a>        <span class="dt">required</span><span class="op">:</span> <span class="kw">false</span><span class="op">,</span></span>
+<span id="cb24-15"><a href="#cb24-15" aria-hidden="true" tabindex="-1"></a>        <span class="dt">description</span><span class="op">:</span> <span class="st">&quot;Specific operation or type name for detailed info&quot;</span></span>
+<span id="cb24-16"><a href="#cb24-16" aria-hidden="true" tabindex="-1"></a>      }</span>
+<span id="cb24-17"><a href="#cb24-17" aria-hidden="true" tabindex="-1"></a>    }</span>
+<span id="cb24-18"><a href="#cb24-18" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb24-19"><a href="#cb24-19" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<h3 id="93-query-types">9.3 Query Types</h3>
+<p><strong>List all operations:</strong></p>
+<div class="sourceCode" id="cb25"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb25-1"><a href="#cb25-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span> <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;introspect&quot;</span><span class="fu">,</span> <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;query&quot;</span><span class="fu">:</span> <span class="st">&quot;operations&quot;</span> <span class="fu">}</span> <span class="fu">}</span></span></code></pre></div>
+<p><strong>Get operation details:</strong></p>
+<div class="sourceCode" id="cb26"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb26-1"><a href="#cb26-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span> <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;introspect&quot;</span><span class="fu">,</span> <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;query&quot;</span><span class="fu">:</span> <span class="st">&quot;operations&quot;</span><span class="fu">,</span> <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;create_item&quot;</span> <span class="fu">}</span> <span class="fu">}</span></span></code></pre></div>
+<p><strong>List all types:</strong></p>
+<div class="sourceCode" id="cb27"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb27-1"><a href="#cb27-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span> <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;introspect&quot;</span><span class="fu">,</span> <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;query&quot;</span><span class="fu">:</span> <span class="st">&quot;types&quot;</span> <span class="fu">}</span> <span class="fu">}</span></span></code></pre></div>
+<p><strong>Get type details:</strong></p>
+<div class="sourceCode" id="cb28"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb28-1"><a href="#cb28-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span> <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;introspect&quot;</span><span class="fu">,</span> <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;query&quot;</span><span class="fu">:</span> <span class="st">&quot;types&quot;</span><span class="fu">,</span> <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;ItemCategory&quot;</span> <span class="fu">}</span> <span class="fu">}</span></span></code></pre></div>
+<h3 id="94-operations-response">9.4 Operations Response</h3>
+<p>When <code>query</code> is "operations" without a <code>name</code>:</p>
+<div class="sourceCode" id="cb29"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb29-1"><a href="#cb29-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb29-2"><a href="#cb29-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb29-3"><a href="#cb29-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;data&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb29-4"><a href="#cb29-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;operations&quot;</span><span class="fu">:</span> <span class="ot">[</span></span>
+<span id="cb29-5"><a href="#cb29-5" aria-hidden="true" tabindex="-1"></a>      <span class="fu">{</span></span>
+<span id="cb29-6"><a href="#cb29-6" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;create_item&quot;</span><span class="fu">,</span></span>
+<span id="cb29-7"><a href="#cb29-7" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;endpoint&quot;</span><span class="fu">:</span> <span class="st">&quot;CREATE&quot;</span><span class="fu">,</span></span>
+<span id="cb29-8"><a href="#cb29-8" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Create a new item&quot;</span></span>
+<span id="cb29-9"><a href="#cb29-9" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb29-10"><a href="#cb29-10" aria-hidden="true" tabindex="-1"></a>      <span class="fu">{</span></span>
+<span id="cb29-11"><a href="#cb29-11" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;list_items&quot;</span><span class="fu">,</span></span>
+<span id="cb29-12"><a href="#cb29-12" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;endpoint&quot;</span><span class="fu">:</span> <span class="st">&quot;READ&quot;</span><span class="fu">,</span></span>
+<span id="cb29-13"><a href="#cb29-13" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;List all items&quot;</span></span>
+<span id="cb29-14"><a href="#cb29-14" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb29-15"><a href="#cb29-15" aria-hidden="true" tabindex="-1"></a>      <span class="fu">{</span></span>
+<span id="cb29-16"><a href="#cb29-16" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;update_item&quot;</span><span class="fu">,</span></span>
+<span id="cb29-17"><a href="#cb29-17" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;endpoint&quot;</span><span class="fu">:</span> <span class="st">&quot;UPDATE&quot;</span><span class="fu">,</span></span>
+<span id="cb29-18"><a href="#cb29-18" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Update item properties&quot;</span></span>
+<span id="cb29-19"><a href="#cb29-19" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb29-20"><a href="#cb29-20" aria-hidden="true" tabindex="-1"></a>      <span class="fu">{</span></span>
+<span id="cb29-21"><a href="#cb29-21" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;delete_item&quot;</span><span class="fu">,</span></span>
+<span id="cb29-22"><a href="#cb29-22" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;endpoint&quot;</span><span class="fu">:</span> <span class="st">&quot;DELETE&quot;</span><span class="fu">,</span></span>
+<span id="cb29-23"><a href="#cb29-23" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Delete an item&quot;</span></span>
+<span id="cb29-24"><a href="#cb29-24" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb29-25"><a href="#cb29-25" aria-hidden="true" tabindex="-1"></a>      <span class="fu">{</span></span>
+<span id="cb29-26"><a href="#cb29-26" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;introspect&quot;</span><span class="fu">,</span></span>
+<span id="cb29-27"><a href="#cb29-27" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;endpoint&quot;</span><span class="fu">:</span> <span class="st">&quot;READ&quot;</span><span class="fu">,</span></span>
+<span id="cb29-28"><a href="#cb29-28" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Discover available operations&quot;</span></span>
+<span id="cb29-29"><a href="#cb29-29" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span></span>
+<span id="cb29-30"><a href="#cb29-30" aria-hidden="true" tabindex="-1"></a>    <span class="ot">]</span></span>
+<span id="cb29-31"><a href="#cb29-31" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb29-32"><a href="#cb29-32" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<h3 id="95-operation-details-response">9.5 Operation Details Response</h3>
+<p>When <code>query</code> is "operations" with a <code>name</code>:</p>
+<div class="sourceCode" id="cb30"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb30-1"><a href="#cb30-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb30-2"><a href="#cb30-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb30-3"><a href="#cb30-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;data&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb30-4"><a href="#cb30-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb30-5"><a href="#cb30-5" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;create_item&quot;</span><span class="fu">,</span></span>
+<span id="cb30-6"><a href="#cb30-6" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;endpoint&quot;</span><span class="fu">:</span> <span class="st">&quot;CREATE&quot;</span><span class="fu">,</span></span>
+<span id="cb30-7"><a href="#cb30-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;mcpTool&quot;</span><span class="fu">:</span> <span class="st">&quot;mcp_aql_create&quot;</span><span class="fu">,</span></span>
+<span id="cb30-8"><a href="#cb30-8" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Create a new item&quot;</span><span class="fu">,</span></span>
+<span id="cb30-9"><a href="#cb30-9" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;permissions&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb30-10"><a href="#cb30-10" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;readOnly&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb30-11"><a href="#cb30-11" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;destructive&quot;</span><span class="fu">:</span> <span class="kw">false</span></span>
+<span id="cb30-12"><a href="#cb30-12" aria-hidden="true" tabindex="-1"></a>      <span class="fu">},</span></span>
+<span id="cb30-13"><a href="#cb30-13" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;parameters&quot;</span><span class="fu">:</span> <span class="ot">[</span></span>
+<span id="cb30-14"><a href="#cb30-14" aria-hidden="true" tabindex="-1"></a>        <span class="fu">{</span></span>
+<span id="cb30-15"><a href="#cb30-15" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;name&quot;</span><span class="fu">,</span></span>
+<span id="cb30-16"><a href="#cb30-16" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;string&quot;</span><span class="fu">,</span></span>
+<span id="cb30-17"><a href="#cb30-17" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;required&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb30-18"><a href="#cb30-18" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Item name&quot;</span></span>
+<span id="cb30-19"><a href="#cb30-19" aria-hidden="true" tabindex="-1"></a>        <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb30-20"><a href="#cb30-20" aria-hidden="true" tabindex="-1"></a>        <span class="fu">{</span></span>
+<span id="cb30-21"><a href="#cb30-21" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;category&quot;</span><span class="fu">,</span></span>
+<span id="cb30-22"><a href="#cb30-22" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;string&quot;</span><span class="fu">,</span></span>
+<span id="cb30-23"><a href="#cb30-23" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;required&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb30-24"><a href="#cb30-24" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Item category&quot;</span><span class="fu">,</span></span>
+<span id="cb30-25"><a href="#cb30-25" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;enum&quot;</span><span class="fu">:</span> <span class="ot">[</span><span class="st">&quot;product&quot;</span><span class="ot">,</span> <span class="st">&quot;service&quot;</span><span class="ot">,</span> <span class="st">&quot;subscription&quot;</span><span class="ot">]</span></span>
+<span id="cb30-26"><a href="#cb30-26" aria-hidden="true" tabindex="-1"></a>        <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb30-27"><a href="#cb30-27" aria-hidden="true" tabindex="-1"></a>        <span class="fu">{</span></span>
+<span id="cb30-28"><a href="#cb30-28" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;price&quot;</span><span class="fu">,</span></span>
+<span id="cb30-29"><a href="#cb30-29" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;number&quot;</span><span class="fu">,</span></span>
+<span id="cb30-30"><a href="#cb30-30" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;required&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb30-31"><a href="#cb30-31" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;minimum&quot;</span><span class="fu">:</span> <span class="dv">0</span><span class="fu">,</span></span>
+<span id="cb30-32"><a href="#cb30-32" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Item price in cents&quot;</span></span>
+<span id="cb30-33"><a href="#cb30-33" aria-hidden="true" tabindex="-1"></a>        <span class="fu">}</span></span>
+<span id="cb30-34"><a href="#cb30-34" aria-hidden="true" tabindex="-1"></a>      <span class="ot">]</span><span class="fu">,</span></span>
+<span id="cb30-35"><a href="#cb30-35" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;returns&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb30-36"><a href="#cb30-36" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;Item&quot;</span><span class="fu">,</span></span>
+<span id="cb30-37"><a href="#cb30-37" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;kind&quot;</span><span class="fu">:</span> <span class="st">&quot;object&quot;</span><span class="fu">,</span></span>
+<span id="cb30-38"><a href="#cb30-38" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Newly created item&quot;</span></span>
+<span id="cb30-39"><a href="#cb30-39" aria-hidden="true" tabindex="-1"></a>      <span class="fu">},</span></span>
+<span id="cb30-40"><a href="#cb30-40" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;examples&quot;</span><span class="fu">:</span> <span class="ot">[</span></span>
+<span id="cb30-41"><a href="#cb30-41" aria-hidden="true" tabindex="-1"></a>        <span class="fu">{</span></span>
+<span id="cb30-42"><a href="#cb30-42" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Create a basic item&quot;</span><span class="fu">,</span></span>
+<span id="cb30-43"><a href="#cb30-43" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;request&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb30-44"><a href="#cb30-44" aria-hidden="true" tabindex="-1"></a>            <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;create_item&quot;</span><span class="fu">,</span></span>
+<span id="cb30-45"><a href="#cb30-45" aria-hidden="true" tabindex="-1"></a>            <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb30-46"><a href="#cb30-46" aria-hidden="true" tabindex="-1"></a>              <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;Widget&quot;</span><span class="fu">,</span></span>
+<span id="cb30-47"><a href="#cb30-47" aria-hidden="true" tabindex="-1"></a>              <span class="dt">&quot;category&quot;</span><span class="fu">:</span> <span class="st">&quot;product&quot;</span></span>
+<span id="cb30-48"><a href="#cb30-48" aria-hidden="true" tabindex="-1"></a>            <span class="fu">}</span></span>
+<span id="cb30-49"><a href="#cb30-49" aria-hidden="true" tabindex="-1"></a>          <span class="fu">}</span></span>
+<span id="cb30-50"><a href="#cb30-50" aria-hidden="true" tabindex="-1"></a>        <span class="fu">}</span></span>
+<span id="cb30-51"><a href="#cb30-51" aria-hidden="true" tabindex="-1"></a>      <span class="ot">]</span></span>
+<span id="cb30-52"><a href="#cb30-52" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb30-53"><a href="#cb30-53" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb30-54"><a href="#cb30-54" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<h3 id="96-types-response">9.6 Types Response</h3>
+<p>When <code>query</code> is "types":</p>
+<div class="sourceCode" id="cb31"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb31-1"><a href="#cb31-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb31-2"><a href="#cb31-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb31-3"><a href="#cb31-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;data&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb31-4"><a href="#cb31-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;types&quot;</span><span class="fu">:</span> <span class="ot">[</span></span>
+<span id="cb31-5"><a href="#cb31-5" aria-hidden="true" tabindex="-1"></a>      <span class="fu">{</span></span>
+<span id="cb31-6"><a href="#cb31-6" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;ItemCategory&quot;</span><span class="fu">,</span></span>
+<span id="cb31-7"><a href="#cb31-7" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;kind&quot;</span><span class="fu">:</span> <span class="st">&quot;enum&quot;</span><span class="fu">,</span></span>
+<span id="cb31-8"><a href="#cb31-8" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;values&quot;</span><span class="fu">:</span> <span class="ot">[</span><span class="st">&quot;product&quot;</span><span class="ot">,</span> <span class="st">&quot;service&quot;</span><span class="ot">,</span> <span class="st">&quot;subscription&quot;</span><span class="ot">]</span></span>
+<span id="cb31-9"><a href="#cb31-9" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb31-10"><a href="#cb31-10" aria-hidden="true" tabindex="-1"></a>      <span class="fu">{</span></span>
+<span id="cb31-11"><a href="#cb31-11" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;Item&quot;</span><span class="fu">,</span></span>
+<span id="cb31-12"><a href="#cb31-12" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;kind&quot;</span><span class="fu">:</span> <span class="st">&quot;object&quot;</span><span class="fu">,</span></span>
+<span id="cb31-13"><a href="#cb31-13" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;fields&quot;</span><span class="fu">:</span> <span class="ot">[</span></span>
+<span id="cb31-14"><a href="#cb31-14" aria-hidden="true" tabindex="-1"></a>          <span class="fu">{</span> <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;id&quot;</span><span class="fu">,</span> <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;string&quot;</span> <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb31-15"><a href="#cb31-15" aria-hidden="true" tabindex="-1"></a>          <span class="fu">{</span> <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;name&quot;</span><span class="fu">,</span> <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;string&quot;</span> <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb31-16"><a href="#cb31-16" aria-hidden="true" tabindex="-1"></a>          <span class="fu">{</span> <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;category&quot;</span><span class="fu">,</span> <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;ItemCategory&quot;</span> <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb31-17"><a href="#cb31-17" aria-hidden="true" tabindex="-1"></a>          <span class="fu">{</span> <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;price&quot;</span><span class="fu">,</span> <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;number&quot;</span> <span class="fu">}</span></span>
+<span id="cb31-18"><a href="#cb31-18" aria-hidden="true" tabindex="-1"></a>        <span class="ot">]</span></span>
+<span id="cb31-19"><a href="#cb31-19" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span></span>
+<span id="cb31-20"><a href="#cb31-20" aria-hidden="true" tabindex="-1"></a>    <span class="ot">]</span></span>
+<span id="cb31-21"><a href="#cb31-21" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb31-22"><a href="#cb31-22" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<hr />
+<h2 id="references">References</h2>
+<ul>
+<li><a href="versions/v1.0.0-draft.html">MCP-AQL Specification v1.0.0-draft</a></li>
+<li><a href="crude-pattern.html">CRUDE Pattern Specification</a></li>
+<li><a href="introspection.html">Introspection Specification</a></li>
+</ul>
+
+          </div>
+        </section>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div class="container">
+      <p>&copy; 2026 DollhouseMCP Inc. d/b/a Dollhouse Research. MCP-AQL public draft documentation portal.</p>
+      <div class="footer-links">
+        <a href="../docs/index.html">Docs Library</a>
+        <a href="index.html">Repo-Synced Spec</a>
+        <a href="https://github.com/MCPAQL">MCPAQL Organization</a>
+        <a href="https://dollhouseresearch.com">Dollhouse Research</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../js/search.js"></script>
+</body>
+</html>

--- a/public/spec/operations.html
+++ b/public/spec/operations.html
@@ -23,7 +23,7 @@
         </ul>
         <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
-          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <input id="site-search-input" data-search-input type="search" placeholder="Search MCP-AQL docs, spec pages, and adapter patterns...">
           <span class="search-count" data-search-count></span>
           <ul class="search-results" data-search-results hidden></ul>
         </form>
@@ -38,7 +38,7 @@
         <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
         <div class="docs-side-group">
   <h3>Core</h3>
-  <ul><li><a href="conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="error-codes.html">Structured Error Codes Specification</a></li><li><a href="introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="mcp-integration.html">MCP Integration Specification</a></li><li><a class="current" href="operations.html">MCP-AQL Operations Specification</a></li><li><a href="overview.html">MCP-AQL Protocol Overview</a></li><li><a href="plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="README.html">MCP-AQL Specification Documentation</a></li><li><a href="repo/README.html">MCP-AQL Specification</a></li></ul>
+  <ul><li><a href="conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="error-codes.html">Structured Error Codes Specification</a></li><li><a href="introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="mcp-integration.html">MCP Integration Specification</a></li><li><a class="current" aria-current="page" href="operations.html">MCP-AQL Operations Specification</a></li><li><a href="overview.html">MCP-AQL Protocol Overview</a></li><li><a href="plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="README.html">MCP-AQL Specification Documentation</a></li><li><a href="repo/README.html">MCP-AQL Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Versions</h3>
   <ul><li><a href="versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
@@ -1127,6 +1127,16 @@
 
           </div>
         </section>
+        <nav class="page-nav" aria-label="Page navigation">
+  <a class="page-nav-link prev" href="mcp-integration.html">
+    <span class="page-nav-eyebrow">Previous spec page</span>
+    <strong class="page-nav-label">MCP Integration Specification</strong>
+  </a>
+  <a class="page-nav-link next" href="overview.html">
+    <span class="page-nav-eyebrow">Next spec page</span>
+    <strong class="page-nav-label">MCP-AQL Protocol Overview</strong>
+  </a>
+</nav>
       </article>
     </div>
   </main>

--- a/public/spec/overview.html
+++ b/public/spec/overview.html
@@ -38,7 +38,7 @@
         <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
         <div class="docs-side-group">
   <h3>Core</h3>
-  <ul><li><a href="conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="error-codes.html">Structured Error Codes Specification</a></li><li><a href="introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="mcp-integration.html">MCP Integration Specification</a></li><li><a href="operations.html">MCP-AQL Operations Specification</a></li><li><a class="current" href="overview.html">MCP-AQL Protocol Overview</a></li><li><a href="plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="README.html">MCP-AQL Specification Documentation</a></li></ul>
+  <ul><li><a href="conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="error-codes.html">Structured Error Codes Specification</a></li><li><a href="introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="mcp-integration.html">MCP Integration Specification</a></li><li><a href="operations.html">MCP-AQL Operations Specification</a></li><li><a class="current" href="overview.html">MCP-AQL Protocol Overview</a></li><li><a href="plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="README.html">MCP-AQL Specification Documentation</a></li><li><a href="repo/README.html">MCP-AQL Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Versions</h3>
   <ul><li><a href="versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
@@ -56,7 +56,7 @@
   <ul><li><a href="guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
-  <ul><li><a href="process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="process/versioning.html">Versioning Strategy</a></li></ul>
+  <ul><li><a href="process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="process/versioning.html">Versioning Strategy</a></li><li><a href="repo/CHANGELOG.html">Changelog</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Architecture</h3>
   <ul><li><a href="architecture/README.html">Architecture Documentation</a></li></ul>

--- a/public/spec/overview.html
+++ b/public/spec/overview.html
@@ -23,7 +23,7 @@
         </ul>
         <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
-          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <input id="site-search-input" data-search-input type="search" placeholder="Search MCP-AQL docs, spec pages, and adapter patterns...">
           <span class="search-count" data-search-count></span>
           <ul class="search-results" data-search-results hidden></ul>
         </form>
@@ -38,7 +38,7 @@
         <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
         <div class="docs-side-group">
   <h3>Core</h3>
-  <ul><li><a href="conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="error-codes.html">Structured Error Codes Specification</a></li><li><a href="introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="mcp-integration.html">MCP Integration Specification</a></li><li><a href="operations.html">MCP-AQL Operations Specification</a></li><li><a class="current" href="overview.html">MCP-AQL Protocol Overview</a></li><li><a href="plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="README.html">MCP-AQL Specification Documentation</a></li><li><a href="repo/README.html">MCP-AQL Specification</a></li></ul>
+  <ul><li><a href="conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="error-codes.html">Structured Error Codes Specification</a></li><li><a href="introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="mcp-integration.html">MCP Integration Specification</a></li><li><a href="operations.html">MCP-AQL Operations Specification</a></li><li><a class="current" aria-current="page" href="overview.html">MCP-AQL Protocol Overview</a></li><li><a href="plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="README.html">MCP-AQL Specification Documentation</a></li><li><a href="repo/README.html">MCP-AQL Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Versions</h3>
   <ul><li><a href="versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
@@ -427,6 +427,16 @@ mcp_aql_execute - EXECUTE operations</code></pre>
 
           </div>
         </section>
+        <nav class="page-nav" aria-label="Page navigation">
+  <a class="page-nav-link prev" href="operations.html">
+    <span class="page-nav-eyebrow">Previous spec page</span>
+    <strong class="page-nav-label">MCP-AQL Operations Specification</strong>
+  </a>
+  <a class="page-nav-link next" href="plugin-contracts.html">
+    <span class="page-nav-eyebrow">Next spec page</span>
+    <strong class="page-nav-label">Plugin Interface Contracts</strong>
+  </a>
+</nav>
       </article>
     </div>
   </main>

--- a/public/spec/overview.html
+++ b/public/spec/overview.html
@@ -73,6 +73,13 @@
       </aside>
 
       <article class="docs-main">
+        <nav class="breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../index.html">Home</a></li>
+            <li><a href="index.html">Full Spec</a></li>
+            <li><span class="current">MCP-AQL Protocol Overview</span></li>
+          </ol>
+        </nav>
         <section class="hero docs-hero">
           <div class="hero-inner">
             <span class="status-pill">REPO-SYNCED SPEC DOC</span>

--- a/public/spec/overview.html
+++ b/public/spec/overview.html
@@ -1,0 +1,441 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="MCP-AQL (Model Context Protocol - Agent Query Language) is a protocol that consolidates discrete MCP tools into 5 CRUDE endpoints (Create, Read, Update, Delete, Execute), providing significant token reduction while maint">
+  <title>MCP-AQL Spec | MCP-AQL Protocol Overview</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../css/style.css">
+</head>
+<body>
+  <header>
+    <div class="container">
+      <nav>
+        <a class="logo" href="../index.html"><span class="logo-mark"></span>MCP-AQL</a>
+        <ul class="nav-links">
+          <li><a href="../index.html">Home</a></li>
+          <li><a href="../docs/index.html">Docs</a></li>
+          <li><a href="../launch-checklist.html">Launch Checklist</a></li>
+          <li><a href="../apis/mcp-server.html">Adapter Patterns</a></li>
+        </ul>
+        <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
+          <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
+          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <span class="search-count" data-search-count></span>
+          <ul class="search-results" data-search-results hidden></ul>
+        </form>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <div class="container docs-shell">
+      <aside class="docs-side">
+        <h2>Repo-Synced Spec</h2>
+        <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
+        <div class="docs-side-group">
+  <h3>Core</h3>
+  <ul><li><a href="conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="error-codes.html">Structured Error Codes Specification</a></li><li><a href="introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="mcp-integration.html">MCP Integration Specification</a></li><li><a href="operations.html">MCP-AQL Operations Specification</a></li><li><a class="current" href="overview.html">MCP-AQL Protocol Overview</a></li><li><a href="plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="README.html">MCP-AQL Specification Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Versions</h3>
+  <ul><li><a href="versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Adapter</h3>
+  <ul><li><a href="adapter/danger-levels.html">Dangerous Operation Classification Specification</a></li><li><a href="adapter/discovery-bundle.html">MCP Server Discovery Bundle</a></li><li><a href="adapter/element-type.html">Adapter Element Type Specification</a></li><li><a href="adapter/generator.html">Adapter Generator Specification</a></li><li><a href="adapter/rate-limiting.html">Rate Limiting and Quota Management Specification</a></li><li><a href="adapter/trust-levels.html">Trust Levels Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Security</h3>
+  <ul><li><a href="security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Features</h3>
+  <ul><li><a href="features/field-selection.html">Field Selection Specification</a></li><li><a href="features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="features/warnings.html">Warnings Array Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Guides</h3>
+  <ul><li><a href="guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="guides/README.html">Developer Guides</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Process</h3>
+  <ul><li><a href="process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="process/versioning.html">Versioning Strategy</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Architecture</h3>
+  <ul><li><a href="architecture/README.html">Architecture Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Research</h3>
+  <ul><li><a href="research/mcp-vs-mcpaql-vs-a2a.html">Protocol Landscape: MCP vs MCP-AQL vs A2A</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Reference</h3>
+  <ul><li><a href="reference/README.html">Reference Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>ADRs</h3>
+  <ul><li><a href="adr/ADR-001-crude-pattern.html">ADR-001: CRUDE Pattern (Extending CRUD with Execute)</a></li><li><a href="adr/ADR-002-graphql-style-input.html">ADR-002: GraphQL-Style Input Objects for Updates</a></li><li><a href="adr/ADR-003-snake-case-parameters.html">ADR-003: snake_case Parameter Convention</a></li><li><a href="adr/ADR-004-schema-driven-operations.html">ADR-004: Schema-Driven Operation Definitions</a></li><li><a href="adr/ADR-005-introspection-system.html">ADR-005: GraphQL-Style Introspection System</a></li><li><a href="adr/ADR-006-discriminated-responses.html">ADR-006: Discriminated Response Format</a></li><li><a href="adr/index.html">Architecture Decision Records</a></li><li><a href="adr/README.html">Architecture Decision Records</a></li></ul>
+</div>
+      </aside>
+
+      <article class="docs-main">
+        <section class="hero docs-hero">
+          <div class="hero-inner">
+            <span class="status-pill">REPO-SYNCED SPEC DOC</span>
+            <h1>MCP-AQL Protocol Overview</h1>
+            <p class="lede">MCP-AQL (Model Context Protocol - Agent Query Language) is a protocol that consolidates discrete MCP tools into 5 CRUDE endpoints (Create, Read, Update, Delete, Execute), providing significant token reduction while maint</p>
+            <div class="spec-meta"><span class="state-chip live">Support document</span></div>
+            <p class="spec-source">Source: <a href="https://github.com/MCPAQL/spec/blob/main/docs/overview.md">spec/docs/overview.md</a></p>
+            <div class="hero-actions">
+              <a class="btn btn-primary" href="https://github.com/MCPAQL/spec/blob/main/docs/overview.md">Open Source Markdown</a>
+              <a class="btn btn-secondary" href="index.html">Browse Full Spec Reference</a>
+            </div>
+          </div>
+        </section>
+
+        <section>
+          <div class="card spec-prose">
+            <blockquote>
+<p><strong>MCP-AQL</strong> (Model Context Protocol - Agent Query Language) is a protocol that consolidates discrete MCP tools into 5 CRUDE endpoints (Create, Read, Update, Delete, Execute), providing significant token reduction while maintaining full functionality.</p>
+<p><strong>Document Status:</strong> This document is <strong>informative</strong>. For normative requirements, see <a href="versions/v1.0.0-draft.html">MCP-AQL Specification v1.0.0</a>.</p>
+</blockquote>
+<h2 id="table-of-contents">Table of Contents</h2>
+<ul>
+<li><a href="#protocol-summary">Protocol Summary</a></li>
+<li><a href="#the-crude-pattern">The CRUDE Pattern</a></li>
+<li><a href="#endpoint-modes">Endpoint Modes</a></li>
+<li><a href="#token-efficiency">Token Efficiency</a></li>
+<li><a href="#core-concepts">Core Concepts</a></li>
+<li><a href="#request-flow">Request Flow</a></li>
+<li><a href="#batch-operations">Batch Operations</a></li>
+</ul>
+<hr />
+<h2 id="protocol-summary">Protocol Summary</h2>
+<p>MCP-AQL defines a schema-driven operation dispatch protocol that:</p>
+<ol type="1">
+<li><strong>Consolidates Operations</strong> - Many discrete tools into 5 semantic endpoints</li>
+<li><strong>Enables Discovery</strong> - GraphQL-style introspection for runtime operation discovery</li>
+<li><strong>Enforces Safety</strong> - Endpoint classification validates operation/endpoint matching</li>
+<li><strong>Supports Flexibility</strong> - Implementations MAY offer CRUDE mode (5 endpoints) or Single mode (1 endpoint)</li>
+</ol>
+<pre><code>+-------------------+
+|    MCP Client     |
++--------+----------+
+         |
+         v
++-------------------+
+|  MCP-AQL Layer    |
+|  +-------------+  |
+|  |  Gatekeeper |  |  Route Validation
+|  +------+------+  |
+|         |         |
+|  +------v------+  |
+|  |   Router    |  |  Endpoint Mapping
+|  +------+------+  |
+|         |         |
+|  +------v------+  |
+|  |   Schema    |  |  Operation Definitions
+|  +------+------+  |
+|         |         |
+|  +------v------+  |
+|  | Dispatcher  |  |  Handler Resolution
+|  +-------------+  |
++--------+----------+
+         |
+         v
++-------------------+
+| Target Handlers   |
++-------------------+</code></pre>
+<hr />
+<h2 id="the-crude-pattern">The CRUDE Pattern</h2>
+<p>MCP-AQL extends traditional CRUD with an <strong>EXECUTE</strong> endpoint, creating the CRUDE pattern:</p>
+<table>
+<thead>
+<tr>
+<th>Endpoint</th>
+<th>Safety</th>
+<th>Description</th>
+<th>Example Operations</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>CREATE</strong></td>
+<td>Non-destructive</td>
+<td>Additive operations that create new state</td>
+<td><code>create_entity</code>, <code>import_resource</code></td>
+</tr>
+<tr>
+<td><strong>READ</strong></td>
+<td>Read-only</td>
+<td>Safe operations that query state</td>
+<td><code>list_entities</code>, <code>get_entity</code>, <code>search</code>, <code>introspect</code></td>
+</tr>
+<tr>
+<td><strong>UPDATE</strong></td>
+<td>Modifying</td>
+<td>Operations that modify existing state</td>
+<td><code>update_entity</code>, <code>update_resource</code></td>
+</tr>
+<tr>
+<td><strong>DELETE</strong></td>
+<td>Destructive</td>
+<td>Operations that remove state</td>
+<td><code>delete_entity</code>, <code>clear</code></td>
+</tr>
+<tr>
+<td><strong>EXECUTE</strong></td>
+<td>Runtime</td>
+<td>Lifecycle operations for executable elements</td>
+<td><code>execute_workflow</code>, <code>cancel_task</code>, <code>resume_workflow</code></td>
+</tr>
+</tbody>
+</table>
+<h3 id="permission-characteristics">Permission Characteristics</h3>
+<p>Each endpoint MUST have defined permission characteristics:</p>
+<table>
+<thead>
+<tr>
+<th>Endpoint</th>
+<th>Read-Only</th>
+<th>Destructive</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>CREATE</td>
+<td>false</td>
+<td>false</td>
+</tr>
+<tr>
+<td>READ</td>
+<td>true</td>
+<td>false</td>
+</tr>
+<tr>
+<td>UPDATE</td>
+<td>false</td>
+<td>true</td>
+</tr>
+<tr>
+<td>DELETE</td>
+<td>false</td>
+<td>true</td>
+</tr>
+<tr>
+<td>EXECUTE</td>
+<td>false</td>
+<td>true</td>
+</tr>
+</tbody>
+</table>
+<p>Implementations MUST classify operations according to these permission characteristics and MUST NOT allow an operation to be called through an endpoint that does not match its classification.</p>
+<h3 id="why-crude-not-crud">Why CRUDE not CRUD?</h3>
+<p>The EXECUTE endpoint exists because certain operations:</p>
+<ul>
+<li>Are inherently <strong>non-idempotent</strong> (calling <code>execute</code> twice creates two separate executions)</li>
+<li>Manage <strong>runtime state</strong> rather than persistent definitions</li>
+<li>Require <strong>lifecycle management</strong> (start, update progress, complete, resume)</li>
+</ul>
+<pre><code>CRUD (Resource Definitions)          EXECUTE (Runtime Lifecycle)
++--------+                           +-------------------+
+| Create |--------------------------&gt;| execute           |
++--------+                           +--------+----------+
+| Read   |                                    |
++--------+                           +--------v----------+
+| Update |                           | get_execution_state|
++--------+                           +--------+----------+
+| Delete |                                    |
++--------+                           +--------v----------+
+                                     | update_execution   |
+                                     +--------+----------+
+                                              |
+                              +---------------+---------------+
+                              |                               |
+                     +--------v----------+           +--------v----------+
+                     | complete_execution|           | continue_execution|
+                     +-------------------+           +-------------------+</code></pre>
+<blockquote>
+<p><strong>Note:</strong> This diagram shows a runtime lifecycle flow, not endpoint classification. Operations like <code>get_execution_state</code> that query execution state belong to the READ endpoint, not EXECUTE. See <a href="crude-pattern.html#61-classification-principle">CRUDE Pattern Classification</a> for details.</p>
+</blockquote>
+<hr />
+<h2 id="endpoint-modes">Endpoint Modes</h2>
+<p>MCP-AQL supports two operational modes. Implementations MUST support at least one mode and SHOULD support both:</p>
+<h3 id="crude-mode">CRUDE Mode</h3>
+<p>Exposes 5 separate endpoints, each with semantic meaning:</p>
+<pre><code>mcp_aql_create  - CREATE operations
+mcp_aql_read    - READ operations
+mcp_aql_update  - UPDATE operations
+mcp_aql_delete  - DELETE operations
+mcp_aql_execute - EXECUTE operations</code></pre>
+<p><strong>Advantages:</strong></p>
+<ul>
+<li>Clear semantic grouping</li>
+<li>Endpoint-level permission control</li>
+<li>Clients MAY choose which endpoints to expose</li>
+</ul>
+<h3 id="single-mode">Single Mode</h3>
+<p>Exposes 1 unified endpoint that routes internally:</p>
+<pre><code>mcp_aql - All operations through single entry point</code></pre>
+<p><strong>Advantages:</strong></p>
+<ul>
+<li>Minimal token footprint</li>
+<li>Simpler client integration</li>
+<li>Server-side routing enforcement</li>
+</ul>
+<p>Implementations using Single Mode MUST still enforce endpoint classification internally. An operation classified as DELETE MUST NOT succeed if the implementation would not allow DELETE operations.</p>
+<hr />
+<h2 id="token-efficiency">Token Efficiency</h2>
+<h3 id="token-reduction">Token Reduction</h3>
+<p>The primary motivation for MCP-AQL is reducing the token cost of tool registration. Empirical measurements demonstrate:</p>
+<table>
+<thead>
+<tr>
+<th>Configuration</th>
+<th>Approximate Token Cost</th>
+<th>Reduction</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Discrete Tools (50+)</td>
+<td>~30,000 tokens</td>
+<td>baseline</td>
+</tr>
+<tr>
+<td>CRUDE Mode (5 endpoints)</td>
+<td>~4,500 tokens</td>
+<td>~85%</td>
+</tr>
+<tr>
+<td>Single Mode (1 endpoint)</td>
+<td>~1,100 tokens</td>
+<td>~96%</td>
+</tr>
+</tbody>
+</table>
+<h3 id="runtime-discovery">Runtime Discovery</h3>
+<p>Instead of parsing many tool schemas at registration time, clients use introspection at runtime:</p>
+<div class="sourceCode" id="cb5"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb5-1"><a href="#cb5-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Query all available operations</span></span>
+<span id="cb5-2"><a href="#cb5-2" aria-hidden="true" tabindex="-1"></a>{ <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;introspect&quot;</span><span class="op">,</span> <span class="dt">params</span><span class="op">:</span> { <span class="dt">query</span><span class="op">:</span> <span class="st">&quot;operations&quot;</span> } }</span>
+<span id="cb5-3"><a href="#cb5-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb5-4"><a href="#cb5-4" aria-hidden="true" tabindex="-1"></a><span class="co">// Get details for a specific operation</span></span>
+<span id="cb5-5"><a href="#cb5-5" aria-hidden="true" tabindex="-1"></a>{ <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;introspect&quot;</span><span class="op">,</span> <span class="dt">params</span><span class="op">:</span> { <span class="dt">query</span><span class="op">:</span> <span class="st">&quot;operations&quot;</span><span class="op">,</span> <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;create_entity&quot;</span> } }</span>
+<span id="cb5-6"><a href="#cb5-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb5-7"><a href="#cb5-7" aria-hidden="true" tabindex="-1"></a><span class="co">// Query available types</span></span>
+<span id="cb5-8"><a href="#cb5-8" aria-hidden="true" tabindex="-1"></a>{ <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;introspect&quot;</span><span class="op">,</span> <span class="dt">params</span><span class="op">:</span> { <span class="dt">query</span><span class="op">:</span> <span class="st">&quot;types&quot;</span><span class="op">,</span> <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;EntityType&quot;</span> } }</span></code></pre></div>
+<p>Implementations MUST support the <code>introspect</code> operation on the READ endpoint.</p>
+<hr />
+<h2 id="core-concepts">Core Concepts</h2>
+<h3 id="schema-driven-operations">Schema-Driven Operations</h3>
+<p>Operations SHOULD be defined declaratively with:</p>
+<ul>
+<li><strong>name</strong> - The operation identifier</li>
+<li><strong>endpoint</strong> - The CRUDE endpoint classification</li>
+<li><strong>description</strong> - Human-readable description</li>
+<li><strong>params</strong> - Required and optional parameter definitions</li>
+<li><strong>handler</strong> - Reference to the implementation handler</li>
+</ul>
+<h3 id="gatekeeper">Gatekeeper</h3>
+<p>The Gatekeeper component enforces that operations are only callable through their designated endpoints. Implementations MUST validate that:</p>
+<ol type="1">
+<li>The operation exists</li>
+<li>The operation is allowed on the requested endpoint</li>
+<li>Required parameters are present</li>
+</ol>
+<h3 id="introspection">Introspection</h3>
+<p>MCP-AQL implementations MUST provide GraphQL-style introspection capabilities:</p>
+<ul>
+<li>List all available operations</li>
+<li>Get detailed information about specific operations</li>
+<li>Query available types and enumerations</li>
+<li>Discover parameter requirements</li>
+</ul>
+<hr />
+<h2 id="request-flow">Request Flow</h2>
+<h3 id="standard-request">Standard Request</h3>
+<pre><code>1. Client sends { operation, params } to endpoint
+2. Gatekeeper validates operation is allowed on endpoint
+3. Router resolves operation to handler
+4. Schema validates required parameters
+5. Dispatcher invokes handler with mapped parameters
+6. Handler returns result
+7. Response formatted as { success: true, data } or { success: false, error }</code></pre>
+<h3 id="response-format">Response Format</h3>
+<p>All MCP-AQL operations MUST return discriminated responses:</p>
+<p><strong>Success:</strong></p>
+<div class="sourceCode" id="cb7"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb7-1"><a href="#cb7-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb7-2"><a href="#cb7-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">success</span><span class="op">:</span> <span class="kw">true</span><span class="op">,</span></span>
+<span id="cb7-3"><a href="#cb7-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">data</span><span class="op">:</span> { <span class="co">/* operation result */</span> }</span>
+<span id="cb7-4"><a href="#cb7-4" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<p><strong>Failure:</strong></p>
+<div class="sourceCode" id="cb8"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb8-1"><a href="#cb8-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb8-2"><a href="#cb8-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">success</span><span class="op">:</span> <span class="kw">false</span><span class="op">,</span></span>
+<span id="cb8-3"><a href="#cb8-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">error</span><span class="op">:</span> {</span>
+<span id="cb8-4"><a href="#cb8-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">code</span><span class="op">:</span> <span class="st">&quot;VALIDATION_ERROR&quot;</span><span class="op">,</span></span>
+<span id="cb8-5"><a href="#cb8-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">message</span><span class="op">:</span> <span class="st">&quot;Required parameter &#39;entity_name&#39; is missing&quot;</span></span>
+<span id="cb8-6"><a href="#cb8-6" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb8-7"><a href="#cb8-7" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<p>Implementations SHOULD include an error <code>code</code> for programmatic handling and MUST include a human-readable <code>message</code>.</p>
+<hr />
+<h2 id="batch-operations">Batch Operations</h2>
+<p>MCP-AQL implementations MAY support batch operations for executing multiple operations in a single request.</p>
+<h3 id="batch-request-format">Batch Request Format</h3>
+<div class="sourceCode" id="cb9"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb9-1"><a href="#cb9-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb9-2"><a href="#cb9-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operations</span><span class="op">:</span> [</span>
+<span id="cb9-3"><a href="#cb9-3" aria-hidden="true" tabindex="-1"></a>    { <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;create_entity&quot;</span><span class="op">,</span> <span class="dt">params</span><span class="op">:</span> { <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;entity1&quot;</span> } }<span class="op">,</span></span>
+<span id="cb9-4"><a href="#cb9-4" aria-hidden="true" tabindex="-1"></a>    { <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;create_entity&quot;</span><span class="op">,</span> <span class="dt">params</span><span class="op">:</span> { <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;entity2&quot;</span> } }<span class="op">,</span></span>
+<span id="cb9-5"><a href="#cb9-5" aria-hidden="true" tabindex="-1"></a>    { <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;activate_entity&quot;</span><span class="op">,</span> <span class="dt">params</span><span class="op">:</span> { <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;entity1&quot;</span> } }</span>
+<span id="cb9-6"><a href="#cb9-6" aria-hidden="true" tabindex="-1"></a>  ]</span>
+<span id="cb9-7"><a href="#cb9-7" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<h3 id="batch-response-format">Batch Response Format</h3>
+<div class="sourceCode" id="cb10"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb10-1"><a href="#cb10-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb10-2"><a href="#cb10-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">success</span><span class="op">:</span> <span class="kw">true</span><span class="op">,</span></span>
+<span id="cb10-3"><a href="#cb10-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">results</span><span class="op">:</span> [</span>
+<span id="cb10-4"><a href="#cb10-4" aria-hidden="true" tabindex="-1"></a>    { <span class="dt">index</span><span class="op">:</span> <span class="dv">0</span><span class="op">,</span> <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;create_entity&quot;</span><span class="op">,</span> <span class="dt">result</span><span class="op">:</span> { <span class="dt">success</span><span class="op">:</span> <span class="kw">true</span><span class="op">,</span> <span class="dt">data</span><span class="op">:</span> { <span class="co">/* ... */</span> } } }<span class="op">,</span></span>
+<span id="cb10-5"><a href="#cb10-5" aria-hidden="true" tabindex="-1"></a>    { <span class="dt">index</span><span class="op">:</span> <span class="dv">1</span><span class="op">,</span> <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;create_entity&quot;</span><span class="op">,</span> <span class="dt">result</span><span class="op">:</span> { <span class="dt">success</span><span class="op">:</span> <span class="kw">true</span><span class="op">,</span> <span class="dt">data</span><span class="op">:</span> { <span class="co">/* ... */</span> } } }<span class="op">,</span></span>
+<span id="cb10-6"><a href="#cb10-6" aria-hidden="true" tabindex="-1"></a>    { <span class="dt">index</span><span class="op">:</span> <span class="dv">2</span><span class="op">,</span> <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;activate_entity&quot;</span><span class="op">,</span> <span class="dt">result</span><span class="op">:</span> { <span class="dt">success</span><span class="op">:</span> <span class="kw">true</span><span class="op">,</span> <span class="dt">data</span><span class="op">:</span> { <span class="co">/* ... */</span> } } }</span>
+<span id="cb10-7"><a href="#cb10-7" aria-hidden="true" tabindex="-1"></a>  ]<span class="op">,</span></span>
+<span id="cb10-8"><a href="#cb10-8" aria-hidden="true" tabindex="-1"></a>  <span class="dt">summary</span><span class="op">:</span> { <span class="dt">total</span><span class="op">:</span> <span class="dv">3</span><span class="op">,</span> <span class="dt">succeeded</span><span class="op">:</span> <span class="dv">3</span><span class="op">,</span> <span class="dt">failed</span><span class="op">:</span> <span class="dv">0</span> }</span>
+<span id="cb10-9"><a href="#cb10-9" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<p>When batch operations are supported, implementations:</p>
+<ul>
+<li>MUST process operations in order</li>
+<li>MUST include results for all operations, including failures</li>
+<li>SHOULD continue processing after individual operation failures</li>
+<li>MAY provide a configuration option to stop on first failure</li>
+</ul>
+<hr />
+<h2 id="conformance">Conformance</h2>
+<p>An MCP-AQL implementation is conformant if it:</p>
+<ol type="1">
+<li>Implements at least one endpoint mode (CRUDE or Single)</li>
+<li>Enforces endpoint classification for all operations</li>
+<li>Provides the <code>introspect</code> operation on the READ endpoint</li>
+<li>Returns discriminated responses for all operations</li>
+<li>Validates required parameters before dispatching</li>
+</ol>
+<hr />
+<h2 id="related-specifications">Related Specifications</h2>
+<ul>
+<li><a href="operations.html">Operations Reference</a> - Complete operation reference</li>
+<li><a href="introspection.html">Introspection</a> - Introspection system specification</li>
+<li><a href="mcp-integration.html">MCP Integration</a> - MCP protocol integration specification</li>
+<li><a href="https://github.com/MCPAQL/spec/blob/main/docs/responses.md">Response Format</a> - Response format specification</li>
+</ul>
+
+          </div>
+        </section>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div class="container">
+      <p>&copy; 2026 DollhouseMCP Inc. d/b/a Dollhouse Research. MCP-AQL public draft documentation portal.</p>
+      <div class="footer-links">
+        <a href="../docs/index.html">Docs Library</a>
+        <a href="index.html">Repo-Synced Spec</a>
+        <a href="https://github.com/MCPAQL">MCPAQL Organization</a>
+        <a href="https://dollhouseresearch.com">Dollhouse Research</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../js/search.js"></script>
+</body>
+</html>

--- a/public/spec/plugin-contracts.html
+++ b/public/spec/plugin-contracts.html
@@ -73,6 +73,13 @@
       </aside>
 
       <article class="docs-main">
+        <nav class="breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../index.html">Home</a></li>
+            <li><a href="index.html">Full Spec</a></li>
+            <li><span class="current">Plugin Interface Contracts</span></li>
+          </ol>
+        </nav>
         <section class="hero docs-hero">
           <div class="hero-inner">
             <span class="status-pill">REPO-SYNCED SPEC DOC</span>

--- a/public/spec/plugin-contracts.html
+++ b/public/spec/plugin-contracts.html
@@ -23,7 +23,7 @@
         </ul>
         <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
-          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <input id="site-search-input" data-search-input type="search" placeholder="Search MCP-AQL docs, spec pages, and adapter patterns...">
           <span class="search-count" data-search-count></span>
           <ul class="search-results" data-search-results hidden></ul>
         </form>
@@ -38,7 +38,7 @@
         <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
         <div class="docs-side-group">
   <h3>Core</h3>
-  <ul><li><a href="conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="error-codes.html">Structured Error Codes Specification</a></li><li><a href="introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="mcp-integration.html">MCP Integration Specification</a></li><li><a href="operations.html">MCP-AQL Operations Specification</a></li><li><a href="overview.html">MCP-AQL Protocol Overview</a></li><li><a class="current" href="plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="README.html">MCP-AQL Specification Documentation</a></li><li><a href="repo/README.html">MCP-AQL Specification</a></li></ul>
+  <ul><li><a href="conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="error-codes.html">Structured Error Codes Specification</a></li><li><a href="introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="mcp-integration.html">MCP Integration Specification</a></li><li><a href="operations.html">MCP-AQL Operations Specification</a></li><li><a href="overview.html">MCP-AQL Protocol Overview</a></li><li><a class="current" aria-current="page" href="plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="README.html">MCP-AQL Specification Documentation</a></li><li><a href="repo/README.html">MCP-AQL Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Versions</h3>
   <ul><li><a href="versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
@@ -590,6 +590,16 @@
 
           </div>
         </section>
+        <nav class="page-nav" aria-label="Page navigation">
+  <a class="page-nav-link prev" href="overview.html">
+    <span class="page-nav-eyebrow">Previous spec page</span>
+    <strong class="page-nav-label">MCP-AQL Protocol Overview</strong>
+  </a>
+  <a class="page-nav-link next" href="README.html">
+    <span class="page-nav-eyebrow">Next spec page</span>
+    <strong class="page-nav-label">MCP-AQL Specification Documentation</strong>
+  </a>
+</nav>
       </article>
     </div>
   </main>

--- a/public/spec/plugin-contracts.html
+++ b/public/spec/plugin-contracts.html
@@ -1,0 +1,604 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="This document defines the normative plugin interface contracts for the MCP-AQL adapter system. Plugins provide modular, composable functionality for transport, protocol, authentication, and serialization. This specificat">
+  <title>MCP-AQL Spec | Plugin Interface Contracts</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../css/style.css">
+</head>
+<body>
+  <header>
+    <div class="container">
+      <nav>
+        <a class="logo" href="../index.html"><span class="logo-mark"></span>MCP-AQL</a>
+        <ul class="nav-links">
+          <li><a href="../index.html">Home</a></li>
+          <li><a href="../docs/index.html">Docs</a></li>
+          <li><a href="../launch-checklist.html">Launch Checklist</a></li>
+          <li><a href="../apis/mcp-server.html">Adapter Patterns</a></li>
+        </ul>
+        <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
+          <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
+          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <span class="search-count" data-search-count></span>
+          <ul class="search-results" data-search-results hidden></ul>
+        </form>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <div class="container docs-shell">
+      <aside class="docs-side">
+        <h2>Repo-Synced Spec</h2>
+        <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
+        <div class="docs-side-group">
+  <h3>Core</h3>
+  <ul><li><a href="conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="error-codes.html">Structured Error Codes Specification</a></li><li><a href="introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="mcp-integration.html">MCP Integration Specification</a></li><li><a href="operations.html">MCP-AQL Operations Specification</a></li><li><a href="overview.html">MCP-AQL Protocol Overview</a></li><li><a class="current" href="plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="README.html">MCP-AQL Specification Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Versions</h3>
+  <ul><li><a href="versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Adapter</h3>
+  <ul><li><a href="adapter/danger-levels.html">Dangerous Operation Classification Specification</a></li><li><a href="adapter/discovery-bundle.html">MCP Server Discovery Bundle</a></li><li><a href="adapter/element-type.html">Adapter Element Type Specification</a></li><li><a href="adapter/generator.html">Adapter Generator Specification</a></li><li><a href="adapter/rate-limiting.html">Rate Limiting and Quota Management Specification</a></li><li><a href="adapter/trust-levels.html">Trust Levels Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Security</h3>
+  <ul><li><a href="security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Features</h3>
+  <ul><li><a href="features/field-selection.html">Field Selection Specification</a></li><li><a href="features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="features/warnings.html">Warnings Array Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Guides</h3>
+  <ul><li><a href="guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="guides/README.html">Developer Guides</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Process</h3>
+  <ul><li><a href="process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="process/versioning.html">Versioning Strategy</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Architecture</h3>
+  <ul><li><a href="architecture/README.html">Architecture Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Research</h3>
+  <ul><li><a href="research/mcp-vs-mcpaql-vs-a2a.html">Protocol Landscape: MCP vs MCP-AQL vs A2A</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Reference</h3>
+  <ul><li><a href="reference/README.html">Reference Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>ADRs</h3>
+  <ul><li><a href="adr/ADR-001-crude-pattern.html">ADR-001: CRUDE Pattern (Extending CRUD with Execute)</a></li><li><a href="adr/ADR-002-graphql-style-input.html">ADR-002: GraphQL-Style Input Objects for Updates</a></li><li><a href="adr/ADR-003-snake-case-parameters.html">ADR-003: snake_case Parameter Convention</a></li><li><a href="adr/ADR-004-schema-driven-operations.html">ADR-004: Schema-Driven Operation Definitions</a></li><li><a href="adr/ADR-005-introspection-system.html">ADR-005: GraphQL-Style Introspection System</a></li><li><a href="adr/ADR-006-discriminated-responses.html">ADR-006: Discriminated Response Format</a></li><li><a href="adr/index.html">Architecture Decision Records</a></li><li><a href="adr/README.html">Architecture Decision Records</a></li></ul>
+</div>
+      </aside>
+
+      <article class="docs-main">
+        <section class="hero docs-hero">
+          <div class="hero-inner">
+            <span class="status-pill">REPO-SYNCED SPEC DOC</span>
+            <h1>Plugin Interface Contracts</h1>
+            <p class="lede">This document defines the normative plugin interface contracts for the MCP-AQL adapter system. Plugins provide modular, composable functionality for transport, protocol, authentication, and serialization. This specificat</p>
+            <div class="spec-meta"><span class="state-chip live">Support document</span><span class="state-chip pending">Draft (MVP)</span><span class="state-chip">1.0.0-draft</span><span class="state-chip">2026-01-27</span></div>
+            <p class="spec-source">Source: <a href="https://github.com/MCPAQL/spec/blob/main/docs/plugin-contracts.md">spec/docs/plugin-contracts.md</a></p>
+            <div class="hero-actions">
+              <a class="btn btn-primary" href="https://github.com/MCPAQL/spec/blob/main/docs/plugin-contracts.md">Open Source Markdown</a>
+              <a class="btn btn-secondary" href="index.html">Browse Full Spec Reference</a>
+            </div>
+          </div>
+        </section>
+
+        <section>
+          <div class="card spec-prose">
+            <p><strong>Version:</strong> 1.0.0-draft <strong>Status:</strong> Draft (MVP) <strong>Last Updated:</strong> 2026-01-27</p>
+<h2 id="abstract">Abstract</h2>
+<p>This document defines the normative plugin interface contracts for the MCP-AQL adapter system. Plugins provide modular, composable functionality for transport, protocol, authentication, and serialization. This specification defines <strong>what</strong> each plugin type MUST provide; implementation details of specific plugins and the composition pipeline are documented in the <a href="https://github.com/MCPAQL/mcpaql-adapter">mcpaql-adapter</a> repository.</p>
+<hr />
+<h2 id="table-of-contents">Table of Contents</h2>
+<ol type="1">
+<li><a href="#1-overview">Overview</a></li>
+<li><a href="#2-plugin-categories">Plugin Categories</a></li>
+<li><a href="#3-base-plugin-interface">Base Plugin Interface</a></li>
+<li><a href="#4-transport-plugin-interface">Transport Plugin Interface</a></li>
+<li><a href="#5-protocol-plugin-interface">Protocol Plugin Interface</a></li>
+<li><a href="#6-serialization-plugin-interface">Serialization Plugin Interface</a></li>
+<li><a href="#7-authentication-plugin-interface">Authentication Plugin Interface</a></li>
+<li><a href="#8-error-code-contracts">Error Code Contracts</a></li>
+</ol>
+<hr />
+<h2 id="1-overview">1. Overview</h2>
+<h3 id="11-purpose">1.1 Purpose</h3>
+<p>Plugins enable the universal adapter runtime to support different communication patterns without adapter-specific code. Each adapter schema references plugins declaratively:</p>
+<div class="sourceCode" id="cb1"><pre class="sourceCode yaml"><code class="sourceCode yaml"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a><span class="fu">target</span><span class="kw">:</span></span>
+<span id="cb1-2"><a href="#cb1-2" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">transport</span><span class="kw">:</span><span class="at"> http</span><span class="co">        # Transport plugin</span></span>
+<span id="cb1-3"><a href="#cb1-3" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">protocol</span><span class="kw">:</span><span class="at"> rest</span><span class="co">         # Protocol plugin</span></span>
+<span id="cb1-4"><a href="#cb1-4" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">serialization</span><span class="kw">:</span><span class="at"> json</span><span class="co">    # Serialization plugin</span></span>
+<span id="cb1-5"><a href="#cb1-5" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb1-6"><a href="#cb1-6" aria-hidden="true" tabindex="-1"></a><span class="fu">auth</span><span class="kw">:</span></span>
+<span id="cb1-7"><a href="#cb1-7" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">type</span><span class="kw">:</span><span class="at"> bearer</span><span class="co">           # Auth plugin</span></span></code></pre></div>
+<p>The runtime loads and composes these plugins to handle API communication.</p>
+<h3 id="12-design-principles">1.2 Design Principles</h3>
+<ol type="1">
+<li><strong>Declarative composition</strong> - Adapters reference plugins by name, runtime composes them</li>
+<li><strong>Single responsibility</strong> - Each plugin handles one concern</li>
+<li><strong>Testable in isolation</strong> - Plugins can be unit tested independently</li>
+<li><strong>Built-in only (MVP)</strong> - No user-extensible plugins in V1</li>
+<li><strong>Future extensibility</strong> - Interfaces designed for later extension</li>
+</ol>
+<h3 id="13-mvp-scope">1.3 MVP Scope</h3>
+<p>This specification covers the Minimum Viable Product plugins:</p>
+<p><strong>Included:</strong></p>
+<table>
+<thead>
+<tr>
+<th>Category</th>
+<th>Plugins</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Transport</td>
+<td><code>http</code></td>
+</tr>
+<tr>
+<td>Protocol</td>
+<td><code>rest</code></td>
+</tr>
+<tr>
+<td>Serialization</td>
+<td><code>json</code></td>
+</tr>
+<tr>
+<td>Auth</td>
+<td><code>none</code>, <code>api_key</code>, <code>bearer</code></td>
+</tr>
+</tbody>
+</table>
+<p><strong>Deferred to future specifications:</strong></p>
+<table>
+<thead>
+<tr>
+<th>Category</th>
+<th>Deferred Plugins</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Transport</td>
+<td><code>websocket</code>, <code>serial</code>, <code>native-*</code></td>
+</tr>
+<tr>
+<td>Protocol</td>
+<td><code>graphql</code>, <code>grpc</code>, <code>jsonrpc</code>, <code>custom</code></td>
+</tr>
+<tr>
+<td>Serialization</td>
+<td><code>xml</code>, <code>protobuf</code>, <code>msgpack</code>, <code>form</code>, <code>multipart</code></td>
+</tr>
+<tr>
+<td>Auth</td>
+<td><code>basic</code>, <code>oauth</code>, <code>mtls</code>, <code>aws-sig4</code></td>
+</tr>
+<tr>
+<td>Pagination</td>
+<td>All pagination plugins (see #37)</td>
+</tr>
+</tbody>
+</table>
+<h3 id="14-requirement-levels">1.4 Requirement Levels</h3>
+<p>The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in <a href="https://www.ietf.org/rfc/rfc2119.txt">RFC 2119</a>.</p>
+<hr />
+<h2 id="2-plugin-categories">2. Plugin Categories</h2>
+<h3 id="21-category-summary">2.1 Category Summary</h3>
+<table>
+<thead>
+<tr>
+<th>Category</th>
+<th>Responsibility</th>
+<th>MVP Plugin</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Transport</td>
+<td>Communication channel</td>
+<td><code>http</code></td>
+</tr>
+<tr>
+<td>Protocol</td>
+<td>Request/response structure</td>
+<td><code>rest</code></td>
+</tr>
+<tr>
+<td>Serialization</td>
+<td>Data encoding/decoding</td>
+<td><code>json</code></td>
+</tr>
+<tr>
+<td>Auth</td>
+<td>Credential attachment</td>
+<td><code>none</code>, <code>api_key</code>, <code>bearer</code></td>
+</tr>
+</tbody>
+</table>
+<h3 id="22-plugin-resolution">2.2 Plugin Resolution</h3>
+<p>Plugins are resolved by name at runtime. Implementations:</p>
+<ol type="1">
+<li>MUST check built-in plugins (shipped with runtime)</li>
+<li>MUST return a plugin instance for known names</li>
+<li>MUST fail with <code>PLUGIN_NOT_FOUND</code> error if the plugin name is unknown</li>
+</ol>
+<hr />
+<h2 id="3-base-plugin-interface">3. Base Plugin Interface</h2>
+<h3 id="31-common-interface">3.1 Common Interface</h3>
+<p>All plugins MUST implement a common base interface:</p>
+<div class="sourceCode" id="cb2"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="kw">interface</span> <span class="bu">Plugin</span> {</span>
+<span id="cb2-2"><a href="#cb2-2" aria-hidden="true" tabindex="-1"></a>  <span class="co">/**</span></span>
+<span id="cb2-3"><a href="#cb2-3" aria-hidden="true" tabindex="-1"></a><span class="co">   * Unique identifier for this plugin</span></span>
+<span id="cb2-4"><a href="#cb2-4" aria-hidden="true" tabindex="-1"></a><span class="co">   */</span></span>
+<span id="cb2-5"><a href="#cb2-5" aria-hidden="true" tabindex="-1"></a>  <span class="kw">readonly</span> name<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb2-6"><a href="#cb2-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb2-7"><a href="#cb2-7" aria-hidden="true" tabindex="-1"></a>  <span class="co">/**</span></span>
+<span id="cb2-8"><a href="#cb2-8" aria-hidden="true" tabindex="-1"></a><span class="co">   * Plugin category</span></span>
+<span id="cb2-9"><a href="#cb2-9" aria-hidden="true" tabindex="-1"></a><span class="co">   */</span></span>
+<span id="cb2-10"><a href="#cb2-10" aria-hidden="true" tabindex="-1"></a>  <span class="kw">readonly</span> category<span class="op">:</span> PluginCategory<span class="op">;</span></span>
+<span id="cb2-11"><a href="#cb2-11" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb2-12"><a href="#cb2-12" aria-hidden="true" tabindex="-1"></a>  <span class="co">/**</span></span>
+<span id="cb2-13"><a href="#cb2-13" aria-hidden="true" tabindex="-1"></a><span class="co">   * Human-readable description</span></span>
+<span id="cb2-14"><a href="#cb2-14" aria-hidden="true" tabindex="-1"></a><span class="co">   */</span></span>
+<span id="cb2-15"><a href="#cb2-15" aria-hidden="true" tabindex="-1"></a>  <span class="kw">readonly</span> description<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb2-16"><a href="#cb2-16" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb2-17"><a href="#cb2-17" aria-hidden="true" tabindex="-1"></a>  <span class="co">/**</span></span>
+<span id="cb2-18"><a href="#cb2-18" aria-hidden="true" tabindex="-1"></a><span class="co">   * Semantic version of the plugin</span></span>
+<span id="cb2-19"><a href="#cb2-19" aria-hidden="true" tabindex="-1"></a><span class="co">   */</span></span>
+<span id="cb2-20"><a href="#cb2-20" aria-hidden="true" tabindex="-1"></a>  <span class="kw">readonly</span> version<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb2-21"><a href="#cb2-21" aria-hidden="true" tabindex="-1"></a>}</span>
+<span id="cb2-22"><a href="#cb2-22" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb2-23"><a href="#cb2-23" aria-hidden="true" tabindex="-1"></a><span class="kw">type</span> PluginCategory <span class="op">=</span> <span class="st">&#39;transport&#39;</span> <span class="op">|</span> <span class="st">&#39;protocol&#39;</span> <span class="op">|</span> <span class="st">&#39;serialization&#39;</span> <span class="op">|</span> <span class="st">&#39;auth&#39;</span><span class="op">;</span></span></code></pre></div>
+<h3 id="32-plugin-lifecycle">3.2 Plugin Lifecycle</h3>
+<p>Plugins are stateless singletons. The runtime:</p>
+<ol type="1">
+<li>Resolves plugins by name at adapter load time</li>
+<li>Validates plugin compatibility</li>
+<li>Composes plugins into a request pipeline</li>
+<li>Invokes pipeline for each operation</li>
+</ol>
+<p>Plugins MUST NOT maintain request-specific state between calls.</p>
+<hr />
+<h2 id="4-transport-plugin-interface">4. Transport Plugin Interface</h2>
+<h3 id="41-purpose">4.1 Purpose</h3>
+<p>Transport plugins handle the underlying communication channel between the runtime and target API.</p>
+<h3 id="42-interface">4.2 Interface</h3>
+<div class="sourceCode" id="cb3"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb3-1"><a href="#cb3-1" aria-hidden="true" tabindex="-1"></a><span class="kw">interface</span> TransportPlugin <span class="kw">extends</span> <span class="bu">Plugin</span> {</span>
+<span id="cb3-2"><a href="#cb3-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">readonly</span> category<span class="op">:</span> <span class="st">&#39;transport&#39;</span><span class="op">;</span></span>
+<span id="cb3-3"><a href="#cb3-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb3-4"><a href="#cb3-4" aria-hidden="true" tabindex="-1"></a>  <span class="co">/**</span></span>
+<span id="cb3-5"><a href="#cb3-5" aria-hidden="true" tabindex="-1"></a><span class="co">   * Send a request and receive a response</span></span>
+<span id="cb3-6"><a href="#cb3-6" aria-hidden="true" tabindex="-1"></a><span class="co">   *</span></span>
+<span id="cb3-7"><a href="#cb3-7" aria-hidden="true" tabindex="-1"></a><span class="co">   * </span><span class="an">@param</span><span class="co"> </span><span class="cv">request</span><span class="co"> - The prepared request</span></span>
+<span id="cb3-8"><a href="#cb3-8" aria-hidden="true" tabindex="-1"></a><span class="co">   * </span><span class="an">@param</span><span class="co"> </span><span class="cv">options</span><span class="co"> - Transport-specific options</span></span>
+<span id="cb3-9"><a href="#cb3-9" aria-hidden="true" tabindex="-1"></a><span class="co">   * </span><span class="an">@returns</span><span class="co"> The raw response</span></span>
+<span id="cb3-10"><a href="#cb3-10" aria-hidden="true" tabindex="-1"></a><span class="co">   */</span></span>
+<span id="cb3-11"><a href="#cb3-11" aria-hidden="true" tabindex="-1"></a>  <span class="fu">send</span>(request<span class="op">:</span> TransportRequest<span class="op">,</span> options<span class="op">:</span> TransportOptions)<span class="op">:</span> <span class="bu">Promise</span><span class="op">&lt;</span>TransportResponse<span class="op">&gt;;</span></span>
+<span id="cb3-12"><a href="#cb3-12" aria-hidden="true" tabindex="-1"></a>}</span>
+<span id="cb3-13"><a href="#cb3-13" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb3-14"><a href="#cb3-14" aria-hidden="true" tabindex="-1"></a><span class="kw">interface</span> TransportRequest {</span>
+<span id="cb3-15"><a href="#cb3-15" aria-hidden="true" tabindex="-1"></a>  <span class="co">/**</span></span>
+<span id="cb3-16"><a href="#cb3-16" aria-hidden="true" tabindex="-1"></a><span class="co">   * Full URL including query parameters</span></span>
+<span id="cb3-17"><a href="#cb3-17" aria-hidden="true" tabindex="-1"></a><span class="co">   */</span></span>
+<span id="cb3-18"><a href="#cb3-18" aria-hidden="true" tabindex="-1"></a>  url<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb3-19"><a href="#cb3-19" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb3-20"><a href="#cb3-20" aria-hidden="true" tabindex="-1"></a>  <span class="co">/**</span></span>
+<span id="cb3-21"><a href="#cb3-21" aria-hidden="true" tabindex="-1"></a><span class="co">   * HTTP method (for HTTP-based transports)</span></span>
+<span id="cb3-22"><a href="#cb3-22" aria-hidden="true" tabindex="-1"></a><span class="co">   */</span></span>
+<span id="cb3-23"><a href="#cb3-23" aria-hidden="true" tabindex="-1"></a>  method<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb3-24"><a href="#cb3-24" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb3-25"><a href="#cb3-25" aria-hidden="true" tabindex="-1"></a>  <span class="co">/**</span></span>
+<span id="cb3-26"><a href="#cb3-26" aria-hidden="true" tabindex="-1"></a><span class="co">   * Request headers</span></span>
+<span id="cb3-27"><a href="#cb3-27" aria-hidden="true" tabindex="-1"></a><span class="co">   */</span></span>
+<span id="cb3-28"><a href="#cb3-28" aria-hidden="true" tabindex="-1"></a>  headers<span class="op">:</span> <span class="bu">Record</span><span class="op">&lt;</span><span class="dt">string</span><span class="op">,</span> <span class="dt">string</span><span class="op">&gt;;</span></span>
+<span id="cb3-29"><a href="#cb3-29" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb3-30"><a href="#cb3-30" aria-hidden="true" tabindex="-1"></a>  <span class="co">/**</span></span>
+<span id="cb3-31"><a href="#cb3-31" aria-hidden="true" tabindex="-1"></a><span class="co">   * Serialized request body (may be undefined)</span></span>
+<span id="cb3-32"><a href="#cb3-32" aria-hidden="true" tabindex="-1"></a><span class="co">   */</span></span>
+<span id="cb3-33"><a href="#cb3-33" aria-hidden="true" tabindex="-1"></a>  body<span class="op">?:</span> <span class="dt">string</span> <span class="op">|</span> <span class="bu">Buffer</span><span class="op">;</span></span>
+<span id="cb3-34"><a href="#cb3-34" aria-hidden="true" tabindex="-1"></a>}</span>
+<span id="cb3-35"><a href="#cb3-35" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb3-36"><a href="#cb3-36" aria-hidden="true" tabindex="-1"></a><span class="kw">interface</span> TransportOptions {</span>
+<span id="cb3-37"><a href="#cb3-37" aria-hidden="true" tabindex="-1"></a>  <span class="co">/**</span></span>
+<span id="cb3-38"><a href="#cb3-38" aria-hidden="true" tabindex="-1"></a><span class="co">   * Request timeout in milliseconds</span></span>
+<span id="cb3-39"><a href="#cb3-39" aria-hidden="true" tabindex="-1"></a><span class="co">   */</span></span>
+<span id="cb3-40"><a href="#cb3-40" aria-hidden="true" tabindex="-1"></a>  timeout<span class="op">?:</span> <span class="dt">number</span><span class="op">;</span></span>
+<span id="cb3-41"><a href="#cb3-41" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb3-42"><a href="#cb3-42" aria-hidden="true" tabindex="-1"></a>  <span class="co">/**</span></span>
+<span id="cb3-43"><a href="#cb3-43" aria-hidden="true" tabindex="-1"></a><span class="co">   * Number of retry attempts</span></span>
+<span id="cb3-44"><a href="#cb3-44" aria-hidden="true" tabindex="-1"></a><span class="co">   */</span></span>
+<span id="cb3-45"><a href="#cb3-45" aria-hidden="true" tabindex="-1"></a>  retries<span class="op">?:</span> <span class="dt">number</span><span class="op">;</span></span>
+<span id="cb3-46"><a href="#cb3-46" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb3-47"><a href="#cb3-47" aria-hidden="true" tabindex="-1"></a>  <span class="co">/**</span></span>
+<span id="cb3-48"><a href="#cb3-48" aria-hidden="true" tabindex="-1"></a><span class="co">   * Base delay between retries in milliseconds</span></span>
+<span id="cb3-49"><a href="#cb3-49" aria-hidden="true" tabindex="-1"></a><span class="co">   */</span></span>
+<span id="cb3-50"><a href="#cb3-50" aria-hidden="true" tabindex="-1"></a>  retryDelay<span class="op">?:</span> <span class="dt">number</span><span class="op">;</span></span>
+<span id="cb3-51"><a href="#cb3-51" aria-hidden="true" tabindex="-1"></a>}</span>
+<span id="cb3-52"><a href="#cb3-52" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb3-53"><a href="#cb3-53" aria-hidden="true" tabindex="-1"></a><span class="kw">interface</span> TransportResponse {</span>
+<span id="cb3-54"><a href="#cb3-54" aria-hidden="true" tabindex="-1"></a>  <span class="co">/**</span></span>
+<span id="cb3-55"><a href="#cb3-55" aria-hidden="true" tabindex="-1"></a><span class="co">   * HTTP status code</span></span>
+<span id="cb3-56"><a href="#cb3-56" aria-hidden="true" tabindex="-1"></a><span class="co">   */</span></span>
+<span id="cb3-57"><a href="#cb3-57" aria-hidden="true" tabindex="-1"></a>  status<span class="op">:</span> <span class="dt">number</span><span class="op">;</span></span>
+<span id="cb3-58"><a href="#cb3-58" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb3-59"><a href="#cb3-59" aria-hidden="true" tabindex="-1"></a>  <span class="co">/**</span></span>
+<span id="cb3-60"><a href="#cb3-60" aria-hidden="true" tabindex="-1"></a><span class="co">   * Status text (e.g., &quot;OK&quot;, &quot;Not Found&quot;)</span></span>
+<span id="cb3-61"><a href="#cb3-61" aria-hidden="true" tabindex="-1"></a><span class="co">   */</span></span>
+<span id="cb3-62"><a href="#cb3-62" aria-hidden="true" tabindex="-1"></a>  statusText<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb3-63"><a href="#cb3-63" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb3-64"><a href="#cb3-64" aria-hidden="true" tabindex="-1"></a>  <span class="co">/**</span></span>
+<span id="cb3-65"><a href="#cb3-65" aria-hidden="true" tabindex="-1"></a><span class="co">   * Response headers</span></span>
+<span id="cb3-66"><a href="#cb3-66" aria-hidden="true" tabindex="-1"></a><span class="co">   */</span></span>
+<span id="cb3-67"><a href="#cb3-67" aria-hidden="true" tabindex="-1"></a>  headers<span class="op">:</span> <span class="bu">Record</span><span class="op">&lt;</span><span class="dt">string</span><span class="op">,</span> <span class="dt">string</span><span class="op">&gt;;</span></span>
+<span id="cb3-68"><a href="#cb3-68" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb3-69"><a href="#cb3-69" aria-hidden="true" tabindex="-1"></a>  <span class="co">/**</span></span>
+<span id="cb3-70"><a href="#cb3-70" aria-hidden="true" tabindex="-1"></a><span class="co">   * Raw response body</span></span>
+<span id="cb3-71"><a href="#cb3-71" aria-hidden="true" tabindex="-1"></a><span class="co">   */</span></span>
+<span id="cb3-72"><a href="#cb3-72" aria-hidden="true" tabindex="-1"></a>  body<span class="op">:</span> <span class="dt">string</span> <span class="op">|</span> <span class="bu">Buffer</span><span class="op">;</span></span>
+<span id="cb3-73"><a href="#cb3-73" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<hr />
+<h2 id="5-protocol-plugin-interface">5. Protocol Plugin Interface</h2>
+<h3 id="51-purpose">5.1 Purpose</h3>
+<p>Protocol plugins translate MCP-AQL operation definitions into protocol-specific requests and parse responses into a standard format.</p>
+<h3 id="52-interface">5.2 Interface</h3>
+<div class="sourceCode" id="cb4"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb4-1"><a href="#cb4-1" aria-hidden="true" tabindex="-1"></a><span class="kw">interface</span> ProtocolPlugin <span class="kw">extends</span> <span class="bu">Plugin</span> {</span>
+<span id="cb4-2"><a href="#cb4-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">readonly</span> category<span class="op">:</span> <span class="st">&#39;protocol&#39;</span><span class="op">;</span></span>
+<span id="cb4-3"><a href="#cb4-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb4-4"><a href="#cb4-4" aria-hidden="true" tabindex="-1"></a>  <span class="co">/**</span></span>
+<span id="cb4-5"><a href="#cb4-5" aria-hidden="true" tabindex="-1"></a><span class="co">   * Build a transport request from an operation definition</span></span>
+<span id="cb4-6"><a href="#cb4-6" aria-hidden="true" tabindex="-1"></a><span class="co">   *</span></span>
+<span id="cb4-7"><a href="#cb4-7" aria-hidden="true" tabindex="-1"></a><span class="co">   * </span><span class="an">@param</span><span class="co"> </span><span class="cv">operation</span><span class="co"> - The operation to execute</span></span>
+<span id="cb4-8"><a href="#cb4-8" aria-hidden="true" tabindex="-1"></a><span class="co">   * </span><span class="an">@param</span><span class="co"> </span><span class="cv">params</span><span class="co"> - Resolved parameter values</span></span>
+<span id="cb4-9"><a href="#cb4-9" aria-hidden="true" tabindex="-1"></a><span class="co">   * </span><span class="an">@param</span><span class="co"> </span><span class="cv">config</span><span class="co"> - Target configuration from adapter</span></span>
+<span id="cb4-10"><a href="#cb4-10" aria-hidden="true" tabindex="-1"></a><span class="co">   * </span><span class="an">@returns</span><span class="co"> A request ready for the transport plugin</span></span>
+<span id="cb4-11"><a href="#cb4-11" aria-hidden="true" tabindex="-1"></a><span class="co">   */</span></span>
+<span id="cb4-12"><a href="#cb4-12" aria-hidden="true" tabindex="-1"></a>  <span class="fu">buildRequest</span>(</span>
+<span id="cb4-13"><a href="#cb4-13" aria-hidden="true" tabindex="-1"></a>    operation<span class="op">:</span> OperationDefinition<span class="op">,</span></span>
+<span id="cb4-14"><a href="#cb4-14" aria-hidden="true" tabindex="-1"></a>    params<span class="op">:</span> <span class="bu">Record</span><span class="op">&lt;</span><span class="dt">string</span><span class="op">,</span> <span class="dt">unknown</span><span class="op">&gt;,</span></span>
+<span id="cb4-15"><a href="#cb4-15" aria-hidden="true" tabindex="-1"></a>    config<span class="op">:</span> TargetConfig</span>
+<span id="cb4-16"><a href="#cb4-16" aria-hidden="true" tabindex="-1"></a>  )<span class="op">:</span> TransportRequest<span class="op">;</span></span>
+<span id="cb4-17"><a href="#cb4-17" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb4-18"><a href="#cb4-18" aria-hidden="true" tabindex="-1"></a>  <span class="co">/**</span></span>
+<span id="cb4-19"><a href="#cb4-19" aria-hidden="true" tabindex="-1"></a><span class="co">   * Parse a transport response into standard format</span></span>
+<span id="cb4-20"><a href="#cb4-20" aria-hidden="true" tabindex="-1"></a><span class="co">   *</span></span>
+<span id="cb4-21"><a href="#cb4-21" aria-hidden="true" tabindex="-1"></a><span class="co">   * </span><span class="an">@param</span><span class="co"> </span><span class="cv">response</span><span class="co"> - Raw response from transport</span></span>
+<span id="cb4-22"><a href="#cb4-22" aria-hidden="true" tabindex="-1"></a><span class="co">   * </span><span class="an">@param</span><span class="co"> </span><span class="cv">operation</span><span class="co"> - The operation that was executed</span></span>
+<span id="cb4-23"><a href="#cb4-23" aria-hidden="true" tabindex="-1"></a><span class="co">   * </span><span class="an">@returns</span><span class="co"> Parsed response data</span></span>
+<span id="cb4-24"><a href="#cb4-24" aria-hidden="true" tabindex="-1"></a><span class="co">   */</span></span>
+<span id="cb4-25"><a href="#cb4-25" aria-hidden="true" tabindex="-1"></a>  <span class="fu">parseResponse</span>(</span>
+<span id="cb4-26"><a href="#cb4-26" aria-hidden="true" tabindex="-1"></a>    response<span class="op">:</span> TransportResponse<span class="op">,</span></span>
+<span id="cb4-27"><a href="#cb4-27" aria-hidden="true" tabindex="-1"></a>    operation<span class="op">:</span> OperationDefinition</span>
+<span id="cb4-28"><a href="#cb4-28" aria-hidden="true" tabindex="-1"></a>  )<span class="op">:</span> ParsedResponse<span class="op">;</span></span>
+<span id="cb4-29"><a href="#cb4-29" aria-hidden="true" tabindex="-1"></a>}</span>
+<span id="cb4-30"><a href="#cb4-30" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb4-31"><a href="#cb4-31" aria-hidden="true" tabindex="-1"></a><span class="kw">interface</span> OperationDefinition {</span>
+<span id="cb4-32"><a href="#cb4-32" aria-hidden="true" tabindex="-1"></a>  name<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb4-33"><a href="#cb4-33" aria-hidden="true" tabindex="-1"></a>  maps_to<span class="op">:</span> <span class="dt">string</span><span class="op">;</span>          <span class="co">// e.g., &quot;GET /repos/{owner}/{repo}&quot;</span></span>
+<span id="cb4-34"><a href="#cb4-34" aria-hidden="true" tabindex="-1"></a>  params<span class="op">?:</span> <span class="bu">Record</span><span class="op">&lt;</span><span class="dt">string</span><span class="op">,</span> ParamDefinition<span class="op">&gt;;</span></span>
+<span id="cb4-35"><a href="#cb4-35" aria-hidden="true" tabindex="-1"></a>}</span>
+<span id="cb4-36"><a href="#cb4-36" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb4-37"><a href="#cb4-37" aria-hidden="true" tabindex="-1"></a><span class="kw">interface</span> TargetConfig {</span>
+<span id="cb4-38"><a href="#cb4-38" aria-hidden="true" tabindex="-1"></a>  base_url<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb4-39"><a href="#cb4-39" aria-hidden="true" tabindex="-1"></a>  transport<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb4-40"><a href="#cb4-40" aria-hidden="true" tabindex="-1"></a>  protocol<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb4-41"><a href="#cb4-41" aria-hidden="true" tabindex="-1"></a>  serialization<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb4-42"><a href="#cb4-42" aria-hidden="true" tabindex="-1"></a>}</span>
+<span id="cb4-43"><a href="#cb4-43" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb4-44"><a href="#cb4-44" aria-hidden="true" tabindex="-1"></a><span class="kw">interface</span> ParsedResponse {</span>
+<span id="cb4-45"><a href="#cb4-45" aria-hidden="true" tabindex="-1"></a>  <span class="co">/**</span></span>
+<span id="cb4-46"><a href="#cb4-46" aria-hidden="true" tabindex="-1"></a><span class="co">   * Whether the request was successful (2xx status)</span></span>
+<span id="cb4-47"><a href="#cb4-47" aria-hidden="true" tabindex="-1"></a><span class="co">   */</span></span>
+<span id="cb4-48"><a href="#cb4-48" aria-hidden="true" tabindex="-1"></a>  ok<span class="op">:</span> <span class="dt">boolean</span><span class="op">;</span></span>
+<span id="cb4-49"><a href="#cb4-49" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb4-50"><a href="#cb4-50" aria-hidden="true" tabindex="-1"></a>  <span class="co">/**</span></span>
+<span id="cb4-51"><a href="#cb4-51" aria-hidden="true" tabindex="-1"></a><span class="co">   * HTTP status code</span></span>
+<span id="cb4-52"><a href="#cb4-52" aria-hidden="true" tabindex="-1"></a><span class="co">   */</span></span>
+<span id="cb4-53"><a href="#cb4-53" aria-hidden="true" tabindex="-1"></a>  status<span class="op">:</span> <span class="dt">number</span><span class="op">;</span></span>
+<span id="cb4-54"><a href="#cb4-54" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb4-55"><a href="#cb4-55" aria-hidden="true" tabindex="-1"></a>  <span class="co">/**</span></span>
+<span id="cb4-56"><a href="#cb4-56" aria-hidden="true" tabindex="-1"></a><span class="co">   * Deserialized response data</span></span>
+<span id="cb4-57"><a href="#cb4-57" aria-hidden="true" tabindex="-1"></a><span class="co">   */</span></span>
+<span id="cb4-58"><a href="#cb4-58" aria-hidden="true" tabindex="-1"></a>  data<span class="op">:</span> <span class="dt">unknown</span><span class="op">;</span></span>
+<span id="cb4-59"><a href="#cb4-59" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb4-60"><a href="#cb4-60" aria-hidden="true" tabindex="-1"></a>  <span class="co">/**</span></span>
+<span id="cb4-61"><a href="#cb4-61" aria-hidden="true" tabindex="-1"></a><span class="co">   * Error information (if not ok)</span></span>
+<span id="cb4-62"><a href="#cb4-62" aria-hidden="true" tabindex="-1"></a><span class="co">   */</span></span>
+<span id="cb4-63"><a href="#cb4-63" aria-hidden="true" tabindex="-1"></a>  error<span class="op">?:</span> {</span>
+<span id="cb4-64"><a href="#cb4-64" aria-hidden="true" tabindex="-1"></a>    message<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb4-65"><a href="#cb4-65" aria-hidden="true" tabindex="-1"></a>    code<span class="op">?:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb4-66"><a href="#cb4-66" aria-hidden="true" tabindex="-1"></a>  }<span class="op">;</span></span>
+<span id="cb4-67"><a href="#cb4-67" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<hr />
+<h2 id="6-serialization-plugin-interface">6. Serialization Plugin Interface</h2>
+<h3 id="61-purpose">6.1 Purpose</h3>
+<p>Serialization plugins handle encoding request bodies and decoding response bodies.</p>
+<h3 id="62-interface">6.2 Interface</h3>
+<div class="sourceCode" id="cb5"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb5-1"><a href="#cb5-1" aria-hidden="true" tabindex="-1"></a><span class="kw">interface</span> SerializationPlugin <span class="kw">extends</span> <span class="bu">Plugin</span> {</span>
+<span id="cb5-2"><a href="#cb5-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">readonly</span> category<span class="op">:</span> <span class="st">&#39;serialization&#39;</span><span class="op">;</span></span>
+<span id="cb5-3"><a href="#cb5-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb5-4"><a href="#cb5-4" aria-hidden="true" tabindex="-1"></a>  <span class="co">/**</span></span>
+<span id="cb5-5"><a href="#cb5-5" aria-hidden="true" tabindex="-1"></a><span class="co">   * Content-Type header value for this format</span></span>
+<span id="cb5-6"><a href="#cb5-6" aria-hidden="true" tabindex="-1"></a><span class="co">   */</span></span>
+<span id="cb5-7"><a href="#cb5-7" aria-hidden="true" tabindex="-1"></a>  <span class="kw">readonly</span> contentType<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb5-8"><a href="#cb5-8" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb5-9"><a href="#cb5-9" aria-hidden="true" tabindex="-1"></a>  <span class="co">/**</span></span>
+<span id="cb5-10"><a href="#cb5-10" aria-hidden="true" tabindex="-1"></a><span class="co">   * Serialize data to string/buffer</span></span>
+<span id="cb5-11"><a href="#cb5-11" aria-hidden="true" tabindex="-1"></a><span class="co">   *</span></span>
+<span id="cb5-12"><a href="#cb5-12" aria-hidden="true" tabindex="-1"></a><span class="co">   * </span><span class="an">@param</span><span class="co"> </span><span class="cv">data</span><span class="co"> - Data to serialize</span></span>
+<span id="cb5-13"><a href="#cb5-13" aria-hidden="true" tabindex="-1"></a><span class="co">   * </span><span class="an">@returns</span><span class="co"> Serialized string or buffer</span></span>
+<span id="cb5-14"><a href="#cb5-14" aria-hidden="true" tabindex="-1"></a><span class="co">   */</span></span>
+<span id="cb5-15"><a href="#cb5-15" aria-hidden="true" tabindex="-1"></a>  <span class="fu">serialize</span>(data<span class="op">:</span> <span class="dt">unknown</span>)<span class="op">:</span> <span class="dt">string</span> <span class="op">|</span> <span class="bu">Buffer</span><span class="op">;</span></span>
+<span id="cb5-16"><a href="#cb5-16" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb5-17"><a href="#cb5-17" aria-hidden="true" tabindex="-1"></a>  <span class="co">/**</span></span>
+<span id="cb5-18"><a href="#cb5-18" aria-hidden="true" tabindex="-1"></a><span class="co">   * Deserialize string/buffer to data</span></span>
+<span id="cb5-19"><a href="#cb5-19" aria-hidden="true" tabindex="-1"></a><span class="co">   *</span></span>
+<span id="cb5-20"><a href="#cb5-20" aria-hidden="true" tabindex="-1"></a><span class="co">   * </span><span class="an">@param</span><span class="co"> </span><span class="cv">raw</span><span class="co"> - Raw response body</span></span>
+<span id="cb5-21"><a href="#cb5-21" aria-hidden="true" tabindex="-1"></a><span class="co">   * </span><span class="an">@returns</span><span class="co"> Deserialized data</span></span>
+<span id="cb5-22"><a href="#cb5-22" aria-hidden="true" tabindex="-1"></a><span class="co">   */</span></span>
+<span id="cb5-23"><a href="#cb5-23" aria-hidden="true" tabindex="-1"></a>  <span class="fu">deserialize</span>(raw<span class="op">:</span> <span class="dt">string</span> <span class="op">|</span> <span class="bu">Buffer</span>)<span class="op">:</span> <span class="dt">unknown</span><span class="op">;</span></span>
+<span id="cb5-24"><a href="#cb5-24" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<hr />
+<h2 id="7-authentication-plugin-interface">7. Authentication Plugin Interface</h2>
+<h3 id="71-purpose">7.1 Purpose</h3>
+<p>Authentication plugins attach credentials to outgoing requests.</p>
+<h3 id="72-interface">7.2 Interface</h3>
+<div class="sourceCode" id="cb6"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb6-1"><a href="#cb6-1" aria-hidden="true" tabindex="-1"></a><span class="kw">interface</span> AuthPlugin <span class="kw">extends</span> <span class="bu">Plugin</span> {</span>
+<span id="cb6-2"><a href="#cb6-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">readonly</span> category<span class="op">:</span> <span class="st">&#39;auth&#39;</span><span class="op">;</span></span>
+<span id="cb6-3"><a href="#cb6-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb6-4"><a href="#cb6-4" aria-hidden="true" tabindex="-1"></a>  <span class="co">/**</span></span>
+<span id="cb6-5"><a href="#cb6-5" aria-hidden="true" tabindex="-1"></a><span class="co">   * Attach authentication to a request</span></span>
+<span id="cb6-6"><a href="#cb6-6" aria-hidden="true" tabindex="-1"></a><span class="co">   *</span></span>
+<span id="cb6-7"><a href="#cb6-7" aria-hidden="true" tabindex="-1"></a><span class="co">   * </span><span class="an">@param</span><span class="co"> </span><span class="cv">request</span><span class="co"> - Request to modify</span></span>
+<span id="cb6-8"><a href="#cb6-8" aria-hidden="true" tabindex="-1"></a><span class="co">   * </span><span class="an">@param</span><span class="co"> </span><span class="cv">config</span><span class="co"> - Auth configuration from adapter</span></span>
+<span id="cb6-9"><a href="#cb6-9" aria-hidden="true" tabindex="-1"></a><span class="co">   * </span><span class="an">@param</span><span class="co"> </span><span class="cv">context</span><span class="co"> - Runtime context for credential resolution</span></span>
+<span id="cb6-10"><a href="#cb6-10" aria-hidden="true" tabindex="-1"></a><span class="co">   * </span><span class="an">@returns</span><span class="co"> Modified request with auth attached</span></span>
+<span id="cb6-11"><a href="#cb6-11" aria-hidden="true" tabindex="-1"></a><span class="co">   */</span></span>
+<span id="cb6-12"><a href="#cb6-12" aria-hidden="true" tabindex="-1"></a>  <span class="fu">authenticate</span>(</span>
+<span id="cb6-13"><a href="#cb6-13" aria-hidden="true" tabindex="-1"></a>    request<span class="op">:</span> TransportRequest<span class="op">,</span></span>
+<span id="cb6-14"><a href="#cb6-14" aria-hidden="true" tabindex="-1"></a>    config<span class="op">:</span> AuthConfig<span class="op">,</span></span>
+<span id="cb6-15"><a href="#cb6-15" aria-hidden="true" tabindex="-1"></a>    context<span class="op">:</span> AuthContext</span>
+<span id="cb6-16"><a href="#cb6-16" aria-hidden="true" tabindex="-1"></a>  )<span class="op">:</span> TransportRequest<span class="op">;</span></span>
+<span id="cb6-17"><a href="#cb6-17" aria-hidden="true" tabindex="-1"></a>}</span>
+<span id="cb6-18"><a href="#cb6-18" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb6-19"><a href="#cb6-19" aria-hidden="true" tabindex="-1"></a><span class="kw">interface</span> AuthConfig {</span>
+<span id="cb6-20"><a href="#cb6-20" aria-hidden="true" tabindex="-1"></a>  type<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb6-21"><a href="#cb6-21" aria-hidden="true" tabindex="-1"></a>  <span class="co">// Type-specific fields</span></span>
+<span id="cb6-22"><a href="#cb6-22" aria-hidden="true" tabindex="-1"></a>  token_env<span class="op">?:</span> <span class="dt">string</span><span class="op">;</span>      <span class="co">// For bearer</span></span>
+<span id="cb6-23"><a href="#cb6-23" aria-hidden="true" tabindex="-1"></a>  header_name<span class="op">?:</span> <span class="dt">string</span><span class="op">;</span>    <span class="co">// For api_key</span></span>
+<span id="cb6-24"><a href="#cb6-24" aria-hidden="true" tabindex="-1"></a>  key_env<span class="op">?:</span> <span class="dt">string</span><span class="op">;</span>        <span class="co">// For api_key</span></span>
+<span id="cb6-25"><a href="#cb6-25" aria-hidden="true" tabindex="-1"></a>}</span>
+<span id="cb6-26"><a href="#cb6-26" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb6-27"><a href="#cb6-27" aria-hidden="true" tabindex="-1"></a><span class="kw">interface</span> AuthContext {</span>
+<span id="cb6-28"><a href="#cb6-28" aria-hidden="true" tabindex="-1"></a>  <span class="co">/**</span></span>
+<span id="cb6-29"><a href="#cb6-29" aria-hidden="true" tabindex="-1"></a><span class="co">   * Resolve an environment variable</span></span>
+<span id="cb6-30"><a href="#cb6-30" aria-hidden="true" tabindex="-1"></a><span class="co">   */</span></span>
+<span id="cb6-31"><a href="#cb6-31" aria-hidden="true" tabindex="-1"></a>  <span class="fu">getEnv</span>(name<span class="op">:</span> <span class="dt">string</span>)<span class="op">:</span> <span class="dt">string</span> <span class="op">|</span> <span class="dt">undefined</span><span class="op">;</span></span>
+<span id="cb6-32"><a href="#cb6-32" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<hr />
+<h2 id="8-error-code-contracts">8. Error Code Contracts</h2>
+<h3 id="81-error-code-convention">8.1 Error Code Convention</h3>
+<p>Plugin errors MUST use a namespaced code format:</p>
+<pre><code>{CATEGORY}_{ERROR_TYPE}</code></pre>
+<p>Examples:</p>
+<ul>
+<li><code>TRANSPORT_TIMEOUT</code></li>
+<li><code>AUTH_CREDENTIAL_MISSING</code></li>
+<li><code>SERIALIZATION_PARSE_ERROR</code></li>
+<li><code>PROTOCOL_INVALID_MAPPING</code></li>
+</ul>
+<h3 id="82-error-propagation">8.2 Error Propagation</h3>
+<p>Errors thrown by plugins MUST include:</p>
+<div class="sourceCode" id="cb8"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb8-1"><a href="#cb8-1" aria-hidden="true" tabindex="-1"></a><span class="kw">interface</span> PluginError <span class="kw">extends</span> <span class="bu">Error</span> {</span>
+<span id="cb8-2"><a href="#cb8-2" aria-hidden="true" tabindex="-1"></a>  code<span class="op">:</span> <span class="dt">string</span><span class="op">;</span>           <span class="co">// Error code</span></span>
+<span id="cb8-3"><a href="#cb8-3" aria-hidden="true" tabindex="-1"></a>  plugin<span class="op">:</span> <span class="dt">string</span><span class="op">;</span>         <span class="co">// Plugin name</span></span>
+<span id="cb8-4"><a href="#cb8-4" aria-hidden="true" tabindex="-1"></a>  category<span class="op">:</span> <span class="dt">string</span><span class="op">;</span>       <span class="co">// Plugin category</span></span>
+<span id="cb8-5"><a href="#cb8-5" aria-hidden="true" tabindex="-1"></a>  cause<span class="op">?:</span> <span class="bu">Error</span><span class="op">;</span>          <span class="co">// Underlying error</span></span>
+<span id="cb8-6"><a href="#cb8-6" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<h3 id="83-mvp-error-codes">8.3 MVP Error Codes</h3>
+<table>
+<thead>
+<tr>
+<th>Code</th>
+<th>Category</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>PLUGIN_NOT_FOUND</code></td>
+<td>Runtime</td>
+<td>Requested plugin does not exist</td>
+</tr>
+<tr>
+<td><code>TRANSPORT_DNS_ERROR</code></td>
+<td>Transport</td>
+<td>DNS resolution failed</td>
+</tr>
+<tr>
+<td><code>TRANSPORT_CONNECTION_REFUSED</code></td>
+<td>Transport</td>
+<td>Connection refused</td>
+</tr>
+<tr>
+<td><code>TRANSPORT_TIMEOUT</code></td>
+<td>Transport</td>
+<td>Request timed out</td>
+</tr>
+<tr>
+<td><code>TRANSPORT_TLS_ERROR</code></td>
+<td>Transport</td>
+<td>TLS/SSL error</td>
+</tr>
+<tr>
+<td><code>TRANSPORT_NETWORK_ERROR</code></td>
+<td>Transport</td>
+<td>General network error</td>
+</tr>
+<tr>
+<td><code>PROTOCOL_INVALID_MAPPING</code></td>
+<td>Protocol</td>
+<td>Invalid maps_to format</td>
+</tr>
+<tr>
+<td><code>PROTOCOL_MISSING_PARAM</code></td>
+<td>Protocol</td>
+<td>Path parameter missing</td>
+</tr>
+<tr>
+<td><code>SERIALIZATION_CIRCULAR_REF</code></td>
+<td>Serialization</td>
+<td>Circular reference in data</td>
+</tr>
+<tr>
+<td><code>SERIALIZATION_PARSE_ERROR</code></td>
+<td>Serialization</td>
+<td>Failed to parse response</td>
+</tr>
+<tr>
+<td><code>AUTH_CONFIG_INVALID</code></td>
+<td>Auth</td>
+<td>Invalid auth configuration</td>
+</tr>
+<tr>
+<td><code>AUTH_CREDENTIAL_MISSING</code></td>
+<td>Auth</td>
+<td>Credential not found</td>
+</tr>
+</tbody>
+</table>
+<hr />
+<h2 id="references">References</h2>
+<ul>
+<li><a href="adapter/element-type.html">Adapter Element Type Specification</a></li>
+<li><a href="error-codes.html">Error Codes Specification</a></li>
+<li><a href="versions/v1.0.0-draft.html">MCP-AQL Specification</a></li>
+<li><a href="https://github.com/MCPAQL/mcpaql-adapter/blob/develop/docs/architecture/plugin-system.md">Plugin System Implementation</a> (implementation details)</li>
+<li>GitHub Issue: <a href="https://github.com/MCPAQL/spec/issues/62">#62</a></li>
+</ul>
+
+          </div>
+        </section>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div class="container">
+      <p>&copy; 2026 DollhouseMCP Inc. d/b/a Dollhouse Research. MCP-AQL public draft documentation portal.</p>
+      <div class="footer-links">
+        <a href="../docs/index.html">Docs Library</a>
+        <a href="index.html">Repo-Synced Spec</a>
+        <a href="https://github.com/MCPAQL">MCPAQL Organization</a>
+        <a href="https://dollhouseresearch.com">Dollhouse Research</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../js/search.js"></script>
+</body>
+</html>

--- a/public/spec/plugin-contracts.html
+++ b/public/spec/plugin-contracts.html
@@ -38,7 +38,7 @@
         <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
         <div class="docs-side-group">
   <h3>Core</h3>
-  <ul><li><a href="conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="error-codes.html">Structured Error Codes Specification</a></li><li><a href="introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="mcp-integration.html">MCP Integration Specification</a></li><li><a href="operations.html">MCP-AQL Operations Specification</a></li><li><a href="overview.html">MCP-AQL Protocol Overview</a></li><li><a class="current" href="plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="README.html">MCP-AQL Specification Documentation</a></li></ul>
+  <ul><li><a href="conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="error-codes.html">Structured Error Codes Specification</a></li><li><a href="introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="mcp-integration.html">MCP Integration Specification</a></li><li><a href="operations.html">MCP-AQL Operations Specification</a></li><li><a href="overview.html">MCP-AQL Protocol Overview</a></li><li><a class="current" href="plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="README.html">MCP-AQL Specification Documentation</a></li><li><a href="repo/README.html">MCP-AQL Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Versions</h3>
   <ul><li><a href="versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
@@ -56,7 +56,7 @@
   <ul><li><a href="guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
-  <ul><li><a href="process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="process/versioning.html">Versioning Strategy</a></li></ul>
+  <ul><li><a href="process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="process/versioning.html">Versioning Strategy</a></li><li><a href="repo/CHANGELOG.html">Changelog</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Architecture</h3>
   <ul><li><a href="architecture/README.html">Architecture Documentation</a></li></ul>

--- a/public/spec/process/breaking-changes.html
+++ b/public/spec/process/breaking-changes.html
@@ -1,0 +1,532 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="This document defines how breaking changes are handled in the MCP-AQL specification, including change classification, deprecation procedures, migration requirements, and communication standards.">
+  <title>MCP-AQL Spec | MCP-AQL Breaking Change Policy</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../../css/style.css">
+</head>
+<body>
+  <header>
+    <div class="container">
+      <nav>
+        <a class="logo" href="../../index.html"><span class="logo-mark"></span>MCP-AQL</a>
+        <ul class="nav-links">
+          <li><a href="../../index.html">Home</a></li>
+          <li><a href="../../docs/index.html">Docs</a></li>
+          <li><a href="../../launch-checklist.html">Launch Checklist</a></li>
+          <li><a href="../../apis/mcp-server.html">Adapter Patterns</a></li>
+        </ul>
+        <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
+          <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
+          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <span class="search-count" data-search-count></span>
+          <ul class="search-results" data-search-results hidden></ul>
+        </form>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <div class="container docs-shell">
+      <aside class="docs-side">
+        <h2>Repo-Synced Spec</h2>
+        <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
+        <div class="docs-side-group">
+  <h3>Core</h3>
+  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Versions</h3>
+  <ul><li><a href="../versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Adapter</h3>
+  <ul><li><a href="../adapter/danger-levels.html">Dangerous Operation Classification Specification</a></li><li><a href="../adapter/discovery-bundle.html">MCP Server Discovery Bundle</a></li><li><a href="../adapter/element-type.html">Adapter Element Type Specification</a></li><li><a href="../adapter/generator.html">Adapter Generator Specification</a></li><li><a href="../adapter/rate-limiting.html">Rate Limiting and Quota Management Specification</a></li><li><a href="../adapter/trust-levels.html">Trust Levels Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Security</h3>
+  <ul><li><a href="../security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="../security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="../security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Features</h3>
+  <ul><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Guides</h3>
+  <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Process</h3>
+  <ul><li><a class="current" href="breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="versioning.html">Versioning Strategy</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Architecture</h3>
+  <ul><li><a href="../architecture/README.html">Architecture Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Research</h3>
+  <ul><li><a href="../research/mcp-vs-mcpaql-vs-a2a.html">Protocol Landscape: MCP vs MCP-AQL vs A2A</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Reference</h3>
+  <ul><li><a href="../reference/README.html">Reference Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>ADRs</h3>
+  <ul><li><a href="../adr/ADR-001-crude-pattern.html">ADR-001: CRUDE Pattern (Extending CRUD with Execute)</a></li><li><a href="../adr/ADR-002-graphql-style-input.html">ADR-002: GraphQL-Style Input Objects for Updates</a></li><li><a href="../adr/ADR-003-snake-case-parameters.html">ADR-003: snake_case Parameter Convention</a></li><li><a href="../adr/ADR-004-schema-driven-operations.html">ADR-004: Schema-Driven Operation Definitions</a></li><li><a href="../adr/ADR-005-introspection-system.html">ADR-005: GraphQL-Style Introspection System</a></li><li><a href="../adr/ADR-006-discriminated-responses.html">ADR-006: Discriminated Response Format</a></li><li><a href="../adr/index.html">Architecture Decision Records</a></li><li><a href="../adr/README.html">Architecture Decision Records</a></li></ul>
+</div>
+      </aside>
+
+      <article class="docs-main">
+        <section class="hero docs-hero">
+          <div class="hero-inner">
+            <span class="status-pill">REPO-SYNCED SPEC DOC</span>
+            <h1>MCP-AQL Breaking Change Policy</h1>
+            <p class="lede">This document defines how breaking changes are handled in the MCP-AQL specification, including change classification, deprecation procedures, migration requirements, and communication standards.</p>
+            <div class="spec-meta"><span class="state-chip live">Support document</span><span class="state-chip pending">Draft</span><span class="state-chip">1.0.0-draft</span><span class="state-chip">2026-01-14</span></div>
+            <p class="spec-source">Source: <a href="https://github.com/MCPAQL/spec/blob/main/docs/process/breaking-changes.md">spec/docs/process/breaking-changes.md</a></p>
+            <div class="hero-actions">
+              <a class="btn btn-primary" href="https://github.com/MCPAQL/spec/blob/main/docs/process/breaking-changes.md">Open Source Markdown</a>
+              <a class="btn btn-secondary" href="../index.html">Browse Full Spec Reference</a>
+            </div>
+          </div>
+        </section>
+
+        <section>
+          <div class="card spec-prose">
+            <p><strong>Version:</strong> 1.0.0-draft <strong>Status:</strong> Draft <strong>Last Updated:</strong> 2026-01-14</p>
+<h2 id="abstract">Abstract</h2>
+<p>This document defines how breaking changes are handled in the MCP-AQL specification, including change classification, deprecation procedures, migration requirements, and communication standards.</p>
+<h2 id="table-of-contents">Table of Contents</h2>
+<ol type="1">
+<li><a href="#1-introduction">Introduction</a></li>
+<li><a href="#2-change-classification">Change Classification</a></li>
+<li><a href="#3-deprecation-policy">Deprecation Policy</a></li>
+<li><a href="#4-migration-guides">Migration Guides</a></li>
+<li><a href="#5-communication">Communication</a></li>
+</ol>
+<hr />
+<h2 id="1-introduction">1. Introduction</h2>
+<h3 id="11-what-is-a-breaking-change">1.1 What is a Breaking Change?</h3>
+<p>A breaking change is any modification to the MCP-AQL specification that could cause existing conforming implementations to:</p>
+<ul>
+<li>Fail to compile or build</li>
+<li>Produce errors at runtime</li>
+<li>Behave differently than documented</li>
+<li>Become non-conformant with the specification</li>
+</ul>
+<h3 id="12-why-this-policy-exists">1.2 Why This Policy Exists</h3>
+<p>MCP-AQL serves as a foundation for interoperability between AI models and MCP servers. Stability is critical because:</p>
+<ul>
+<li><strong>Adapter Authors</strong> depend on stable interfaces to build reliable implementations</li>
+<li><strong>AI Models</strong> rely on consistent behavior for effective operation discovery</li>
+<li><strong>End Users</strong> expect existing integrations to continue working after updates</li>
+</ul>
+<p>This policy ensures that necessary evolution of the specification happens in a predictable, well-communicated manner that minimizes disruption to the ecosystem.</p>
+<h3 id="13-scope">1.3 Scope</h3>
+<p>This policy applies to:</p>
+<ul>
+<li>The core MCP-AQL specification</li>
+<li>Required operations (currently only <code>introspect</code>)</li>
+<li>CRUDE endpoint definitions</li>
+<li>Protocol types and response structures</li>
+<li>Introspection response formats</li>
+</ul>
+<hr />
+<h2 id="2-change-classification">2. Change Classification</h2>
+<h3 id="21-breaking-changes-major-version-bump">2.1 Breaking Changes (Major Version Bump)</h3>
+<p>Breaking changes require a major version increment (e.g., 1.x.x to 2.0.0) and trigger the full deprecation and migration process.</p>
+<p><strong>Examples of Breaking Changes:</strong></p>
+<table>
+<thead>
+<tr>
+<th>Change Type</th>
+<th>Example</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Removing required operations</td>
+<td>Removing the <code>introspect</code> operation</td>
+</tr>
+<tr>
+<td>Incompatible request structure changes</td>
+<td>Changing <code>operation</code> field to <code>op</code></td>
+</tr>
+<tr>
+<td>Incompatible response structure changes</td>
+<td>Restructuring the success/error envelope</td>
+</tr>
+<tr>
+<td>Removing CRUDE endpoints</td>
+<td>Eliminating the EXECUTE endpoint</td>
+</tr>
+<tr>
+<td>Changing introspection response format</td>
+<td>Altering the structure of OperationDetails</td>
+</tr>
+<tr>
+<td>Removing required fields from protocol types</td>
+<td>Removing <code>endpoint</code> from OperationInfo</td>
+</tr>
+<tr>
+<td>Changing field types incompatibly</td>
+<td>Changing <code>required</code> from boolean to string</td>
+</tr>
+<tr>
+<td>Changing endpoint routing rules</td>
+<td>Requiring different operation-to-endpoint mappings</td>
+</tr>
+</tbody>
+</table>
+<h3 id="22-non-breaking-changes-minor-version-bump">2.2 Non-Breaking Changes (Minor Version Bump)</h3>
+<p>Non-breaking changes add new capabilities without affecting existing implementations. These require a minor version increment (e.g., 1.0.x to 1.1.0).</p>
+<p><strong>Examples of Non-Breaking Changes:</strong></p>
+<table>
+<thead>
+<tr>
+<th>Change Type</th>
+<th>Example</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Adding new optional operations</td>
+<td>New <code>validate</code> operation on READ endpoint</td>
+</tr>
+<tr>
+<td>Adding new optional parameters</td>
+<td>Adding <code>timeout</code> parameter to existing operations</td>
+</tr>
+<tr>
+<td>Adding new fields to responses (additive)</td>
+<td>Adding <code>deprecated</code> flag to OperationInfo</td>
+</tr>
+<tr>
+<td>New optional features</td>
+<td>Field selection support</td>
+</tr>
+<tr>
+<td>Deprecating features (without removal)</td>
+<td>Marking an operation as deprecated</td>
+</tr>
+<tr>
+<td>Adding new optional protocol types</td>
+<td>New TypeInfo subtypes</td>
+</tr>
+<tr>
+<td>Extending enum values</td>
+<td>Adding new endpoint mode options</td>
+</tr>
+</tbody>
+</table>
+<h3 id="23-patch-changes-patch-version-bump">2.3 Patch Changes (Patch Version Bump)</h3>
+<p>Patch changes do not affect implementation behavior. These require a patch version increment (e.g., 1.0.0 to 1.0.1).</p>
+<p><strong>Examples of Patch Changes:</strong></p>
+<table>
+<thead>
+<tr>
+<th>Change Type</th>
+<th>Example</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Clarifications that don't change behavior</td>
+<td>Explaining existing edge case handling</td>
+</tr>
+<tr>
+<td>Typo fixes</td>
+<td>Correcting spelling in specification text</td>
+</tr>
+<tr>
+<td>Example corrections</td>
+<td>Fixing incorrect JSON in examples</td>
+</tr>
+<tr>
+<td>Documentation improvements</td>
+<td>Adding diagrams or additional context</td>
+</tr>
+<tr>
+<td>Formatting changes</td>
+<td>Restructuring sections for clarity</td>
+</tr>
+<tr>
+<td>Non-normative additions</td>
+<td>Adding implementation notes</td>
+</tr>
+</tbody>
+</table>
+<h3 id="24-classification-decision-tree">2.4 Classification Decision Tree</h3>
+<pre><code>Is existing conforming code affected?
+    |
+    No --&gt; Is new functionality added?
+    |          |
+    |         Yes --&gt; MINOR version bump
+    |          |
+    |         No --&gt; PATCH version bump
+    |
+   Yes --&gt; MAJOR version bump (Breaking Change)</code></pre>
+<hr />
+<h2 id="3-deprecation-policy">3. Deprecation Policy</h2>
+<h3 id="31-deprecation-period">3.1 Deprecation Period</h3>
+<p>All breaking changes MUST go through a deprecation period before removal:</p>
+<ul>
+<li><strong>Minimum Duration:</strong> 1 minor version OR 3 months, whichever is longer</li>
+<li><strong>Maximum Duration:</strong> Until the next major version release</li>
+</ul>
+<p>For example, if a feature is deprecated in version 1.2.0, it:</p>
+<ul>
+<li>MUST remain available through at least version 1.3.0</li>
+<li>MUST remain available for at least 3 months after 1.2.0 release</li>
+<li>MAY be removed in version 2.0.0</li>
+</ul>
+<h3 id="32-deprecation-communication">3.2 Deprecation Communication</h3>
+<p>When a feature is deprecated, the following communication is required:</p>
+<p><strong>In Specification Documents:</strong></p>
+<div class="sourceCode" id="cb2"><pre class="sourceCode markdown"><code class="sourceCode markdown"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="at">&gt; **DEPRECATED:** This feature is deprecated as of version X.Y.Z and will be</span></span>
+<span id="cb2-2"><a href="#cb2-2" aria-hidden="true" tabindex="-1"></a><span class="at">&gt; removed in version A.0.0. Use </span><span class="co">[</span><span class="ot">alternative</span><span class="co">]</span><span class="at"> instead.</span></span></code></pre></div>
+<p><strong>In Introspection Responses:</strong></p>
+<p>Implementations SHOULD include deprecation information in introspection:</p>
+<div class="sourceCode" id="cb3"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb3-1"><a href="#cb3-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb3-2"><a href="#cb3-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb3-3"><a href="#cb3-3" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;legacy_operation&quot;</span><span class="fu">,</span></span>
+<span id="cb3-4"><a href="#cb3-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;endpoint&quot;</span><span class="fu">:</span> <span class="st">&quot;READ&quot;</span><span class="fu">,</span></span>
+<span id="cb3-5"><a href="#cb3-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;deprecated&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb3-6"><a href="#cb3-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;deprecationMessage&quot;</span><span class="fu">:</span> <span class="st">&quot;Use &#39;new_operation&#39; instead. Will be removed in v2.0.0.&quot;</span><span class="fu">,</span></span>
+<span id="cb3-7"><a href="#cb3-7" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;deprecatedSince&quot;</span><span class="fu">:</span> <span class="st">&quot;1.2.0&quot;</span><span class="fu">,</span></span>
+<span id="cb3-8"><a href="#cb3-8" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;removalVersion&quot;</span><span class="fu">:</span> <span class="st">&quot;2.0.0&quot;</span></span>
+<span id="cb3-9"><a href="#cb3-9" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb3-10"><a href="#cb3-10" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<h3 id="33-deprecation-warning-fields">3.3 Deprecation Warning Fields</h3>
+<p>When implementing deprecation warnings in introspection, include:</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Type</th>
+<th>Required</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>deprecated</code></td>
+<td>boolean</td>
+<td>Yes</td>
+<td>Whether the item is deprecated</td>
+</tr>
+<tr>
+<td><code>deprecationMessage</code></td>
+<td>string</td>
+<td>Yes</td>
+<td>Human-readable explanation and alternative</td>
+</tr>
+<tr>
+<td><code>deprecatedSince</code></td>
+<td>string</td>
+<td>No</td>
+<td>Version when deprecation began</td>
+</tr>
+<tr>
+<td><code>removalVersion</code></td>
+<td>string</td>
+<td>No</td>
+<td>Version when item will be removed</td>
+</tr>
+</tbody>
+</table>
+<h3 id="34-deprecation-stages">3.4 Deprecation Stages</h3>
+<ol type="1">
+<li><strong>Announced:</strong> Feature marked deprecated in specification and changelog</li>
+<li><strong>Warning:</strong> Implementations begin returning deprecation warnings</li>
+<li><strong>Final Notice:</strong> Last minor version before removal</li>
+<li><strong>Removed:</strong> Feature removed in new major version</li>
+</ol>
+<hr />
+<h2 id="4-migration-guides">4. Migration Guides</h2>
+<h3 id="41-requirement">4.1 Requirement</h3>
+<p>Every breaking change MUST include a migration guide that enables implementers to update their code.</p>
+<h3 id="42-migration-guide-structure">4.2 Migration Guide Structure</h3>
+<p>Migration guides MUST follow this structure:</p>
+<div class="sourceCode" id="cb4"><pre class="sourceCode markdown"><code class="sourceCode markdown"><span id="cb4-1"><a href="#cb4-1" aria-hidden="true" tabindex="-1"></a><span class="fu"># Migration Guide: [Brief Description]</span></span>
+<span id="cb4-2"><a href="#cb4-2" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb4-3"><a href="#cb4-3" aria-hidden="true" tabindex="-1"></a>**From:** Version X.Y.Z</span>
+<span id="cb4-4"><a href="#cb4-4" aria-hidden="true" tabindex="-1"></a>**To:** Version A.B.C</span>
+<span id="cb4-5"><a href="#cb4-5" aria-hidden="true" tabindex="-1"></a>**Breaking Change:** <span class="co">[</span><span class="ot">Category from Section 2.1</span><span class="co">]</span></span>
+<span id="cb4-6"><a href="#cb4-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb4-7"><a href="#cb4-7" aria-hidden="true" tabindex="-1"></a><span class="fu">## Summary</span></span>
+<span id="cb4-8"><a href="#cb4-8" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb4-9"><a href="#cb4-9" aria-hidden="true" tabindex="-1"></a><span class="co">[</span><span class="ot">One paragraph explaining what changed and why</span><span class="co">]</span></span>
+<span id="cb4-10"><a href="#cb4-10" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb4-11"><a href="#cb4-11" aria-hidden="true" tabindex="-1"></a><span class="fu">## What&#39;s Changing</span></span>
+<span id="cb4-12"><a href="#cb4-12" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb4-13"><a href="#cb4-13" aria-hidden="true" tabindex="-1"></a><span class="co">[</span><span class="ot">Detailed explanation of the change</span><span class="co">]</span></span>
+<span id="cb4-14"><a href="#cb4-14" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb4-15"><a href="#cb4-15" aria-hidden="true" tabindex="-1"></a><span class="fu">### Before (Version X.Y.Z)</span></span>
+<span id="cb4-16"><a href="#cb4-16" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb4-17"><a href="#cb4-17" aria-hidden="true" tabindex="-1"></a><span class="co">[</span><span class="ot">Code example showing old behavior</span><span class="co">]</span></span>
+<span id="cb4-18"><a href="#cb4-18" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb4-19"><a href="#cb4-19" aria-hidden="true" tabindex="-1"></a><span class="fu">### After (Version A.B.C)</span></span>
+<span id="cb4-20"><a href="#cb4-20" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb4-21"><a href="#cb4-21" aria-hidden="true" tabindex="-1"></a><span class="co">[</span><span class="ot">Code example showing new behavior</span><span class="co">]</span></span>
+<span id="cb4-22"><a href="#cb4-22" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb4-23"><a href="#cb4-23" aria-hidden="true" tabindex="-1"></a><span class="fu">## Migration Steps</span></span>
+<span id="cb4-24"><a href="#cb4-24" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb4-25"><a href="#cb4-25" aria-hidden="true" tabindex="-1"></a><span class="ss">1. </span><span class="co">[</span><span class="ot">Step-by-step instructions</span><span class="co">]</span></span>
+<span id="cb4-26"><a href="#cb4-26" aria-hidden="true" tabindex="-1"></a><span class="ss">2. </span><span class="co">[</span><span class="ot">Include code transformations where applicable</span><span class="co">]</span></span>
+<span id="cb4-27"><a href="#cb4-27" aria-hidden="true" tabindex="-1"></a><span class="ss">3. </span><span class="co">[</span><span class="ot">Note any automated migration tools if available</span><span class="co">]</span></span>
+<span id="cb4-28"><a href="#cb4-28" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb4-29"><a href="#cb4-29" aria-hidden="true" tabindex="-1"></a><span class="fu">## Timeline</span></span>
+<span id="cb4-30"><a href="#cb4-30" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb4-31"><a href="#cb4-31" aria-hidden="true" tabindex="-1"></a><span class="ss">- </span>**Deprecated:** Version X.Y.Z (YYYY-MM-DD)</span>
+<span id="cb4-32"><a href="#cb4-32" aria-hidden="true" tabindex="-1"></a><span class="ss">- </span>**Removal:** Version A.0.0 (estimated YYYY-MM-DD)</span>
+<span id="cb4-33"><a href="#cb4-33" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb4-34"><a href="#cb4-34" aria-hidden="true" tabindex="-1"></a><span class="fu">## Questions</span></span>
+<span id="cb4-35"><a href="#cb4-35" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb4-36"><a href="#cb4-36" aria-hidden="true" tabindex="-1"></a>For questions about this migration, <span class="co">[</span><span class="ot">contact information or issue tracker link</span><span class="co">]</span>.</span></code></pre></div>
+<h3 id="43-migration-guide-location">4.3 Migration Guide Location</h3>
+<p>Migration guides MUST be:</p>
+<ul>
+<li>Published in <code>docs/migrations/</code> directory</li>
+<li>Named with format: <code>vX-to-vY-[brief-description].md</code></li>
+<li>Linked from the changelog entry</li>
+<li>Referenced in deprecation warnings</li>
+</ul>
+<h3 id="44-example-migration-guide">4.4 Example Migration Guide</h3>
+<div class="sourceCode" id="cb5"><pre class="sourceCode markdown"><code class="sourceCode markdown"><span id="cb5-1"><a href="#cb5-1" aria-hidden="true" tabindex="-1"></a><span class="fu"># Migration Guide: Introspection Response Restructure</span></span>
+<span id="cb5-2"><a href="#cb5-2" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb5-3"><a href="#cb5-3" aria-hidden="true" tabindex="-1"></a>**From:** Version 1.x</span>
+<span id="cb5-4"><a href="#cb5-4" aria-hidden="true" tabindex="-1"></a>**To:** Version 2.0.0</span>
+<span id="cb5-5"><a href="#cb5-5" aria-hidden="true" tabindex="-1"></a>**Breaking Change:** Changing introspection response format</span>
+<span id="cb5-6"><a href="#cb5-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb5-7"><a href="#cb5-7" aria-hidden="true" tabindex="-1"></a><span class="fu">## Summary</span></span>
+<span id="cb5-8"><a href="#cb5-8" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb5-9"><a href="#cb5-9" aria-hidden="true" tabindex="-1"></a>Version 2.0.0 restructures the introspection response to provide better</span>
+<span id="cb5-10"><a href="#cb5-10" aria-hidden="true" tabindex="-1"></a>type safety and support for new features. The <span class="in">`data`</span> wrapper now includes</span>
+<span id="cb5-11"><a href="#cb5-11" aria-hidden="true" tabindex="-1"></a>explicit type discriminators.</span>
+<span id="cb5-12"><a href="#cb5-12" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb5-13"><a href="#cb5-13" aria-hidden="true" tabindex="-1"></a><span class="fu">## What&#39;s Changing</span></span>
+<span id="cb5-14"><a href="#cb5-14" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb5-15"><a href="#cb5-15" aria-hidden="true" tabindex="-1"></a><span class="fu">### Before (Version 1.x)</span></span>
+<span id="cb5-16"><a href="#cb5-16" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb5-17"><a href="#cb5-17" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb5-18"><a href="#cb5-18" aria-hidden="true" tabindex="-1"></a>  &quot;success&quot;: true,</span>
+<span id="cb5-19"><a href="#cb5-19" aria-hidden="true" tabindex="-1"></a>  &quot;data&quot;: {</span>
+<span id="cb5-20"><a href="#cb5-20" aria-hidden="true" tabindex="-1"></a>    &quot;operations&quot;: <span class="co">[</span><span class="ot">...</span><span class="co">]</span></span>
+<span id="cb5-21"><a href="#cb5-21" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb5-22"><a href="#cb5-22" aria-hidden="true" tabindex="-1"></a>}</span>
+<span id="cb5-23"><a href="#cb5-23" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb5-24"><a href="#cb5-24" aria-hidden="true" tabindex="-1"></a><span class="fu">### After (Version 2.0.0)</span></span>
+<span id="cb5-25"><a href="#cb5-25" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb5-26"><a href="#cb5-26" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb5-27"><a href="#cb5-27" aria-hidden="true" tabindex="-1"></a>  &quot;success&quot;: true,</span>
+<span id="cb5-28"><a href="#cb5-28" aria-hidden="true" tabindex="-1"></a>  &quot;data&quot;: {</span>
+<span id="cb5-29"><a href="#cb5-29" aria-hidden="true" tabindex="-1"></a>    &quot;type&quot;: &quot;operation_list&quot;,</span>
+<span id="cb5-30"><a href="#cb5-30" aria-hidden="true" tabindex="-1"></a>    &quot;items&quot;: <span class="co">[</span><span class="ot">...</span><span class="co">]</span></span>
+<span id="cb5-31"><a href="#cb5-31" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb5-32"><a href="#cb5-32" aria-hidden="true" tabindex="-1"></a>}</span>
+<span id="cb5-33"><a href="#cb5-33" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb5-34"><a href="#cb5-34" aria-hidden="true" tabindex="-1"></a><span class="fu">## Migration Steps</span></span>
+<span id="cb5-35"><a href="#cb5-35" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb5-36"><a href="#cb5-36" aria-hidden="true" tabindex="-1"></a><span class="ss">1. </span>Update response parsing to handle the new <span class="in">`type`</span> field</span>
+<span id="cb5-37"><a href="#cb5-37" aria-hidden="true" tabindex="-1"></a><span class="ss">2. </span>Change array access from <span class="in">`data.operations`</span> to <span class="in">`data.items`</span></span>
+<span id="cb5-38"><a href="#cb5-38" aria-hidden="true" tabindex="-1"></a><span class="ss">3. </span>Add type checking based on <span class="in">`data.type`</span> value</span>
+<span id="cb5-39"><a href="#cb5-39" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb5-40"><a href="#cb5-40" aria-hidden="true" tabindex="-1"></a><span class="fu">## Timeline</span></span>
+<span id="cb5-41"><a href="#cb5-41" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb5-42"><a href="#cb5-42" aria-hidden="true" tabindex="-1"></a><span class="ss">- </span>**Deprecated:** Version 1.3.0 (2026-04-01)</span>
+<span id="cb5-43"><a href="#cb5-43" aria-hidden="true" tabindex="-1"></a><span class="ss">- </span>**Removal:** Version 2.0.0 (estimated 2026-07-01)</span></code></pre></div>
+<hr />
+<h2 id="5-communication">5. Communication</h2>
+<h3 id="51-changelog-format">5.1 Changelog Format</h3>
+<p>Breaking changes MUST be prominently documented in the changelog using this format:</p>
+<div class="sourceCode" id="cb6"><pre class="sourceCode markdown"><code class="sourceCode markdown"><span id="cb6-1"><a href="#cb6-1" aria-hidden="true" tabindex="-1"></a><span class="fu">## [2.0.0] - YYYY-MM-DD</span></span>
+<span id="cb6-2"><a href="#cb6-2" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb6-3"><a href="#cb6-3" aria-hidden="true" tabindex="-1"></a><span class="fu">### BREAKING CHANGES</span></span>
+<span id="cb6-4"><a href="#cb6-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb6-5"><a href="#cb6-5" aria-hidden="true" tabindex="-1"></a><span class="ss">- </span>**[Category]:** Brief description of breaking change</span>
+<span id="cb6-6"><a href="#cb6-6" aria-hidden="true" tabindex="-1"></a><span class="ss">  - </span>Migration guide: <span class="co">[</span><span class="ot">link to migration guide</span><span class="co">]</span></span>
+<span id="cb6-7"><a href="#cb6-7" aria-hidden="true" tabindex="-1"></a><span class="ss">  - </span>Deprecation notice: Deprecated in v1.X.0</span>
+<span id="cb6-8"><a href="#cb6-8" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb6-9"><a href="#cb6-9" aria-hidden="true" tabindex="-1"></a><span class="fu">### Removed</span></span>
+<span id="cb6-10"><a href="#cb6-10" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb6-11"><a href="#cb6-11" aria-hidden="true" tabindex="-1"></a><span class="ss">- </span><span class="co">[</span><span class="ot">List of removed features that were previously deprecated</span><span class="co">]</span></span>
+<span id="cb6-12"><a href="#cb6-12" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb6-13"><a href="#cb6-13" aria-hidden="true" tabindex="-1"></a><span class="fu">### Changed</span></span>
+<span id="cb6-14"><a href="#cb6-14" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb6-15"><a href="#cb6-15" aria-hidden="true" tabindex="-1"></a><span class="ss">- </span><span class="co">[</span><span class="ot">List of changed behaviors</span><span class="co">]</span></span></code></pre></div>
+<h3 id="52-announcement-requirements">5.2 Announcement Requirements</h3>
+<p><strong>For Major Versions (Breaking Changes):</strong></p>
+<ul>
+<li>Changelog entry with full details</li>
+<li>Migration guide(s) published</li>
+<li>Announcement in repository README or main documentation</li>
+<li>Minimum 30 days notice before release</li>
+<li>Release notes highlighting all breaking changes</li>
+</ul>
+<p><strong>For Minor Versions:</strong></p>
+<ul>
+<li>Changelog entry listing new features and deprecations</li>
+<li>Documentation updates for new features</li>
+<li>Deprecation warnings added to relevant sections</li>
+</ul>
+<p><strong>For Patch Versions:</strong></p>
+<ul>
+<li>Changelog entry listing fixes and clarifications</li>
+</ul>
+<h3 id="53-changelog-entry-examples">5.3 Changelog Entry Examples</h3>
+<p><strong>Breaking Change Entry:</strong></p>
+<div class="sourceCode" id="cb7"><pre class="sourceCode markdown"><code class="sourceCode markdown"><span id="cb7-1"><a href="#cb7-1" aria-hidden="true" tabindex="-1"></a><span class="fu">## [2.0.0] - 2026-07-01</span></span>
+<span id="cb7-2"><a href="#cb7-2" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb7-3"><a href="#cb7-3" aria-hidden="true" tabindex="-1"></a><span class="fu">### BREAKING CHANGES</span></span>
+<span id="cb7-4"><a href="#cb7-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb7-5"><a href="#cb7-5" aria-hidden="true" tabindex="-1"></a><span class="ss">- </span>**Introspection Response:** The operation list response structure has changed.</span>
+<span id="cb7-6"><a href="#cb7-6" aria-hidden="true" tabindex="-1"></a>  The <span class="in">`operations`</span> array is now <span class="in">`items`</span> within a typed wrapper.</span>
+<span id="cb7-7"><a href="#cb7-7" aria-hidden="true" tabindex="-1"></a><span class="ss">  - </span>Migration guide: <span class="co">[</span><span class="ot">v1-to-v2-introspection-response.md</span><span class="co">](migrations/v1-to-v2-introspection-response.md)</span></span>
+<span id="cb7-8"><a href="#cb7-8" aria-hidden="true" tabindex="-1"></a><span class="ss">  - </span>Deprecation notice: Deprecated in v1.3.0 (2026-04-01)</span>
+<span id="cb7-9"><a href="#cb7-9" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb7-10"><a href="#cb7-10" aria-hidden="true" tabindex="-1"></a><span class="ss">- </span>**Required Fields:** The <span class="in">`mcpTool`</span> field in OperationDetails is now required</span>
+<span id="cb7-11"><a href="#cb7-11" aria-hidden="true" tabindex="-1"></a>  rather than optional.</span>
+<span id="cb7-12"><a href="#cb7-12" aria-hidden="true" tabindex="-1"></a><span class="ss">  - </span>Migration guide: <span class="co">[</span><span class="ot">v1-to-v2-required-fields.md</span><span class="co">](migrations/v1-to-v2-required-fields.md)</span></span>
+<span id="cb7-13"><a href="#cb7-13" aria-hidden="true" tabindex="-1"></a><span class="ss">  - </span>Deprecation notice: Deprecated in v1.4.0 (2026-05-01)</span></code></pre></div>
+<p><strong>Deprecation Entry:</strong></p>
+<div class="sourceCode" id="cb8"><pre class="sourceCode markdown"><code class="sourceCode markdown"><span id="cb8-1"><a href="#cb8-1" aria-hidden="true" tabindex="-1"></a><span class="fu">## [1.3.0] - 2026-04-01</span></span>
+<span id="cb8-2"><a href="#cb8-2" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb8-3"><a href="#cb8-3" aria-hidden="true" tabindex="-1"></a><span class="fu">### Deprecated</span></span>
+<span id="cb8-4"><a href="#cb8-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb8-5"><a href="#cb8-5" aria-hidden="true" tabindex="-1"></a><span class="ss">- </span>**Introspection Response Structure:** The current <span class="in">`data.operations`</span> array</span>
+<span id="cb8-6"><a href="#cb8-6" aria-hidden="true" tabindex="-1"></a>  format is deprecated. Version 2.0.0 will use a typed wrapper structure.</span>
+<span id="cb8-7"><a href="#cb8-7" aria-hidden="true" tabindex="-1"></a>  See <span class="co">[</span><span class="ot">v1-to-v2-introspection-response.md</span><span class="co">](migrations/v1-to-v2-introspection-response.md)</span></span>
+<span id="cb8-8"><a href="#cb8-8" aria-hidden="true" tabindex="-1"></a>  for migration guidance.</span></code></pre></div>
+<h3 id="54-pre-release-versions">5.4 Pre-Release Versions</h3>
+<p>Pre-release versions (alpha, beta, release candidates) MAY contain breaking changes without following the full deprecation process. However:</p>
+<ul>
+<li>Breaking changes between pre-releases SHOULD still be documented</li>
+<li>Migration guidance SHOULD still be provided</li>
+<li>Users of pre-release versions accept the risk of breaking changes</li>
+</ul>
+<hr />
+<h2 id="references">References</h2>
+<ul>
+<li><a href="../versions/v1.0.0-draft.html">MCP-AQL Specification v1.0.0-draft</a></li>
+<li><a href="../crude-pattern.html">CRUDE Pattern Specification</a></li>
+<li><a href="../introspection.html">Introspection Specification</a></li>
+</ul>
+
+          </div>
+        </section>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div class="container">
+      <p>&copy; 2026 DollhouseMCP Inc. d/b/a Dollhouse Research. MCP-AQL public draft documentation portal.</p>
+      <div class="footer-links">
+        <a href="../../docs/index.html">Docs Library</a>
+        <a href="../index.html">Repo-Synced Spec</a>
+        <a href="https://github.com/MCPAQL">MCPAQL Organization</a>
+        <a href="https://dollhouseresearch.com">Dollhouse Research</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../../js/search.js"></script>
+</body>
+</html>

--- a/public/spec/process/breaking-changes.html
+++ b/public/spec/process/breaking-changes.html
@@ -73,6 +73,13 @@
       </aside>
 
       <article class="docs-main">
+        <nav class="breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../../index.html">Home</a></li>
+            <li><a href="../index.html">Full Spec</a></li>
+            <li><span class="current">MCP-AQL Breaking Change Policy</span></li>
+          </ol>
+        </nav>
         <section class="hero docs-hero">
           <div class="hero-inner">
             <span class="status-pill">REPO-SYNCED SPEC DOC</span>

--- a/public/spec/process/breaking-changes.html
+++ b/public/spec/process/breaking-changes.html
@@ -38,7 +38,7 @@
         <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
         <div class="docs-side-group">
   <h3>Core</h3>
-  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li></ul>
+  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li><li><a href="../repo/README.html">MCP-AQL Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Versions</h3>
   <ul><li><a href="../versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
@@ -56,7 +56,7 @@
   <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
-  <ul><li><a class="current" href="breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="versioning.html">Versioning Strategy</a></li></ul>
+  <ul><li><a class="current" href="breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="versioning.html">Versioning Strategy</a></li><li><a href="../repo/CHANGELOG.html">Changelog</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Architecture</h3>
   <ul><li><a href="../architecture/README.html">Architecture Documentation</a></li></ul>

--- a/public/spec/process/breaking-changes.html
+++ b/public/spec/process/breaking-changes.html
@@ -23,7 +23,7 @@
         </ul>
         <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
-          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <input id="site-search-input" data-search-input type="search" placeholder="Search MCP-AQL docs, spec pages, and adapter patterns...">
           <span class="search-count" data-search-count></span>
           <ul class="search-results" data-search-results hidden></ul>
         </form>
@@ -56,7 +56,7 @@
   <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
-  <ul><li><a class="current" href="breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="versioning.html">Versioning Strategy</a></li><li><a href="../repo/CHANGELOG.html">Changelog</a></li></ul>
+  <ul><li><a class="current" aria-current="page" href="breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="versioning.html">Versioning Strategy</a></li><li><a href="../repo/CHANGELOG.html">Changelog</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Architecture</h3>
   <ul><li><a href="../architecture/README.html">Architecture Documentation</a></li></ul>
@@ -518,6 +518,16 @@
 
           </div>
         </section>
+        <nav class="page-nav" aria-label="Page navigation">
+  <a class="page-nav-link prev" href="../guides/README.html">
+    <span class="page-nav-eyebrow">Previous spec page</span>
+    <strong class="page-nav-label">Developer Guides</strong>
+  </a>
+  <a class="page-nav-link next" href="preliminary-public-launch-checklist.html">
+    <span class="page-nav-eyebrow">Next spec page</span>
+    <strong class="page-nav-label">Preliminary Public Launch Checklist</strong>
+  </a>
+</nav>
       </article>
     </div>
   </main>

--- a/public/spec/process/preliminary-public-launch-checklist.html
+++ b/public/spec/process/preliminary-public-launch-checklist.html
@@ -1,0 +1,170 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="This checklist defines the minimum quality bar for a coordinated preliminary public launch of:">
+  <title>MCP-AQL Spec | Preliminary Public Launch Checklist</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../../css/style.css">
+</head>
+<body>
+  <header>
+    <div class="container">
+      <nav>
+        <a class="logo" href="../../index.html"><span class="logo-mark"></span>MCP-AQL</a>
+        <ul class="nav-links">
+          <li><a href="../../index.html">Home</a></li>
+          <li><a href="../../docs/index.html">Docs</a></li>
+          <li><a href="../../launch-checklist.html">Launch Checklist</a></li>
+          <li><a href="../../apis/mcp-server.html">Adapter Patterns</a></li>
+        </ul>
+        <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
+          <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
+          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <span class="search-count" data-search-count></span>
+          <ul class="search-results" data-search-results hidden></ul>
+        </form>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <div class="container docs-shell">
+      <aside class="docs-side">
+        <h2>Repo-Synced Spec</h2>
+        <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
+        <div class="docs-side-group">
+  <h3>Core</h3>
+  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Versions</h3>
+  <ul><li><a href="../versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Adapter</h3>
+  <ul><li><a href="../adapter/danger-levels.html">Dangerous Operation Classification Specification</a></li><li><a href="../adapter/discovery-bundle.html">MCP Server Discovery Bundle</a></li><li><a href="../adapter/element-type.html">Adapter Element Type Specification</a></li><li><a href="../adapter/generator.html">Adapter Generator Specification</a></li><li><a href="../adapter/rate-limiting.html">Rate Limiting and Quota Management Specification</a></li><li><a href="../adapter/trust-levels.html">Trust Levels Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Security</h3>
+  <ul><li><a href="../security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="../security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="../security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Features</h3>
+  <ul><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Guides</h3>
+  <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Process</h3>
+  <ul><li><a href="breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a class="current" href="preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="versioning.html">Versioning Strategy</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Architecture</h3>
+  <ul><li><a href="../architecture/README.html">Architecture Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Research</h3>
+  <ul><li><a href="../research/mcp-vs-mcpaql-vs-a2a.html">Protocol Landscape: MCP vs MCP-AQL vs A2A</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Reference</h3>
+  <ul><li><a href="../reference/README.html">Reference Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>ADRs</h3>
+  <ul><li><a href="../adr/ADR-001-crude-pattern.html">ADR-001: CRUDE Pattern (Extending CRUD with Execute)</a></li><li><a href="../adr/ADR-002-graphql-style-input.html">ADR-002: GraphQL-Style Input Objects for Updates</a></li><li><a href="../adr/ADR-003-snake-case-parameters.html">ADR-003: snake_case Parameter Convention</a></li><li><a href="../adr/ADR-004-schema-driven-operations.html">ADR-004: Schema-Driven Operation Definitions</a></li><li><a href="../adr/ADR-005-introspection-system.html">ADR-005: GraphQL-Style Introspection System</a></li><li><a href="../adr/ADR-006-discriminated-responses.html">ADR-006: Discriminated Response Format</a></li><li><a href="../adr/index.html">Architecture Decision Records</a></li><li><a href="../adr/README.html">Architecture Decision Records</a></li></ul>
+</div>
+      </aside>
+
+      <article class="docs-main">
+        <section class="hero docs-hero">
+          <div class="hero-inner">
+            <span class="status-pill">REPO-SYNCED SPEC DOC</span>
+            <h1>Preliminary Public Launch Checklist</h1>
+            <p class="lede">This checklist defines the minimum quality bar for a coordinated preliminary public launch of:</p>
+            <div class="spec-meta"><span class="state-chip live">Support document</span><span class="state-chip pending">Working</span><span class="state-chip">1.0.0-draft</span><span class="state-chip">2026-03-06</span></div>
+            <p class="spec-source">Source: <a href="https://github.com/MCPAQL/spec/blob/main/docs/process/preliminary-public-launch-checklist.md">spec/docs/process/preliminary-public-launch-checklist.md</a></p>
+            <div class="hero-actions">
+              <a class="btn btn-primary" href="https://github.com/MCPAQL/spec/blob/main/docs/process/preliminary-public-launch-checklist.md">Open Source Markdown</a>
+              <a class="btn btn-secondary" href="../index.html">Browse Full Spec Reference</a>
+            </div>
+          </div>
+        </section>
+
+        <section>
+          <div class="card spec-prose">
+            <p><strong>Version:</strong> 1.0.0-draft<br />
+<strong>Status:</strong> Working<br />
+<strong>Last Updated:</strong> 2026-03-06 This checklist defines the minimum quality bar for a coordinated preliminary public launch of:</p>
+<ul>
+<li>The MCP-AQL specification draft (<code>MCPAQL/spec</code>)</li>
+<li>The DollhouseMCP practical reference profile (<code>DollhouseMCP/mcp-server-v2-refactor</code>)</li>
+</ul>
+<h2 id="positioning">Positioning</h2>
+<p>Launch messaging MUST clearly state:</p>
+<ol type="1">
+<li>MCP-AQL is a <strong>preliminary public draft</strong> focused on demonstrable utility and interoperability direction.</li>
+<li>DollhouseMCP is a <strong>practical reference profile</strong>, not the canonical protocol definition.</li>
+<li>Normative protocol authority lives in <a href="../versions/v1.0.0-draft.html"><code>docs/versions/v1.0.0-draft.md</code></a>.</li>
+</ol>
+<h2 id="track-a-spec-draft-readiness">Track A: Spec Draft Readiness</h2>
+<ul class="task-list">
+<li><label><input type="checkbox" />Resolve phase-1 robustness blockers in <code>MCPAQL/spec</code>:</label>
+<ul>
+<li><a href="https://github.com/MCPAQL/spec/issues/193">#193</a> (MCP protocol capability alignment audit)</li>
+<li><a href="https://github.com/MCPAQL/spec/issues/197">#197</a> (batch/resource exhaustion limits)</li>
+<li><a href="https://github.com/MCPAQL/spec/issues/199">#199</a> (structured error surface alignment)</li>
+</ul></li>
+<li><label><input type="checkbox" />Ensure release-plan epic <a href="https://github.com/MCPAQL/spec/issues/194">#194</a> has explicit launch-scope outcomes marked done.</label></li>
+<li><label><input type="checkbox" />Keep normative/informative boundaries explicit across docs.</label></li>
+<li><label><input type="checkbox" />Keep schema validation and fixture checks passing in CI.</label></li>
+</ul>
+<h2 id="track-b-dollhouse-reference-profile-readiness">Track B: Dollhouse Reference Profile Readiness</h2>
+<ul class="task-list">
+<li><label><input type="checkbox" />Ship additive spec-alignment items tracked in Dollhouse roadmap <a href="https://github.com/DollhouseMCP/mcp-server-v2-refactor/issues/578">#578</a>.</label></li>
+<li><label><input type="checkbox" />Land structured error surfacing work:</label>
+<ul>
+<li><a href="https://github.com/DollhouseMCP/mcp-server-v2-refactor/issues/545">#545</a></li>
+<li><a href="https://github.com/DollhouseMCP/mcp-server-v2-refactor/issues/298">#298</a></li>
+</ul></li>
+<li><label><input type="checkbox" />Land batch safety limit work:</label>
+<ul>
+<li><a href="https://github.com/DollhouseMCP/mcp-server-v2-refactor/issues/543">#543</a></li>
+</ul></li>
+<li><label><input type="checkbox" />Publish clear reference-profile notes documenting intentional deltas from generic MCP-AQL.</label></li>
+</ul>
+<h2 id="coordinated-launch-artifacts">Coordinated Launch Artifacts</h2>
+<ul class="task-list">
+<li><label><input type="checkbox" />Draft launch post summarizing protocol goals, current scope, and known open items.</label></li>
+<li><label><input type="checkbox" />Side-by-side statement:</label>
+<ul>
+<li>Generic MCP-AQL protocol scope (spec repo)</li>
+<li>Dollhouse practical profile scope (Dollhouse repo)</li>
+</ul></li>
+<li><label><input type="checkbox" />Public quickstart that demonstrates token-efficiency gains and introspection-first operation discovery.</label></li>
+<li><label><input type="checkbox" />Explicit "current limitations" section to reduce expectation mismatch.</label></li>
+</ul>
+<h2 id="non-goals-for-preliminary-launch">Non-Goals for Preliminary Launch</h2>
+<ul>
+<li>Full certification-grade conformance automation</li>
+<li>Complete adapter ecosystem coverage</li>
+<li>Closure of phase-4/phase-5 feature backlog</li>
+</ul>
+
+          </div>
+        </section>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div class="container">
+      <p>&copy; 2026 DollhouseMCP Inc. d/b/a Dollhouse Research. MCP-AQL public draft documentation portal.</p>
+      <div class="footer-links">
+        <a href="../../docs/index.html">Docs Library</a>
+        <a href="../index.html">Repo-Synced Spec</a>
+        <a href="https://github.com/MCPAQL">MCPAQL Organization</a>
+        <a href="https://dollhouseresearch.com">Dollhouse Research</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../../js/search.js"></script>
+</body>
+</html>

--- a/public/spec/process/preliminary-public-launch-checklist.html
+++ b/public/spec/process/preliminary-public-launch-checklist.html
@@ -38,7 +38,7 @@
         <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
         <div class="docs-side-group">
   <h3>Core</h3>
-  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li></ul>
+  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li><li><a href="../repo/README.html">MCP-AQL Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Versions</h3>
   <ul><li><a href="../versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
@@ -56,7 +56,7 @@
   <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
-  <ul><li><a href="breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a class="current" href="preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="versioning.html">Versioning Strategy</a></li></ul>
+  <ul><li><a href="breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a class="current" href="preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="versioning.html">Versioning Strategy</a></li><li><a href="../repo/CHANGELOG.html">Changelog</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Architecture</h3>
   <ul><li><a href="../architecture/README.html">Architecture Documentation</a></li></ul>

--- a/public/spec/process/preliminary-public-launch-checklist.html
+++ b/public/spec/process/preliminary-public-launch-checklist.html
@@ -23,7 +23,7 @@
         </ul>
         <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
-          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <input id="site-search-input" data-search-input type="search" placeholder="Search MCP-AQL docs, spec pages, and adapter patterns...">
           <span class="search-count" data-search-count></span>
           <ul class="search-results" data-search-results hidden></ul>
         </form>
@@ -56,7 +56,7 @@
   <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
-  <ul><li><a href="breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a class="current" href="preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="versioning.html">Versioning Strategy</a></li><li><a href="../repo/CHANGELOG.html">Changelog</a></li></ul>
+  <ul><li><a href="breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a class="current" aria-current="page" href="preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="versioning.html">Versioning Strategy</a></li><li><a href="../repo/CHANGELOG.html">Changelog</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Architecture</h3>
   <ul><li><a href="../architecture/README.html">Architecture Documentation</a></li></ul>
@@ -156,6 +156,16 @@
 
           </div>
         </section>
+        <nav class="page-nav" aria-label="Page navigation">
+  <a class="page-nav-link prev" href="breaking-changes.html">
+    <span class="page-nav-eyebrow">Previous spec page</span>
+    <strong class="page-nav-label">MCP-AQL Breaking Change Policy</strong>
+  </a>
+  <a class="page-nav-link next" href="rfc-process.html">
+    <span class="page-nav-eyebrow">Next spec page</span>
+    <strong class="page-nav-label">RFC Process for MCP-AQL Specification</strong>
+  </a>
+</nav>
       </article>
     </div>
   </main>

--- a/public/spec/process/preliminary-public-launch-checklist.html
+++ b/public/spec/process/preliminary-public-launch-checklist.html
@@ -73,6 +73,13 @@
       </aside>
 
       <article class="docs-main">
+        <nav class="breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../../index.html">Home</a></li>
+            <li><a href="../index.html">Full Spec</a></li>
+            <li><span class="current">Preliminary Public Launch Checklist</span></li>
+          </ol>
+        </nav>
         <section class="hero docs-hero">
           <div class="hero-inner">
             <span class="status-pill">REPO-SYNCED SPEC DOC</span>

--- a/public/spec/process/rfc-process.html
+++ b/public/spec/process/rfc-process.html
@@ -38,7 +38,7 @@
         <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
         <div class="docs-side-group">
   <h3>Core</h3>
-  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li></ul>
+  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li><li><a href="../repo/README.html">MCP-AQL Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Versions</h3>
   <ul><li><a href="../versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
@@ -56,7 +56,7 @@
   <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
-  <ul><li><a href="breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a class="current" href="rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="versioning.html">Versioning Strategy</a></li></ul>
+  <ul><li><a href="breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a class="current" href="rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="versioning.html">Versioning Strategy</a></li><li><a href="../repo/CHANGELOG.html">Changelog</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Architecture</h3>
   <ul><li><a href="../architecture/README.html">Architecture Documentation</a></li></ul>

--- a/public/spec/process/rfc-process.html
+++ b/public/spec/process/rfc-process.html
@@ -73,6 +73,13 @@
       </aside>
 
       <article class="docs-main">
+        <nav class="breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../../index.html">Home</a></li>
+            <li><a href="../index.html">Full Spec</a></li>
+            <li><span class="current">RFC Process for MCP-AQL Specification</span></li>
+          </ol>
+        </nav>
         <section class="hero docs-hero">
           <div class="hero-inner">
             <span class="status-pill">REPO-SYNCED SPEC DOC</span>

--- a/public/spec/process/rfc-process.html
+++ b/public/spec/process/rfc-process.html
@@ -23,7 +23,7 @@
         </ul>
         <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
-          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <input id="site-search-input" data-search-input type="search" placeholder="Search MCP-AQL docs, spec pages, and adapter patterns...">
           <span class="search-count" data-search-count></span>
           <ul class="search-results" data-search-results hidden></ul>
         </form>
@@ -56,7 +56,7 @@
   <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
-  <ul><li><a href="breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a class="current" href="rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="versioning.html">Versioning Strategy</a></li><li><a href="../repo/CHANGELOG.html">Changelog</a></li></ul>
+  <ul><li><a href="breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a class="current" aria-current="page" href="rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="versioning.html">Versioning Strategy</a></li><li><a href="../repo/CHANGELOG.html">Changelog</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Architecture</h3>
   <ul><li><a href="../architecture/README.html">Architecture Documentation</a></li></ul>
@@ -477,6 +477,16 @@
 
           </div>
         </section>
+        <nav class="page-nav" aria-label="Page navigation">
+  <a class="page-nav-link prev" href="preliminary-public-launch-checklist.html">
+    <span class="page-nav-eyebrow">Previous spec page</span>
+    <strong class="page-nav-label">Preliminary Public Launch Checklist</strong>
+  </a>
+  <a class="page-nav-link next" href="versioning.html">
+    <span class="page-nav-eyebrow">Next spec page</span>
+    <strong class="page-nav-label">Versioning Strategy</strong>
+  </a>
+</nav>
       </article>
     </div>
   </main>

--- a/public/spec/process/rfc-process.html
+++ b/public/spec/process/rfc-process.html
@@ -1,0 +1,491 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="This document describes the formal process for proposing, reviewing, and accepting changes to the MCP-AQL specification through Requests for Comments (RFCs).">
+  <title>MCP-AQL Spec | RFC Process for MCP-AQL Specification</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../../css/style.css">
+</head>
+<body>
+  <header>
+    <div class="container">
+      <nav>
+        <a class="logo" href="../../index.html"><span class="logo-mark"></span>MCP-AQL</a>
+        <ul class="nav-links">
+          <li><a href="../../index.html">Home</a></li>
+          <li><a href="../../docs/index.html">Docs</a></li>
+          <li><a href="../../launch-checklist.html">Launch Checklist</a></li>
+          <li><a href="../../apis/mcp-server.html">Adapter Patterns</a></li>
+        </ul>
+        <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
+          <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
+          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <span class="search-count" data-search-count></span>
+          <ul class="search-results" data-search-results hidden></ul>
+        </form>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <div class="container docs-shell">
+      <aside class="docs-side">
+        <h2>Repo-Synced Spec</h2>
+        <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
+        <div class="docs-side-group">
+  <h3>Core</h3>
+  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Versions</h3>
+  <ul><li><a href="../versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Adapter</h3>
+  <ul><li><a href="../adapter/danger-levels.html">Dangerous Operation Classification Specification</a></li><li><a href="../adapter/discovery-bundle.html">MCP Server Discovery Bundle</a></li><li><a href="../adapter/element-type.html">Adapter Element Type Specification</a></li><li><a href="../adapter/generator.html">Adapter Generator Specification</a></li><li><a href="../adapter/rate-limiting.html">Rate Limiting and Quota Management Specification</a></li><li><a href="../adapter/trust-levels.html">Trust Levels Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Security</h3>
+  <ul><li><a href="../security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="../security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="../security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Features</h3>
+  <ul><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Guides</h3>
+  <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Process</h3>
+  <ul><li><a href="breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a class="current" href="rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="versioning.html">Versioning Strategy</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Architecture</h3>
+  <ul><li><a href="../architecture/README.html">Architecture Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Research</h3>
+  <ul><li><a href="../research/mcp-vs-mcpaql-vs-a2a.html">Protocol Landscape: MCP vs MCP-AQL vs A2A</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Reference</h3>
+  <ul><li><a href="../reference/README.html">Reference Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>ADRs</h3>
+  <ul><li><a href="../adr/ADR-001-crude-pattern.html">ADR-001: CRUDE Pattern (Extending CRUD with Execute)</a></li><li><a href="../adr/ADR-002-graphql-style-input.html">ADR-002: GraphQL-Style Input Objects for Updates</a></li><li><a href="../adr/ADR-003-snake-case-parameters.html">ADR-003: snake_case Parameter Convention</a></li><li><a href="../adr/ADR-004-schema-driven-operations.html">ADR-004: Schema-Driven Operation Definitions</a></li><li><a href="../adr/ADR-005-introspection-system.html">ADR-005: GraphQL-Style Introspection System</a></li><li><a href="../adr/ADR-006-discriminated-responses.html">ADR-006: Discriminated Response Format</a></li><li><a href="../adr/index.html">Architecture Decision Records</a></li><li><a href="../adr/README.html">Architecture Decision Records</a></li></ul>
+</div>
+      </aside>
+
+      <article class="docs-main">
+        <section class="hero docs-hero">
+          <div class="hero-inner">
+            <span class="status-pill">REPO-SYNCED SPEC DOC</span>
+            <h1>RFC Process for MCP-AQL Specification</h1>
+            <p class="lede">This document describes the formal process for proposing, reviewing, and accepting changes to the MCP-AQL specification through Requests for Comments (RFCs).</p>
+            <div class="spec-meta"><span class="state-chip live">Support document</span><span class="state-chip pending">Active</span><span class="state-chip">1.0.0</span></div>
+            <p class="spec-source">Source: <a href="https://github.com/MCPAQL/spec/blob/main/docs/process/rfc-process.md">spec/docs/process/rfc-process.md</a></p>
+            <div class="hero-actions">
+              <a class="btn btn-primary" href="https://github.com/MCPAQL/spec/blob/main/docs/process/rfc-process.md">Open Source Markdown</a>
+              <a class="btn btn-secondary" href="../index.html">Browse Full Spec Reference</a>
+            </div>
+          </div>
+        </section>
+
+        <section>
+          <div class="card spec-prose">
+            <p>This document describes the formal process for proposing, reviewing, and accepting changes to the MCP-AQL specification through Requests for Comments (RFCs).</p>
+<h2 id="table-of-contents">Table of Contents</h2>
+<ul>
+<li><a href="#introduction">Introduction</a></li>
+<li><a href="#rfc-lifecycle">RFC Lifecycle</a></li>
+<li><a href="#submitting-an-rfc">Submitting an RFC</a></li>
+<li><a href="#review-process">Review Process</a></li>
+<li><a href="#after-acceptance">After Acceptance</a></li>
+<li><a href="#rfc-numbering">RFC Numbering</a></li>
+</ul>
+<hr />
+<h2 id="introduction">Introduction</h2>
+<h3 id="what-is-an-rfc">What is an RFC?</h3>
+<p>An RFC (Request for Comments) is a formal proposal for a significant change to the MCP-AQL specification. RFCs provide a consistent and controlled process for introducing new features, modifying existing behaviors, or making other substantive changes to the protocol.</p>
+<p>The RFC process ensures that:</p>
+<ul>
+<li>Changes are thoroughly documented before implementation</li>
+<li>The community has opportunity to provide feedback</li>
+<li>Design decisions are recorded for future reference</li>
+<li>Breaking changes are carefully considered</li>
+<li>Implementations can prepare for upcoming changes</li>
+</ul>
+<p>Formal proposals are stored in the <a href="https://github.com/MCPAQL/spec/blob/main/proposals/"><code>proposals/</code></a> directory using the standard template.</p>
+<h3 id="when-to-use-an-rfc">When to Use an RFC</h3>
+<p>You SHOULD submit an RFC for:</p>
+<ul>
+<li><strong>New operations or endpoints</strong>: Adding new functionality to the CRUDE pattern</li>
+<li><strong>Behavioral changes</strong>: Modifying how existing operations work</li>
+<li><strong>New parameters or fields</strong>: Extending request/response schemas</li>
+<li><strong>Security-related changes</strong>: Modifications to authentication, authorization, or access control</li>
+<li><strong>Breaking changes</strong>: Any change that affects backward compatibility</li>
+<li><strong>Architectural changes</strong>: Modifications to core patterns or design principles</li>
+</ul>
+<p>You MAY skip the RFC process for:</p>
+<ul>
+<li>Editorial corrections (typos, grammar, clarifications)</li>
+<li>Documentation improvements that do not change the specification</li>
+<li>Adding conformance tests for existing features</li>
+<li>Bug fixes to specification text that correct obvious errors</li>
+</ul>
+<p>When in doubt, start with a GitHub Issue to discuss whether an RFC is appropriate.</p>
+<hr />
+<h2 id="rfc-lifecycle">RFC Lifecycle</h2>
+<p>RFCs progress through five stages from initial concept to integration into the specification.</p>
+<h3 id="stage-0-pre-rfc-discussion">Stage 0: Pre-RFC (Discussion)</h3>
+<p><strong>Purpose</strong>: Gather initial feedback before investing effort in a formal proposal.</p>
+<p><strong>Process</strong>:</p>
+<ol type="1">
+<li>Open a GitHub Issue describing the problem or enhancement</li>
+<li>Use the <code>discussion</code> label to indicate this is exploratory</li>
+<li>Engage with community feedback</li>
+<li>Refine the idea based on input</li>
+</ol>
+<p><strong>Exit Criteria</strong>:</p>
+<ul>
+<li>General agreement that the change is worth pursuing</li>
+<li>Clear understanding of the problem being solved</li>
+<li>Initial design direction identified</li>
+</ul>
+<p><strong>Duration</strong>: No minimum; proceed when ready</p>
+<h3 id="stage-1-draft-formal-proposal">Stage 1: Draft (Formal Proposal)</h3>
+<p><strong>Purpose</strong>: Submit a complete, formal proposal for review.</p>
+<p><strong>Process</strong>:</p>
+<ol type="1">
+<li>Create a new Issue using the RFC issue template</li>
+<li>Complete all required sections (see <a href="#submitting-an-rfc">Submitting an RFC</a>)</li>
+<li>Apply the <code>rfc</code> and <code>proposal</code> labels</li>
+<li>Link to any related Pre-RFC discussions</li>
+</ol>
+<p><strong>Exit Criteria</strong>:</p>
+<ul>
+<li>RFC is complete and well-formed</li>
+<li>All required sections are filled out</li>
+<li>Examples and use cases are provided</li>
+</ul>
+<p><strong>Duration</strong>: Immediate upon submission</p>
+<h3 id="stage-2-review-community-and-maintainer-review">Stage 2: Review (Community and Maintainer Review)</h3>
+<p><strong>Purpose</strong>: Gather comprehensive feedback and iterate on the design.</p>
+<p><strong>Process</strong>:</p>
+<ol type="1">
+<li>The RFC enters the minimum 14-day discussion period</li>
+<li>Community members provide feedback via Issue comments</li>
+<li>Maintainers review for technical accuracy and consistency</li>
+<li>The RFC author addresses feedback and updates the proposal</li>
+<li>Spec editors may request changes or clarifications</li>
+</ol>
+<p><strong>Exit Criteria</strong>:</p>
+<ul>
+<li>Minimum discussion period has elapsed</li>
+<li>All blocking concerns have been addressed</li>
+<li>Maintainer consensus is reached</li>
+</ul>
+<p><strong>Duration</strong>: Minimum 14 days; may extend based on complexity or ongoing discussion</p>
+<h3 id="stage-3-accepted-approved-for-implementation">Stage 3: Accepted (Approved for Implementation)</h3>
+<p><strong>Purpose</strong>: Signal that the RFC is approved and ready for implementation.</p>
+<p><strong>Process</strong>:</p>
+<ol type="1">
+<li>A maintainer applies the <code>accepted</code> label</li>
+<li>The RFC Issue is updated to reflect acceptance</li>
+<li>An RFC number is assigned (see <a href="#rfc-numbering">RFC Numbering</a>)</li>
+<li>The RFC is added to the accepted RFC tracking list</li>
+</ol>
+<p><strong>Exit Criteria</strong>:</p>
+<ul>
+<li>RFC has been formally accepted by maintainers</li>
+<li>RFC number has been assigned</li>
+<li>Implementation can begin</li>
+</ul>
+<p><strong>Duration</strong>: Immediate upon acceptance decision</p>
+<h3 id="stage-4-integrated-merged-into-spec">Stage 4: Integrated (Merged into Spec)</h3>
+<p><strong>Purpose</strong>: The RFC changes have been merged into the specification.</p>
+<p><strong>Process</strong>:</p>
+<ol type="1">
+<li>Specification changes are implemented in a PR</li>
+<li>The PR undergoes review and is merged</li>
+<li>The RFC Issue is closed with the <code>integrated</code> label</li>
+<li>The changelog is updated to reference the RFC</li>
+</ol>
+<p><strong>Exit Criteria</strong>:</p>
+<ul>
+<li>All specification changes from the RFC are merged</li>
+<li>Changelog updated</li>
+<li>RFC Issue closed</li>
+</ul>
+<p><strong>Duration</strong>: Varies based on implementation complexity</p>
+<hr />
+<h2 id="submitting-an-rfc">Submitting an RFC</h2>
+<h3 id="using-the-rfc-issue-template">Using the RFC Issue Template</h3>
+<p>All RFCs MUST be submitted using the RFC issue template located at <code>.github/ISSUE_TEMPLATE/rfc.md</code>. This ensures consistency and completeness across proposals.</p>
+<p>To create an RFC:</p>
+<ol type="1">
+<li>Navigate to the repository's Issues tab</li>
+<li>Click "New Issue"</li>
+<li>Select the "RFC Proposal" template</li>
+<li>Fill out all sections completely</li>
+</ol>
+<h3 id="required-sections">Required Sections</h3>
+<p>Every RFC MUST include the following sections:</p>
+<h4 id="summary">Summary</h4>
+<p>A concise, one-paragraph description of the proposed change. This should be understandable without reading the full RFC.</p>
+<p><strong>Example</strong>:</p>
+<blockquote>
+<p>This RFC proposes adding a <code>batch</code> operation to the CRUDE pattern, allowing multiple operations to be submitted and executed in a single request, with support for transactional semantics.</p>
+</blockquote>
+<h4 id="motivation">Motivation</h4>
+<p>Explain why this change is needed:</p>
+<ul>
+<li>What problem does it solve?</li>
+<li>What use cases does it enable?</li>
+<li>Why is the current approach insufficient?</li>
+<li>Who benefits from this change?</li>
+</ul>
+<h4 id="detailed-design">Detailed Design</h4>
+<p>Provide a comprehensive description of the proposal:</p>
+<ul>
+<li>Specific changes to the specification text</li>
+<li>New operations, parameters, or behaviors introduced</li>
+<li>Request and response examples (in JSON format)</li>
+<li>How the change interacts with existing features</li>
+<li>Edge cases and their handling</li>
+</ul>
+<h4 id="drawbacks">Drawbacks</h4>
+<p>Honestly assess the potential downsides:</p>
+<ul>
+<li>Complexity added to the specification</li>
+<li>Implementation burden for adapters</li>
+<li>Breaking changes or migration requirements</li>
+<li>Performance implications</li>
+<li>Security considerations</li>
+</ul>
+<h4 id="alternatives">Alternatives</h4>
+<p>Document other approaches that were considered:</p>
+<ul>
+<li>Alternative designs and why they were rejected</li>
+<li>Status quo (doing nothing) and its implications</li>
+<li>Partial solutions and their trade-offs</li>
+</ul>
+<h3 id="optional-sections">Optional Sections</h3>
+<p>The following sections are encouraged but not required:</p>
+<h4 id="prior-art">Prior Art</h4>
+<p>References to similar features in other specifications, protocols, or systems.</p>
+<h4 id="unresolved-questions">Unresolved Questions</h4>
+<p>Open design decisions that need further discussion or will be resolved during implementation.</p>
+<h3 id="discussion-period">Discussion Period</h3>
+<p>All RFCs are subject to a <strong>minimum 14-day discussion period</strong> from the date of submission. This period:</p>
+<ul>
+<li>Allows sufficient time for community review</li>
+<li>Enables asynchronous participation across time zones</li>
+<li>Provides opportunity for implementation feedback</li>
+</ul>
+<p>The discussion period MAY be extended for:</p>
+<ul>
+<li>Complex or controversial proposals</li>
+<li>Significant ongoing discussion</li>
+<li>Requests from maintainers or active participants</li>
+</ul>
+<hr />
+<h2 id="review-process">Review Process</h2>
+<h3 id="who-reviews-rfcs">Who Reviews RFCs</h3>
+<p>RFCs are reviewed by two groups:</p>
+<h4 id="maintainers">Maintainers</h4>
+<p>Project maintainers have final authority on RFC acceptance. They evaluate:</p>
+<ul>
+<li>Alignment with specification goals and philosophy</li>
+<li>Technical soundness and feasibility</li>
+<li>Impact on existing implementations</li>
+<li>Long-term maintenance implications</li>
+</ul>
+<h4 id="spec-editors">Spec Editors</h4>
+<p>Spec editors focus on:</p>
+<ul>
+<li>Consistency with existing specification language</li>
+<li>Completeness of the proposal</li>
+<li>Clarity and precision of the design</li>
+<li>Integration with other specification sections</li>
+</ul>
+<h3 id="criteria-for-acceptance">Criteria for Acceptance</h3>
+<p>An RFC is accepted when it meets the following criteria:</p>
+<ol type="1">
+<li><strong>Completeness</strong>: All required sections are filled out thoroughly</li>
+<li><strong>Technical Soundness</strong>: The design is technically feasible and well-reasoned</li>
+<li><strong>Consistency</strong>: The proposal aligns with existing specification patterns</li>
+<li><strong>Addressed Feedback</strong>: All substantive concerns have been resolved</li>
+<li><strong>Consensus</strong>: Maintainers agree the change should proceed</li>
+<li><strong>Clear Benefit</strong>: The proposal provides meaningful value to the specification</li>
+</ol>
+<h3 id="determining-consensus">Determining Consensus</h3>
+<p>Consensus is determined through the following process:</p>
+<ol type="1">
+<li><strong>Discussion</strong>: All feedback is considered and addressed</li>
+<li><strong>Maintainer Review</strong>: At least two maintainers must review the RFC</li>
+<li><strong>Approval</strong>: A maintainer signals readiness to accept</li>
+<li><strong>Objection Period</strong>: 48 hours for final objections</li>
+<li><strong>Decision</strong>: If no blocking objections, the RFC is accepted</li>
+</ol>
+<p>Blocking objections MUST include:</p>
+<ul>
+<li>A clear statement of the concern</li>
+<li>Specific changes that would resolve the objection</li>
+<li>Willingness to engage in discussion</li>
+</ul>
+<p>If consensus cannot be reached, maintainers may:</p>
+<ul>
+<li>Request additional changes to address concerns</li>
+<li>Defer the RFC for future consideration</li>
+<li>Close the RFC as not accepted (with explanation)</li>
+</ul>
+<hr />
+<h2 id="after-acceptance">After Acceptance</h2>
+<h3 id="create-rfc-branch">Create rfc/* Branch</h3>
+<p>Once an RFC is accepted:</p>
+<ol type="1">
+<li>Create a branch named <code>rfc/RFC-NNNN-short-description</code>
+<ul>
+<li>Example: <code>rfc/RFC-0001-batch-operations</code></li>
+</ul></li>
+<li>Branch from <code>develop</code> (not <code>main</code>)</li>
+<li>Reference the RFC number in the branch name</li>
+</ol>
+<h3 id="implement-spec-changes">Implement Spec Changes</h3>
+<p>Implement the accepted RFC in the branch:</p>
+<ol type="1">
+<li>Update relevant specification documents</li>
+<li>Add or modify examples as needed</li>
+<li>Update schema files if applicable</li>
+<li>Add conformance tests for new features</li>
+<li>Ensure all existing tests pass</li>
+</ol>
+<h3 id="pr-review-process">PR Review Process</h3>
+<p>Submit a Pull Request for the implementation:</p>
+<ol type="1">
+<li>Title format: <code>[RFC-NNNN] Brief description</code></li>
+<li>Reference the RFC Issue in the PR description</li>
+<li>Provide a checklist of all specification changes made</li>
+<li>Request review from maintainers</li>
+</ol>
+<p>The PR review focuses on:</p>
+<ul>
+<li>Accurate implementation of the accepted RFC</li>
+<li>Quality of specification language</li>
+<li>Completeness of examples</li>
+<li>Test coverage</li>
+</ul>
+<h3 id="changelog-updates">Changelog Updates</h3>
+<p>All RFC implementations MUST update the changelog:</p>
+<ol type="1">
+<li>Add an entry under "Unreleased" or the appropriate version</li>
+<li>Reference the RFC number: <code>[RFC-NNNN]</code></li>
+<li>Provide a brief description of the change</li>
+<li>Link to the RFC Issue and PR</li>
+</ol>
+<p><strong>Example changelog entry</strong>:</p>
+<div class="sourceCode" id="cb1"><pre class="sourceCode markdown"><code class="sourceCode markdown"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a><span class="fu">### Added</span></span>
+<span id="cb1-2"><a href="#cb1-2" aria-hidden="true" tabindex="-1"></a><span class="ss">- </span>Batch operations support (<span class="co">[</span><span class="ot">RFC-0001</span><span class="co">](link-to-issue)</span>) - Enables multiple operations in a single request with transactional semantics</span></code></pre></div>
+<hr />
+<h2 id="rfc-numbering">RFC Numbering</h2>
+<h3 id="assignment">Assignment</h3>
+<p>RFC numbers are assigned sequentially, starting from RFC-0001. Numbers are assigned:</p>
+<ul>
+<li>When an RFC is accepted (Stage 3)</li>
+<li>By a maintainer updating the RFC Issue</li>
+<li>In chronological order of acceptance</li>
+</ul>
+<h3 id="format">Format</h3>
+<p>RFC numbers use a four-digit format with leading zeros:</p>
+<ul>
+<li><code>RFC-0001</code></li>
+<li><code>RFC-0042</code></li>
+<li><code>RFC-0123</code></li>
+</ul>
+<h3 id="tracking">Tracking</h3>
+<p>Accepted and integrated RFCs are tracked in the repository:</p>
+<ul>
+<li>A comment on the RFC Issue includes the assigned number</li>
+<li>The RFC is listed in project documentation</li>
+<li>Branch names and PR titles reference the RFC number</li>
+</ul>
+<h3 id="numbers-are-permanent">Numbers Are Permanent</h3>
+<p>Once assigned, RFC numbers are never reused, even if:</p>
+<ul>
+<li>The RFC is later withdrawn</li>
+<li>The implementation is reverted</li>
+<li>The feature is deprecated</li>
+</ul>
+<p>This ensures stable references in documentation, changelogs, and external resources.</p>
+<hr />
+<h2 id="quick-reference">Quick Reference</h2>
+<table>
+<thead>
+<tr>
+<th>Stage</th>
+<th>Name</th>
+<th>Duration</th>
+<th>Exit Criteria</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>0</td>
+<td>Pre-RFC</td>
+<td>No minimum</td>
+<td>Ready to formalize</td>
+</tr>
+<tr>
+<td>1</td>
+<td>Draft</td>
+<td>Immediate</td>
+<td>Complete submission</td>
+</tr>
+<tr>
+<td>2</td>
+<td>Review</td>
+<td>14+ days</td>
+<td>Consensus reached</td>
+</tr>
+<tr>
+<td>3</td>
+<td>Accepted</td>
+<td>Immediate</td>
+<td>Number assigned</td>
+</tr>
+<tr>
+<td>4</td>
+<td>Integrated</td>
+<td>Varies</td>
+<td>PR merged</td>
+</tr>
+</tbody>
+</table>
+<hr />
+<h2 id="related-documents">Related Documents</h2>
+<ul>
+<li><a href="https://github.com/MCPAQL/spec/blob/main/CONTRIBUTING.md">CONTRIBUTING.md</a> - General contribution guidelines</li>
+<li><a href="https://github.com/MCPAQL/spec/blob/main/.github/ISSUE_TEMPLATE/rfc.md">RFC Issue Template</a> - Template for RFC submissions</li>
+<li><a href="https://github.com/MCPAQL/spec/blob/main/CONTRIBUTING.md#branching-strategy">Branching Strategy</a> - Branch naming conventions</li>
+</ul>
+<hr />
+<p><em>This document is part of the MCP-AQL specification. See <a href="https://github.com/MCPAQL/spec/blob/main/LICENSING.md">LICENSING.md</a> for license information.</em></p>
+
+          </div>
+        </section>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div class="container">
+      <p>&copy; 2026 DollhouseMCP Inc. d/b/a Dollhouse Research. MCP-AQL public draft documentation portal.</p>
+      <div class="footer-links">
+        <a href="../../docs/index.html">Docs Library</a>
+        <a href="../index.html">Repo-Synced Spec</a>
+        <a href="https://github.com/MCPAQL">MCPAQL Organization</a>
+        <a href="https://dollhouseresearch.com">Dollhouse Research</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../../js/search.js"></script>
+</body>
+</html>

--- a/public/spec/process/versioning.html
+++ b/public/spec/process/versioning.html
@@ -23,7 +23,7 @@
         </ul>
         <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
-          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <input id="site-search-input" data-search-input type="search" placeholder="Search MCP-AQL docs, spec pages, and adapter patterns...">
           <span class="search-count" data-search-count></span>
           <ul class="search-results" data-search-results hidden></ul>
         </form>
@@ -56,7 +56,7 @@
   <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
-  <ul><li><a href="breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a class="current" href="versioning.html">Versioning Strategy</a></li><li><a href="../repo/CHANGELOG.html">Changelog</a></li></ul>
+  <ul><li><a href="breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a class="current" aria-current="page" href="versioning.html">Versioning Strategy</a></li><li><a href="../repo/CHANGELOG.html">Changelog</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Architecture</h3>
   <ul><li><a href="../architecture/README.html">Architecture Documentation</a></li></ul>
@@ -340,6 +340,16 @@
 
           </div>
         </section>
+        <nav class="page-nav" aria-label="Page navigation">
+  <a class="page-nav-link prev" href="rfc-process.html">
+    <span class="page-nav-eyebrow">Previous spec page</span>
+    <strong class="page-nav-label">RFC Process for MCP-AQL Specification</strong>
+  </a>
+  <a class="page-nav-link next" href="../repo/CHANGELOG.html">
+    <span class="page-nav-eyebrow">Next spec page</span>
+    <strong class="page-nav-label">Changelog</strong>
+  </a>
+</nav>
       </article>
     </div>
   </main>

--- a/public/spec/process/versioning.html
+++ b/public/spec/process/versioning.html
@@ -1,0 +1,354 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="This document describes the version numbering scheme and release process for the MCPAQL specification.">
+  <title>MCP-AQL Spec | Versioning Strategy</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../../css/style.css">
+</head>
+<body>
+  <header>
+    <div class="container">
+      <nav>
+        <a class="logo" href="../../index.html"><span class="logo-mark"></span>MCP-AQL</a>
+        <ul class="nav-links">
+          <li><a href="../../index.html">Home</a></li>
+          <li><a href="../../docs/index.html">Docs</a></li>
+          <li><a href="../../launch-checklist.html">Launch Checklist</a></li>
+          <li><a href="../../apis/mcp-server.html">Adapter Patterns</a></li>
+        </ul>
+        <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
+          <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
+          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <span class="search-count" data-search-count></span>
+          <ul class="search-results" data-search-results hidden></ul>
+        </form>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <div class="container docs-shell">
+      <aside class="docs-side">
+        <h2>Repo-Synced Spec</h2>
+        <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
+        <div class="docs-side-group">
+  <h3>Core</h3>
+  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Versions</h3>
+  <ul><li><a href="../versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Adapter</h3>
+  <ul><li><a href="../adapter/danger-levels.html">Dangerous Operation Classification Specification</a></li><li><a href="../adapter/discovery-bundle.html">MCP Server Discovery Bundle</a></li><li><a href="../adapter/element-type.html">Adapter Element Type Specification</a></li><li><a href="../adapter/generator.html">Adapter Generator Specification</a></li><li><a href="../adapter/rate-limiting.html">Rate Limiting and Quota Management Specification</a></li><li><a href="../adapter/trust-levels.html">Trust Levels Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Security</h3>
+  <ul><li><a href="../security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="../security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="../security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Features</h3>
+  <ul><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Guides</h3>
+  <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Process</h3>
+  <ul><li><a href="breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a class="current" href="versioning.html">Versioning Strategy</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Architecture</h3>
+  <ul><li><a href="../architecture/README.html">Architecture Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Research</h3>
+  <ul><li><a href="../research/mcp-vs-mcpaql-vs-a2a.html">Protocol Landscape: MCP vs MCP-AQL vs A2A</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Reference</h3>
+  <ul><li><a href="../reference/README.html">Reference Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>ADRs</h3>
+  <ul><li><a href="../adr/ADR-001-crude-pattern.html">ADR-001: CRUDE Pattern (Extending CRUD with Execute)</a></li><li><a href="../adr/ADR-002-graphql-style-input.html">ADR-002: GraphQL-Style Input Objects for Updates</a></li><li><a href="../adr/ADR-003-snake-case-parameters.html">ADR-003: snake_case Parameter Convention</a></li><li><a href="../adr/ADR-004-schema-driven-operations.html">ADR-004: Schema-Driven Operation Definitions</a></li><li><a href="../adr/ADR-005-introspection-system.html">ADR-005: GraphQL-Style Introspection System</a></li><li><a href="../adr/ADR-006-discriminated-responses.html">ADR-006: Discriminated Response Format</a></li><li><a href="../adr/index.html">Architecture Decision Records</a></li><li><a href="../adr/README.html">Architecture Decision Records</a></li></ul>
+</div>
+      </aside>
+
+      <article class="docs-main">
+        <section class="hero docs-hero">
+          <div class="hero-inner">
+            <span class="status-pill">REPO-SYNCED SPEC DOC</span>
+            <h1>Versioning Strategy</h1>
+            <p class="lede">This document describes the version numbering scheme and release process for the MCPAQL specification.</p>
+            <div class="spec-meta"><span class="state-chip live">Support document</span><span class="state-chip pending">draft</span><span class="state-chip">1.0.0-draft</span></div>
+            <p class="spec-source">Source: <a href="https://github.com/MCPAQL/spec/blob/main/docs/process/versioning.md">spec/docs/process/versioning.md</a></p>
+            <div class="hero-actions">
+              <a class="btn btn-primary" href="https://github.com/MCPAQL/spec/blob/main/docs/process/versioning.md">Open Source Markdown</a>
+              <a class="btn btn-secondary" href="../index.html">Browse Full Spec Reference</a>
+            </div>
+          </div>
+        </section>
+
+        <section>
+          <div class="card spec-prose">
+            <p>This document describes the version numbering scheme and release process for the MCPAQL specification.</p>
+<h2 id="overview">Overview</h2>
+<p>MCPAQL follows <a href="https://semver.org/">Semantic Versioning 2.0.0</a> (SemVer) for core <code>MAJOR.MINOR.PATCH</code> compatibility signaling. For publication stages, MCP-AQL also uses project-specific draft lifecycle tags (<code>draft</code>, <code>alpha.N</code>, <code>beta.N</code>, <code>rc.N</code>) to communicate spec maturity.</p>
+<h2 id="version-format">Version Format</h2>
+<pre><code>MAJOR.MINOR.PATCH[-PRERELEASE]</code></pre>
+<h3 id="components">Components</h3>
+<table>
+<thead>
+<tr>
+<th>Component</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>MAJOR</td>
+<td>Breaking changes that require implementation updates</td>
+</tr>
+<tr>
+<td>MINOR</td>
+<td>New features, backward compatible</td>
+</tr>
+<tr>
+<td>PATCH</td>
+<td>Bug fixes, clarifications, backward compatible</td>
+</tr>
+<tr>
+<td>PRERELEASE</td>
+<td>Optional tag indicating release maturity</td>
+</tr>
+</tbody>
+</table>
+<h3 id="examples">Examples</h3>
+<table>
+<thead>
+<tr>
+<th>Version</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>1.0.0-draft</code></td>
+<td>Current working draft</td>
+</tr>
+<tr>
+<td><code>1.0.0</code></td>
+<td>First stable release</td>
+</tr>
+<tr>
+<td><code>1.1.0</code></td>
+<td>New features added (backward compatible)</td>
+</tr>
+<tr>
+<td><code>1.1.1</code></td>
+<td>Bug fixes or clarifications</td>
+</tr>
+<tr>
+<td><code>2.0.0</code></td>
+<td>Breaking changes from v1.x</td>
+</tr>
+</tbody>
+</table>
+<h2 id="pre-release-tags">Pre-release Tags</h2>
+<p>Pre-release versions use the following tags appended to the version number:</p>
+<h3 id="-draft"><code>-draft</code></h3>
+<p>Working draft, subject to significant change. Not recommended for production implementations.</p>
+<pre><code>1.0.0-draft</code></pre>
+<h3 id="-alphan"><code>-alpha.N</code></h3>
+<p>Early preview releases for initial feedback. APIs and behaviors may change substantially.</p>
+<pre><code>1.0.0-alpha.1
+1.0.0-alpha.2</code></pre>
+<h3 id="-betan"><code>-beta.N</code></h3>
+<p>Feature complete preview. APIs are stabilizing but may still change based on feedback.</p>
+<pre><code>1.0.0-beta.1
+1.0.0-beta.2</code></pre>
+<h3 id="-rcn"><code>-rc.N</code></h3>
+<p>Release candidate. Final testing before stable release. Only critical bug fixes expected.</p>
+<pre><code>1.0.0-rc.1
+1.0.0-rc.2</code></pre>
+<h3 id="pre-release-progression">Pre-release Progression</h3>
+<pre><code>draft -&gt; alpha.1 -&gt; alpha.N -&gt; beta.1 -&gt; beta.N -&gt; rc.1 -&gt; rc.N -&gt; stable</code></pre>
+<h3 id="draft-label-convention">Draft Label Convention</h3>
+<p><code>v1.0.0-draft</code> is intentionally treated as the active public working-draft line, even though earlier snapshots such as <code>v1.0.0-alpha.1</code> exist in repository history.</p>
+<p>This is a deliberate publication-stage convention (RFC/W3C-style draft signaling), not a strict semver precedence claim across mixed pre-release labels.</p>
+<p>Implementations and tooling SHOULD use <code>SPEC_VERSION</code> and release notes as the source of truth for the current normative draft target rather than inferring maturity solely from lexical pre-release sorting.</p>
+<h2 id="version-increment-rules">Version Increment Rules</h2>
+<h3 id="major-version-increment">MAJOR Version Increment</h3>
+<p>Increment MAJOR when making incompatible changes that require existing implementations to be updated:</p>
+<ul>
+<li>Removing or renaming required operations</li>
+<li>Changing the behavior of existing operations in breaking ways</li>
+<li>Modifying required request/response schemas incompatibly</li>
+<li>Removing or renaming required element types</li>
+<li>Changing security requirements in ways that break existing implementations</li>
+</ul>
+<p><strong>Example</strong>: Renaming the <code>list_elements</code> operation to <code>list_all</code> would require a MAJOR version bump.</p>
+<h3 id="minor-version-increment">MINOR Version Increment</h3>
+<p>Increment MINOR when adding functionality in a backward compatible manner:</p>
+<ul>
+<li>Adding new optional operations</li>
+<li>Adding new element types</li>
+<li>Adding optional fields to existing schemas</li>
+<li>Extending capabilities without breaking existing implementations</li>
+<li>Adding new pre-defined values to enumerations (when implementations ignore unknown values)</li>
+</ul>
+<p><strong>Example</strong>: Adding a new <code>archive_element</code> operation would require a MINOR version bump.</p>
+<h3 id="patch-version-increment">PATCH Version Increment</h3>
+<p>Increment PATCH for backward compatible bug fixes and clarifications:</p>
+<ul>
+<li>Correcting typos or unclear wording in the specification</li>
+<li>Adding examples or clarifications</li>
+<li>Fixing errors in documentation</li>
+<li>Non-functional improvements to the specification text</li>
+</ul>
+<p><strong>Example</strong>: Clarifying the expected behavior when an element is not found would be a PATCH release.</p>
+<h2 id="release-process">Release Process</h2>
+<h3 id="1-create-release-branch">1. Create Release Branch</h3>
+<p>Create a release branch from <code>develop</code>:</p>
+<div class="sourceCode" id="cb7"><pre class="sourceCode bash"><code class="sourceCode bash"><span id="cb7-1"><a href="#cb7-1" aria-hidden="true" tabindex="-1"></a><span class="fu">git</span> checkout develop</span>
+<span id="cb7-2"><a href="#cb7-2" aria-hidden="true" tabindex="-1"></a><span class="fu">git</span> pull origin develop</span>
+<span id="cb7-3"><a href="#cb7-3" aria-hidden="true" tabindex="-1"></a><span class="fu">git</span> checkout <span class="at">-b</span> release/vX.Y.Z</span></code></pre></div>
+<h3 id="2-update-version-numbers">2. Update Version Numbers</h3>
+<p>Update version references throughout the repository:</p>
+<ul>
+<li>Specification document in <code>docs/versions/</code></li>
+<li>Version badges and references in <code>README.md</code></li>
+<li>Any version constants or metadata</li>
+</ul>
+<h3 id="3-update-changelog">3. Update CHANGELOG</h3>
+<p>Add a new section to <code>CHANGELOG.md</code> documenting:</p>
+<ul>
+<li>New features</li>
+<li>Changes</li>
+<li>Deprecations</li>
+<li>Bug fixes</li>
+<li>Breaking changes (if MAJOR release)</li>
+</ul>
+<h3 id="4-create-pull-request">4. Create Pull Request</h3>
+<p>Open a pull request from <code>release/vX.Y.Z</code> to <code>main</code>:</p>
+<ul>
+<li>Title: <code>Release vX.Y.Z</code></li>
+<li>Description: Summary of changes, link to CHANGELOG entry</li>
+<li>Request reviews from maintainers</li>
+</ul>
+<h3 id="5-tag-release">5. Tag Release</h3>
+<p>After PR approval and merge:</p>
+<div class="sourceCode" id="cb8"><pre class="sourceCode bash"><code class="sourceCode bash"><span id="cb8-1"><a href="#cb8-1" aria-hidden="true" tabindex="-1"></a><span class="fu">git</span> checkout main</span>
+<span id="cb8-2"><a href="#cb8-2" aria-hidden="true" tabindex="-1"></a><span class="fu">git</span> pull origin main</span>
+<span id="cb8-3"><a href="#cb8-3" aria-hidden="true" tabindex="-1"></a><span class="fu">git</span> tag <span class="at">-a</span> vX.Y.Z <span class="at">-m</span> <span class="st">&quot;Release vX.Y.Z&quot;</span></span>
+<span id="cb8-4"><a href="#cb8-4" aria-hidden="true" tabindex="-1"></a><span class="fu">git</span> push origin vX.Y.Z</span></code></pre></div>
+<h3 id="6-create-github-release">6. Create GitHub Release</h3>
+<p>Create a GitHub release from the tag:</p>
+<ul>
+<li>Title: <code>vX.Y.Z</code></li>
+<li>Description: Copy relevant CHANGELOG section</li>
+<li>Attach any release artifacts if applicable</li>
+<li>Mark as pre-release if using pre-release tags</li>
+</ul>
+<h3 id="7-post-release">7. Post-Release</h3>
+<p>After release:</p>
+<div class="sourceCode" id="cb9"><pre class="sourceCode bash"><code class="sourceCode bash"><span id="cb9-1"><a href="#cb9-1" aria-hidden="true" tabindex="-1"></a><span class="fu">git</span> checkout develop</span>
+<span id="cb9-2"><a href="#cb9-2" aria-hidden="true" tabindex="-1"></a><span class="fu">git</span> merge main</span>
+<span id="cb9-3"><a href="#cb9-3" aria-hidden="true" tabindex="-1"></a><span class="fu">git</span> push origin develop</span></code></pre></div>
+<h2 id="version-locations">Version Locations</h2>
+<p>Version information is maintained in the following locations:</p>
+<table>
+<thead>
+<tr>
+<th>Location</th>
+<th>Purpose</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>docs/versions/vX.Y.Z.md</code></td>
+<td>Full specification document for each version</td>
+</tr>
+<tr>
+<td><code>CHANGELOG.md</code></td>
+<td>Complete version history with changes</td>
+</tr>
+<tr>
+<td><code>README.md</code></td>
+<td>Version badge showing current stable version</td>
+</tr>
+</tbody>
+</table>
+<h3 id="specification-document-naming">Specification Document Naming</h3>
+<p>Each version of the specification is stored as a separate document:</p>
+<pre><code>docs/versions/
+  v1.0.0-draft.md
+  v1.0.0.md
+  v1.1.0.md
+  v2.0.0.md</code></pre>
+<h2 id="release-cadence">Release Cadence</h2>
+<h3 id="patch-releases">Patch Releases</h3>
+<ul>
+<li><strong>Frequency</strong>: As needed</li>
+<li><strong>Trigger</strong>: Documentation errors, clarifications, or minor corrections</li>
+<li><strong>Review</strong>: Minimal review required</li>
+</ul>
+<h3 id="minor-releases">Minor Releases</h3>
+<ul>
+<li><strong>Frequency</strong>: Quarterly, or as features accumulate</li>
+<li><strong>Trigger</strong>: New features, enhancements, or accumulated improvements</li>
+<li><strong>Review</strong>: Full review cycle with community feedback period</li>
+</ul>
+<h3 id="major-releases">Major Releases</h3>
+<ul>
+<li><strong>Frequency</strong>: Only when breaking changes are required</li>
+<li><strong>Trigger</strong>: Fundamental changes to the specification that cannot be made backward compatible</li>
+<li><strong>Review</strong>: Extended review cycle with migration guide and deprecation period</li>
+</ul>
+<h3 id="release-schedule-considerations">Release Schedule Considerations</h3>
+<ul>
+<li>Avoid releasing during major holidays or conference periods</li>
+<li>Provide adequate notice for breaking changes (MAJOR releases)</li>
+<li>Consider implementation burden when planning release frequency</li>
+<li>Batch related changes when possible to reduce release overhead</li>
+</ul>
+<h2 id="version-compatibility">Version Compatibility</h2>
+<h3 id="backward-compatibility">Backward Compatibility</h3>
+<p>MINOR and PATCH releases maintain backward compatibility:</p>
+<ul>
+<li>Implementations conforming to vX.Y.Z should work with vX.Y+1.Z specifications</li>
+<li>New optional features may not be supported, but existing functionality remains</li>
+</ul>
+<h3 id="forward-compatibility">Forward Compatibility</h3>
+<p>Implementations should be designed for forward compatibility where possible:</p>
+<ul>
+<li>Ignore unknown fields in responses</li>
+<li>Handle unknown enumeration values gracefully</li>
+<li>Provide fallback behavior for unrecognized operations</li>
+</ul>
+<h2 id="see-also">See Also</h2>
+<ul>
+<li><a href="https://semver.org/">Semantic Versioning 2.0.0</a></li>
+<li><a href="https://github.com/MCPAQL/spec/blob/main/CHANGELOG.md">CHANGELOG.md</a></li>
+<li><a href="https://github.com/MCPAQL/spec/blob/main/CONTRIBUTING.md">Contributing Guide</a></li>
+</ul>
+
+          </div>
+        </section>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div class="container">
+      <p>&copy; 2026 DollhouseMCP Inc. d/b/a Dollhouse Research. MCP-AQL public draft documentation portal.</p>
+      <div class="footer-links">
+        <a href="../../docs/index.html">Docs Library</a>
+        <a href="../index.html">Repo-Synced Spec</a>
+        <a href="https://github.com/MCPAQL">MCPAQL Organization</a>
+        <a href="https://dollhouseresearch.com">Dollhouse Research</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../../js/search.js"></script>
+</body>
+</html>

--- a/public/spec/process/versioning.html
+++ b/public/spec/process/versioning.html
@@ -73,6 +73,13 @@
       </aside>
 
       <article class="docs-main">
+        <nav class="breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../../index.html">Home</a></li>
+            <li><a href="../index.html">Full Spec</a></li>
+            <li><span class="current">Versioning Strategy</span></li>
+          </ol>
+        </nav>
         <section class="hero docs-hero">
           <div class="hero-inner">
             <span class="status-pill">REPO-SYNCED SPEC DOC</span>

--- a/public/spec/process/versioning.html
+++ b/public/spec/process/versioning.html
@@ -38,7 +38,7 @@
         <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
         <div class="docs-side-group">
   <h3>Core</h3>
-  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li></ul>
+  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li><li><a href="../repo/README.html">MCP-AQL Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Versions</h3>
   <ul><li><a href="../versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
@@ -56,7 +56,7 @@
   <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
-  <ul><li><a href="breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a class="current" href="versioning.html">Versioning Strategy</a></li></ul>
+  <ul><li><a href="breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a class="current" href="versioning.html">Versioning Strategy</a></li><li><a href="../repo/CHANGELOG.html">Changelog</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Architecture</h3>
   <ul><li><a href="../architecture/README.html">Architecture Documentation</a></li></ul>
@@ -327,7 +327,7 @@
 <h2 id="see-also">See Also</h2>
 <ul>
 <li><a href="https://semver.org/">Semantic Versioning 2.0.0</a></li>
-<li><a href="https://github.com/MCPAQL/spec/blob/main/CHANGELOG.md">CHANGELOG.md</a></li>
+<li><a href="../repo/CHANGELOG.html">CHANGELOG.md</a></li>
 <li><a href="https://github.com/MCPAQL/spec/blob/main/CONTRIBUTING.md">Contributing Guide</a></li>
 </ul>
 

--- a/public/spec/reference/README.html
+++ b/public/spec/reference/README.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Detailed specifications for schemas, formats, and protocol structures.">
+  <title>MCP-AQL Spec | Reference Documentation</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../../css/style.css">
+</head>
+<body>
+  <header>
+    <div class="container">
+      <nav>
+        <a class="logo" href="../../index.html"><span class="logo-mark"></span>MCP-AQL</a>
+        <ul class="nav-links">
+          <li><a href="../../index.html">Home</a></li>
+          <li><a href="../../docs/index.html">Docs</a></li>
+          <li><a href="../../launch-checklist.html">Launch Checklist</a></li>
+          <li><a href="../../apis/mcp-server.html">Adapter Patterns</a></li>
+        </ul>
+        <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
+          <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
+          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <span class="search-count" data-search-count></span>
+          <ul class="search-results" data-search-results hidden></ul>
+        </form>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <div class="container docs-shell">
+      <aside class="docs-side">
+        <h2>Repo-Synced Spec</h2>
+        <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
+        <div class="docs-side-group">
+  <h3>Core</h3>
+  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Versions</h3>
+  <ul><li><a href="../versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Adapter</h3>
+  <ul><li><a href="../adapter/danger-levels.html">Dangerous Operation Classification Specification</a></li><li><a href="../adapter/discovery-bundle.html">MCP Server Discovery Bundle</a></li><li><a href="../adapter/element-type.html">Adapter Element Type Specification</a></li><li><a href="../adapter/generator.html">Adapter Generator Specification</a></li><li><a href="../adapter/rate-limiting.html">Rate Limiting and Quota Management Specification</a></li><li><a href="../adapter/trust-levels.html">Trust Levels Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Security</h3>
+  <ul><li><a href="../security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="../security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="../security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Features</h3>
+  <ul><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Guides</h3>
+  <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Process</h3>
+  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Architecture</h3>
+  <ul><li><a href="../architecture/README.html">Architecture Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Research</h3>
+  <ul><li><a href="../research/mcp-vs-mcpaql-vs-a2a.html">Protocol Landscape: MCP vs MCP-AQL vs A2A</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Reference</h3>
+  <ul><li><a class="current" href="README.html">Reference Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>ADRs</h3>
+  <ul><li><a href="../adr/ADR-001-crude-pattern.html">ADR-001: CRUDE Pattern (Extending CRUD with Execute)</a></li><li><a href="../adr/ADR-002-graphql-style-input.html">ADR-002: GraphQL-Style Input Objects for Updates</a></li><li><a href="../adr/ADR-003-snake-case-parameters.html">ADR-003: snake_case Parameter Convention</a></li><li><a href="../adr/ADR-004-schema-driven-operations.html">ADR-004: Schema-Driven Operation Definitions</a></li><li><a href="../adr/ADR-005-introspection-system.html">ADR-005: GraphQL-Style Introspection System</a></li><li><a href="../adr/ADR-006-discriminated-responses.html">ADR-006: Discriminated Response Format</a></li><li><a href="../adr/index.html">Architecture Decision Records</a></li><li><a href="../adr/README.html">Architecture Decision Records</a></li></ul>
+</div>
+      </aside>
+
+      <article class="docs-main">
+        <section class="hero docs-hero">
+          <div class="hero-inner">
+            <span class="status-pill">REPO-SYNCED SPEC DOC</span>
+            <h1>Reference Documentation</h1>
+            <p class="lede">Detailed specifications for schemas, formats, and protocol structures.</p>
+            <div class="spec-meta"><span class="state-chip live">Support document</span></div>
+            <p class="spec-source">Source: <a href="https://github.com/MCPAQL/spec/blob/main/docs/reference/README.md">spec/docs/reference/README.md</a></p>
+            <div class="hero-actions">
+              <a class="btn btn-primary" href="https://github.com/MCPAQL/spec/blob/main/docs/reference/README.md">Open Source Markdown</a>
+              <a class="btn btn-secondary" href="../index.html">Browse Full Spec Reference</a>
+            </div>
+          </div>
+        </section>
+
+        <section>
+          <div class="card spec-prose">
+            <p>Detailed specifications for schemas, formats, and protocol structures.</p>
+
+          </div>
+        </section>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div class="container">
+      <p>&copy; 2026 DollhouseMCP Inc. d/b/a Dollhouse Research. MCP-AQL public draft documentation portal.</p>
+      <div class="footer-links">
+        <a href="../../docs/index.html">Docs Library</a>
+        <a href="../index.html">Repo-Synced Spec</a>
+        <a href="https://github.com/MCPAQL">MCPAQL Organization</a>
+        <a href="https://dollhouseresearch.com">Dollhouse Research</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../../js/search.js"></script>
+</body>
+</html>

--- a/public/spec/reference/README.html
+++ b/public/spec/reference/README.html
@@ -38,7 +38,7 @@
         <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
         <div class="docs-side-group">
   <h3>Core</h3>
-  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li></ul>
+  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li><li><a href="../repo/README.html">MCP-AQL Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Versions</h3>
   <ul><li><a href="../versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
@@ -56,7 +56,7 @@
   <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
-  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li></ul>
+  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li><li><a href="../repo/CHANGELOG.html">Changelog</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Architecture</h3>
   <ul><li><a href="../architecture/README.html">Architecture Documentation</a></li></ul>

--- a/public/spec/reference/README.html
+++ b/public/spec/reference/README.html
@@ -23,7 +23,7 @@
         </ul>
         <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
-          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <input id="site-search-input" data-search-input type="search" placeholder="Search MCP-AQL docs, spec pages, and adapter patterns...">
           <span class="search-count" data-search-count></span>
           <ul class="search-results" data-search-results hidden></ul>
         </form>
@@ -65,7 +65,7 @@
   <ul><li><a href="../research/mcp-vs-mcpaql-vs-a2a.html">Protocol Landscape: MCP vs MCP-AQL vs A2A</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Reference</h3>
-  <ul><li><a class="current" href="README.html">Reference Documentation</a></li></ul>
+  <ul><li><a class="current" aria-current="page" href="README.html">Reference Documentation</a></li></ul>
 </div><div class="docs-side-group">
   <h3>ADRs</h3>
   <ul><li><a href="../adr/ADR-001-crude-pattern.html">ADR-001: CRUDE Pattern (Extending CRUD with Execute)</a></li><li><a href="../adr/ADR-002-graphql-style-input.html">ADR-002: GraphQL-Style Input Objects for Updates</a></li><li><a href="../adr/ADR-003-snake-case-parameters.html">ADR-003: snake_case Parameter Convention</a></li><li><a href="../adr/ADR-004-schema-driven-operations.html">ADR-004: Schema-Driven Operation Definitions</a></li><li><a href="../adr/ADR-005-introspection-system.html">ADR-005: GraphQL-Style Introspection System</a></li><li><a href="../adr/ADR-006-discriminated-responses.html">ADR-006: Discriminated Response Format</a></li><li><a href="../adr/index.html">Architecture Decision Records</a></li><li><a href="../adr/README.html">Architecture Decision Records</a></li></ul>
@@ -100,6 +100,16 @@
 
           </div>
         </section>
+        <nav class="page-nav" aria-label="Page navigation">
+  <a class="page-nav-link prev" href="../research/mcp-vs-mcpaql-vs-a2a.html">
+    <span class="page-nav-eyebrow">Previous spec page</span>
+    <strong class="page-nav-label">Protocol Landscape: MCP vs MCP-AQL vs A2A</strong>
+  </a>
+  <a class="page-nav-link next" href="../adr/ADR-001-crude-pattern.html">
+    <span class="page-nav-eyebrow">Next spec page</span>
+    <strong class="page-nav-label">ADR-001: CRUDE Pattern (Extending CRUD with Execute)</strong>
+  </a>
+</nav>
       </article>
     </div>
   </main>

--- a/public/spec/reference/README.html
+++ b/public/spec/reference/README.html
@@ -73,6 +73,13 @@
       </aside>
 
       <article class="docs-main">
+        <nav class="breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../../index.html">Home</a></li>
+            <li><a href="../index.html">Full Spec</a></li>
+            <li><span class="current">Reference Documentation</span></li>
+          </ol>
+        </nav>
         <section class="hero docs-hero">
           <div class="hero-inner">
             <span class="status-pill">REPO-SYNCED SPEC DOC</span>

--- a/public/spec/repo/CHANGELOG.html
+++ b/public/spec/repo/CHANGELOG.html
@@ -73,6 +73,13 @@
       </aside>
 
       <article class="docs-main">
+        <nav class="breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../../index.html">Home</a></li>
+            <li><a href="../index.html">Full Spec</a></li>
+            <li><span class="current">Changelog</span></li>
+          </ol>
+        </nav>
         <section class="hero docs-hero">
           <div class="hero-inner">
             <span class="status-pill">REPO-SYNCED SPEC DOC</span>

--- a/public/spec/repo/CHANGELOG.html
+++ b/public/spec/repo/CHANGELOG.html
@@ -1,0 +1,690 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="All notable changes to the MCP-AQL specification will be documented in this file.">
+  <title>MCP-AQL Spec | Changelog</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../../css/style.css">
+</head>
+<body>
+  <header>
+    <div class="container">
+      <nav>
+        <a class="logo" href="../../index.html"><span class="logo-mark"></span>MCP-AQL</a>
+        <ul class="nav-links">
+          <li><a href="../../index.html">Home</a></li>
+          <li><a href="../../docs/index.html">Docs</a></li>
+          <li><a href="../../launch-checklist.html">Launch Checklist</a></li>
+          <li><a href="../../apis/mcp-server.html">Adapter Patterns</a></li>
+        </ul>
+        <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
+          <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
+          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <span class="search-count" data-search-count></span>
+          <ul class="search-results" data-search-results hidden></ul>
+        </form>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <div class="container docs-shell">
+      <aside class="docs-side">
+        <h2>Repo-Synced Spec</h2>
+        <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
+        <div class="docs-side-group">
+  <h3>Core</h3>
+  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li><li><a href="README.html">MCP-AQL Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Versions</h3>
+  <ul><li><a href="../versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Adapter</h3>
+  <ul><li><a href="../adapter/danger-levels.html">Dangerous Operation Classification Specification</a></li><li><a href="../adapter/discovery-bundle.html">MCP Server Discovery Bundle</a></li><li><a href="../adapter/element-type.html">Adapter Element Type Specification</a></li><li><a href="../adapter/generator.html">Adapter Generator Specification</a></li><li><a href="../adapter/rate-limiting.html">Rate Limiting and Quota Management Specification</a></li><li><a href="../adapter/trust-levels.html">Trust Levels Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Security</h3>
+  <ul><li><a href="../security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="../security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="../security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Features</h3>
+  <ul><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Guides</h3>
+  <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Process</h3>
+  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li><li><a class="current" href="CHANGELOG.html">Changelog</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Architecture</h3>
+  <ul><li><a href="../architecture/README.html">Architecture Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Research</h3>
+  <ul><li><a href="../research/mcp-vs-mcpaql-vs-a2a.html">Protocol Landscape: MCP vs MCP-AQL vs A2A</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Reference</h3>
+  <ul><li><a href="../reference/README.html">Reference Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>ADRs</h3>
+  <ul><li><a href="../adr/ADR-001-crude-pattern.html">ADR-001: CRUDE Pattern (Extending CRUD with Execute)</a></li><li><a href="../adr/ADR-002-graphql-style-input.html">ADR-002: GraphQL-Style Input Objects for Updates</a></li><li><a href="../adr/ADR-003-snake-case-parameters.html">ADR-003: snake_case Parameter Convention</a></li><li><a href="../adr/ADR-004-schema-driven-operations.html">ADR-004: Schema-Driven Operation Definitions</a></li><li><a href="../adr/ADR-005-introspection-system.html">ADR-005: GraphQL-Style Introspection System</a></li><li><a href="../adr/ADR-006-discriminated-responses.html">ADR-006: Discriminated Response Format</a></li><li><a href="../adr/index.html">Architecture Decision Records</a></li><li><a href="../adr/README.html">Architecture Decision Records</a></li></ul>
+</div>
+      </aside>
+
+      <article class="docs-main">
+        <section class="hero docs-hero">
+          <div class="hero-inner">
+            <span class="status-pill">REPO-SYNCED SPEC DOC</span>
+            <h1>Changelog</h1>
+            <p class="lede">All notable changes to the MCP-AQL specification will be documented in this file.</p>
+            <div class="spec-meta"><span class="state-chip live">Repository source</span></div>
+            <p class="spec-source">Source: <a href="https://github.com/MCPAQL/spec/blob/main/CHANGELOG.md">spec/CHANGELOG.md</a></p>
+            <div class="hero-actions">
+              <a class="btn btn-primary" href="https://github.com/MCPAQL/spec/blob/main/CHANGELOG.md">Open Source Markdown</a>
+              <a class="btn btn-secondary" href="../index.html">Browse Full Spec Reference</a>
+            </div>
+          </div>
+        </section>
+
+        <section>
+          <div class="card spec-prose">
+            <p>All notable changes to the MCP-AQL specification will be documented in this file.</p>
+<p>The format is based on <a href="https://keepachangelog.com/en/1.1.0/">Keep a Changelog</a>, and this project adheres to <a href="https://semver.org/spec/v2.0.0.html">Semantic Versioning</a>.</p>
+<h2 id="unreleased">[Unreleased]</h2>
+<h3 id="added">Added</h3>
+<ul>
+<li>Discovery-bundle contract and schema for MCP server interrogation pipelines (PR #220)
+<ul>
+<li>Added <code>docs/adapter/discovery-bundle.md</code> as informative support text for the GitHub golden-path capture workflow</li>
+<li>Added <code>schemas/discovery-bundle.schema.json</code> as a non-normative intermediate artifact schema</li>
+<li>Documented raw capture vs normalized bundle responsibilities, provenance expectations, and current transport/auth scope notes</li>
+</ul></li>
+<li>Execution safety loop as opt-in enforcement boundary for agent actions (#208)
+<ul>
+<li>New normative Section 8.6 defining the execution safety loop pattern</li>
+<li>Opt-in activation via <code>execute_agent</code> or adapter configuration</li>
+<li>Mandatory action reporting (<code>nextActionHint</code>) when active</li>
+<li>Continuous enforcement via <code>AutonomyDirective</code> responses</li>
+<li>Scope includes ALL tool calls, not only MCP-AQL operations</li>
+<li>Support for disabling, monitoring-only, and logging-only modes</li>
+</ul></li>
+<li>Safety dongle deployment model and execution safety loop specification (#205)
+<ul>
+<li>New document <code>docs/security/execution-safety-loop.md</code></li>
+<li>Defines the safety dongle as a standalone MCP-AQL server for safety enforcement</li>
+<li>Minimal operation surface: 7 operations across 3 endpoints</li>
+<li>Permission architecture: endpoint classification determines friction levels</li>
+<li>Gatekeeper integration with pattern-based policy evaluation</li>
+<li>Danger Zone integration with out-of-band verification</li>
+<li>Deployment examples: minimal dongle, multi-server, embedded safety</li>
+</ul></li>
+<li>Autonomy Evaluator model for per-action risk assessment (#206)
+<ul>
+<li>New normative Section 8.7 defining the <code>AutonomyDirective</code> response contract</li>
+<li>5-stage evaluation pipeline: step limit, outcome check, pattern matching, safety tier, risk tolerance</li>
+<li>Agent notification system (<code>permission_pending</code>, <code>autonomy_pause</code>, <code>danger_zone</code>)</li>
+<li>Configurable elements: step limits, risk tolerance, approval/auto-approve patterns</li>
+<li>Minimum viable implementation requirements (step limit is the only MUST stage)</li>
+</ul></li>
+<li>Out-of-band verification protocol for Danger Zone enforcement (#207)
+<ul>
+<li>New normative Section 8.8 defining challenge-response protocol for highest-risk actions</li>
+<li>Trigger conditions: <code>danger_zone</code> safety tier or hard-block pattern match</li>
+<li>Challenge protocol: 128-bit entropy codes displayed through AI-inaccessible channels</li>
+<li>Blocking semantics: agent-level blocks that persist across server restarts</li>
+<li>Channel separation requirements ensuring AI cannot observe verification codes</li>
+<li>Rate limiting for failed verification attempts (brute-force prevention)</li>
+<li>Implementation flexibility: OS dialogs, hardware tokens, SMS, dashboards</li>
+</ul></li>
+<li>Canonical operation verbs per CRUDE endpoint (#159)
+<ul>
+<li>New Section 8.5 (Operation Naming Grammar) in v1.0.0-draft.md</li>
+<li>Canonical verbs: create, get/list, update, delete, execute/cancel</li>
+<li><code>{verb}_{resource}</code> naming pattern with non-canonical verb guidance</li>
+<li>Reserved operation names (<code>introspect</code>)</li>
+<li>HTTP method mapping table for REST developers</li>
+<li>Updated operations.md Section 6.2 to mark canonical vs additional verbs</li>
+<li>Added Section 6.5 (Canonical Verbs) to crude-pattern.md</li>
+</ul></li>
+<li>Session lifecycle definition (#160)
+<ul>
+<li>New Section 2.3 (Session Lifecycle) in v1.0.0-draft.md</li>
+<li>Session defined as lifetime of a single MCP connection (initialize → shutdown/disconnect)</li>
+<li>Session-scoped vs cross-session persistent state distinguished</li>
+<li>Session identification guidance for adapters</li>
+<li>Updated confirmation-tokens.md with explicit session cross-references</li>
+<li>Updated introspection.md caching guidance with session definition</li>
+<li>Added session cross-references in gatekeeper.md and warnings.md</li>
+</ul></li>
+<li>Unknown parameter rejection requirement (#157)
+<ul>
+<li>New Section 4.6 in v1.0.0-draft.md defines normative requirement for unknown parameter handling</li>
+<li><code>VALIDATION_UNKNOWN_PARAM</code> error code added to MVP error code registry</li>
+<li>Error response includes <code>unknown_params</code> and <code>valid_params</code> arrays for actionable feedback</li>
+<li>Prevents LLM hallucination of non-existent parameters and silent typo failures</li>
+<li>Optional <code>strict_mode</code> configuration allows development-time warnings instead of rejection</li>
+</ul></li>
+<li>Data types and encoding requirements section (#156)
+<ul>
+<li>New Section 4.7 in v1.0.0-draft.md defining interoperability requirements</li>
+<li>UTF-8 character encoding requirement with <code>VALIDATION_INVALID_ENCODING</code> error</li>
+<li>ISO 8601 date/time format requirement</li>
+<li>IEEE 754 number handling with guidance for high-precision values</li>
+<li>Base64 binary data encoding with metadata fields</li>
+<li>Payload size limits (request, response, string, array, nesting depth)</li>
+<li><code>VALIDATION_PAYLOAD_TOO_LARGE</code> error code for limit violations</li>
+<li>Null handling semantics documentation</li>
+</ul></li>
+<li>Batch confirmation behavior specification (#158)
+<ul>
+<li>New Section 7.5 (Confirmation-Gated Batch Operations) in operations.md</li>
+<li>Defines batch halting behavior when CONFIRMATION_REQUIRED is encountered</li>
+<li>Includes continuation mechanism with confirmation token</li>
+<li>Documents alternative skip-and-continue mode with warnings about state consistency</li>
+<li><code>CONFIRMATION_REQUIRED</code> is NOT a failure — it is a halting condition</li>
+<li>Updated batch-operation.schema.json with <code>halted_at</code>, <code>pending_operations</code>, and extended <code>summary</code></li>
+</ul></li>
+<li>Execution lifecycle state machine for EXECUTE operations (#155)
+<ul>
+<li>Core states: pending, running, completed, failed, cancelled</li>
+<li>State transition diagram with valid transitions</li>
+<li>State response format with required and optional fields</li>
+<li>Progress reporting object specification</li>
+<li>Adapter extension rules for custom states</li>
+<li>LifecycleInfo schema in introspection-response.schema.json</li>
+<li>Cross-reference from crude-pattern.md Section 2.5</li>
+</ul></li>
+<li>Automated schema example validation script and CI integration (#172)
+<ul>
+<li><code>scripts/validate-schema-examples.mjs</code> validates inline <code>examples</code> in all schema files</li>
+<li>Supports wrapped example format (danger-level) and standard format</li>
+<li>Added example and fixture validation steps to <code>schema-validate.yml</code> workflow</li>
+</ul></li>
+</ul>
+<h3 id="changed">Changed</h3>
+<ul>
+<li>Clarified preliminary public draft positioning and launch boundaries (PR #218)
+<ul>
+<li>Added explicit preliminary-draft status language to README and v1.0.0-draft status section</li>
+<li>Removed hardcoded date from README conformance status note to avoid stale timestamp drift</li>
+<li>Clarified normative vs informative document authority in docs index</li>
+<li>Marked conformance framework status as informative with current implementation note</li>
+<li>Added coordinated preliminary launch checklist spanning spec and Dollhouse reference profile tracks</li>
+<li>Aligned <code>SPEC_VERSION</code> to <code>v1.0.0-draft</code></li>
+<li>Documented draft-label convention in <code>docs/process/versioning.md</code> to explain why <code>v1.0.0-draft</code> is the active target after earlier <code>v1.0.0-alpha.1</code> snapshots</li>
+<li>Added <code>scripts/sync-doc-dates.mjs</code> plus npm scripts (<code>docs:dates</code>, <code>docs:dates:check</code>) to automate date metadata updates for changed docs</li>
+<li>Added PR-time CI enforcement in <code>docs-lint.yml</code> for stale metadata dates and hardcoded status-note calendar dates</li>
+</ul></li>
+<li>Comprehensive rewrite of <code>docs/security/execution-safety-loop.md</code> Section 9 compliance checklist (#216)
+<ul>
+<li>Every normative MUST/SHOULD/MAY in Sections 8.6–8.8 now mapped to a compliance bullet</li>
+<li>Section 9.1 expanded from 11 to 23 MUST requirements (organized by topic area)</li>
+<li>Section 9.2 expanded from 7 to 20 SHOULD requirements (covering rate limiting, verify tier, configuration)</li>
+<li>Section 9.3 expanded from 4 to 5 MAY requirements (with normative section references)</li>
+<li>New Section 9.4 cross-reference table mapping normative sections to compliance bullets</li>
+</ul></li>
+<li>Clarified <code>params</code> vs <code>parameters</code> terminology across spec documents (#163)
+<ul>
+<li><code>params</code> is the request-time object carrying runtime values</li>
+<li><code>parameters</code> is the introspection-time array of <code>ParameterInfo</code> definitions</li>
+<li>Added terminology notes to normative spec (Section 4.3), introspection.md, and operations.md</li>
+</ul></li>
+<li>Upgraded snake_case naming from SHOULD to MUST for operation names and parameters (#162)
+<ul>
+<li>Aligns operation name prose with schema enforcement (<code>^[a-z][a-z0-9_]*$</code> pattern); establishes normative prose requirement for parameter names</li>
+<li>Separates snake_case format requirement (MUST) from verb_resource convention (SHOULD)</li>
+</ul></li>
+<li>Aligned example operation names with canonical verbs from Section 8.5 (#159)
+<ul>
+<li><code>run</code> → <code>execute</code> as canonical verb for EXECUTE endpoint in informative docs</li>
+<li><code>run_job</code> → <code>execute_job</code> in v1.0.0-draft.md and crude-pattern.md</li>
+<li><code>edit_entity</code> → <code>update_entity</code> in overview.md endpoint table</li>
+<li><code>get_execution_state</code> → <code>resume_workflow</code> in overview.md EXECUTE examples (READ op was misplaced)</li>
+<li>Restored <code>execute_workflow</code> as canonical example in introspection.md and protocol-comparison.md</li>
+</ul></li>
+<li>Minor documentation improvements from Sprint 4 review feedback (#129)
+<ul>
+<li>Clarified "history" → "historical context" in CONTRIBUTING.md cross-reference guidelines</li>
+<li>Added "(strictest mode)" clarification for tolerance=0 in confirmation-tokens.md</li>
+<li>Added cross-reference to Section 6.1 (Replay Attack Prevention) in confirmation-tokens.md</li>
+<li>Noted numeric severity mapping aligns with syslog conventions in warnings.md</li>
+</ul></li>
+<li>Added clock skew tolerance validation code example to confirmation tokens (#111)
+<ul>
+<li>Shows how to apply tolerance by adding to expiry time</li>
+<li>Updated validateToken example to reference clock skew handling</li>
+</ul></li>
+<li>Added deployment environment table for clock skew tolerance (#112)
+<ul>
+<li>Recommended values for typical, air-gapped, IoT, high-security, and zero-trust environments</li>
+</ul></li>
+<li>Added reference links to MVP error codes for consistency with Phase 1 codes (#86)
+<ul>
+<li>MVP codes reference this specification as primary source</li>
+<li>HTTP-mapped codes include RFC 9110 section links</li>
+</ul></li>
+<li>Enhanced RATE_LIMIT_QUOTA_WARNING note to better distinguish it from error codes (#87)
+<ul>
+<li>Added warning emoji and IMPORTANT label for visual prominence</li>
+<li>Cross-reference to Warnings Specification</li>
+</ul></li>
+<li>Added explanatory notes for CONFIRMATION_REQUIRED error code category placement (#85)
+<ul>
+<li>Explains why it's under "Permission" category (part of permission gating flow)</li>
+<li>Documents conditional denial with recovery path pattern</li>
+</ul></li>
+<li>Added bidirectional navigation links between spec documents for improved discoverability (#69)
+<ul>
+<li>error-codes.md, trust-levels.md, rate-limiting.md, danger-levels.md, element-type.md, plugin-contracts.md</li>
+</ul></li>
+</ul>
+<h3 id="fixed">Fixed</h3>
+<ul>
+<li><code>get_execution_status</code> misclassified as EXECUTE instead of READ (#161)
+<ul>
+<li>Moved to READ examples in crude-pattern.md Section 2.2</li>
+<li>Added Section 6.1 clarifying classification is by effect, not subject</li>
+<li>Renumbered subsequent classification guideline sections (6.2→6.3, 6.3→6.4, 6.4→6.5)</li>
+</ul></li>
+<li>TypeDetails <code>allOf</code>+<code>oneOf</code> ambiguity allowing cross-variant field pollution (#154)
+<ul>
+<li>Flattened into pure <code>oneOf</code> with <code>additionalProperties: false</code> on each variant</li>
+<li>Each variant (enum, object, union, scalar) now self-contained with all properties</li>
+</ul></li>
+<li><code>OperationDetails.examples</code> schema defined as <code>string[]</code> but prose showed <code>object[]</code> (#152)
+<ul>
+<li>Changed to structured <code>object[]</code> with <code>{ description?, request }</code> format</li>
+<li>Updated schema inline examples and introspection.md to match</li>
+</ul></li>
+<li>Operation detail response wrapping mismatch between schema and prose (#151)
+<ul>
+<li>operations.md Section 9.5 now uses <code>data.operation.{...}</code> matching schema</li>
+<li>Added required <code>mcpTool</code>, <code>permissions</code>, and <code>returns</code> fields to example</li>
+</ul></li>
+<li>MUST/SHOULD contradictions across spec documents (#136)
+<ul>
+<li>Routing enforcement: operations.md now uses MUST (aligns with v1.0.0-draft.md)</li>
+<li>Endpoint mode support: overview.md now uses MUST (aligns with v1.0.0-draft.md)</li>
+<li>Added informative banners to supporting documents (overview, operations, endpoint-modes, introspection, crude-pattern)</li>
+<li>Added normative status declaration to v1.0.0-draft.md establishing document hierarchy</li>
+</ul></li>
+<li>Error examples in operations.md now use structured format (#133)
+<ul>
+<li>Updated TypeScript interface to use <code>ErrorDetail</code> instead of <code>error: string</code></li>
+<li>All error response examples now include <code>code</code>, <code>message</code>, and optional <code>details</code></li>
+<li>Error category table aligned with error-codes.md taxonomy</li>
+<li>Added cross-references to Structured Error Codes Specification</li>
+</ul></li>
+<li>Danger level enum inconsistency across schemas (#99)
+<ul>
+<li>Aligned all schemas and docs with canonical <code>danger-levels.md</code> spec</li>
+<li>Renamed <code>moderate</code> → <code>reversible</code> for clearer semantic meaning</li>
+<li>Canonical enum: <code>["safe", "reversible", "destructive", "dangerous", "forbidden"]</code></li>
+</ul></li>
+<li>Claude auto-review workflow not triggering on pull_request events (#95)</li>
+</ul>
+<h3 id="removed">Removed</h3>
+<ul>
+<li><p>Internal working documents from spec repository (#139)</p>
+<ul>
+<li>docs/handoff/ - Implementation handoff notes</li>
+<li>docs/session-notes/ - Session logs</li>
+<li>docs/agent/ - Agent development logs</li>
+<li>docs/ISSUE_MAPPING.md - Issue tracker mapping</li>
+<li>docs/process/session-notes-2026-01-26-prioritization.md - Prioritization session</li>
+</ul></li>
+<li><p>Updated cross-references in trust-levels.md from GitHub issues to file paths (#78)</p></li>
+<li><p>Deduplicated trust-to-danger gating matrix (#81)</p>
+<ul>
+<li><p>danger-levels.md is now the canonical source for the gating matrix</p></li>
+<li><p>trust-levels.md references danger-levels.md instead of duplicating the matrix</p></li>
+<li><p>Consistent terminology: <code>introspect_only</code> instead of <code>introspect</code></p></li>
+<li><p><code>package.json</code> with ajv/ajv-formats for local and CI validation</p></li>
+</ul></li>
+<li><p>TypeDetails cross-variant rejection test fixtures (#173)</p>
+<ul>
+<li><code>tests/schema/typedetails-fixtures.json</code> with 7 positive and 13 negative test cases</li>
+<li>Validates that <code>additionalProperties: false</code> on each <code>oneOf</code> variant correctly rejects cross-variant field pollution (e.g., enum with fields, object with values)</li>
+<li>Fixture runner integrated into <code>validate-schema-examples.mjs</code> via <code>--fixtures</code> flag</li>
+</ul></li>
+<li><p>UPDATE Input Pattern (Section 4.5) in normative spec (#153)</p>
+<ul>
+<li>Nested <code>input</code> object structure separating identifiers from updateable fields</li>
+<li>Deep-merge semantics: top-level replace, nested objects merge, arrays replace, null removes</li>
+<li>Validation rules for <code>input</code> object</li>
+<li>Specification Impact section added to ADR-002</li>
+<li>Cross-reference from operations.md</li>
+</ul></li>
+<li><p>Proposals directory with template for specification changes (#140)</p>
+<ul>
+<li>proposals/README.md with process overview</li>
+<li>proposals/TEMPLATE.md with standard proposal format</li>
+<li>Reference from docs/process/rfc-process.md</li>
+</ul></li>
+<li><p>Protocol version metadata in introspection response (#138)</p>
+<ul>
+<li><code>_protocol</code> object in operations list response</li>
+<li>Version, conformance level, mode, and capabilities fields</li>
+<li>ProtocolMetadata and ProtocolCapabilities in introspection-response.schema.json</li>
+<li>Documentation in introspection.md Section 4.1.1</li>
+</ul></li>
+<li><p>Extension fields in operation-result schema for documented features (#134)</p>
+<ul>
+<li>Success: <code>_meta</code> (response metadata), <code>results</code>/<code>summary</code> (batch operations)</li>
+<li>Failure: <code>confirmation</code> (gating flow), deprecation fields</li>
+<li>Schema documentation in schemas/README.md with field reference table</li>
+</ul></li>
+<li><p>Request concurrency model documentation (#137)</p>
+<ul>
+<li>Section 9.3 in v1.0.0-draft.md with concurrency categories</li>
+<li>Serialized, read-concurrent, fully-concurrent, resource-locked modes</li>
+<li>Optimistic concurrency control with ETag/version guidance</li>
+<li>Protocol metadata extension for concurrency discovery</li>
+<li>Cross-reference from CONFLICT_VERSION_MISMATCH in error-codes.md</li>
+</ul></li>
+<li><p>Constraint metadata fields in ParameterInfo schema (#135)</p>
+<ul>
+<li>enum, minimum, maximum, minLength, maxLength, pattern, format, items, sensitive</li>
+<li>Updated introspection-response.schema.json with full constraint support</li>
+<li>Updated introspection.md Section 3.4 with constraint field documentation</li>
+<li>Added examples showing constraint usage in operation details</li>
+</ul></li>
+<li><p>MCP Integration specification for protocol bridging (#132)</p>
+<ul>
+<li>Tool description templates with normative <code>introspect</code> operation reference</li>
+<li>Input schema composition rules for CRUDE and Single mode</li>
+<li>Error mapping between MCP-AQL and MCP protocols</li>
+<li>Progress notification mapping for EXECUTE operations</li>
+<li>Multi-adapter deployment patterns with tool prefix support</li>
+</ul></li>
+<li><p>SCHEMA_ error code category for generator validation errors (#128)</p>
+<ul>
+<li>Added to Category Prefixes table in error-codes.md</li>
+<li>Explanatory note distinguishing generator-time from runtime errors</li>
+<li>Cross-reference to adapter generator specification Section 2.2</li>
+</ul></li>
+<li><p>Warning deduplication guidance in warnings specification (#92)</p>
+<ul>
+<li>Server-side deduplication strategies with optional occurrence_count field</li>
+<li>Client-side deduplication patterns (session, time-based, code filtering)</li>
+<li>Recommendations table for different contexts</li>
+</ul></li>
+<li><p>Optional severity field for warnings to enable client prioritization (#93)</p>
+<ul>
+<li>Levels: low, medium (default), high</li>
+<li>Implementation guidelines and client handling examples</li>
+</ul></li>
+<li><p>Severity recommendations for standard warning codes (#117)</p>
+<ul>
+<li>RATE_LIMIT_QUOTA_WARNING: high (&gt;90%), medium (at threshold)</li>
+<li>DEPRECATION_WARNING: high (&lt;30 days), medium (&gt;30 days), low (no date)</li>
+<li>VALIDATION_TRUNCATED_WARNING: medium (&gt;50%), low (≤50%)</li>
+<li>PERFORMANCE_SLOW_QUERY_WARNING: high (&gt;10x), medium (2-10x), low (&lt;2x)</li>
+</ul></li>
+<li><p>Numeric severity mapping convention (#118)</p>
+<ul>
+<li>high=0, medium=1, low=2 for consistent sorting and comparison</li>
+<li>Enables database storage and threshold filtering</li>
+</ul></li>
+<li><p>Clock skew tolerance configurability documentation for confirmation tokens (#94)</p>
+<ul>
+<li>Default 30s accommodates typical NTP-synchronized systems</li>
+<li>Guidance for air-gapped, high-security, and IoT deployments</li>
+</ul></li>
+<li><p>Adapter generator specification (#21)</p>
+<ul>
+<li>Schema input format with AdapterSchema interface</li>
+<li>Generated output structure and directory layout</li>
+<li>Licensing artifacts (AGPL-3.0, NOTICE.md, COMMERCIAL-LICENSE.md)</li>
+<li>Provenance information with MCPAQL-PROVENANCE.json</li>
+<li>Language template guidance (TypeScript, JavaScript required)</li>
+<li>Generator and adapter conformance requirements</li>
+</ul></li>
+<li><p>Generator CLI interface specification (#113)</p>
+<ul>
+<li>Required arguments (--schema, --target)</li>
+<li>Optional arguments (--output, --config, --verbose, etc.)</li>
+<li>Exit codes for different failure modes</li>
+<li>JSON output format for programmatic consumption</li>
+</ul></li>
+<li><p>Schema version evolution strategy documentation (#114)</p>
+<ul>
+<li>Version format rationale (major.minor vs semver)</li>
+<li>Evolution strategy with change type examples</li>
+<li>Backward compatibility requirements</li>
+<li>Version handling code example with deprecation support</li>
+</ul></li>
+<li><p>Validation error code examples for adapter generator (#115)</p>
+<ul>
+<li>Error codes for each validation requirement (SCHEMA_MISSING_FIELD, etc.)</li>
+<li>Example validation error response format</li>
+</ul></li>
+<li><p>Conformance Testing specification with Level 1/Level 2 definitions (#10, #55, #56)</p>
+<ul>
+<li>Level 1 Basic: introspect, endpoint routing, response format, error handling</li>
+<li>Level 2 Full: field selection, batch operations, cross-cutting params</li>
+<li>Five test categories: Introspection Fidelity, Parameter Handling, Error Quality, Round-Trip Integrity, Constraint Documentation</li>
+<li>Two-tier evaluation methodology (structural + semantic) for LLM discoverability testing</li>
+</ul></li>
+<li><p>mcpaql-conformance CLI interface specification (#116)</p>
+<ul>
+<li>Commands: test, report, version</li>
+<li>Options: --level, --output, --format, --verbose, --tier, --category, --timeout</li>
+<li>Exit codes for different test outcomes (0-5)</li>
+<li>Integration guidance with adapter generator</li>
+</ul></li>
+<li><p>JSON Schema definitions for batch operations, field selection, and adapter schemas (#9)</p>
+<ul>
+<li><code>batch-operation.schema.json</code>: Batch request/response validation</li>
+<li><code>field-selection.schema.json</code>: Field selection parameters and presets</li>
+<li><code>adapter-schema.schema.json</code>: Adapter definition file validation</li>
+</ul></li>
+<li><p>RFC 2119 conformance requirements from DollhouseMCP learnings (#54, #57)</p>
+<ul>
+<li>Introspection accuracy MUST requirements (parameter names, types, required status)</li>
+<li>Parameter completeness MUST requirements (all handler params in introspection)</li>
+<li>Error message quality MUST requirements (no implementation leakage)</li>
+<li>Unknown parameter handling, element-type constraints SHOULD requirements</li>
+</ul></li>
+<li><p>Cross-cutting parameter standard in operations.md (#58)</p>
+<ul>
+<li>Standard params: fields, limit, offset, page, page_size, sort, order, dry_run</li>
+<li>Shared parameter definition pattern with $ref mechanism</li>
+<li>Consistency requirements for multi-operation parameters</li>
+</ul></li>
+<li><p>Warnings Array specification for non-fatal conditions in successful responses (#80)</p>
+<ul>
+<li>Optional <code>warnings</code> array extension to discriminated response format</li>
+<li>Warning object schema matching error object structure</li>
+<li>Standard warning codes: RATE_LIMIT_QUOTA_WARNING, DEPRECATION_WARNING, VALIDATION_TRUNCATED_WARNING, PERFORMANCE_SLOW_QUERY_WARNING</li>
+<li>Client processing requirements and display guidelines</li>
+<li>ADR-006 updated to include warnings in success response schema</li>
+</ul></li>
+<li><p>Confirmation Token specification for gating dangerous operations and quota continuations (#79)</p>
+<ul>
+<li>Token format with <code>conf_</code> and <code>quota_continue_</code> prefixes</li>
+<li>Cryptographic generation requirements (128+ bit entropy from secure random source)</li>
+<li>Scope binding with SHA-256 parameter hashing</li>
+<li>Validation checks (existence, expiry, single-use, scope matching)</li>
+<li>Token lifecycle (expiration, single-use, revocation, session-scoped)</li>
+<li><code>TOKEN_</code> error category: <code>TOKEN_INVALID</code>, <code>TOKEN_EXPIRED</code>, <code>TOKEN_ALREADY_USED</code>, <code>TOKEN_SCOPE_MISMATCH</code></li>
+</ul></li>
+<li><p>Trust Levels specification for adapter verification and validation status (#59)</p>
+<ul>
+<li>Trust level enum: untested, generated, validated, community_reviewed, certified</li>
+<li>Trust metadata schema with promotion history</li>
+<li>Promotion and demotion rules</li>
+<li>Trust-to-operation permission gating matrix</li>
+<li>Integration with danger levels for combined security gating</li>
+</ul></li>
+<li><p>Dangerous Operation Classification specification for operation risk management (#49)</p>
+<ul>
+<li>Danger level enum: safe (0), reversible (1), destructive (2), dangerous (3), forbidden (4)</li>
+<li>Operation danger metadata schema with reasons and confirmation messages</li>
+<li>Trust-to-danger gating matrix for combined security decisions</li>
+<li>Automatic lockdown behavior with pattern-based classification</li>
+<li>Standard dangerous/forbidden operation patterns</li>
+<li>Confirmation flow with token-based acknowledgment</li>
+</ul></li>
+<li><p>Rate Limiting and Quota Management specification for API usage control (#60)</p>
+<ul>
+<li>API limits schema for target API rate constraints</li>
+<li>User-configurable quotas with warn/pause/hard_stop thresholds</li>
+<li>Cost estimation and tracking for paid APIs</li>
+<li>Enforcement behavior with progressive response</li>
+<li>Rate limit error codes: RATE_LIMIT_EXCEEDED, RATE_LIMIT_QUOTA_PAUSE, RATE_LIMIT_QUOTA_EXHAUSTED</li>
+<li>Introspection of quota status</li>
+</ul></li>
+<li><p>Cursor-based Pagination specification for collection operations (#37)</p>
+<ul>
+<li>Pagination parameters: first, after, last, before</li>
+<li>PageInfo response structure with hasNextPage, hasPreviousPage, cursors</li>
+<li>Connection-style response format with items or edges (mutually exclusive)</li>
+<li>Uses existing VALIDATION_INVALID_TYPE for pagination errors</li>
+<li>Introspection of pagination support</li>
+</ul></li>
+<li><p>Phase 1 error codes formally added to error-codes.md (#77)</p>
+<ul>
+<li>PERMISSION_TRUST_LEVEL_INSUFFICIENT - adapter trust level too low</li>
+<li>PERMISSION_DANGER_LEVEL_DENIED - operation danger level exceeds trust</li>
+<li>CONFIRMATION_REQUIRED - dangerous operation requires confirmation</li>
+<li>RATE_LIMIT_EXCEEDED - API rate limit reached</li>
+<li>RATE_LIMIT_QUOTA_PAUSE - user quota pause threshold</li>
+<li>RATE_LIMIT_QUOTA_EXHAUSTED - user quota hard stop</li>
+<li>RATE_LIMIT_QUOTA_WARNING - approaching quota limit (warning)</li>
+</ul></li>
+</ul>
+<h2 id="100-alpha1---2026-01-28">[1.0.0-alpha.1] - 2026-01-28</h2>
+<h3 id="security">Security</h3>
+<ul>
+<li>Fix script injection vulnerabilities in CI workflows
+<ul>
+<li>Pass step outputs and PR number through <code>env:</code> blocks instead of direct <code>${{ }}</code> interpolation in shell scripts</li>
+<li>Remove user-controlled PR title from Claude review prompt to prevent prompt injection</li>
+<li>Narrow Claude review bot API access to only PR/issue comment endpoints</li>
+</ul></li>
+</ul>
+<h3 id="added-1">Added</h3>
+<ul>
+<li>Adapter Element Type specification (MVP) defining declarative adapter schema format (#61)
+<ul>
+<li>Required fields: name, type, version, description</li>
+<li>Target configuration for HTTP/REST/JSON</li>
+<li>Authentication support: bearer, api_key, none</li>
+<li>Operation definitions with typed parameters</li>
+</ul></li>
+<li>GitHub API adapter example demonstrating all CRUDE operations</li>
+<li>Plugin Interface specification (MVP) for adapter extensibility (#62)
+<ul>
+<li>Transport plugins: HTTP</li>
+<li>Protocol plugins: REST</li>
+<li>Serialization plugins: JSON</li>
+<li>Auth plugins: bearer, api_key, none</li>
+<li>Plugin composition pipeline documentation</li>
+</ul></li>
+<li>Universal Adapter Runtime specification (MVP) for schema-driven execution (#63)
+<ul>
+<li>Schema loading and validation</li>
+<li>Operation dispatch pipeline</li>
+<li>Error mapping to structured codes</li>
+<li>Response transformation</li>
+</ul></li>
+<li>Structured Error Codes specification (MVP) for machine-readable errors (#35)
+<ul>
+<li>6 MVP error codes: VALIDATION_MISSING_PARAM, VALIDATION_INVALID_TYPE, NOT_FOUND_OPERATION, NOT_FOUND_RESOURCE, PERMISSION_DENIED, INTERNAL_ERROR</li>
+<li>Error response format with code, message, and optional details</li>
+<li>JSON Schema for error response validation</li>
+</ul></li>
+<li>CI workflows for documentation quality (markdown lint, link check, spell check)</li>
+<li>CI workflow for JSON Schema validation</li>
+<li>CI workflow for changelog enforcement</li>
+<li>Git flow branching strategy with <code>develop</code> branch</li>
+<li>Issue templates (bug report, feature request, RFC proposal)</li>
+<li>Pull request template with checklist</li>
+<li>CODEOWNERS file for review auto-assignment</li>
+<li>Process documentation:
+<ul>
+<li>RFC process for specification changes</li>
+<li>Breaking change policy</li>
+<li>Versioning strategy</li>
+</ul></li>
+<li>Initial JSON schemas for operation input/result formats</li>
+<li>JSON Schema for introspection response format (<code>introspection-response.schema.json</code>)</li>
+<li>JSON Schema for danger level classification (<code>danger-level.schema.json</code>)</li>
+<li>Schema documentation with usage examples (<code>schemas/README.md</code>)</li>
+<li>Core specification documents:
+<ul>
+<li>Protocol overview (<code>docs/overview.md</code>)</li>
+<li>Introspection system (<code>docs/introspection.md</code>)</li>
+<li>Endpoint modes (<code>docs/endpoint-modes.md</code>)</li>
+<li>Operations reference (<code>docs/operations.md</code>)</li>
+<li>Protocol comparison guide (<code>docs/guides/protocol-comparison.md</code>)</li>
+</ul></li>
+<li>Architecture Decision Records (ADRs):
+<ul>
+<li>ADR-001: CRUDE Pattern</li>
+<li>ADR-002: GraphQL-style Input Objects</li>
+<li>ADR-003: snake_case Parameters</li>
+<li>ADR-004: Schema-driven Operations</li>
+<li>ADR-005: Introspection System</li>
+<li>ADR-006: Discriminated Responses</li>
+</ul></li>
+<li>Main specification document updates (<code>docs/versions/v1.0.0-draft.md</code>):
+<ul>
+<li>Added Appendix D with JSON Schema references</li>
+<li>Added links to all new documentation in Appendix B</li>
+<li>Renamed <code>CRUDEndpoint</code> to <code>EndpointCategory</code> in type system section</li>
+</ul></li>
+</ul>
+<h3 id="changed-1">Changed</h3>
+<ul>
+<li>Rewrite Claude Code review prompt for substantive peer-quality reviews on every run</li>
+<li>Broaden lychee link checker exclude to all MCPAQL GitHub repos (private, return 404 from CI)</li>
+<li>Made specification fully generic (removed DollhouseMCP-specific terminology)</li>
+<li>Changed operations.md from prescriptive list to design guide</li>
+<li>Clarified that only <code>introspect</code> operation is required by protocol</li>
+<li>Updated token efficiency examples to be generic</li>
+<li>Enhanced Claude code review workflow with comprehensive prompt:
+<ul>
+<li>Project context and key concepts</li>
+<li>Specific review criteria for spec documents, schemas, and examples</li>
+<li>Structured output format (Summary, Strengths, Issues, Suggestions, Verdict)</li>
+<li>Progress tracking enabled</li>
+</ul></li>
+</ul>
+<h3 id="fixed-1">Fixed</h3>
+<ul>
+<li>Fixed markdown lint errors (MD022) in session notes - missing blank lines after headings</li>
+<li>Added DollhouseMCP/mcp-server-v2-refactor to lychee exclusions (historical references)</li>
+</ul>
+<h2 id="100-draft---2026-01-05">[1.0.0-draft] - 2026-01-05</h2>
+<h3 id="added-2">Added</h3>
+<ul>
+<li>Initial draft specification for MCP-AQL (Model Context Protocol - AQL Query Language)</li>
+<li>CRUDE pattern defining five operation categories: Create, Read, Update, Delete, Execute</li>
+<li>Introspection system for runtime schema and capability discovery</li>
+<li>Operations reference documenting standard operations and parameters</li>
+</ul>
+
+          </div>
+        </section>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div class="container">
+      <p>&copy; 2026 DollhouseMCP Inc. d/b/a Dollhouse Research. MCP-AQL public draft documentation portal.</p>
+      <div class="footer-links">
+        <a href="../../docs/index.html">Docs Library</a>
+        <a href="../index.html">Repo-Synced Spec</a>
+        <a href="https://github.com/MCPAQL">MCPAQL Organization</a>
+        <a href="https://dollhouseresearch.com">Dollhouse Research</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../../js/search.js"></script>
+</body>
+</html>

--- a/public/spec/repo/CHANGELOG.html
+++ b/public/spec/repo/CHANGELOG.html
@@ -23,7 +23,7 @@
         </ul>
         <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
-          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <input id="site-search-input" data-search-input type="search" placeholder="Search MCP-AQL docs, spec pages, and adapter patterns...">
           <span class="search-count" data-search-count></span>
           <ul class="search-results" data-search-results hidden></ul>
         </form>
@@ -56,7 +56,7 @@
   <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
-  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li><li><a class="current" href="CHANGELOG.html">Changelog</a></li></ul>
+  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li><li><a class="current" aria-current="page" href="CHANGELOG.html">Changelog</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Architecture</h3>
   <ul><li><a href="../architecture/README.html">Architecture Documentation</a></li></ul>
@@ -676,6 +676,16 @@
 
           </div>
         </section>
+        <nav class="page-nav" aria-label="Page navigation">
+  <a class="page-nav-link prev" href="../process/versioning.html">
+    <span class="page-nav-eyebrow">Previous spec page</span>
+    <strong class="page-nav-label">Versioning Strategy</strong>
+  </a>
+  <a class="page-nav-link next" href="../architecture/README.html">
+    <span class="page-nav-eyebrow">Next spec page</span>
+    <strong class="page-nav-label">Architecture Documentation</strong>
+  </a>
+</nav>
       </article>
     </div>
   </main>

--- a/public/spec/repo/README.html
+++ b/public/spec/repo/README.html
@@ -73,6 +73,13 @@
       </aside>
 
       <article class="docs-main">
+        <nav class="breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../../index.html">Home</a></li>
+            <li><a href="../index.html">Full Spec</a></li>
+            <li><span class="current">MCP-AQL Specification</span></li>
+          </ol>
+        </nav>
         <section class="hero docs-hero">
           <div class="hero-inner">
             <span class="status-pill">REPO-SYNCED SPEC DOC</span>

--- a/public/spec/repo/README.html
+++ b/public/spec/repo/README.html
@@ -1,0 +1,309 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Model Context Protocol - Advanced Agent API Adapter Query Language">
+  <title>MCP-AQL Spec | MCP-AQL Specification</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../../css/style.css">
+</head>
+<body>
+  <header>
+    <div class="container">
+      <nav>
+        <a class="logo" href="../../index.html"><span class="logo-mark"></span>MCP-AQL</a>
+        <ul class="nav-links">
+          <li><a href="../../index.html">Home</a></li>
+          <li><a href="../../docs/index.html">Docs</a></li>
+          <li><a href="../../launch-checklist.html">Launch Checklist</a></li>
+          <li><a href="../../apis/mcp-server.html">Adapter Patterns</a></li>
+        </ul>
+        <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
+          <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
+          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <span class="search-count" data-search-count></span>
+          <ul class="search-results" data-search-results hidden></ul>
+        </form>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <div class="container docs-shell">
+      <aside class="docs-side">
+        <h2>Repo-Synced Spec</h2>
+        <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
+        <div class="docs-side-group">
+  <h3>Core</h3>
+  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li><li><a class="current" href="README.html">MCP-AQL Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Versions</h3>
+  <ul><li><a href="../versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Adapter</h3>
+  <ul><li><a href="../adapter/danger-levels.html">Dangerous Operation Classification Specification</a></li><li><a href="../adapter/discovery-bundle.html">MCP Server Discovery Bundle</a></li><li><a href="../adapter/element-type.html">Adapter Element Type Specification</a></li><li><a href="../adapter/generator.html">Adapter Generator Specification</a></li><li><a href="../adapter/rate-limiting.html">Rate Limiting and Quota Management Specification</a></li><li><a href="../adapter/trust-levels.html">Trust Levels Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Security</h3>
+  <ul><li><a href="../security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="../security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="../security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Features</h3>
+  <ul><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Guides</h3>
+  <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Process</h3>
+  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li><li><a href="CHANGELOG.html">Changelog</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Architecture</h3>
+  <ul><li><a href="../architecture/README.html">Architecture Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Research</h3>
+  <ul><li><a href="../research/mcp-vs-mcpaql-vs-a2a.html">Protocol Landscape: MCP vs MCP-AQL vs A2A</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Reference</h3>
+  <ul><li><a href="../reference/README.html">Reference Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>ADRs</h3>
+  <ul><li><a href="../adr/ADR-001-crude-pattern.html">ADR-001: CRUDE Pattern (Extending CRUD with Execute)</a></li><li><a href="../adr/ADR-002-graphql-style-input.html">ADR-002: GraphQL-Style Input Objects for Updates</a></li><li><a href="../adr/ADR-003-snake-case-parameters.html">ADR-003: snake_case Parameter Convention</a></li><li><a href="../adr/ADR-004-schema-driven-operations.html">ADR-004: Schema-Driven Operation Definitions</a></li><li><a href="../adr/ADR-005-introspection-system.html">ADR-005: GraphQL-Style Introspection System</a></li><li><a href="../adr/ADR-006-discriminated-responses.html">ADR-006: Discriminated Response Format</a></li><li><a href="../adr/index.html">Architecture Decision Records</a></li><li><a href="../adr/README.html">Architecture Decision Records</a></li></ul>
+</div>
+      </aside>
+
+      <article class="docs-main">
+        <section class="hero docs-hero">
+          <div class="hero-inner">
+            <span class="status-pill">REPO-SYNCED SPEC DOC</span>
+            <h1>MCP-AQL Specification</h1>
+            <p class="lede">Model Context Protocol - Advanced Agent API Adapter Query Language</p>
+            <div class="spec-meta"><span class="state-chip live">Repository source</span></div>
+            <p class="spec-source">Source: <a href="https://github.com/MCPAQL/spec/blob/main/README.md">spec/README.md</a></p>
+            <div class="hero-actions">
+              <a class="btn btn-primary" href="https://github.com/MCPAQL/spec/blob/main/README.md">Open Source Markdown</a>
+              <a class="btn btn-secondary" href="../index.html">Browse Full Spec Reference</a>
+            </div>
+          </div>
+        </section>
+
+        <section>
+          <div class="card spec-prose">
+            <p><strong>Model Context Protocol - Advanced Agent API Adapter Query Language</strong></p>
+<blockquote>
+<p>MCP-AQL is both a protocol specification and a concrete implementation toolkit, including an interrogator (introspection), compiler (schema-driven dispatch), and adapter generator.</p>
+</blockquote>
+<p><a href="../versions/v1.0.0-draft.html"><img src="https://img.shields.io/badge/spec-v1.0.0--draft-blue" alt="Spec Version" /></a> <a href="https://github.com/MCPAQL/spec/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-AGPL%20v3-blue.svg" alt="License: AGPL v3" /></a></p>
+<h2 id="overview">Overview</h2>
+<p>MCP-AQL is a protocol specification that consolidates multiple MCP (Model Context Protocol) tools into semantic endpoints, providing approximately <strong>96% token reduction</strong> while maintaining full functionality. It enables structured communication between AI models and context-providing services through a unified query language.</p>
+<h2 id="preliminary-draft-positioning">Preliminary Draft Positioning</h2>
+<p>The current publication target is a <strong>preliminary public draft</strong> of MCP-AQL.</p>
+<p>This draft is intended to:</p>
+<ul>
+<li>Demonstrate protocol viability and real-world utility</li>
+<li>Show how semantic endpoint consolidation reduces token bloat</li>
+<li>Validate flexibility for modular integrations (security, execution, code/compute workflows)</li>
+</ul>
+<p>This draft is not yet a final certification baseline. Some conformance automation and ecosystem hardening work is still in progress.</p>
+<h2 id="the-crude-pattern">The CRUDE Pattern</h2>
+<p>MCP-AQL extends traditional CRUD with an <strong>Execute</strong> endpoint, creating the CRUDE pattern:</p>
+<table>
+<thead>
+<tr>
+<th>Endpoint</th>
+<th>Safety</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>Create</strong></td>
+<td>Non-destructive</td>
+<td>Additive operations that create new state</td>
+</tr>
+<tr>
+<td><strong>Read</strong></td>
+<td>Read-only</td>
+<td>Safe operations that query state</td>
+</tr>
+<tr>
+<td><strong>Update</strong></td>
+<td>Modifying</td>
+<td>Operations that modify existing state</td>
+</tr>
+<tr>
+<td><strong>Delete</strong></td>
+<td>Destructive</td>
+<td>Operations that remove state</td>
+</tr>
+<tr>
+<td><strong>Execute</strong></td>
+<td>Stateful</td>
+<td>Runtime lifecycle operations (non-idempotent)</td>
+</tr>
+</tbody>
+</table>
+<h2 id="token-efficiency">Token Efficiency</h2>
+<p>MCP-AQL dramatically reduces token consumption for LLM interactions.</p>
+<p><strong>Per-tool overhead:</strong> A typical MCP tool definition consumes ~500-700 tokens in context.</p>
+<table>
+<thead>
+<tr>
+<th>Configuration</th>
+<th>Tool Count</th>
+<th>Token Cost</th>
+<th>Reduction</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Discrete Tools</td>
+<td>~30 tools</td>
+<td>~18,000</td>
+<td>Baseline</td>
+</tr>
+<tr>
+<td>Discrete Tools</td>
+<td>~50 tools</td>
+<td>~30,000</td>
+<td>Baseline</td>
+</tr>
+<tr>
+<td><strong>CRUDE Mode</strong></td>
+<td>5 endpoints</td>
+<td>~4,000</td>
+<td>~80-85%</td>
+</tr>
+<tr>
+<td><strong>Single Mode</strong></td>
+<td>1 endpoint</td>
+<td>~1,000</td>
+<td><strong>~95%+</strong></td>
+</tr>
+</tbody>
+</table>
+<p>The savings scale with adapter complexity - the more operations your adapter supports, the greater the benefit of consolidation.</p>
+<h2 id="key-features">Key Features</h2>
+<ul>
+<li><strong>Unified Query Syntax</strong> - Consistent grammar for operations across all endpoints</li>
+<li><strong>GraphQL-Style Introspection</strong> - On-demand operation discovery at runtime</li>
+<li><strong>Schema-Driven Dispatch</strong> - Declarative operation definitions with automatic validation</li>
+<li><strong>Flexible Parameter Resolution</strong> - Multiple sources checked for each parameter</li>
+<li><strong>Batch Operations</strong> - Execute multiple operations in a single request</li>
+<li><strong>Field Selection</strong> - Control response payload size for additional token savings</li>
+</ul>
+<h2 id="quick-start">Quick Start</h2>
+<h3 id="discover-available-operations">Discover Available Operations</h3>
+<div class="sourceCode" id="cb1"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb1-2"><a href="#cb1-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;introspect&quot;</span><span class="op">,</span></span>
+<span id="cb1-3"><a href="#cb1-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> { <span class="dt">query</span><span class="op">:</span> <span class="st">&quot;operations&quot;</span> }</span>
+<span id="cb1-4"><a href="#cb1-4" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<h3 id="get-operation-details">Get Operation Details</h3>
+<div class="sourceCode" id="cb2"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb2-2"><a href="#cb2-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;introspect&quot;</span><span class="op">,</span></span>
+<span id="cb2-3"><a href="#cb2-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> { <span class="dt">query</span><span class="op">:</span> <span class="st">&quot;operations&quot;</span><span class="op">,</span> <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;create_user&quot;</span> }</span>
+<span id="cb2-4"><a href="#cb2-4" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<h3 id="execute-an-operation">Execute an Operation</h3>
+<div class="sourceCode" id="cb3"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb3-1"><a href="#cb3-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Operations are adapter-specific - this example from a user management adapter</span></span>
+<span id="cb3-2"><a href="#cb3-2" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb3-3"><a href="#cb3-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;create_user&quot;</span><span class="op">,</span></span>
+<span id="cb3-4"><a href="#cb3-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> {</span>
+<span id="cb3-5"><a href="#cb3-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">email</span><span class="op">:</span> <span class="st">&quot;alice@example.com&quot;</span><span class="op">,</span></span>
+<span id="cb3-6"><a href="#cb3-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;Alice&quot;</span><span class="op">,</span></span>
+<span id="cb3-7"><a href="#cb3-7" aria-hidden="true" tabindex="-1"></a>    <span class="dt">role</span><span class="op">:</span> <span class="st">&quot;admin&quot;</span></span>
+<span id="cb3-8"><a href="#cb3-8" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb3-9"><a href="#cb3-9" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<h2 id="specification-documents">Specification Documents</h2>
+<table>
+<thead>
+<tr>
+<th>Document</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a href="../versions/v1.0.0-draft.html">Specification v1.0.0-draft</a></td>
+<td>Current working draft</td>
+</tr>
+<tr>
+<td><a href="../crude-pattern.html">CRUDE Pattern</a></td>
+<td>Detailed endpoint semantics</td>
+</tr>
+<tr>
+<td><a href="../introspection.html">Introspection</a></td>
+<td>Discovery system specification</td>
+</tr>
+<tr>
+<td><a href="../operations.html">Operations Guide</a></td>
+<td>Operation design patterns</td>
+</tr>
+<tr>
+<td><a href="../adapter/discovery-bundle.html">MCP Server Discovery Bundle</a></td>
+<td>Interrogation bundle contract for MCP-to-MCP-AQL generation</td>
+</tr>
+<tr>
+<td><a href="../README.html">Documentation Index</a></td>
+<td>Full documentation structure</td>
+</tr>
+<tr>
+<td><a href="CHANGELOG.html">Changelog</a></td>
+<td>Version history</td>
+</tr>
+</tbody>
+</table>
+<h2 id="reference-profile">Reference Profile</h2>
+<p><a href="https://github.com/DollhouseMCP/mcp-server">DollhouseMCP</a> serves as a <strong>practical reference profile</strong> for MCP-AQL.</p>
+<p>It demonstrates the protocol in a large, production-oriented server, including security-loop integrations (Gatekeeper and Danger Zone). It is not the canonical definition of the protocol itself; normative behavior is defined by this repository's specification documents.</p>
+<h2 id="conformance">Conformance</h2>
+<p>Implementations claiming MCP-AQL conformance MUST:</p>
+<ol type="1">
+<li>Implement the <code>introspect</code> operation for runtime discovery</li>
+<li>Use the CRUDE endpoint pattern (or single endpoint mode)</li>
+<li>Return discriminated union responses (<code>{ success, data }</code> or <code>{ success, error }</code>)</li>
+<li>Document supported operations via introspection</li>
+</ol>
+<p>Implementations SHOULD also pass the conformance test suite in <a href="https://github.com/MCPAQL/spec/blob/main/tests/">tests/</a>.</p>
+<blockquote>
+<p><strong>Status Note:</strong> Schema/example validation is implemented in this repository. The full cross-implementation conformance runner described in <code>docs/conformance-testing.md</code> is still being finalized.</p>
+</blockquote>
+<h2 id="contributing">Contributing</h2>
+<p>We welcome contributions to the specification. Please see <a href="https://github.com/MCPAQL/spec/blob/main/CONTRIBUTING.md">CONTRIBUTING.md</a> for guidelines.</p>
+<h2 id="license">License</h2>
+<p>This repository uses split licensing:</p>
+<ul>
+<li><strong>Specification text (docs)</strong>: Creative Commons Attribution 4.0 International (CC BY 4.0). See <code>LICENSE-DOCS</code>.
+<ul>
+<li>Applies to: <code>spec/docs/</code>, <code>spec/README.md</code>, and other narrative documentation content.</li>
+</ul></li>
+<li><strong>Code and other software artifacts</strong>: GNU Affero General Public License v3.0 (AGPL-3.0). See <code>LICENSE</code>.
+<ul>
+<li>Applies to: <code>spec/schemas/</code>, <code>spec/tests/</code>, and any code/scripts included in this repository.</li>
+</ul></li>
+</ul>
+<p>For the authoritative path-based scope rules, see <code>spec/LICENSING.md</code>.</p>
+<p>Commercial licenses are available. See <code>COMMERCIAL-LICENSE.md</code> or contact <a href="mailto:licensing@mcpaql.org"><span>licensing@mcpaql.org</span></a>.</p>
+<h2 id="acknowledgments">Acknowledgments</h2>
+<p>MCP-AQL builds upon the <a href="https://modelcontextprotocol.io">Model Context Protocol</a> specification by Anthropic.</p>
+
+          </div>
+        </section>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div class="container">
+      <p>&copy; 2026 DollhouseMCP Inc. d/b/a Dollhouse Research. MCP-AQL public draft documentation portal.</p>
+      <div class="footer-links">
+        <a href="../../docs/index.html">Docs Library</a>
+        <a href="../index.html">Repo-Synced Spec</a>
+        <a href="https://github.com/MCPAQL">MCPAQL Organization</a>
+        <a href="https://dollhouseresearch.com">Dollhouse Research</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../../js/search.js"></script>
+</body>
+</html>

--- a/public/spec/repo/README.html
+++ b/public/spec/repo/README.html
@@ -23,7 +23,7 @@
         </ul>
         <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
-          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <input id="site-search-input" data-search-input type="search" placeholder="Search MCP-AQL docs, spec pages, and adapter patterns...">
           <span class="search-count" data-search-count></span>
           <ul class="search-results" data-search-results hidden></ul>
         </form>
@@ -38,7 +38,7 @@
         <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
         <div class="docs-side-group">
   <h3>Core</h3>
-  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li><li><a class="current" href="README.html">MCP-AQL Specification</a></li></ul>
+  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li><li><a class="current" aria-current="page" href="README.html">MCP-AQL Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Versions</h3>
   <ul><li><a href="../versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
@@ -295,6 +295,16 @@
 
           </div>
         </section>
+        <nav class="page-nav" aria-label="Page navigation">
+  <a class="page-nav-link prev" href="../README.html">
+    <span class="page-nav-eyebrow">Previous spec page</span>
+    <strong class="page-nav-label">MCP-AQL Specification Documentation</strong>
+  </a>
+  <a class="page-nav-link next" href="../versions/v1.0.0-draft.html">
+    <span class="page-nav-eyebrow">Next spec page</span>
+    <strong class="page-nav-label">MCP-AQL Specification</strong>
+  </a>
+</nav>
       </article>
     </div>
   </main>

--- a/public/spec/research/mcp-vs-mcpaql-vs-a2a.html
+++ b/public/spec/research/mcp-vs-mcpaql-vs-a2a.html
@@ -1,0 +1,1340 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="A strategic comparison of three protocols shaping how AI agents interact with the world: where they overlap, where they diverge, and where the gaps are.">
+  <title>MCP-AQL Spec | Protocol Landscape: MCP vs MCP-AQL vs A2A</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../../css/style.css">
+</head>
+<body>
+  <header>
+    <div class="container">
+      <nav>
+        <a class="logo" href="../../index.html"><span class="logo-mark"></span>MCP-AQL</a>
+        <ul class="nav-links">
+          <li><a href="../../index.html">Home</a></li>
+          <li><a href="../../docs/index.html">Docs</a></li>
+          <li><a href="../../launch-checklist.html">Launch Checklist</a></li>
+          <li><a href="../../apis/mcp-server.html">Adapter Patterns</a></li>
+        </ul>
+        <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
+          <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
+          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <span class="search-count" data-search-count></span>
+          <ul class="search-results" data-search-results hidden></ul>
+        </form>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <div class="container docs-shell">
+      <aside class="docs-side">
+        <h2>Repo-Synced Spec</h2>
+        <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
+        <div class="docs-side-group">
+  <h3>Core</h3>
+  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Versions</h3>
+  <ul><li><a href="../versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Adapter</h3>
+  <ul><li><a href="../adapter/danger-levels.html">Dangerous Operation Classification Specification</a></li><li><a href="../adapter/discovery-bundle.html">MCP Server Discovery Bundle</a></li><li><a href="../adapter/element-type.html">Adapter Element Type Specification</a></li><li><a href="../adapter/generator.html">Adapter Generator Specification</a></li><li><a href="../adapter/rate-limiting.html">Rate Limiting and Quota Management Specification</a></li><li><a href="../adapter/trust-levels.html">Trust Levels Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Security</h3>
+  <ul><li><a href="../security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="../security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="../security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Features</h3>
+  <ul><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Guides</h3>
+  <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Process</h3>
+  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Architecture</h3>
+  <ul><li><a href="../architecture/README.html">Architecture Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Research</h3>
+  <ul><li><a class="current" href="mcp-vs-mcpaql-vs-a2a.html">Protocol Landscape: MCP vs MCP-AQL vs A2A</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Reference</h3>
+  <ul><li><a href="../reference/README.html">Reference Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>ADRs</h3>
+  <ul><li><a href="../adr/ADR-001-crude-pattern.html">ADR-001: CRUDE Pattern (Extending CRUD with Execute)</a></li><li><a href="../adr/ADR-002-graphql-style-input.html">ADR-002: GraphQL-Style Input Objects for Updates</a></li><li><a href="../adr/ADR-003-snake-case-parameters.html">ADR-003: snake_case Parameter Convention</a></li><li><a href="../adr/ADR-004-schema-driven-operations.html">ADR-004: Schema-Driven Operation Definitions</a></li><li><a href="../adr/ADR-005-introspection-system.html">ADR-005: GraphQL-Style Introspection System</a></li><li><a href="../adr/ADR-006-discriminated-responses.html">ADR-006: Discriminated Response Format</a></li><li><a href="../adr/index.html">Architecture Decision Records</a></li><li><a href="../adr/README.html">Architecture Decision Records</a></li></ul>
+</div>
+      </aside>
+
+      <article class="docs-main">
+        <section class="hero docs-hero">
+          <div class="hero-inner">
+            <span class="status-pill">REPO-SYNCED SPEC DOC</span>
+            <h1>Protocol Landscape: MCP vs MCP-AQL vs A2A</h1>
+            <p class="lede">A strategic comparison of three protocols shaping how AI agents interact with the world: where they overlap, where they diverge, and where the gaps are.</p>
+            <div class="spec-meta"><span class="state-chip live">Support document</span><span class="state-chip pending">research</span><span class="state-chip">1.0.0</span></div>
+            <p class="spec-source">Source: <a href="https://github.com/MCPAQL/spec/blob/main/docs/research/mcp-vs-mcpaql-vs-a2a.md">spec/docs/research/mcp-vs-mcpaql-vs-a2a.md</a></p>
+            <div class="hero-actions">
+              <a class="btn btn-primary" href="https://github.com/MCPAQL/spec/blob/main/docs/research/mcp-vs-mcpaql-vs-a2a.md">Open Source Markdown</a>
+              <a class="btn btn-secondary" href="../index.html">Browse Full Spec Reference</a>
+            </div>
+          </div>
+        </section>
+
+        <section>
+          <div class="card spec-prose">
+            <h2 id="protocol-landscape-mcp-vs-mcp-aql-vs-a2a">Protocol Landscape: MCP vs MCP-AQL vs A2A</h2>
+<blockquote>
+<p>A strategic comparison of three protocols shaping how AI agents interact with the world: where they overlap, where they diverge, and where the gaps are.</p>
+</blockquote>
+<h2 id="table-of-contents">Table of Contents</h2>
+<ul>
+<li><a href="#executive-summary">Executive Summary</a></li>
+<li><a href="#1-what-each-protocol-is">1. What Each Protocol Is</a></li>
+<li><a href="#2-architecture-stack">2. Architecture Stack</a></li>
+<li><a href="#3-the-core-problem-each-solves">3. The Core Problem Each Solves</a></li>
+<li><a href="#4-how-each-protocol-works">4. How Each Protocol Works</a></li>
+<li><a href="#5-key-capabilities-comparison">5. Key Capabilities Comparison</a></li>
+<li><a href="#6-strengths-and-weaknesses">6. Strengths and Weaknesses</a></li>
+<li><a href="#7-overlap-and-toe-stepping-analysis">7. Overlap and Toe-Stepping Analysis</a></li>
+<li><a href="#8-gap-analysis">8. Gap Analysis</a></li>
+<li><a href="#9-a2a-under-the-hood-what-it-provides-vs-what-it-doesnt">9. A2A Under the Hood: What It Provides vs. What It Doesn't</a></li>
+<li><a href="#10-the-comms-element-type-and-protocol-specific-variants">10. The COMMS Element Type and Protocol-Specific Variants</a></li>
+<li><a href="#11-the-composite-architecture">11. The Composite Architecture</a></li>
+<li><a href="#12-scenario-guide">12. Scenario Guide</a></li>
+<li><a href="#13-maturity-and-adoption">13. Maturity and Adoption</a></li>
+<li><a href="#14-key-takeaways">14. Key Takeaways</a></li>
+<li><a href="#sources">Sources</a></li>
+</ul>
+<hr />
+<h2 id="executive-summary">Executive Summary</h2>
+<p>Three protocols are shaping how AI agents interact with the world. They are not competitors -- they are layers of the same stack, each solving a different fundamental problem:</p>
+<ul>
+<li><strong>MCP</strong> (Model Context Protocol) is the <strong>wiring standard</strong> -- it defines how an LLM application connects to external tools, data, and services.</li>
+<li><strong>MCP-AQL</strong> (MCP Advanced Agent API Adapter Query Language) is the <strong>universal translation layer</strong> -- it makes any API safely and efficiently accessible to LLMs through a single, self-describing interface.</li>
+<li><strong>A2A</strong> (Agent-to-Agent Protocol) is the <strong>diplomatic protocol</strong> -- it defines how autonomous AI agents discover each other and collaborate across vendor and framework boundaries.</li>
+</ul>
+<p>This document examines where they overlap, where they step on each other's toes (or don't), and where gaps remain.</p>
+<hr />
+<h2 id="1-what-each-protocol-is">1. What Each Protocol Is</h2>
+<h3 id="mcp----the-wiring-standard">MCP -- The Wiring Standard</h3>
+<p><strong>Origin:</strong> Anthropic, November 2024 <strong>Governance:</strong> Agentic AI Foundation (Linux Foundation), December 2025 <strong>Current spec:</strong> 2025-11-25 (4th revision) <strong>Backers:</strong> Anthropic, OpenAI, Google, Microsoft, AWS, Cloudflare, Block, Bloomberg, and hundreds more</p>
+<p>MCP standardizes how LLM applications connect to external capabilities. It solves the <strong>M x N integration problem</strong> -- without a standard, every AI application must build custom integrations for every external service. MCP replaces this with a universal protocol inspired by the Language Server Protocol (LSP), which solved the same problem for IDE-to-language tooling.</p>
+<p><strong>Core primitives:</strong></p>
+<ul>
+<li><strong>Tools</strong> -- Executable actions the AI model can invoke (function calling)</li>
+<li><strong>Resources</strong> -- Read-only data sources for context (files, databases, configurations)</li>
+<li><strong>Prompts</strong> -- Predefined message templates that guide AI behavior</li>
+</ul>
+<p><strong>Architecture:</strong> Host → Client → Server model over JSON-RPC 2.0. Transports include stdio (local) and Streamable HTTP (remote). Stateful sessions with capability negotiation at connect time.</p>
+<p><strong>Ecosystem:</strong> 10,000+ servers in production, 300+ clients, 97M+ monthly SDK downloads across TypeScript, Python, Java, C#, Go, and Rust.</p>
+<h3 id="mcp-aql----the-universal-translation-layer">MCP-AQL -- The Universal Translation Layer</h3>
+<p><strong>Origin:</strong> MCPAQL Organization, 2025 <strong>Current spec:</strong> v1.0.0-draft (nearing v1.0-rc) <strong>Reference implementation:</strong> DollhouseMCP (private beta V2) <strong>Status:</strong> Launch expected within weeks</p>
+<p>MCP-AQL is a protocol specification that makes <strong>any system with an API</strong> safely and efficiently accessible to LLMs through a uniform, self-describing interface. It sits on top of MCP as a transport but its purpose extends far beyond MCP optimization.</p>
+<p>The core insight: <strong>LLMs struggle to correctly call arbitrary APIs.</strong> They hallucinate parameters, miss constraints, trigger destructive operations blindly, and waste enormous amounts of context window on tool schemas they may never use. MCP-AQL solves this by providing:</p>
+<ol type="1">
+<li><strong>A universal translation layer</strong> that wraps any API (REST, GraphQL, gRPC, OS native, hardware, other MCP servers, other agents) behind a consistent CRUDE interface</li>
+<li><strong>Runtime introspection</strong> with rich constraint metadata (enums, min/max, patterns, formats) that tells the LLM exactly what values are valid -- eliminating hallucinated parameters</li>
+<li><strong>Protocol-enforced safety</strong> via a Gatekeeper that cannot be bypassed by prompt injection -- because "LLM instructions are suggestions; adapter policies are enforcement"</li>
+<li><strong>Radical token efficiency</strong> (~85-96% reduction) as a natural consequence of the consolidated, progressive-disclosure design</li>
+</ol>
+<p><strong>Key distinction:</strong> MCP-AQL doesn't just optimize MCP -- it's a <strong>computational middleware layer</strong> that handles messy API translation so the LLM only deals with clean, structured, safe interactions.</p>
+<h3 id="a2a----the-diplomatic-protocol">A2A -- The Diplomatic Protocol</h3>
+<p><strong>Origin:</strong> Google, April 2025 <strong>Governance:</strong> Linux Foundation (LF AI &amp; Data), July 2025 <strong>Current spec:</strong> v0.3 (July 2025) <strong>Backers:</strong> Google, AWS, Cisco, SAP, Salesforce, ServiceNow, IBM, Atlassian, PayPal, MongoDB, LangChain, 150+ organizations</p>
+<p>A2A standardizes how autonomous AI agents discover each other and collaborate on tasks across vendor and framework boundaries. It solves the <strong>agent interoperability problem</strong> -- agents built on different frameworks (LangChain, CrewAI, Google ADK) exist in silos and cannot communicate.</p>
+<p><strong>Core concepts:</strong></p>
+<ul>
+<li><strong>Agent Cards</strong> -- JSON metadata published at <code>/.well-known/agent.json</code> describing what an agent can do</li>
+<li><strong>Tasks</strong> -- Stateful units of work with lifecycle (working → completed/failed/canceled)</li>
+<li><strong>Messages</strong> -- Multi-turn conversational exchanges between agents</li>
+<li><strong>Artifacts</strong> -- Tangible outputs/deliverables produced by agents</li>
+</ul>
+<p><strong>Design philosophy:</strong> Agents are <strong>opaque</strong> to each other -- they share no internal state, tools, or memory. Collaboration happens through natural, unstructured multi-turn conversation, not rigid API contracts.</p>
+<p><strong>Protocol:</strong> JSON-RPC 2.0 and gRPC (as of v0.3), with synchronous, streaming (SSE), and push notification delivery modes. IBM's Agent Communication Protocol (ACP) was merged into A2A in August 2025.</p>
+<hr />
+<h2 id="2-architecture-stack">2. Architecture Stack</h2>
+<pre><code>┌──────────────────────────────────────────────────────────────┐
+│                    A2A (Agent ↔ Agent)                        │
+│        Discovery, delegation, multi-turn task negotiation     │
+│        Agents are opaque autonomous peers                     │
+├──────────────────────────────────────────────────────────────┤
+│               MCP-AQL (Universal Translation)                 │
+│        Any API → uniform CRUDE interface for LLMs            │
+│        Declarative adapters, introspection, safety,          │
+│        constraint enforcement, computational middleware       │
+├──────────────────────────────────────────────────────────────┤
+│               MCP (Wiring Standard)                           │
+│        Transport + primitives (Tools, Resources, Prompts)    │
+│        stdio / Streamable HTTP / JSON-RPC 2.0                │
+├──────────────────────────────────────────────────────────────┤
+│                    Target Systems                             │
+│        REST APIs, GraphQL, gRPC, databases, OS native,       │
+│        hardware (serial/USB), IoT, file systems,             │
+│        other MCP servers, other agents                        │
+└──────────────────────────────────────────────────────────────┘</code></pre>
+<hr />
+<h2 id="3-the-core-problem-each-solves">3. The Core Problem Each Solves</h2>
+<table>
+<thead>
+<tr>
+<th></th>
+<th>MCP</th>
+<th>MCP-AQL</th>
+<th>A2A</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>Core problem</strong></td>
+<td>Every AI app builds custom integrations for every tool/service (M x N explosion)</td>
+<td>LLMs can't reliably call arbitrary APIs -- they hallucinate parameters, miss constraints, and waste context on schemas</td>
+<td>Agents from different vendors/frameworks can't discover or collaborate with each other</td>
+</tr>
+<tr>
+<td><strong>Solution</strong></td>
+<td>Standardize the connection protocol (one universal wire format)</td>
+<td>Translate any API into an LLM-native interface with self-describing operations, constraint metadata, and safety enforcement</td>
+<td>Standardize agent discovery and task delegation via Agent Cards and multi-turn task conversations</td>
+</tr>
+<tr>
+<td><strong>Analogy</strong></td>
+<td>USB-C: a universal connector</td>
+<td>A universal interpreter that speaks every API dialect but presents one clean language</td>
+<td>Embassy communications between sovereign nations</td>
+</tr>
+</tbody>
+</table>
+<hr />
+<h2 id="4-how-each-protocol-works">4. How Each Protocol Works</h2>
+<h3 id="mcp-connect-and-call">MCP: Connect and Call</h3>
+<ol type="1">
+<li>Host launches MCP server (local process or remote HTTP endpoint)</li>
+<li>Client connects and performs capability negotiation (both sides declare what they support)</li>
+<li>Server exposes Tools, Resources, and Prompts -- all definitions loaded into LLM context at connect time</li>
+<li>LLM calls tools via structured function calling, gets responses</li>
+<li>Client can also provide Sampling (server requests LLM completions) and Elicitation (server requests user input)</li>
+</ol>
+<p><strong>Wire format:</strong> JSON-RPC 2.0 messages over stdio or Streamable HTTP <strong>State:</strong> Stateful session (capabilities fixed for session lifetime)</p>
+<h3 id="mcp-aql-translate-and-dispatch">MCP-AQL: Translate and Dispatch</h3>
+<ol type="1">
+<li>An adapter wraps a target system (REST API, MCP server, OS, hardware, etc.) using a <strong>declarative schema file</strong> (Markdown + YAML front matter -- no code generation required)</li>
+<li>The universal runtime interprets the schema at call time</li>
+<li>LLM connects via MCP and sees 1-5 semantic endpoints instead of dozens of tools</li>
+<li>On first contact with an unfamiliar API, the LLM introspects to discover operations and their constraints</li>
+<li>On subsequent calls, the LLM sends operations directly -- no introspection needed</li>
+<li>The Gatekeeper enforces safety policies server-side, regardless of what the LLM was instructed to do</li>
+</ol>
+<p><strong>Request format:</strong></p>
+<div class="sourceCode" id="cb2"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb2-2"><a href="#cb2-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;create_element&quot;</span><span class="op">,</span></span>
+<span id="cb2-3"><a href="#cb2-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> { <span class="dt">element_name</span><span class="op">:</span> <span class="st">&quot;foo&quot;</span><span class="op">,</span> <span class="dt">description</span><span class="op">:</span> <span class="st">&quot;A new element&quot;</span> }</span>
+<span id="cb2-4"><a href="#cb2-4" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<p><strong>Discovery flow (first contact only):</strong></p>
+<div class="sourceCode" id="cb3"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb3-1"><a href="#cb3-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Step 1: What operations exist?</span></span>
+<span id="cb3-2"><a href="#cb3-2" aria-hidden="true" tabindex="-1"></a>{ <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;introspect&quot;</span><span class="op">,</span> <span class="dt">params</span><span class="op">:</span> { <span class="dt">query</span><span class="op">:</span> <span class="st">&quot;operations&quot;</span> } }</span>
+<span id="cb3-3"><a href="#cb3-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb3-4"><a href="#cb3-4" aria-hidden="true" tabindex="-1"></a><span class="co">// Step 2: How do I call this specific one?</span></span>
+<span id="cb3-5"><a href="#cb3-5" aria-hidden="true" tabindex="-1"></a>{ <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;introspect&quot;</span><span class="op">,</span> <span class="dt">params</span><span class="op">:</span> { <span class="dt">query</span><span class="op">:</span> <span class="st">&quot;operations&quot;</span><span class="op">,</span> <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;create_element&quot;</span> } }</span>
+<span id="cb3-6"><a href="#cb3-6" aria-hidden="true" tabindex="-1"></a><span class="co">// Returns: params with types, enums, min/max, patterns, examples</span></span>
+<span id="cb3-7"><a href="#cb3-7" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb3-8"><a href="#cb3-8" aria-hidden="true" tabindex="-1"></a><span class="co">// Step 3: Make the call</span></span>
+<span id="cb3-9"><a href="#cb3-9" aria-hidden="true" tabindex="-1"></a>{ <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;create_element&quot;</span><span class="op">,</span> <span class="dt">params</span><span class="op">:</span> { <span class="op">...</span> } }</span></code></pre></div>
+<p><strong>Confident call (already knows the API):</strong></p>
+<div class="sourceCode" id="cb4"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb4-1"><a href="#cb4-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Single call, single response -- same round-trip cost as discrete tools</span></span>
+<span id="cb4-2"><a href="#cb4-2" aria-hidden="true" tabindex="-1"></a>{ <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;create_element&quot;</span><span class="op">,</span> <span class="dt">params</span><span class="op">:</span> { <span class="dt">element_name</span><span class="op">:</span> <span class="st">&quot;foo&quot;</span><span class="op">,</span> <span class="op">...</span> } }</span></code></pre></div>
+<p><strong>Fire-and-forget (telemetry/feedback):</strong></p>
+<div class="sourceCode" id="cb5"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb5-1"><a href="#cb5-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Request</span></span>
+<span id="cb5-2"><a href="#cb5-2" aria-hidden="true" tabindex="-1"></a>{ <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;notify&quot;</span><span class="op">,</span> <span class="dt">type</span><span class="op">:</span> <span class="st">&quot;element_used&quot;</span><span class="op">,</span></span>
+<span id="cb5-3"><a href="#cb5-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> { <span class="dt">element_type</span><span class="op">:</span> <span class="st">&quot;persona&quot;</span><span class="op">,</span> <span class="dt">element_name</span><span class="op">:</span> <span class="st">&quot;Advisor&quot;</span> } }</span>
+<span id="cb5-4"><a href="#cb5-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb5-5"><a href="#cb5-5" aria-hidden="true" tabindex="-1"></a><span class="co">// Minimal response (~15 tokens)</span></span>
+<span id="cb5-6"><a href="#cb5-6" aria-hidden="true" tabindex="-1"></a>{ <span class="dt">ack</span><span class="op">:</span> <span class="kw">true</span> }</span></code></pre></div>
+<p><strong>Response format (discriminated union):</strong></p>
+<div class="sourceCode" id="cb6"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb6-1"><a href="#cb6-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Success</span></span>
+<span id="cb6-2"><a href="#cb6-2" aria-hidden="true" tabindex="-1"></a>{ <span class="dt">success</span><span class="op">:</span> <span class="kw">true</span><span class="op">,</span> <span class="dt">data</span><span class="op">:</span> { <span class="co">/* ... */</span> }<span class="op">,</span> <span class="dt">warnings</span><span class="op">:</span> [ <span class="co">/* optional */</span> ] }</span>
+<span id="cb6-3"><a href="#cb6-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb6-4"><a href="#cb6-4" aria-hidden="true" tabindex="-1"></a><span class="co">// Failure</span></span>
+<span id="cb6-5"><a href="#cb6-5" aria-hidden="true" tabindex="-1"></a>{ <span class="dt">success</span><span class="op">:</span> <span class="kw">false</span><span class="op">,</span> <span class="dt">error</span><span class="op">:</span> { <span class="dt">code</span><span class="op">:</span> <span class="st">&quot;VALIDATION_MISSING_PARAM&quot;</span><span class="op">,</span> <span class="dt">message</span><span class="op">:</span> <span class="st">&quot;...&quot;</span> } }</span></code></pre></div>
+<h3 id="a2a-discover-and-delegate">A2A: Discover and Delegate</h3>
+<ol type="1">
+<li>Client agent fetches Agent Cards from potential collaborators at <code>/.well-known/agent.json</code></li>
+<li>Agent Card describes the remote agent's skills, authentication requirements, and capabilities</li>
+<li>Client sends a task to the remote agent via JSON-RPC or gRPC</li>
+<li>Remote agent processes the task, potentially through multiple conversation turns</li>
+<li>Task progresses through lifecycle states (working → input_required → completed)</li>
+<li>Client receives results as Artifacts (text, files, structured data, multimedia)</li>
+</ol>
+<p><strong>Minimum viable interaction (JSON-RPC binding):</strong></p>
+<pre><code>POST https://remote-agent.example.com/a2a
+Content-Type: application/json
+Authorization: Bearer &lt;token&gt;</code></pre>
+<div class="sourceCode" id="cb8"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb8-1"><a href="#cb8-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb8-2"><a href="#cb8-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;jsonrpc&quot;</span><span class="fu">:</span> <span class="st">&quot;2.0&quot;</span><span class="fu">,</span></span>
+<span id="cb8-3"><a href="#cb8-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;id&quot;</span><span class="fu">:</span> <span class="dv">1</span><span class="fu">,</span></span>
+<span id="cb8-4"><a href="#cb8-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;method&quot;</span><span class="fu">:</span> <span class="st">&quot;a2a.SendMessage&quot;</span><span class="fu">,</span></span>
+<span id="cb8-5"><a href="#cb8-5" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb8-6"><a href="#cb8-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb8-7"><a href="#cb8-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;messageId&quot;</span><span class="fu">:</span> <span class="st">&quot;msg-001&quot;</span><span class="fu">,</span></span>
+<span id="cb8-8"><a href="#cb8-8" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;role&quot;</span><span class="fu">:</span> <span class="st">&quot;user&quot;</span><span class="fu">,</span></span>
+<span id="cb8-9"><a href="#cb8-9" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;parts&quot;</span><span class="fu">:</span> <span class="ot">[</span><span class="fu">{</span> <span class="dt">&quot;kind&quot;</span><span class="fu">:</span> <span class="st">&quot;text&quot;</span><span class="fu">,</span> <span class="dt">&quot;text&quot;</span><span class="fu">:</span> <span class="st">&quot;Find the population of Tokyo.&quot;</span> <span class="fu">}</span><span class="ot">]</span></span>
+<span id="cb8-10"><a href="#cb8-10" aria-hidden="true" tabindex="-1"></a>    <span class="fu">},</span></span>
+<span id="cb8-11"><a href="#cb8-11" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;configuration&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;blocking&quot;</span><span class="fu">:</span> <span class="kw">true</span> <span class="fu">}</span></span>
+<span id="cb8-12"><a href="#cb8-12" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb8-13"><a href="#cb8-13" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<p><strong>Communication modes:</strong></p>
+<ul>
+<li>Synchronous request/response (<code>blocking: true</code>)</li>
+<li>Streaming via SSE</li>
+<li>Asynchronous via push notifications (webhooks) for long-running tasks</li>
+</ul>
+<hr />
+<h2 id="5-key-capabilities-comparison">5. Key Capabilities Comparison</h2>
+<h3 id="discovery-and-self-description">Discovery and Self-Description</h3>
+<table>
+<thead>
+<tr>
+<th></th>
+<th>MCP</th>
+<th>MCP-AQL</th>
+<th>A2A</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>Discovery mechanism</strong></td>
+<td>Static -- client connects to pre-configured servers</td>
+<td>Runtime introspection -- <code>introspect</code> operation discovers operations on demand</td>
+<td>Agent Cards at well-known URLs</td>
+</tr>
+<tr>
+<td><strong>Schema loading</strong></td>
+<td>All tool definitions loaded upfront into LLM context</td>
+<td>Progressive disclosure -- discover what you need, when you need it</td>
+<td>Agent Card skills are high-level descriptions, not detailed schemas</td>
+</tr>
+<tr>
+<td><strong>Constraint metadata</strong></td>
+<td>Tool annotations (readOnly, destructive hints) + JSON Schema for inputs</td>
+<td>Rich constraints: enums, min/max, patterns, formats, sensitive markers, examples</td>
+<td>Minimal -- skill descriptions are natural language</td>
+</tr>
+<tr>
+<td><strong>Token cost of discovery</strong></td>
+<td>~500-700 tokens per tool (50 tools = ~30,000 tokens upfront)</td>
+<td>~1,100 tokens total (single mode) for unlimited operations</td>
+<td>Agent Cards fetched out of band, not in LLM context</td>
+</tr>
+</tbody>
+</table>
+<h3 id="token-efficiency">Token Efficiency</h3>
+<table>
+<thead>
+<tr>
+<th></th>
+<th>MCP</th>
+<th>MCP-AQL</th>
+<th>A2A</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>Registration overhead</strong></td>
+<td>~30,000 tokens for 50 tools</td>
+<td>~1,100 (single mode) to ~4,300 (CRUDE mode) for 50+ operations</td>
+<td>N/A -- agents, not tools</td>
+</tr>
+<tr>
+<td><strong>Reduction from baseline</strong></td>
+<td>Baseline (0%)</td>
+<td>85-96% reduction</td>
+<td>Not comparable</td>
+</tr>
+<tr>
+<td><strong>Response efficiency</strong></td>
+<td>Raw tool output dumped to context</td>
+<td>Field selection (minimal/standard/full presets) provides 65-86% additional reduction</td>
+<td>Artifacts with structured Parts</td>
+</tr>
+<tr>
+<td><strong>Repeated call optimization</strong></td>
+<td>Same cost every time</td>
+<td>"Ditto" shorthand pattern: 97% reduction on repeated calls (~15 tokens vs ~450)</td>
+<td>N/A</td>
+</tr>
+<tr>
+<td><strong>Fire-and-forget</strong></td>
+<td>No -- every tool call requires full response processing</td>
+<td><code>notify</code> operation returns minimal <code>{ ack: true }</code> (~15 tokens)</td>
+<td>N/A</td>
+</tr>
+</tbody>
+</table>
+<h3 id="safety-and-security">Safety and Security</h3>
+<table>
+<thead>
+<tr>
+<th></th>
+<th>MCP</th>
+<th>MCP-AQL</th>
+<th>A2A</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>Safety model</strong></td>
+<td>Tool annotations are hints; client decides whether to honor them</td>
+<td><strong>Protocol-enforced Gatekeeper</strong> -- 4-layer defense-in-depth; server-side enforcement that LLM cannot bypass</td>
+<td>Agent can reject tasks; standard auth schemes</td>
+</tr>
+<tr>
+<td><strong>Danger classification</strong></td>
+<td>Binary: readOnly or destructive annotation</td>
+<td>5-level system: safe → reversible → destructive → dangerous → forbidden</td>
+<td>N/A</td>
+</tr>
+<tr>
+<td><strong>Trust model</strong></td>
+<td>Implicit trust in configured servers</td>
+<td>5-level trust: untested → generated → validated → community_reviewed → certified; gating matrix with danger levels</td>
+<td>Authentication schemes (OAuth, OIDC, mTLS)</td>
+</tr>
+<tr>
+<td><strong>Hallucination prevention</strong></td>
+<td>Depends on tool description quality</td>
+<td>Unknown parameter rejection -- if LLM hallucinates <code>force: true</code>, adapter rejects and returns valid params</td>
+<td>Depends on Agent Card quality</td>
+</tr>
+<tr>
+<td><strong>Confirmation workflow</strong></td>
+<td>Human-in-the-loop via Sampling</td>
+<td>Confirmation tokens for destructive operations; pattern-based auto-classification (<code>force_*</code> → dangerous, <code>drop_*</code> → forbidden)</td>
+<td>N/A</td>
+</tr>
+<tr>
+<td><strong>Auth</strong></td>
+<td>OAuth 2.1 (as of Jun 2025)</td>
+<td>Inherits MCP + per-adapter auth plugins (API key, Bearer, OAuth, mTLS, AWS SigV4)</td>
+<td>OAuth 2.0, OIDC, mTLS, API keys, in-task auth escalation</td>
+</tr>
+<tr>
+<td><strong>Core principle</strong></td>
+<td>Security by design (but client-enforced)</td>
+<td>"LLM instructions are suggestions. Adapter policies are enforcement."</td>
+<td>Secure by default (enterprise-grade from day one)</td>
+</tr>
+</tbody>
+</table>
+<h3 id="scope-and-reach">Scope and Reach</h3>
+<table>
+<thead>
+<tr>
+<th></th>
+<th>MCP</th>
+<th>MCP-AQL</th>
+<th>A2A</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>What it connects to</strong></td>
+<td>MCP-compatible servers</td>
+<td><strong>Any system with an API</strong>: REST, GraphQL, gRPC, MCP servers, OS native APIs, hardware (serial/USB), IoT, databases, file systems, other agents</td>
+<td>Other A2A-compatible agents</td>
+</tr>
+<tr>
+<td><strong>Adapter creation</strong></td>
+<td>SDK integration + custom code per server</td>
+<td><strong>Declarative schema file</strong> (Markdown + YAML) -- no code generation, hot-reloadable</td>
+<td>SDK integration per agent</td>
+</tr>
+<tr>
+<td><strong>Plugin system</strong></td>
+<td>N/A</td>
+<td>Transport (HTTP, WebSocket, serial, native OS), Protocol (REST, GraphQL, gRPC, JSON-RPC), Serialization (JSON, XML, Protobuf, MessagePack), Auth (multiple schemes), Pagination (cursor, offset, page)</td>
+<td>N/A</td>
+</tr>
+<tr>
+<td><strong>Performance tiers</strong></td>
+<td>Single implementation</td>
+<td>Three-tier architecture planned: Standard (TypeScript) for MCP wrapping, Local Systems (Rust, 5-50x faster) for OS/hardware, Network API (Rust) for concurrent web API processing</td>
+<td>Single implementation</td>
+</tr>
+</tbody>
+</table>
+<h3 id="agent-to-agent-capabilities">Agent-to-Agent Capabilities</h3>
+<table>
+<thead>
+<tr>
+<th></th>
+<th>MCP</th>
+<th>MCP-AQL</th>
+<th>A2A</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>Agent-to-agent</strong></td>
+<td>No</td>
+<td>Yes -- via adapter chains, distributed tracing (W3C Trace Context), EXECUTE lifecycle</td>
+<td><strong>Primary purpose</strong></td>
+</tr>
+<tr>
+<td><strong>Task delegation</strong></td>
+<td>No</td>
+<td>EXECUTE endpoint with state machine (pending → running → completed/failed/cancelled)</td>
+<td>First-class task lifecycle with 7-state machine and multi-turn conversation</td>
+</tr>
+<tr>
+<td><strong>Multi-agent coordination</strong></td>
+<td>No</td>
+<td>Optimistic concurrency (ETags), notifications/telemetry for inter-agent signaling</td>
+<td>Discovery via Agent Cards, context IDs for conversation threading</td>
+</tr>
+<tr>
+<td><strong>Distributed tracing</strong></td>
+<td>No</td>
+<td>W3C Trace Context propagation across adapter chains (traceId, spanId, parentSpanId)</td>
+<td>No built-in (implementer responsibility)</td>
+</tr>
+</tbody>
+</table>
+<h3 id="computational-middleware">Computational Middleware</h3>
+<table>
+<thead>
+<tr>
+<th></th>
+<th>MCP</th>
+<th>MCP-AQL</th>
+<th>A2A</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>Processing model</strong></td>
+<td>LLM calls tool → gets raw result → reasons about it</td>
+<td>Adapter can process server-side: computed fields, aggregations, multi-step API iteration <strong>without returning to the LLM</strong> -- LLM only sees final processed result</td>
+<td>Remote agent does all internal processing; returns artifacts</td>
+</tr>
+<tr>
+<td><strong>Server-side computation</strong></td>
+<td>Not built in</td>
+<td>Computed fields (so LLM doesn't do math), server-side aggregations (counts, groupings without fetching all records)</td>
+<td>Agent handles internally</td>
+</tr>
+<tr>
+<td><strong>Batch operations</strong></td>
+<td>No native batching</td>
+<td>Optional batch operations with per-item results, continueOnError, and atomic modes</td>
+<td>N/A</td>
+</tr>
+<tr>
+<td><strong>Dry-run mode</strong></td>
+<td>No</td>
+<td>Preview consequences before committing, including policy checks and estimated token costs</td>
+<td>No</td>
+</tr>
+</tbody>
+</table>
+<hr />
+<h2 id="6-strengths-and-weaknesses">6. Strengths and Weaknesses</h2>
+<h3 id="mcp">MCP</h3>
+<p><strong>Strengths:</strong></p>
+<ul>
+<li>De facto industry standard with massive ecosystem and adoption</li>
+<li>Clean three-primitive model (Tools, Resources, Prompts) with clear separation</li>
+<li>Transport flexibility (stdio for dev, Streamable HTTP for production)</li>
+<li>Capability negotiation prevents feature mismatches at connect time</li>
+<li>Sampling and Elicitation enable rich bidirectional LLM-server interaction</li>
+<li>Async Tasks (Nov 2025) handle long-running operations</li>
+<li>Under neutral governance with every major AI company backing it</li>
+</ul>
+<p><strong>Weaknesses:</strong></p>
+<ul>
+<li><strong>Tool sprawl is the critical pain point</strong> -- many tools consume thousands of tokens for schemas before any work begins, crowding out context for actual reasoning</li>
+<li>No native agent-to-agent communication</li>
+<li>Stateful sessions complicate horizontal scaling (sticky sessions or distributed state required)</li>
+<li>Security is well-designed in spec but problematic in practice (43% command injection in one audit of real-world implementations; all verified servers lacked authentication in a Knostic scan)</li>
+<li>Multiple spec revisions with breaking changes have required repeated rework from early adopters</li>
+<li>Every tool call gets raw output dumped to context -- wasteful for data-heavy operations</li>
+</ul>
+<h3 id="mcp-aql">MCP-AQL</h3>
+<p><strong>Strengths:</strong></p>
+<ul>
+<li><strong>Universal translation layer</strong> -- one interface for any API, OS, hardware, or agent</li>
+<li><strong>Zero-code adapters</strong> -- declarative schema files (Markdown + YAML), no compilation, hot-reloadable</li>
+<li><strong>LLM-native design</strong> -- constraint metadata in introspection responses directly eliminates hallucinated parameters</li>
+<li><strong>Protocol-enforced safety</strong> -- Gatekeeper cannot be bypassed by prompt injection or context manipulation; server-side authority is absolute</li>
+<li><strong>Token efficiency is a natural consequence</strong> (~85-96% on registration, 65-86% on responses via field selection, 97% on repeated calls via Ditto shorthand)</li>
+<li><strong>Progressive disclosure</strong> matches how LLMs actually work</li>
+<li><strong>No introspection required for confident calls</strong> -- single round-trip, same as discrete tools</li>
+<li><strong>Fire-and-forget via <code>notify</code></strong> -- minimal <code>{ ack: true }</code> (~15 tokens) for telemetry</li>
+<li><strong>Computational middleware</strong> -- server-side processing shields LLM from raw API complexity</li>
+<li><strong>Three-tier performance architecture</strong> planned (TypeScript, Rust local, Rust network)</li>
+<li><strong>Agent-to-agent capable</strong> via distributed tracing, EXECUTE lifecycle, and optimistic concurrency</li>
+<li><strong>Domain-agnostic</strong> -- each adapter defines its own operations for its own domain</li>
+</ul>
+<p><strong>Weaknesses:</strong></p>
+<ul>
+<li><strong>First-contact discovery takes multiple round trips</strong> (one-time cost, not per-call)</li>
+<li><strong>Draft specification</strong> -- v1.0.0-draft, though nearing v1.0-rc with launch imminent</li>
+<li><strong>Single reference implementation</strong> (DollhouseMCP private beta V2)</li>
+<li><strong>Advanced transport plugins</strong> (serial, native OS, gRPC, Rust tiers) are future work</li>
+<li><strong>CRUDE pattern unfamiliarity</strong> -- minor learning curve beyond standard CRUD</li>
+<li><strong>Single endpoint mode trades safety for efficiency</strong> -- no endpoint-level permission blocking in single mode</li>
+<li><strong>Adapter quality depends on schema authors</strong> -- mitigated by canonical operation verbs</li>
+</ul>
+<h3 id="a2a">A2A</h3>
+<p><strong>Strengths:</strong></p>
+<ul>
+<li>Fills a gap nothing else addresses -- true agent-to-agent interoperability across vendors</li>
+<li>Opaque agent model protects intellectual property and proprietary logic</li>
+<li>Rich task lifecycle with multi-turn conversations, streaming, and push notifications</li>
+<li>Multimodal content support (text, files, structured data, audio, video)</li>
+<li>Enterprise-grade security from day one (OAuth 2.0, OIDC, mTLS, in-task auth escalation)</li>
+<li>gRPC support (v0.3) for high-performance binary communication</li>
+<li>Signed Agent Cards (v0.3) for cryptographic identity verification</li>
+<li>Strong governance trajectory (Linux Foundation, 150+ orgs, IBM ACP merger)</li>
+</ul>
+<p><strong>Weaknesses:</strong></p>
+<ul>
+<li><strong>O(n squared) scaling</strong> -- 50 agents = 1,200+ connections to manage</li>
+<li><strong>No built-in orchestration</strong> -- conflict resolution, cascading failure handling, and circular dependency prevention left to implementers</li>
+<li><strong>Agent Card skill descriptions are high-level</strong> -- imprecise for task routing</li>
+<li><strong>Early-stage maturity</strong> -- v0.3 draft; breaking changes expected</li>
+<li><strong>Missing economics</strong> -- no pricing, SLAs, or inter-agent billing</li>
+<li><strong>Observability challenges</strong> -- tracing gaps across agent chains</li>
+<li><strong>State management gaps</strong> -- elaborate state infrastructure required</li>
+<li><strong>Security surface concerns</strong> -- Agent Card spoofing, tool squatting, data sovereignty across agent chains are unsolved</li>
+</ul>
+<hr />
+<h2 id="7-overlap-and-toe-stepping-analysis">7. Overlap and Toe-Stepping Analysis</h2>
+<h3 id="does-mcp-aql-step-on-mcps-toes">Does MCP-AQL Step on MCP's Toes?</h3>
+<p><strong>No.</strong> MCP-AQL rides on top of MCP -- it uses MCP as its transport layer. MCP-AQL registers as 1-5 MCP tools and communicates via the standard <code>CallToolResult</code> mechanism. MCP-AQL doesn't replace MCP; it makes MCP-connected servers more efficient and safer to use. They are symbiotic, not competitive.</p>
+<h3 id="does-mcp-aql-step-on-a2as-toes">Does MCP-AQL Step on A2A's Toes?</h3>
+<p><strong>Partially, in a good way.</strong> There is genuine overlap at the agent-to-agent boundary:</p>
+<table>
+<thead>
+<tr>
+<th>Capability</th>
+<th>MCP-AQL</th>
+<th>A2A</th>
+<th>Overlap?</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Agent discovery</td>
+<td>Introspection (what operations exist?)</td>
+<td>Agent Cards (what can this agent do?)</td>
+<td><strong>Complementary</strong> -- different granularity</td>
+</tr>
+<tr>
+<td>Task delegation</td>
+<td>EXECUTE endpoint with lifecycle states</td>
+<td>Task lifecycle with 7-state machine</td>
+<td><strong>Overlapping</strong> -- but MCP-AQL is structured/typed while A2A is conversational</td>
+</tr>
+<tr>
+<td>Multi-turn interaction</td>
+<td>Not native (each call is independent)</td>
+<td>First-class multi-turn with context IDs</td>
+<td><strong>A2A is stronger here</strong></td>
+</tr>
+<tr>
+<td>Distributed tracing</td>
+<td>W3C Trace Context across adapter chains</td>
+<td>Not built in</td>
+<td><strong>MCP-AQL is stronger here</strong></td>
+</tr>
+<tr>
+<td>Safety enforcement</td>
+<td>Gatekeeper with danger/trust levels</td>
+<td>Agent-level accept/reject</td>
+<td><strong>Different philosophy, both valid</strong></td>
+</tr>
+</tbody>
+</table>
+<p>The overlap is at the <strong>precision-flexibility boundary</strong>:</p>
+<ul>
+<li><strong>MCP-AQL</strong> provides a normalized API endpoint for agents -- typed, constrained, validated, with protocol-enforced safety. Best when one agent needs to <em>correctly execute a specific operation</em> on another system.</li>
+<li><strong>A2A</strong> provides unstructured multi-turn negotiation between opaque peers. Best when agents need to <em>reason together about ambiguous, evolving tasks</em>.</li>
+</ul>
+<p>These are complementary, not competing. A system might use A2A for high-level delegation ("Research Agent, investigate this") and MCP-AQL for the precise operations within that delegation.</p>
+<h3 id="does-a2a-step-on-mcps-toes">Does A2A Step on MCP's Toes?</h3>
+<p><strong>No.</strong> A2A and MCP are explicitly complementary. A2A's own documentation describes the relationship: MCP handles agent-to-tool (vertical), A2A handles agent-to-agent (horizontal). An agent uses MCP internally to access tools and A2A externally to collaborate with other agents.</p>
+<h3 id="does-a2a-step-on-mcp-aqls-toes">Does A2A Step on MCP-AQL's Toes?</h3>
+<p><strong>Slightly, at the edges.</strong> A2A's task lifecycle (7 states, multi-turn, streaming, push notifications) is more mature than MCP-AQL's EXECUTE endpoint lifecycle. If your use case is <em>primarily</em> agent-to-agent task delegation with rich conversational context, A2A is the right choice. MCP-AQL's agent-to-agent capabilities are structured and precise but less flexible for open-ended collaboration.</p>
+<hr />
+<h2 id="8-gap-analysis">8. Gap Analysis</h2>
+<h3 id="gaps-in-mcp-addressed-by-the-other-two">Gaps in MCP (Addressed by the Other Two)</h3>
+<table>
+<thead>
+<tr>
+<th>Gap</th>
+<th>Who fills it</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Tool sprawl / context window bloat</td>
+<td><strong>MCP-AQL</strong> (85-96% token reduction)</td>
+</tr>
+<tr>
+<td>No agent-to-agent communication</td>
+<td><strong>A2A</strong> (primary purpose) and <strong>MCP-AQL</strong> (via adapter chains)</td>
+</tr>
+<tr>
+<td>Safety is advisory, not enforced</td>
+<td><strong>MCP-AQL</strong> (Gatekeeper with server-side authority)</td>
+</tr>
+<tr>
+<td>No progressive discovery</td>
+<td><strong>MCP-AQL</strong> (introspection on demand)</td>
+</tr>
+<tr>
+<td>Raw tool output wastes tokens</td>
+<td><strong>MCP-AQL</strong> (field selection, server-side computation)</td>
+</tr>
+</tbody>
+</table>
+<h3 id="gaps-in-a2a-not-yet-addressed">Gaps in A2A (Not Yet Addressed)</h3>
+<table>
+<thead>
+<tr>
+<th>Gap</th>
+<th>Description</th>
+<th>Potential fill</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>No message persistence</strong></td>
+<td>The spec does not specify whether agents must persist messages after task completion, how long task state must be retained, or storage format. An A2A server could lose everything on restart and still be conformant.</td>
+<td><strong>COMMS element type</strong> (file-based, database, Redis backends)</td>
+</tr>
+<tr>
+<td><strong>No message queuing</strong></td>
+<td>No guaranteed delivery, no ordering guarantees beyond streaming, no dead-letter queues, no backpressure mechanism. Push notification retry policy is the closest thing.</td>
+<td><strong>COMMS element type</strong> or external message broker</td>
+</tr>
+<tr>
+<td><strong>No offline delivery</strong></td>
+<td>If the server agent is unreachable, the request fails. No store-and-forward, no inbox/outbox pattern.</td>
+<td><strong>COMMS element type</strong> (file-based persistence survives offline)</td>
+</tr>
+<tr>
+<td><strong>No local agent-to-agent communication</strong></td>
+<td>All three standard bindings (JSON-RPC/HTTP, gRPC, REST) assume network communication. No Unix socket, shared memory, IPC, or localhost optimization.</td>
+<td><strong>COMMS element type</strong> (filesystem IPC at <code>~/.dollhouse/team-ipc/</code>)</td>
+</tr>
+<tr>
+<td><strong>No state management between sessions</strong></td>
+<td>No session concept at the protocol level, no session tokens or resumption, no requirement that context IDs persist across restarts.</td>
+<td><strong>Memory elements</strong> + <strong>COMMS element type</strong></td>
+</tr>
+<tr>
+<td><strong>No orchestration</strong></td>
+<td>No workflow definition, conditional branching, routing, fan-out/fan-in, saga patterns, circuit breakers, or load balancing. Explicitly out of scope.</td>
+<td>Application layer / <strong>TEAM element type</strong></td>
+</tr>
+<tr>
+<td><strong>No discovery registry</strong></td>
+<td>Agent Cards at well-known URLs require knowing the URL in advance. No search, marketplace, or broadcast discovery.</td>
+<td><strong>MCP-AQL adapter registry</strong> / <strong>COMMS discovery</strong></td>
+</tr>
+<tr>
+<td><strong>No distributed tracing</strong></td>
+<td>No built-in tracing format; metadata maps can carry trace IDs but nothing is standardized.</td>
+<td><strong>MCP-AQL</strong> (W3C Trace Context)</td>
+</tr>
+<tr>
+<td><strong>No economics</strong></td>
+<td>No pricing, SLAs, inter-agent billing, or dispute resolution.</td>
+<td>Not addressed by any protocol yet</td>
+</tr>
+<tr>
+<td><strong>No streaming client-to-server</strong></td>
+<td>Clients cannot stream large inputs during task execution; only agents stream output back.</td>
+<td>Not addressed</td>
+</tr>
+</tbody>
+</table>
+<h3 id="gaps-in-mcp-aql-not-yet-addressed">Gaps in MCP-AQL (Not Yet Addressed)</h3>
+<table>
+<thead>
+<tr>
+<th>Gap</th>
+<th>Description</th>
+<th>Potential fill</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>Multi-turn conversational context</strong></td>
+<td>Each MCP-AQL call is independent; no built-in context threading across calls</td>
+<td><strong>A2A</strong> (context IDs, multi-turn tasks)</td>
+</tr>
+<tr>
+<td><strong>Agent opaqueness</strong></td>
+<td>MCP-AQL introspection reveals operation details; no mechanism to hide internals when that's desirable</td>
+<td><strong>A2A</strong> (opaque by design)</td>
+</tr>
+<tr>
+<td><strong>Multimodal content exchange</strong></td>
+<td>MCP-AQL responses are structured JSON; no native audio, video, or rich media support</td>
+<td><strong>A2A</strong> (multimodal Parts)</td>
+</tr>
+<tr>
+<td><strong>Cross-vendor interoperability</strong></td>
+<td>MCP-AQL requires MCP as transport; cannot directly interoperate with non-MCP agents</td>
+<td><strong>A2A</strong> (framework-agnostic)</td>
+</tr>
+</tbody>
+</table>
+<hr />
+<h2 id="9-a2a-under-the-hood-what-it-provides-vs-what-it-doesnt">9. A2A Under the Hood: What It Provides vs. What It Doesn't</h2>
+<p>A critical question for positioning MCP-AQL relative to A2A: <strong>does A2A have its own wiring, or is it simply a description of how agents interact?</strong></p>
+<h3 id="what-a2a-actually-provides">What A2A Actually Provides</h3>
+<p>A2A is a <strong>real protocol with real wire bindings</strong>, not just a description. It has three layers:</p>
+<table>
+<thead>
+<tr>
+<th>Layer</th>
+<th>What A2A Defines</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>Canonical Data Model</strong></td>
+<td>Protocol Buffers (<code>a2a.proto</code>) defining Task, Message, AgentCard, Artifact, Part types</td>
+</tr>
+<tr>
+<td><strong>Abstract Operations</strong></td>
+<td>11 transport-agnostic operations (SendMessage, GetTask, ListTasks, CancelTask, SubscribeToTask, etc.)</td>
+</tr>
+<tr>
+<td><strong>Protocol Bindings</strong></td>
+<td>Concrete mappings to JSON-RPC 2.0 over HTTP, gRPC over HTTP/2, and REST over HTTP</td>
+</tr>
+</tbody>
+</table>
+<p>A2A mandates TLS 1.2+, registers an IANA media type (<code>application/a2a+json</code>), and defines HTTP headers (<code>A2A-Version</code>, <code>A2A-Extensions</code>). It provides real message formats, real state machines, and real security schemes.</p>
+<h3 id="what-a2a-leaves-to-implementers">What A2A Leaves to Implementers</h3>
+<p>This is where the gaps are significant:</p>
+<table>
+<thead>
+<tr>
+<th>Concern</th>
+<th>A2A's Position</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>Message persistence</strong></td>
+<td>Completely unspecified</td>
+</tr>
+<tr>
+<td><strong>Message queuing / guaranteed delivery</strong></td>
+<td>Not addressed; push notification retry is closest</td>
+</tr>
+<tr>
+<td><strong>Offline delivery</strong></td>
+<td>Not supported; synchronous with async extensions</td>
+</tr>
+<tr>
+<td><strong>Local IPC (same machine)</strong></td>
+<td>Not addressed; all bindings assume network</td>
+</tr>
+<tr>
+<td><strong>Session state management</strong></td>
+<td>Not specified; no session concept</td>
+</tr>
+<tr>
+<td><strong>Orchestration / routing</strong></td>
+<td>Explicitly out of scope</td>
+</tr>
+<tr>
+<td><strong>Agent registry / search</strong></td>
+<td>Not provided; must know URL to fetch Agent Card</td>
+</tr>
+<tr>
+<td><strong>Distributed tracing</strong></td>
+<td>Not standardized; metadata can carry trace IDs</td>
+</tr>
+<tr>
+<td><strong>Economics / billing</strong></td>
+<td>Not addressed</td>
+</tr>
+</tbody>
+</table>
+<h3 id="could-a2a-run-on-mcp">Could A2A Run on MCP?</h3>
+<p>Technically possible via A2A's custom binding mechanism (Section 12), but <strong>architecturally awkward</strong> because:</p>
+<ol type="1">
+<li><strong>Role inversion</strong> -- MCP treats remote parties as stateless tools; A2A treats them as autonomous agents with state machines</li>
+<li><strong>Streaming mismatch</strong> -- A2A's task-lifecycle-aware streaming doesn't map cleanly to MCP's generic SSE</li>
+<li><strong>Discovery conflict</strong> -- Two discovery systems (tool listings vs. Agent Cards) would need reconciliation</li>
+</ol>
+<p>The intended relationship is <strong>side by side</strong>, not layered: A2A for inter-agent delegation, MCP for tool invocation.</p>
+<hr />
+<h2 id="10-the-comms-element-type-and-protocol-specific-variants">10. The COMMS Element Type and Protocol-Specific Variants</h2>
+<p>DollhouseMCP has a planned (but not yet specified) <strong>COMMS element type</strong> designed for inter-agent, inter-session, and inter-computer communication. It is part of the broader <strong>TEAM element</strong> hierarchy for multi-computer orchestration.</p>
+<blockquote>
+<p><strong>Note:</strong> COMMS elements are <strong>DollhouseMCP-specific</strong> -- they are not part of the core MCP-AQL protocol specification. MCP-AQL is domain-agnostic and does not prescribe element types. COMMS are discussed here because they illustrate how an MCP-AQL implementation can address gaps in the agent communication landscape, but any MCP-AQL adapter could implement its own approach to agent communication.</p>
+</blockquote>
+<h3 id="comms-as-a-protocol-specific-element-category">COMMS as a Protocol-Specific Element Category</h3>
+<p>A critical design decision: COMMS is not a single monolithic element type. It is an <strong>element type category</strong> with <strong>protocol-specific variants</strong>. Each variant presents a focused, constrained interface to the AI for a specific communication protocol's semantics.</p>
+<p>This follows the same philosophy as MCP-AQL itself: rather than giving the AI one giant comms element with a thousand protocol-specific options to navigate, each protocol variant presents a clean, limited set of operations that the AI can correctly use.</p>
+<p><strong>Potential COMMS variants:</strong></p>
+<table>
+<thead>
+<tr>
+<th>Variant</th>
+<th>Protocol</th>
+<th>Use Case</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>A2A comms</strong></td>
+<td>Google A2A</td>
+<td>Cross-vendor agent-to-agent delegation with task lifecycle</td>
+</tr>
+<tr>
+<td><strong>TCP/IP comms</strong></td>
+<td>Raw TCP/IP</td>
+<td>Low-level network communication, custom protocols</td>
+</tr>
+<tr>
+<td><strong>HTTP comms</strong></td>
+<td>HTTP/REST</td>
+<td>Direct web API messaging, webhooks</td>
+</tr>
+<tr>
+<td><strong>SMTP comms</strong></td>
+<td>SMTP/email</td>
+<td>Email-based notifications and async communication</td>
+</tr>
+<tr>
+<td><strong>WebSocket comms</strong></td>
+<td>WebSocket</td>
+<td>Real-time bidirectional messaging</td>
+</tr>
+<tr>
+<td><strong>Filesystem comms</strong></td>
+<td>Local IPC</td>
+<td>Same-machine agent-to-agent via file-based messaging</td>
+</tr>
+<tr>
+<td><strong>Mesh comms</strong></td>
+<td>WireGuard/Tailscale</td>
+<td>Encrypted multi-node agent mesh networking</td>
+</tr>
+</tbody>
+</table>
+<p>Each variant is a separate element that encapsulates its protocol's semantics. An AI using "A2A comms" sees Agent Cards, Tasks, Messages, and Artifacts. An AI using "TCP/IP comms" sees connections, packets, and streams. An AI using "SMTP comms" sees recipients, subjects, and message bodies. The protocol complexity is contained within each variant, not dumped into a single generic element.</p>
+<h3 id="element-hierarchy">Element Hierarchy</h3>
+<pre><code>TEAM (orchestrates computers/sessions)
+  → uses COMMS variants (protocol-specific message passing)
+      → A2A comms (cross-vendor agent delegation)
+      → Filesystem comms (local IPC)
+      → Mesh comms (encrypted multi-node)
+      → HTTP comms (webhooks, REST messaging)
+      → ...
+  → uses MEMORY (for shared state persistence)
+  → contains ENSEMBLES (which contain agents, personas, skills, etc.)</code></pre>
+<h3 id="transport-mechanisms">Transport Mechanisms</h3>
+<table>
+<thead>
+<tr>
+<th>Scope</th>
+<th>Likely Variant</th>
+<th>Mechanism</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Same computer, different sessions</td>
+<td>Filesystem comms</td>
+<td>File-based IPC at <code>~/.dollhouse/team-ipc/</code></td>
+</tr>
+<tr>
+<td>Different computers (network)</td>
+<td>HTTP comms / A2A comms</td>
+<td>REST/HTTP or A2A task delegation</td>
+</tr>
+<tr>
+<td>Encrypted enterprise mesh</td>
+<td>Mesh comms</td>
+<td>WireGuard via Tailscale or Headscale (self-hosted)</td>
+</tr>
+<tr>
+<td>Cross-vendor agent collaboration</td>
+<td>A2A comms</td>
+<td>A2A protocol with Agent Cards and task lifecycle</td>
+</tr>
+<tr>
+<td>Async notifications</td>
+<td>SMTP comms / HTTP comms</td>
+<td>Email or webhook-based</td>
+</tr>
+</tbody>
+</table>
+<h3 id="a2a-as-one-comms-variant-not-the-comms-element">A2A as One COMMS Variant (Not THE Comms Element)</h3>
+<p>This distinction matters. A2A is an excellent protocol for cross-vendor agent interoperability and would be a natural fit as one COMMS variant. But COMMS should not be designed as "A2A plus extras" -- that would:</p>
+<ol type="1">
+<li><strong>Conflate the transport layer with a specific protocol's semantics.</strong> COMMS is about <em>how messages move</em>. A2A is about <em>what agents say to each other</em>. These are separate concerns even when they overlap.</li>
+<li><strong>Limit future protocol support.</strong> If COMMS is designed around A2A's data model (Tasks, Messages, Artifacts), adding TCP/IP or SMTP variants later would be awkward -- those protocols have fundamentally different semantics.</li>
+<li><strong>Present the AI with an unnecessarily complex interface.</strong> An AI doing simple filesystem IPC between local agents doesn't need to navigate A2A's 7-state task machine. An AI sending email notifications doesn't need Agent Cards.</li>
+</ol>
+<p>Instead, each COMMS variant is a self-contained element that the AI understands on its own terms. The protocol specifics stay inside the variant.</p>
+<h3 id="where-comms-variants-fill-a2as-gaps">Where COMMS Variants Fill A2A's Gaps</h3>
+<p>A2A leaves significant infrastructure gaps (see Section 9). Different COMMS variants address different gaps:</p>
+<table>
+<thead>
+<tr>
+<th>A2A Gap</th>
+<th>Which COMMS Variant Fills It</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>No message persistence</strong></td>
+<td>Filesystem comms, database-backed variants</td>
+</tr>
+<tr>
+<td><strong>No message queuing</strong></td>
+<td>Filesystem comms (natural queue semantics), database variants</td>
+</tr>
+<tr>
+<td><strong>No offline delivery</strong></td>
+<td>Filesystem comms (persists regardless of recipient availability)</td>
+</tr>
+<tr>
+<td><strong>No local IPC</strong></td>
+<td>Filesystem comms at <code>~/.dollhouse/team-ipc/</code> (sub-100ms)</td>
+</tr>
+<tr>
+<td><strong>No state between sessions</strong></td>
+<td>Memory elements + any persistent COMMS variant</td>
+</tr>
+<tr>
+<td><strong>No orchestration</strong></td>
+<td>TEAM element coordinates across COMMS variants</td>
+</tr>
+<tr>
+<td><strong>No discovery on local network</strong></td>
+<td>TEAM session discovery protocol (planned)</td>
+</tr>
+</tbody>
+</table>
+<h3 id="where-a2a-provides-what-comms-variants-dont">Where A2A Provides What COMMS Variants Don't</h3>
+<table>
+<thead>
+<tr>
+<th>Gap</th>
+<th>What A2A Provides</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>Cross-vendor interoperability</strong></td>
+<td>A2A works across any framework; COMMS variants are DollhouseMCP elements</td>
+</tr>
+<tr>
+<td><strong>Standardized Agent Cards</strong></td>
+<td>A2A's discovery model is an industry standard</td>
+</tr>
+<tr>
+<td><strong>Multi-turn conversational protocol</strong></td>
+<td>A2A has formal message/task/artifact semantics</td>
+</tr>
+<tr>
+<td><strong>Multimodal content</strong></td>
+<td>A2A's Part type supports text, files, data, UI components</td>
+</tr>
+<tr>
+<td><strong>Industry governance</strong></td>
+<td>A2A is under the Linux Foundation with 150+ backers</td>
+</tr>
+</tbody>
+</table>
+<p>An <strong>A2A comms variant</strong> would bring all of these into the DollhouseMCP ecosystem while keeping A2A's semantics cleanly separated from other communication protocols.</p>
+<h3 id="the-architecture">The Architecture</h3>
+<pre><code>┌──────────────────────────────────────┐
+│  Agent (DollhouseMCP)                │
+│  ┌────────────────────────────────┐  │
+│  │ COMMS variants (protocol-      │  │
+│  │ specific elements)             │  │
+│  │                                │  │
+│  │  ┌──────────┐ ┌────────────┐  │  │
+│  │  │ A2A      │ │ Filesystem │  │  │
+│  │  │ comms    │ │ comms      │  │  │
+│  │  │ (agents) │ │ (local)    │  │  │
+│  │  └──────────┘ └────────────┘  │  │
+│  │  ┌──────────┐ ┌────────────┐  │  │
+│  │  │ HTTP     │ │ Mesh       │  │  │
+│  │  │ comms    │ │ comms      │  │  │
+│  │  │ (webhooks│ │ (encrypted)│  │  │
+│  │  └──────────┘ └────────────┘  │  │
+│  ├────────────────────────────────┤  │
+│  │ MCP-AQL adapter                │  │  ← CRUDE interface for all variants
+│  │ (safety, constraints)          │  │
+│  ├────────────────────────────────┤  │
+│  │ MCP transport                  │  │  ← Wire format
+│  └────────────────────────────────┘  │
+└──────────────────────────────────────┘</code></pre>
+<hr />
+<h2 id="11-the-composite-architecture">11. The Composite Architecture</h2>
+<p>The end state for a sophisticated system uses all layers:</p>
+<pre><code>┌────────────────────────────────────────────────────────────────┐
+│                     Enterprise AI Platform                      │
+├────────────────────────────────────────────────────────────────┤
+│                                                                │
+│  ┌──────────┐    A2A     ┌──────────┐    A2A    ┌──────────┐  │
+│  │ Research │◄──────────►│ Planning │◄─────────►│ Execution│  │
+│  │  Agent   │            │  Agent   │           │  Agent   │  │
+│  └────┬─────┘            └────┬─────┘           └────┬─────┘  │
+│       │                       │                      │        │
+│       │ MCP-AQL               │ MCP-AQL              │ MCP-AQL│
+│       │                       │                      │        │
+│  ┌────┴─────┐            ┌────┴─────┐          ┌────┴─────┐  │
+│  │ Web APIs │            │ Database │          │ OS / CI  │  │
+│  │ (REST,   │            │ (SQL,    │          │ (Native, │  │
+│  │  GraphQL)│            │  NoSQL)  │          │  Docker) │  │
+│  └──────────┘            └──────────┘          └──────────┘  │
+│       ▲                       ▲                      ▲        │
+│       └───────────────────────┴──────────────────────┘        │
+│                          MCP Transport                         │
+└────────────────────────────────────────────────────────────────┘</code></pre>
+<p>On a single machine with local agents, a <strong>filesystem comms</strong> element provides IPC with sub-100ms latency, no network overhead, and offline persistence. When agents span multiple machines, an <strong>A2A comms</strong> element handles cross-vendor delegation, or a <strong>mesh comms</strong> element provides encrypted WireGuard networking. Different protocol variants for different scopes -- same CRUDE interface to the AI through MCP-AQL.</p>
+<p><strong>A2A</strong> handles high-level discovery and task delegation between agents.</p>
+<p>Each agent uses <strong>MCP-AQL adapters</strong> to safely interact with its systems through CRUDE endpoints with protocol-enforced safety.</p>
+<p><strong>MCP</strong> provides the underlying transport and session management.</p>
+<p>The <strong>Gatekeeper</strong> ensures no agent can execute forbidden operations without authorization and confirmation, regardless of instructions.</p>
+<hr />
+<h2 id="12-scenario-guide">12. Scenario Guide</h2>
+<table>
+<thead>
+<tr>
+<th>Scenario</th>
+<th>Best fit</th>
+<th>Why</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Connect my LLM to a few specific tools quickly</td>
+<td><strong>MCP</strong></td>
+<td>Simple, direct, massive ecosystem</td>
+</tr>
+<tr>
+<td>50+ MCP tools and context window is choking</td>
+<td><strong>MCP-AQL</strong></td>
+<td>85-96% token reduction; progressive disclosure</td>
+</tr>
+<tr>
+<td>LLM needs to correctly call an unfamiliar REST API</td>
+<td><strong>MCP-AQL</strong></td>
+<td>Introspection with constraint metadata eliminates hallucination</td>
+</tr>
+<tr>
+<td>Sales agent delegates to a research agent</td>
+<td><strong>A2A</strong></td>
+<td>Agent discovery and multi-turn task delegation</td>
+</tr>
+<tr>
+<td>Agents from LangChain and CrewAI need to collaborate</td>
+<td><strong>A2A</strong></td>
+<td>Cross-framework interoperability</td>
+</tr>
+<tr>
+<td>Permission control over destructive operations</td>
+<td><strong>MCP-AQL</strong></td>
+<td>CRUDE + Gatekeeper + danger levels + confirmation tokens</td>
+</tr>
+<tr>
+<td>LLM needs to interact with OS or hardware APIs</td>
+<td><strong>MCP-AQL</strong></td>
+<td>Plugin system with native transport; Rust adapters planned</td>
+</tr>
+<tr>
+<td>Multi-day async tasks across agent boundaries</td>
+<td><strong>A2A</strong></td>
+<td>First-class long-running task lifecycle with push notifications</td>
+</tr>
+<tr>
+<td>Wrap any API for LLM access with zero code</td>
+<td><strong>MCP-AQL</strong></td>
+<td>Declarative adapter schemas; hot-reloadable</td>
+</tr>
+<tr>
+<td>Trace operations across a chain of systems</td>
+<td><strong>MCP-AQL</strong></td>
+<td>W3C Trace Context propagation</td>
+</tr>
+<tr>
+<td>Agents reasoning together about ambiguous problems</td>
+<td><strong>A2A</strong></td>
+<td>Unstructured multi-turn conversation between opaque peers</td>
+</tr>
+<tr>
+<td>Same-machine agent-to-agent messaging</td>
+<td><strong>Filesystem comms</strong></td>
+<td>IPC, sub-100ms, no network overhead</td>
+</tr>
+<tr>
+<td>Agent communication with offline persistence</td>
+<td><strong>Filesystem comms</strong></td>
+<td>File/database-backed; survives restarts and outages</td>
+</tr>
+<tr>
+<td>Cross-vendor agent delegation over network</td>
+<td><strong>A2A comms</strong></td>
+<td>A2A protocol with Agent Cards and task lifecycle</td>
+</tr>
+<tr>
+<td>Enterprise multi-computer agent orchestration</td>
+<td><strong>Mesh comms + TEAM</strong></td>
+<td>Encrypted WireGuard mesh, hierarchical coordination</td>
+</tr>
+</tbody>
+</table>
+<hr />
+<h2 id="13-maturity-and-adoption">13. Maturity and Adoption</h2>
+<table>
+<thead>
+<tr>
+<th></th>
+<th>MCP</th>
+<th>MCP-AQL</th>
+<th>A2A</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>Announced</strong></td>
+<td>November 2024</td>
+<td>2025</td>
+<td>April 2025</td>
+</tr>
+<tr>
+<td><strong>Current version</strong></td>
+<td>2025-11-25 (4th revision)</td>
+<td>v1.0.0-draft</td>
+<td>v0.3</td>
+</tr>
+<tr>
+<td><strong>Governance</strong></td>
+<td>Agentic AI Foundation (Linux Foundation)</td>
+<td>Independent</td>
+<td>Linux Foundation (LF AI &amp; Data)</td>
+</tr>
+<tr>
+<td><strong>Spec maturity</strong></td>
+<td>Production-stable, widely adopted</td>
+<td>Nearing v1.0-rc; launch imminent</td>
+<td>Draft; breaking changes expected</td>
+</tr>
+<tr>
+<td><strong>Ecosystem</strong></td>
+<td>10,000+ servers, 300+ clients</td>
+<td>1 reference impl (DollhouseMCP V2 private beta)</td>
+<td>150+ backing organizations, Python SDK</td>
+</tr>
+<tr>
+<td><strong>SDK availability</strong></td>
+<td>TypeScript, Python, Java, C#, Go, Rust</td>
+<td>Via MCP SDKs (runs on MCP transport)</td>
+<td>Python</td>
+</tr>
+<tr>
+<td><strong>Notable adopters</strong></td>
+<td>OpenAI, Google, Microsoft, AWS, Cloudflare</td>
+<td>DollhouseMCP</td>
+<td>Google, AWS, SAP, Salesforce, IBM, Atlassian</td>
+</tr>
+</tbody>
+</table>
+<hr />
+<h2 id="14-key-takeaways">14. Key Takeaways</h2>
+<ol type="1">
+<li><p><strong>They're layers, not competitors.</strong> MCP provides wiring. MCP-AQL provides translation and safety. A2A provides agent collaboration. Each solves a problem the others don't address.</p></li>
+<li><p><strong>MCP-AQL is a universal translation layer, not a token optimizer.</strong> Its core purpose is making any API correctly callable by an LLM on the first try, through constraint-rich introspection, protocol-enforced safety, and computational middleware. Token efficiency is a consequence, not the goal.</p></li>
+<li><p><strong>MCP's biggest pain point (tool sprawl) is MCP-AQL's reason for existing.</strong> The 85-96% reduction directly addresses the most frequently cited MCP production problem.</p></li>
+<li><p><strong>A2A defines the semantics of agent collaboration but leaves infrastructure to implementers.</strong> Message persistence, queuing, offline delivery, local IPC, session state, orchestration, and distributed tracing are all out of scope. These are real gaps for production deployments.</p></li>
+<li><p><strong>The COMMS element type category fills A2A's infrastructure gaps</strong> -- but COMMS is broader than A2A. It is a protocol-specific element category where A2A is one variant alongside TCP/IP, HTTP, SMTP, filesystem IPC, and encrypted mesh comms. Each variant presents a focused interface to the AI for that protocol's semantics, rather than exposing a single monolithic element with every protocol's complexity.</p></li>
+<li><p><strong>MCP-AQL does not step on A2A's toes.</strong> They overlap at the agent interaction boundary but from different philosophical positions: MCP-AQL provides typed/constrained/safe structured operations; A2A provides flexible/opaque conversational collaboration. Both are needed for different scenarios.</p></li>
+<li><p><strong>Safety philosophy differs fundamentally across all three.</strong> MCP provides advisory annotations. A2A provides agent-level accept/reject. MCP-AQL provides <strong>protocol-enforced server-side authority</strong> that the LLM cannot override -- the strongest safety guarantee of the three.</p></li>
+<li><p><strong>The composite future is all layers working together.</strong> A2A for cross-vendor discovery and delegation (via an A2A comms variant), protocol-specific COMMS variants for different transport needs, MCP-AQL for safe and efficient system interaction, MCP for transport, and the Gatekeeper ensuring no agent operates beyond its authorization regardless of its instructions.</p></li>
+</ol>
+<hr />
+<h2 id="sources">Sources</h2>
+<h3 id="mcp-1">MCP</h3>
+<ul>
+<li><a href="https://modelcontextprotocol.io/specification/2025-11-25">MCP Specification (2025-11-25)</a></li>
+<li><a href="https://en.wikipedia.org/wiki/Model_Context_Protocol">Model Context Protocol - Wikipedia</a></li>
+<li><a href="http://blog.modelcontextprotocol.io/posts/2025-11-25-first-mcp-anniversary/">One Year of MCP</a></li>
+<li><a href="http://blog.modelcontextprotocol.io/posts/2025-12-09-mcp-joins-agentic-ai-foundation/">MCP joins the Agentic AI Foundation</a></li>
+<li><a href="https://www.linuxfoundation.org/press/linux-foundation-announces-the-formation-of-the-agentic-ai-foundation">Linux Foundation Announces AAIF</a></li>
+<li><a href="https://www.elastic.co/search-labs/blog/mcp-current-state">The Current State of MCP - Elasticsearch Labs</a></li>
+<li><a href="https://workos.com/blog/mcp-features-guide">MCP Features Guide - WorkOS</a></li>
+<li><a href="https://thenewstack.io/why-the-model-context-protocol-won/">Why the Model Context Protocol Won - The New Stack</a></li>
+</ul>
+<h3 id="mcp-aql-1">MCP-AQL</h3>
+<ul>
+<li><a href="https://github.com/MCPAQL/spec">MCP-AQL Specification v1.0.0-draft</a></li>
+<li>MCPAQL/spec issue tracker (183 issues reviewed)</li>
+<li>DollhouseMCP/mcp-server-v2-refactor issue tracker (450+ issues reviewed)</li>
+<li>Normative specification: <code>docs/versions/v1.0.0-draft.md</code></li>
+<li>CRUDE Pattern: <code>docs/crude-pattern.md</code></li>
+<li>Introspection System: <code>docs/introspection.md</code></li>
+<li>Gatekeeper Security: <code>docs/security/gatekeeper.md</code></li>
+<li>Adapter Element Type: <code>docs/adapter/element-type.md</code></li>
+<li>Plugin Interface Contracts: <code>docs/plugin-contracts.md</code></li>
+<li>Endpoint Modes: <code>docs/endpoint-modes.md</code></li>
+<li>Three-Tier Adapter Architecture: DollhouseMCP/mcp-server-v2-refactor#172</li>
+<li>Ditto Shorthand Pattern: DollhouseMCP/mcp-server-v2-refactor#166</li>
+<li>Notifications with Minimal Acknowledgment: DollhouseMCP/mcp-server-v2-refactor#308</li>
+<li>TEAM Element / COMMS Design: DollhouseMCP/experimental-server#108</li>
+</ul>
+<h3 id="a2a-1">A2A</h3>
+<ul>
+<li><a href="https://a2a-protocol.org/latest/specification/">A2A Protocol Specification (Latest)</a></li>
+<li><a href="https://a2a-protocol.org/latest/">A2A Protocol Official Documentation</a></li>
+<li><a href="https://a2a-protocol.org/latest/topics/a2a-and-mcp/">A2A and MCP - A2A Protocol Docs</a></li>
+<li><a href="https://developers.googleblog.com/en/a2a-a-new-era-of-agent-interoperability/">Announcing A2A - Google Developers</a></li>
+<li><a href="https://www.ibm.com/think/topics/agent2agent-protocol">What Is Agent2Agent Protocol? - IBM</a></li>
+<li><a href="https://www.linuxfoundation.org/press/linux-foundation-launches-the-agent2agent-protocol-project-to-enable-secure-intelligent-communication-between-ai-agents">Linux Foundation Launches A2A Project</a></li>
+<li><a href="https://www.hivemq.com/blog/a2a-enterprise-scale-agentic-ai-collaboration-part-1/">A2A for Enterprise-Scale AI - HiveMQ</a></li>
+<li><a href="https://auth0.com/blog/mcp-vs-a2a/">MCP vs A2A - Auth0</a></li>
+<li><a href="https://github.com/a2aproject/A2A">A2A GitHub Repository</a></li>
+<li><a href="https://deepwiki.com/google/A2A">A2A Protocol Architecture - DeepWiki</a></li>
+</ul>
+
+          </div>
+        </section>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div class="container">
+      <p>&copy; 2026 DollhouseMCP Inc. d/b/a Dollhouse Research. MCP-AQL public draft documentation portal.</p>
+      <div class="footer-links">
+        <a href="../../docs/index.html">Docs Library</a>
+        <a href="../index.html">Repo-Synced Spec</a>
+        <a href="https://github.com/MCPAQL">MCPAQL Organization</a>
+        <a href="https://dollhouseresearch.com">Dollhouse Research</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../../js/search.js"></script>
+</body>
+</html>

--- a/public/spec/research/mcp-vs-mcpaql-vs-a2a.html
+++ b/public/spec/research/mcp-vs-mcpaql-vs-a2a.html
@@ -23,7 +23,7 @@
         </ul>
         <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
-          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <input id="site-search-input" data-search-input type="search" placeholder="Search MCP-AQL docs, spec pages, and adapter patterns...">
           <span class="search-count" data-search-count></span>
           <ul class="search-results" data-search-results hidden></ul>
         </form>
@@ -62,7 +62,7 @@
   <ul><li><a href="../architecture/README.html">Architecture Documentation</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Research</h3>
-  <ul><li><a class="current" href="mcp-vs-mcpaql-vs-a2a.html">Protocol Landscape: MCP vs MCP-AQL vs A2A</a></li></ul>
+  <ul><li><a class="current" aria-current="page" href="mcp-vs-mcpaql-vs-a2a.html">Protocol Landscape: MCP vs MCP-AQL vs A2A</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Reference</h3>
   <ul><li><a href="../reference/README.html">Reference Documentation</a></li></ul>
@@ -1326,6 +1326,16 @@ Authorization: Bearer &lt;token&gt;</code></pre>
 
           </div>
         </section>
+        <nav class="page-nav" aria-label="Page navigation">
+  <a class="page-nav-link prev" href="../architecture/README.html">
+    <span class="page-nav-eyebrow">Previous spec page</span>
+    <strong class="page-nav-label">Architecture Documentation</strong>
+  </a>
+  <a class="page-nav-link next" href="../reference/README.html">
+    <span class="page-nav-eyebrow">Next spec page</span>
+    <strong class="page-nav-label">Reference Documentation</strong>
+  </a>
+</nav>
       </article>
     </div>
   </main>

--- a/public/spec/research/mcp-vs-mcpaql-vs-a2a.html
+++ b/public/spec/research/mcp-vs-mcpaql-vs-a2a.html
@@ -38,7 +38,7 @@
         <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
         <div class="docs-side-group">
   <h3>Core</h3>
-  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li></ul>
+  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li><li><a href="../repo/README.html">MCP-AQL Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Versions</h3>
   <ul><li><a href="../versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
@@ -56,7 +56,7 @@
   <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
-  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li></ul>
+  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li><li><a href="../repo/CHANGELOG.html">Changelog</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Architecture</h3>
   <ul><li><a href="../architecture/README.html">Architecture Documentation</a></li></ul>

--- a/public/spec/research/mcp-vs-mcpaql-vs-a2a.html
+++ b/public/spec/research/mcp-vs-mcpaql-vs-a2a.html
@@ -73,6 +73,13 @@
       </aside>
 
       <article class="docs-main">
+        <nav class="breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../../index.html">Home</a></li>
+            <li><a href="../index.html">Full Spec</a></li>
+            <li><span class="current">Protocol Landscape: MCP vs MCP-AQL vs A2A</span></li>
+          </ol>
+        </nav>
         <section class="hero docs-hero">
           <div class="hero-inner">
             <span class="status-pill">REPO-SYNCED SPEC DOC</span>

--- a/public/spec/security/confirmation-tokens.html
+++ b/public/spec/security/confirmation-tokens.html
@@ -73,6 +73,13 @@
       </aside>
 
       <article class="docs-main">
+        <nav class="breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../../index.html">Home</a></li>
+            <li><a href="../index.html">Full Spec</a></li>
+            <li><span class="current">Confirmation Token Specification</span></li>
+          </ol>
+        </nav>
         <section class="hero docs-hero">
           <div class="hero-inner">
             <span class="status-pill">REPO-SYNCED SPEC DOC</span>

--- a/public/spec/security/confirmation-tokens.html
+++ b/public/spec/security/confirmation-tokens.html
@@ -1,0 +1,714 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="This document specifies the confirmation token mechanism used by MCP-AQL adapters to gate dangerous operations and quota continuations. Confirmation tokens provide a secure, time-limited method for clients to acknowledge">
+  <title>MCP-AQL Spec | Confirmation Token Specification</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../../css/style.css">
+</head>
+<body>
+  <header>
+    <div class="container">
+      <nav>
+        <a class="logo" href="../../index.html"><span class="logo-mark"></span>MCP-AQL</a>
+        <ul class="nav-links">
+          <li><a href="../../index.html">Home</a></li>
+          <li><a href="../../docs/index.html">Docs</a></li>
+          <li><a href="../../launch-checklist.html">Launch Checklist</a></li>
+          <li><a href="../../apis/mcp-server.html">Adapter Patterns</a></li>
+        </ul>
+        <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
+          <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
+          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <span class="search-count" data-search-count></span>
+          <ul class="search-results" data-search-results hidden></ul>
+        </form>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <div class="container docs-shell">
+      <aside class="docs-side">
+        <h2>Repo-Synced Spec</h2>
+        <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
+        <div class="docs-side-group">
+  <h3>Core</h3>
+  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Versions</h3>
+  <ul><li><a href="../versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Adapter</h3>
+  <ul><li><a href="../adapter/danger-levels.html">Dangerous Operation Classification Specification</a></li><li><a href="../adapter/discovery-bundle.html">MCP Server Discovery Bundle</a></li><li><a href="../adapter/element-type.html">Adapter Element Type Specification</a></li><li><a href="../adapter/generator.html">Adapter Generator Specification</a></li><li><a href="../adapter/rate-limiting.html">Rate Limiting and Quota Management Specification</a></li><li><a href="../adapter/trust-levels.html">Trust Levels Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Security</h3>
+  <ul><li><a class="current" href="confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Features</h3>
+  <ul><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Guides</h3>
+  <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Process</h3>
+  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Architecture</h3>
+  <ul><li><a href="../architecture/README.html">Architecture Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Research</h3>
+  <ul><li><a href="../research/mcp-vs-mcpaql-vs-a2a.html">Protocol Landscape: MCP vs MCP-AQL vs A2A</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Reference</h3>
+  <ul><li><a href="../reference/README.html">Reference Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>ADRs</h3>
+  <ul><li><a href="../adr/ADR-001-crude-pattern.html">ADR-001: CRUDE Pattern (Extending CRUD with Execute)</a></li><li><a href="../adr/ADR-002-graphql-style-input.html">ADR-002: GraphQL-Style Input Objects for Updates</a></li><li><a href="../adr/ADR-003-snake-case-parameters.html">ADR-003: snake_case Parameter Convention</a></li><li><a href="../adr/ADR-004-schema-driven-operations.html">ADR-004: Schema-Driven Operation Definitions</a></li><li><a href="../adr/ADR-005-introspection-system.html">ADR-005: GraphQL-Style Introspection System</a></li><li><a href="../adr/ADR-006-discriminated-responses.html">ADR-006: Discriminated Response Format</a></li><li><a href="../adr/index.html">Architecture Decision Records</a></li><li><a href="../adr/README.html">Architecture Decision Records</a></li></ul>
+</div>
+      </aside>
+
+      <article class="docs-main">
+        <section class="hero docs-hero">
+          <div class="hero-inner">
+            <span class="status-pill">REPO-SYNCED SPEC DOC</span>
+            <h1>Confirmation Token Specification</h1>
+            <p class="lede">This document specifies the confirmation token mechanism used by MCP-AQL adapters to gate dangerous operations and quota continuations. Confirmation tokens provide a secure, time-limited method for clients to acknowledge</p>
+            <div class="spec-meta"><span class="state-chip live">Support document</span><span class="state-chip pending">Draft</span><span class="state-chip">1.0.0-draft</span><span class="state-chip">2026-01-28</span></div>
+            <p class="spec-source">Source: <a href="https://github.com/MCPAQL/spec/blob/main/docs/security/confirmation-tokens.md">spec/docs/security/confirmation-tokens.md</a></p>
+            <div class="hero-actions">
+              <a class="btn btn-primary" href="https://github.com/MCPAQL/spec/blob/main/docs/security/confirmation-tokens.md">Open Source Markdown</a>
+              <a class="btn btn-secondary" href="../index.html">Browse Full Spec Reference</a>
+            </div>
+          </div>
+        </section>
+
+        <section>
+          <div class="card spec-prose">
+            <p><strong>Version:</strong> 1.0.0-draft <strong>Status:</strong> Draft <strong>Last Updated:</strong> 2026-01-28</p>
+<h2 id="abstract">Abstract</h2>
+<p>This document specifies the confirmation token mechanism used by MCP-AQL adapters to gate dangerous operations and quota continuations. Confirmation tokens provide a secure, time-limited method for clients to acknowledge and proceed with operations that require explicit consent.</p>
+<hr />
+<h2 id="table-of-contents">Table of Contents</h2>
+<ol type="1">
+<li><a href="#1-overview">Overview</a></li>
+<li><a href="#2-token-format">Token Format</a></li>
+<li><a href="#3-token-generation">Token Generation</a></li>
+<li><a href="#4-token-validation">Token Validation</a></li>
+<li><a href="#5-token-lifecycle">Token Lifecycle</a></li>
+<li><a href="#6-security-considerations">Security Considerations</a></li>
+<li><a href="#7-implementation-requirements">Implementation Requirements</a></li>
+</ol>
+<hr />
+<h2 id="1-overview">1. Overview</h2>
+<h3 id="11-purpose">1.1 Purpose</h3>
+<p>Confirmation tokens serve as cryptographic proof that a client has acknowledged a warning and explicitly consents to proceed with a gated operation. They are used in two primary contexts:</p>
+<ul>
+<li><strong>Dangerous operation confirmation</strong> - Operations requiring explicit consent due to their danger level (see <a href="../adapter/danger-levels.html">Dangerous Operation Classification</a>)</li>
+<li><strong>Quota continuation</strong> - Proceeding past soft quota limits (see <a href="../adapter/rate-limiting.html">Rate Limiting Specification</a>)</li>
+</ul>
+<h3 id="12-design-principles">1.2 Design Principles</h3>
+<ol type="1">
+<li><strong>Single-use by default</strong> - Tokens SHOULD be consumed upon successful use</li>
+<li><strong>Time-bounded</strong> - Tokens MUST have an expiration time</li>
+<li><strong>Scope-bound</strong> - Tokens are tied to a specific operation and parameters</li>
+<li><strong>Tamper-resistant</strong> - Tokens cannot be forged or modified by clients</li>
+<li><strong>Auditable</strong> - Token issuance and redemption are logged</li>
+</ol>
+<h3 id="13-token-flow">1.3 Token Flow</h3>
+<pre><code>Client Request
+      │
+      ▼
+┌─────────────────┐
+│ Gatekeeper      │
+│ (confirmation   │
+│  required)      │
+└────────┬────────┘
+         │
+         ▼
+┌─────────────────┐     Token + Expiry
+│ Issue Token     │─────────────────────► Client
+└─────────────────┘
+
+Client Retry (with token)
+      │
+      ▼
+┌─────────────────┐
+│ Validate Token  │
+│ (scope, expiry, │
+│  single-use)    │
+└────────┬────────┘
+         │
+         ▼
+┌─────────────────┐
+│ Execute         │
+│ Operation       │
+└─────────────────┘</code></pre>
+<hr />
+<h2 id="2-token-format">2. Token Format</h2>
+<h3 id="21-token-structure">2.1 Token Structure</h3>
+<p>Tokens are opaque strings with a prefix indicating their purpose:</p>
+<table>
+<thead>
+<tr>
+<th>Prefix</th>
+<th>Purpose</th>
+<th>Example</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>conf_</code></td>
+<td>Dangerous operation confirmation</td>
+<td><code>conf_a1b2c3d4e5f6g7h8</code></td>
+</tr>
+<tr>
+<td><code>quota_continue_</code></td>
+<td>Quota pause continuation</td>
+<td><code>quota_continue_def456</code></td>
+</tr>
+</tbody>
+</table>
+<h3 id="22-token-syntax">2.2 Token Syntax</h3>
+<pre><code>token = prefix &quot;_&quot; identifier
+prefix = &quot;conf&quot; | &quot;quota_continue&quot;
+identifier = 1*64(ALPHA / DIGIT / &quot;_&quot; / &quot;-&quot;)</code></pre>
+<p><strong>Constraints:</strong></p>
+<ul>
+<li>Total token length: 8-80 characters</li>
+<li>Identifier: URL-safe characters only (alphanumeric, underscore, hyphen)</li>
+<li>Case-sensitive</li>
+</ul>
+<h3 id="23-token-payload-internal">2.3 Token Payload (Internal)</h3>
+<p>While tokens are opaque to clients, implementations SHOULD encode or reference:</p>
+<div class="sourceCode" id="cb3"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb3-1"><a href="#cb3-1" aria-hidden="true" tabindex="-1"></a><span class="kw">interface</span> TokenPayload {</span>
+<span id="cb3-2"><a href="#cb3-2" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** Token identifier - the full token string including prefix (e.g., &#39;conf_abc123xyz789&#39;) */</span></span>
+<span id="cb3-3"><a href="#cb3-3" aria-hidden="true" tabindex="-1"></a>  id<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb3-4"><a href="#cb3-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb3-5"><a href="#cb3-5" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** Purpose of the token */</span></span>
+<span id="cb3-6"><a href="#cb3-6" aria-hidden="true" tabindex="-1"></a>  type<span class="op">:</span> <span class="st">&#39;confirmation&#39;</span> <span class="op">|</span> <span class="st">&#39;quota_continue&#39;</span><span class="op">;</span></span>
+<span id="cb3-7"><a href="#cb3-7" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb3-8"><a href="#cb3-8" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** Operation this token gates */</span></span>
+<span id="cb3-9"><a href="#cb3-9" aria-hidden="true" tabindex="-1"></a>  operation<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb3-10"><a href="#cb3-10" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb3-11"><a href="#cb3-11" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** Hash of bound parameters (prevents parameter tampering) */</span></span>
+<span id="cb3-12"><a href="#cb3-12" aria-hidden="true" tabindex="-1"></a>  params_hash<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb3-13"><a href="#cb3-13" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb3-14"><a href="#cb3-14" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** Adapter that issued the token */</span></span>
+<span id="cb3-15"><a href="#cb3-15" aria-hidden="true" tabindex="-1"></a>  adapter_name<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb3-16"><a href="#cb3-16" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb3-17"><a href="#cb3-17" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** Issuance timestamp (ISO 8601) */</span></span>
+<span id="cb3-18"><a href="#cb3-18" aria-hidden="true" tabindex="-1"></a>  issued_at<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb3-19"><a href="#cb3-19" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb3-20"><a href="#cb3-20" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** Expiration timestamp (ISO 8601) */</span></span>
+<span id="cb3-21"><a href="#cb3-21" aria-hidden="true" tabindex="-1"></a>  expires_at<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb3-22"><a href="#cb3-22" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb3-23"><a href="#cb3-23" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** Whether token has been used */</span></span>
+<span id="cb3-24"><a href="#cb3-24" aria-hidden="true" tabindex="-1"></a>  consumed<span class="op">:</span> <span class="dt">boolean</span><span class="op">;</span></span>
+<span id="cb3-25"><a href="#cb3-25" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb3-26"><a href="#cb3-26" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** Additional context for audit */</span></span>
+<span id="cb3-27"><a href="#cb3-27" aria-hidden="true" tabindex="-1"></a>  context<span class="op">?:</span> {</span>
+<span id="cb3-28"><a href="#cb3-28" aria-hidden="true" tabindex="-1"></a>    danger_level<span class="op">?:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb3-29"><a href="#cb3-29" aria-hidden="true" tabindex="-1"></a>    quota_metric<span class="op">?:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb3-30"><a href="#cb3-30" aria-hidden="true" tabindex="-1"></a>    reasons<span class="op">?:</span> <span class="dt">string</span>[]<span class="op">;</span></span>
+<span id="cb3-31"><a href="#cb3-31" aria-hidden="true" tabindex="-1"></a>  }<span class="op">;</span></span>
+<span id="cb3-32"><a href="#cb3-32" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<hr />
+<h2 id="3-token-generation">3. Token Generation</h2>
+<h3 id="31-entropy-requirements">3.1 Entropy Requirements</h3>
+<p>Token identifiers MUST be generated with sufficient entropy to prevent guessing:</p>
+<table>
+<thead>
+<tr>
+<th>Requirement</th>
+<th>Specification</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Minimum entropy</td>
+<td>128 bits</td>
+</tr>
+<tr>
+<td>Recommended</td>
+<td>256 bits</td>
+</tr>
+<tr>
+<td>Source</td>
+<td>Cryptographically secure random number generator (CSPRNG)</td>
+</tr>
+</tbody>
+</table>
+<p><strong>Acceptable generation methods:</strong></p>
+<ul>
+<li><code>crypto.randomBytes(16).toString('hex')</code> (Node.js)</li>
+<li><code>secrets.token_hex(16)</code> (Python)</li>
+<li><code>uuid.uuid4().hex</code> (UUID v4, 122 bits entropy)</li>
+</ul>
+<p><strong>Unacceptable methods:</strong></p>
+<ul>
+<li>Sequential counters</li>
+<li>Timestamps alone</li>
+<li><code>Math.random()</code> or similar non-cryptographic PRNGs</li>
+</ul>
+<h3 id="32-scope-binding">3.2 Scope Binding</h3>
+<p>Tokens MUST be bound to the specific operation and parameters they gate.</p>
+<p><strong>Hash algorithm:</strong> Implementations SHOULD use SHA-256 or stronger for parameter binding. The hash MUST be computed over a canonicalized representation of the critical parameters.</p>
+<div class="sourceCode" id="cb4"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb4-1"><a href="#cb4-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Token issuance binds to operation + critical parameters</span></span>
+<span id="cb4-2"><a href="#cb4-2" aria-hidden="true" tabindex="-1"></a><span class="co">// Hash algorithm: SHA-256 or stronger</span></span>
+<span id="cb4-3"><a href="#cb4-3" aria-hidden="true" tabindex="-1"></a><span class="kw">const</span> paramsHash <span class="op">=</span> <span class="fu">sha256</span>({</span>
+<span id="cb4-4"><a href="#cb4-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;delete_repo&quot;</span><span class="op">,</span></span>
+<span id="cb4-5"><a href="#cb4-5" aria-hidden="true" tabindex="-1"></a>  <span class="dt">owner</span><span class="op">:</span> <span class="st">&quot;acme&quot;</span><span class="op">,</span></span>
+<span id="cb4-6"><a href="#cb4-6" aria-hidden="true" tabindex="-1"></a>  <span class="dt">repo</span><span class="op">:</span> <span class="st">&quot;widgets&quot;</span></span>
+<span id="cb4-7"><a href="#cb4-7" aria-hidden="true" tabindex="-1"></a>})<span class="op">;</span></span>
+<span id="cb4-8"><a href="#cb4-8" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb4-9"><a href="#cb4-9" aria-hidden="true" tabindex="-1"></a><span class="kw">const</span> token <span class="op">=</span> {</span>
+<span id="cb4-10"><a href="#cb4-10" aria-hidden="true" tabindex="-1"></a>  <span class="dt">id</span><span class="op">:</span> <span class="fu">generateTokenId</span>()<span class="op">,</span></span>
+<span id="cb4-11"><a href="#cb4-11" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;delete_repo&quot;</span><span class="op">,</span></span>
+<span id="cb4-12"><a href="#cb4-12" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params_hash</span><span class="op">:</span> paramsHash<span class="op">,</span></span>
+<span id="cb4-13"><a href="#cb4-13" aria-hidden="true" tabindex="-1"></a>  <span class="co">// ...</span></span>
+<span id="cb4-14"><a href="#cb4-14" aria-hidden="true" tabindex="-1"></a>}<span class="op">;</span></span></code></pre></div>
+<p><strong>Critical parameters</strong> are those that affect the operation's impact:</p>
+<ul>
+<li>Resource identifiers (IDs, names, paths)</li>
+<li>Scope modifiers (<code>force</code>, <code>permanent</code>, <code>recursive</code>)</li>
+<li>NOT metadata like timestamps or request IDs</li>
+</ul>
+<h3 id="33-token-response-format">3.3 Token Response Format</h3>
+<p>When issuing a confirmation token:</p>
+<div class="sourceCode" id="cb5"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb5-1"><a href="#cb5-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb5-2"><a href="#cb5-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb5-3"><a href="#cb5-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;error&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb5-4"><a href="#cb5-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;code&quot;</span><span class="fu">:</span> <span class="st">&quot;CONFIRMATION_REQUIRED&quot;</span><span class="fu">,</span></span>
+<span id="cb5-5"><a href="#cb5-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;This operation requires confirmation&quot;</span><span class="fu">,</span></span>
+<span id="cb5-6"><a href="#cb5-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;details&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb5-7"><a href="#cb5-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;delete_repo&quot;</span><span class="fu">,</span></span>
+<span id="cb5-8"><a href="#cb5-8" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;danger_level&quot;</span><span class="fu">:</span> <span class="st">&quot;destructive&quot;</span><span class="fu">,</span></span>
+<span id="cb5-9"><a href="#cb5-9" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;reasons&quot;</span><span class="fu">:</span> <span class="ot">[</span></span>
+<span id="cb5-10"><a href="#cb5-10" aria-hidden="true" tabindex="-1"></a>        <span class="st">&quot;Permanently removes repository and all contents&quot;</span><span class="ot">,</span></span>
+<span id="cb5-11"><a href="#cb5-11" aria-hidden="true" tabindex="-1"></a>        <span class="st">&quot;Cannot be recovered after grace period&quot;</span></span>
+<span id="cb5-12"><a href="#cb5-12" aria-hidden="true" tabindex="-1"></a>      <span class="ot">]</span><span class="fu">,</span></span>
+<span id="cb5-13"><a href="#cb5-13" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;confirmation_message&quot;</span><span class="fu">:</span> <span class="st">&quot;Delete repository &#39;acme/widgets&#39;? This cannot be undone.&quot;</span><span class="fu">,</span></span>
+<span id="cb5-14"><a href="#cb5-14" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;confirmation_token&quot;</span><span class="fu">:</span> <span class="st">&quot;conf_a1b2c3d4e5f6g7h8&quot;</span><span class="fu">,</span></span>
+<span id="cb5-15"><a href="#cb5-15" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;expires_at&quot;</span><span class="fu">:</span> <span class="st">&quot;2026-01-28T12:05:00Z&quot;</span></span>
+<span id="cb5-16"><a href="#cb5-16" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb5-17"><a href="#cb5-17" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb5-18"><a href="#cb5-18" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<hr />
+<h2 id="4-token-validation">4. Token Validation</h2>
+<h3 id="41-validation-checks">4.1 Validation Checks</h3>
+<p>Token validation MUST perform all of the following checks:</p>
+<table>
+<thead>
+<tr>
+<th>Check</th>
+<th>Error Code</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Token exists</td>
+<td><code>TOKEN_INVALID</code></td>
+<td>Token ID not found in store</td>
+</tr>
+<tr>
+<td>Not expired</td>
+<td><code>TOKEN_EXPIRED</code></td>
+<td>Current time &gt; expires_at</td>
+</tr>
+<tr>
+<td>Not consumed</td>
+<td><code>TOKEN_ALREADY_USED</code></td>
+<td>Token already redeemed</td>
+</tr>
+<tr>
+<td>Operation matches</td>
+<td><code>TOKEN_SCOPE_MISMATCH</code></td>
+<td>Token issued for different operation</td>
+</tr>
+<tr>
+<td>Parameters match</td>
+<td><code>TOKEN_SCOPE_MISMATCH</code></td>
+<td>Critical parameters changed</td>
+</tr>
+<tr>
+<td>Adapter matches</td>
+<td><code>TOKEN_SCOPE_MISMATCH</code></td>
+<td>Token issued by different adapter</td>
+</tr>
+</tbody>
+</table>
+<h3 id="42-validation-response-failure">4.2 Validation Response (Failure)</h3>
+<div class="sourceCode" id="cb6"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb6-1"><a href="#cb6-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb6-2"><a href="#cb6-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb6-3"><a href="#cb6-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;error&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb6-4"><a href="#cb6-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;code&quot;</span><span class="fu">:</span> <span class="st">&quot;TOKEN_EXPIRED&quot;</span><span class="fu">,</span></span>
+<span id="cb6-5"><a href="#cb6-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;Confirmation token has expired&quot;</span><span class="fu">,</span></span>
+<span id="cb6-6"><a href="#cb6-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;details&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb6-7"><a href="#cb6-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;token&quot;</span><span class="fu">:</span> <span class="st">&quot;conf_a1b2c3d4e5f6g7h8&quot;</span><span class="fu">,</span></span>
+<span id="cb6-8"><a href="#cb6-8" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;expired_at&quot;</span><span class="fu">:</span> <span class="st">&quot;2026-01-28T12:05:00Z&quot;</span><span class="fu">,</span></span>
+<span id="cb6-9"><a href="#cb6-9" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;current_time&quot;</span><span class="fu">:</span> <span class="st">&quot;2026-01-28T12:07:30Z&quot;</span></span>
+<span id="cb6-10"><a href="#cb6-10" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb6-11"><a href="#cb6-11" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb6-12"><a href="#cb6-12" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<h3 id="43-parameter-hash-verification">4.3 Parameter Hash Verification</h3>
+<p>When validating, recompute the parameter hash and compare:</p>
+<div class="sourceCode" id="cb7"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb7-1"><a href="#cb7-1" aria-hidden="true" tabindex="-1"></a><span class="kw">function</span> <span class="fu">validateToken</span>(token<span class="op">,</span> operation<span class="op">,</span> params) {</span>
+<span id="cb7-2"><a href="#cb7-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">const</span> stored <span class="op">=</span> tokenStore<span class="op">.</span><span class="fu">get</span>(token)<span class="op">;</span></span>
+<span id="cb7-3"><a href="#cb7-3" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> (<span class="op">!</span>stored) <span class="cf">return</span> { <span class="dt">valid</span><span class="op">:</span> <span class="kw">false</span><span class="op">,</span> <span class="dt">code</span><span class="op">:</span> <span class="st">&#39;TOKEN_INVALID&#39;</span> }<span class="op">;</span></span>
+<span id="cb7-4"><a href="#cb7-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb7-5"><a href="#cb7-5" aria-hidden="true" tabindex="-1"></a>  <span class="co">// Check operation match</span></span>
+<span id="cb7-6"><a href="#cb7-6" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> (stored<span class="op">.</span><span class="at">operation</span> <span class="op">!==</span> operation) {</span>
+<span id="cb7-7"><a href="#cb7-7" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> { <span class="dt">valid</span><span class="op">:</span> <span class="kw">false</span><span class="op">,</span> <span class="dt">code</span><span class="op">:</span> <span class="st">&#39;TOKEN_SCOPE_MISMATCH&#39;</span> }<span class="op">;</span></span>
+<span id="cb7-8"><a href="#cb7-8" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb7-9"><a href="#cb7-9" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb7-10"><a href="#cb7-10" aria-hidden="true" tabindex="-1"></a>  <span class="co">// Recompute and compare parameter hash</span></span>
+<span id="cb7-11"><a href="#cb7-11" aria-hidden="true" tabindex="-1"></a>  <span class="kw">const</span> currentHash <span class="op">=</span> <span class="fu">hashCriticalParams</span>(operation<span class="op">,</span> params)<span class="op">;</span></span>
+<span id="cb7-12"><a href="#cb7-12" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> (stored<span class="op">.</span><span class="at">params_hash</span> <span class="op">!==</span> currentHash) {</span>
+<span id="cb7-13"><a href="#cb7-13" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> { <span class="dt">valid</span><span class="op">:</span> <span class="kw">false</span><span class="op">,</span> <span class="dt">code</span><span class="op">:</span> <span class="st">&#39;TOKEN_SCOPE_MISMATCH&#39;</span> }<span class="op">;</span></span>
+<span id="cb7-14"><a href="#cb7-14" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb7-15"><a href="#cb7-15" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb7-16"><a href="#cb7-16" aria-hidden="true" tabindex="-1"></a>  <span class="co">// Check expiry (with optional clock skew tolerance, see Section 5.1)</span></span>
+<span id="cb7-17"><a href="#cb7-17" aria-hidden="true" tabindex="-1"></a>  <span class="kw">const</span> expiryResult <span class="op">=</span> <span class="fu">checkTokenExpiry</span>(stored<span class="op">,</span> config)<span class="op">;</span></span>
+<span id="cb7-18"><a href="#cb7-18" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> (<span class="op">!</span>expiryResult<span class="op">.</span><span class="at">valid</span>) {</span>
+<span id="cb7-19"><a href="#cb7-19" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> expiryResult<span class="op">;</span></span>
+<span id="cb7-20"><a href="#cb7-20" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb7-21"><a href="#cb7-21" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb7-22"><a href="#cb7-22" aria-hidden="true" tabindex="-1"></a>  <span class="co">// Check consumption</span></span>
+<span id="cb7-23"><a href="#cb7-23" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> (stored<span class="op">.</span><span class="at">consumed</span>) {</span>
+<span id="cb7-24"><a href="#cb7-24" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> { <span class="dt">valid</span><span class="op">:</span> <span class="kw">false</span><span class="op">,</span> <span class="dt">code</span><span class="op">:</span> <span class="st">&#39;TOKEN_ALREADY_USED&#39;</span> }<span class="op">;</span></span>
+<span id="cb7-25"><a href="#cb7-25" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb7-26"><a href="#cb7-26" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb7-27"><a href="#cb7-27" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> { <span class="dt">valid</span><span class="op">:</span> <span class="kw">true</span> }<span class="op">;</span></span>
+<span id="cb7-28"><a href="#cb7-28" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<hr />
+<h2 id="5-token-lifecycle">5. Token Lifecycle</h2>
+<h3 id="51-expiration">5.1 Expiration</h3>
+<p>Token expiration MUST be enforced:</p>
+<table>
+<thead>
+<tr>
+<th>Context</th>
+<th>Default TTL</th>
+<th>Maximum TTL</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Dangerous operation (destructive/dangerous - levels 2-3)</td>
+<td>5 minutes</td>
+<td>15 minutes</td>
+</tr>
+<tr>
+<td>Dangerous operation (forbidden - level 4)</td>
+<td>2 minutes</td>
+<td>5 minutes</td>
+</tr>
+<tr>
+<td>Quota continuation</td>
+<td>5 minutes</td>
+<td>10 minutes</td>
+</tr>
+</tbody>
+</table>
+<p>Danger level values reference the danger level enum from <a href="../adapter/danger-levels.html">Dangerous Operation Classification</a>: safe (0), reversible (1), destructive (2), dangerous (3), forbidden (4).</p>
+<p><strong>Expiration is a MUST requirement:</strong></p>
+<ul>
+<li>Tokens without expiration MUST be rejected</li>
+<li>Expired tokens MUST NOT be accepted under any circumstances</li>
+<li>Clock skew tolerance: implementations MAY allow up to 30 seconds grace (see below)</li>
+</ul>
+<p><strong>Clock skew tolerance configurability:</strong></p>
+<p>Implementations SHOULD allow operators to configure the clock skew tolerance value:</p>
+<table>
+<thead>
+<tr>
+<th>Setting</th>
+<th>Default</th>
+<th>Range</th>
+<th>Notes</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>clock_skew_tolerance_seconds</code></td>
+<td>30</td>
+<td>0-300</td>
+<td>0 disables tolerance (strictest mode)</td>
+</tr>
+</tbody>
+</table>
+<p><strong>Configuration guidance:</strong></p>
+<ul>
+<li>The default of 30 seconds accommodates typical NTP-synchronized systems</li>
+<li>Environments with known clock synchronization issues (e.g., air-gapped systems, certain IoT deployments) MAY need higher values</li>
+<li>Security-sensitive deployments MAY reduce this to 0-5 seconds</li>
+<li>Values above 60 seconds SHOULD trigger a warning in logs, as they significantly increase the window for replay attacks (see <a href="#61-replay-attack-prevention">Section 6.1</a>)</li>
+</ul>
+<p><strong>Deployment environment recommendations:</strong></p>
+<table>
+<thead>
+<tr>
+<th>Environment</th>
+<th>Recommended Value</th>
+<th>Rationale</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Typical (NTP-synced)</td>
+<td>30s (default)</td>
+<td>Accommodates normal clock drift</td>
+</tr>
+<tr>
+<td>Air-gapped systems</td>
+<td>60-120s</td>
+<td>May have significant clock sync drift</td>
+</tr>
+<tr>
+<td>IoT / embedded</td>
+<td>60-120s</td>
+<td>Often lack reliable NTP access</td>
+</tr>
+<tr>
+<td>High-security</td>
+<td>0-5s</td>
+<td>Minimize replay attack window</td>
+</tr>
+<tr>
+<td>Zero-trust</td>
+<td>0s</td>
+<td>Strict timing, requires synchronized clocks</td>
+</tr>
+</tbody>
+</table>
+<p><strong>Example configuration:</strong></p>
+<div class="sourceCode" id="cb8"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb8-1"><a href="#cb8-1" aria-hidden="true" tabindex="-1"></a><span class="kw">const</span> tokenConfig <span class="op">=</span> {</span>
+<span id="cb8-2"><a href="#cb8-2" aria-hidden="true" tabindex="-1"></a>  <span class="co">// Default: 30 seconds</span></span>
+<span id="cb8-3"><a href="#cb8-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">clock_skew_tolerance_seconds</span><span class="op">:</span> <span class="dv">30</span><span class="op">,</span></span>
+<span id="cb8-4"><a href="#cb8-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb8-5"><a href="#cb8-5" aria-hidden="true" tabindex="-1"></a>  <span class="co">// Strict mode for high-security environments</span></span>
+<span id="cb8-6"><a href="#cb8-6" aria-hidden="true" tabindex="-1"></a>  <span class="co">// clock_skew_tolerance_seconds: 5,</span></span>
+<span id="cb8-7"><a href="#cb8-7" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb8-8"><a href="#cb8-8" aria-hidden="true" tabindex="-1"></a>  <span class="co">// Relaxed mode for environments with clock sync issues</span></span>
+<span id="cb8-9"><a href="#cb8-9" aria-hidden="true" tabindex="-1"></a>  <span class="co">// clock_skew_tolerance_seconds: 120,</span></span>
+<span id="cb8-10"><a href="#cb8-10" aria-hidden="true" tabindex="-1"></a>}<span class="op">;</span></span></code></pre></div>
+<p><strong>Applying tolerance in validation:</strong></p>
+<p>The tolerance is added to the expiry time, accepting tokens that expired within the tolerance window:</p>
+<div class="sourceCode" id="cb9"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb9-1"><a href="#cb9-1" aria-hidden="true" tabindex="-1"></a><span class="kw">function</span> <span class="fu">checkTokenExpiry</span>(stored<span class="op">,</span> config) {</span>
+<span id="cb9-2"><a href="#cb9-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">const</span> now <span class="op">=</span> <span class="kw">new</span> <span class="bu">Date</span>()<span class="op">;</span></span>
+<span id="cb9-3"><a href="#cb9-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">const</span> expiresAt <span class="op">=</span> <span class="kw">new</span> <span class="bu">Date</span>(stored<span class="op">.</span><span class="at">expires_at</span>)<span class="op">;</span></span>
+<span id="cb9-4"><a href="#cb9-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb9-5"><a href="#cb9-5" aria-hidden="true" tabindex="-1"></a>  <span class="co">// Add tolerance to expiry time (not subtract from current time)</span></span>
+<span id="cb9-6"><a href="#cb9-6" aria-hidden="true" tabindex="-1"></a>  <span class="co">// This accepts tokens expired within the tolerance window</span></span>
+<span id="cb9-7"><a href="#cb9-7" aria-hidden="true" tabindex="-1"></a>  <span class="kw">const</span> toleranceMs <span class="op">=</span> (config<span class="op">.</span><span class="at">clock_skew_tolerance_seconds</span> <span class="op">||</span> <span class="dv">30</span>) <span class="op">*</span> <span class="dv">1000</span><span class="op">;</span></span>
+<span id="cb9-8"><a href="#cb9-8" aria-hidden="true" tabindex="-1"></a>  <span class="kw">const</span> expiryWithTolerance <span class="op">=</span> <span class="kw">new</span> <span class="bu">Date</span>(expiresAt<span class="op">.</span><span class="fu">getTime</span>() <span class="op">+</span> toleranceMs)<span class="op">;</span></span>
+<span id="cb9-9"><a href="#cb9-9" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb9-10"><a href="#cb9-10" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> (now <span class="op">&gt;</span> expiryWithTolerance) {</span>
+<span id="cb9-11"><a href="#cb9-11" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> { <span class="dt">valid</span><span class="op">:</span> <span class="kw">false</span><span class="op">,</span> <span class="dt">code</span><span class="op">:</span> <span class="st">&#39;TOKEN_EXPIRED&#39;</span> }<span class="op">;</span></span>
+<span id="cb9-12"><a href="#cb9-12" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb9-13"><a href="#cb9-13" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb9-14"><a href="#cb9-14" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> { <span class="dt">valid</span><span class="op">:</span> <span class="kw">true</span> }<span class="op">;</span></span>
+<span id="cb9-15"><a href="#cb9-15" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<h3 id="52-single-use-enforcement">5.2 Single-Use Enforcement</h3>
+<p>Tokens SHOULD be single-use by default:</p>
+<div class="sourceCode" id="cb10"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb10-1"><a href="#cb10-1" aria-hidden="true" tabindex="-1"></a><span class="kw">function</span> <span class="fu">redeemToken</span>(tokenId) {</span>
+<span id="cb10-2"><a href="#cb10-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">const</span> token <span class="op">=</span> tokenStore<span class="op">.</span><span class="fu">get</span>(tokenId)<span class="op">;</span></span>
+<span id="cb10-3"><a href="#cb10-3" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> (<span class="op">!</span>token <span class="op">||</span> token<span class="op">.</span><span class="at">consumed</span>) {</span>
+<span id="cb10-4"><a href="#cb10-4" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> { <span class="dt">valid</span><span class="op">:</span> <span class="kw">false</span> }<span class="op">;</span></span>
+<span id="cb10-5"><a href="#cb10-5" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb10-6"><a href="#cb10-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb10-7"><a href="#cb10-7" aria-hidden="true" tabindex="-1"></a>  <span class="co">// Mark as consumed BEFORE executing operation</span></span>
+<span id="cb10-8"><a href="#cb10-8" aria-hidden="true" tabindex="-1"></a>  token<span class="op">.</span><span class="at">consumed</span> <span class="op">=</span> <span class="kw">true</span><span class="op">;</span></span>
+<span id="cb10-9"><a href="#cb10-9" aria-hidden="true" tabindex="-1"></a>  token<span class="op">.</span><span class="at">consumed_at</span> <span class="op">=</span> <span class="kw">new</span> <span class="bu">Date</span>()<span class="op">.</span><span class="fu">toISOString</span>()<span class="op">;</span></span>
+<span id="cb10-10"><a href="#cb10-10" aria-hidden="true" tabindex="-1"></a>  tokenStore<span class="op">.</span><span class="fu">update</span>(token)<span class="op">;</span></span>
+<span id="cb10-11"><a href="#cb10-11" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb10-12"><a href="#cb10-12" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> { <span class="dt">valid</span><span class="op">:</span> <span class="kw">true</span> }<span class="op">;</span></span>
+<span id="cb10-13"><a href="#cb10-13" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<p><strong>Multi-use tokens</strong> MAY be supported for specific scenarios:</p>
+<ul>
+<li>Session-scoped confirmations (see Section 5.4)</li>
+<li>Batch operations with the same parameters</li>
+</ul>
+<h3 id="53-revocation">5.3 Revocation</h3>
+<p>Tokens MAY be revoked before expiration:</p>
+<p><strong>Automatic revocation triggers:</strong></p>
+<ul>
+<li>Session termination (MCP connection ends; see <a href="../versions/v1.0.0-draft.html#23-session-lifecycle">Section 2.3</a> of the core specification)</li>
+<li>User logout</li>
+<li>Adapter configuration change</li>
+<li>Security event detection</li>
+</ul>
+<p><strong>Manual revocation:</strong></p>
+<div class="sourceCode" id="cb11"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb11-1"><a href="#cb11-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb11-2"><a href="#cb11-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;introspect&quot;</span><span class="op">,</span></span>
+<span id="cb11-3"><a href="#cb11-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> {</span>
+<span id="cb11-4"><a href="#cb11-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">query</span><span class="op">:</span> <span class="st">&quot;revoke_token&quot;</span><span class="op">,</span></span>
+<span id="cb11-5"><a href="#cb11-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">token</span><span class="op">:</span> <span class="st">&quot;conf_a1b2c3d4e5f6g7h8&quot;</span></span>
+<span id="cb11-6"><a href="#cb11-6" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb11-7"><a href="#cb11-7" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<h3 id="54-session-scoped-tokens">5.4 Session-Scoped Tokens</h3>
+<p>Implementations MAY support session-scoped confirmations for improved UX:</p>
+<div class="sourceCode" id="cb12"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb12-1"><a href="#cb12-1" aria-hidden="true" tabindex="-1"></a><span class="kw">interface</span> SessionScopedToken <span class="kw">extends</span> TokenPayload {</span>
+<span id="cb12-2"><a href="#cb12-2" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** Session this token is valid for */</span></span>
+<span id="cb12-3"><a href="#cb12-3" aria-hidden="true" tabindex="-1"></a>  session_id<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb12-4"><a href="#cb12-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb12-5"><a href="#cb12-5" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** Number of times token can be used (default: 1) */</span></span>
+<span id="cb12-6"><a href="#cb12-6" aria-hidden="true" tabindex="-1"></a>  max_uses<span class="op">?:</span> <span class="dt">number</span><span class="op">;</span></span>
+<span id="cb12-7"><a href="#cb12-7" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb12-8"><a href="#cb12-8" aria-hidden="true" tabindex="-1"></a>  <span class="co">/** Current use count */</span></span>
+<span id="cb12-9"><a href="#cb12-9" aria-hidden="true" tabindex="-1"></a>  use_count<span class="op">:</span> <span class="dt">number</span><span class="op">;</span></span>
+<span id="cb12-10"><a href="#cb12-10" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<p>Session tokens:</p>
+<ul>
+<li>Are invalidated when the MCP connection terminates (see <a href="../versions/v1.0.0-draft.html#23-session-lifecycle">Section 2.3</a> of the core specification)</li>
+<li>MAY be reused within the session for identical operations</li>
+<li>MUST still respect expiration time</li>
+</ul>
+<h3 id="55-storage-requirements">5.5 Storage Requirements</h3>
+<table>
+<thead>
+<tr>
+<th>Requirement</th>
+<th>Specification</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Persistence</td>
+<td>At minimum, in-memory with TTL eviction</td>
+</tr>
+<tr>
+<td>Cleanup</td>
+<td>Expired tokens SHOULD be purged within 1 hour</td>
+</tr>
+<tr>
+<td>Capacity</td>
+<td>SHOULD support at least 1000 active tokens per adapter</td>
+</tr>
+</tbody>
+</table>
+<hr />
+<h2 id="6-security-considerations">6. Security Considerations</h2>
+<h3 id="61-replay-attack-prevention">6.1 Replay Attack Prevention</h3>
+<p>Tokens MUST NOT be replayable:</p>
+<ol type="1">
+<li><strong>Single-use enforcement</strong> - Default behavior prevents replay</li>
+<li><strong>Scope binding</strong> - Token only valid for original operation + parameters</li>
+<li><strong>Time limits</strong> - Short TTL reduces replay window</li>
+<li><strong>Session binding</strong> - Optional additional protection</li>
+</ol>
+<h3 id="62-token-tampering">6.2 Token Tampering</h3>
+<p>Tokens MUST be tamper-resistant:</p>
+<p><strong>Server-side storage (RECOMMENDED):</strong></p>
+<ul>
+<li>Token ID is a random lookup key</li>
+<li>All payload data stored server-side</li>
+<li>Client cannot modify scope or expiration</li>
+</ul>
+<p><strong>Signed tokens (ALTERNATIVE):</strong></p>
+<ul>
+<li>If tokens encode payload, use HMAC-SHA256 or similar</li>
+<li>Signature covers all payload fields</li>
+<li>Signature key MUST NOT be exposed to clients</li>
+</ul>
+<h3 id="63-information-disclosure">6.3 Information Disclosure</h3>
+<p>Token responses SHOULD limit information disclosure:</p>
+<p><strong>DO:</strong></p>
+<ul>
+<li>Provide confirmation message explaining the action</li>
+<li>Include expiration time</li>
+<li>List reasons for confirmation requirement</li>
+</ul>
+<p><strong>DO NOT:</strong></p>
+<ul>
+<li>Include internal system details in token</li>
+<li>Expose parameter values in error messages for failed validation</li>
+<li>Return different errors for "token not found" vs "token invalid"</li>
+</ul>
+<h3 id="64-audit-requirements">6.4 Audit Requirements</h3>
+<p>All token operations MUST be logged:</p>
+<div class="sourceCode" id="cb13"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb13-1"><a href="#cb13-1" aria-hidden="true" tabindex="-1"></a><span class="kw">interface</span> TokenAuditEntry {</span>
+<span id="cb13-2"><a href="#cb13-2" aria-hidden="true" tabindex="-1"></a>  timestamp<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb13-3"><a href="#cb13-3" aria-hidden="true" tabindex="-1"></a>  event<span class="op">:</span> <span class="st">&#39;TOKEN_ISSUED&#39;</span> <span class="op">|</span> <span class="st">&#39;TOKEN_VALIDATED&#39;</span> <span class="op">|</span> <span class="st">&#39;TOKEN_REJECTED&#39;</span> <span class="op">|</span> <span class="st">&#39;TOKEN_REVOKED&#39;</span><span class="op">;</span></span>
+<span id="cb13-4"><a href="#cb13-4" aria-hidden="true" tabindex="-1"></a>  token_id<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb13-5"><a href="#cb13-5" aria-hidden="true" tabindex="-1"></a>  operation<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb13-6"><a href="#cb13-6" aria-hidden="true" tabindex="-1"></a>  adapter_name<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb13-7"><a href="#cb13-7" aria-hidden="true" tabindex="-1"></a>  outcome<span class="op">:</span> <span class="st">&#39;success&#39;</span> <span class="op">|</span> <span class="st">&#39;failure&#39;</span><span class="op">;</span></span>
+<span id="cb13-8"><a href="#cb13-8" aria-hidden="true" tabindex="-1"></a>  failure_reason<span class="op">?:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb13-9"><a href="#cb13-9" aria-hidden="true" tabindex="-1"></a>  client_context<span class="op">?:</span> {</span>
+<span id="cb13-10"><a href="#cb13-10" aria-hidden="true" tabindex="-1"></a>    session_id<span class="op">?:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb13-11"><a href="#cb13-11" aria-hidden="true" tabindex="-1"></a>    user_id<span class="op">?:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb13-12"><a href="#cb13-12" aria-hidden="true" tabindex="-1"></a>  }<span class="op">;</span></span>
+<span id="cb13-13"><a href="#cb13-13" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<h3 id="65-rate-limiting-token-requests">6.5 Rate Limiting Token Requests</h3>
+<p>Implementations SHOULD rate limit token-related operations to prevent abuse:</p>
+<ul>
+<li>Token issuance: Limit repeated CONFIRMATION_REQUIRED responses</li>
+<li>Token validation: Limit failed validation attempts</li>
+<li>Token revocation: Limit revocation requests</li>
+</ul>
+<hr />
+<h2 id="7-implementation-requirements">7. Implementation Requirements</h2>
+<h3 id="71-must-requirements">7.1 MUST Requirements</h3>
+<p>Implementations using confirmation tokens MUST:</p>
+<ol type="1">
+<li>Generate tokens with at least 128 bits of entropy from a cryptographically secure random source</li>
+<li>Enforce expiration times on all tokens</li>
+<li>Bind tokens to specific operations and critical parameters</li>
+<li>Reject tokens that fail any validation check</li>
+<li>Log token issuance and redemption events</li>
+<li>Return appropriate error codes for token failures</li>
+</ol>
+<h3 id="72-should-requirements">7.2 SHOULD Requirements</h3>
+<p>Implementations using confirmation tokens SHOULD:</p>
+<ol type="1">
+<li>Use single-use tokens by default</li>
+<li>Store token state server-side (not in the token itself)</li>
+<li>Purge expired tokens within 1 hour</li>
+<li>Support token revocation</li>
+<li>Rate limit token-related operations</li>
+</ol>
+<h3 id="73-may-requirements">7.3 MAY Requirements</h3>
+<p>Implementations using confirmation tokens MAY:</p>
+<ol type="1">
+<li>Support session-scoped tokens for improved UX</li>
+<li>Support multi-use tokens for batch scenarios</li>
+<li>Implement signed tokens for stateless validation</li>
+<li>Provide introspection queries for token status</li>
+</ol>
+<hr />
+<h2 id="references">References</h2>
+<ul>
+<li><a href="../adapter/danger-levels.html">Dangerous Operation Classification</a> - Confirmation flows for danger levels</li>
+<li><a href="../adapter/rate-limiting.html">Rate Limiting Specification</a> - Quota continuation tokens</li>
+<li><a href="gatekeeper.html">Security Model: Gatekeeper</a> - Overall security architecture</li>
+<li><a href="../error-codes.html">Error Codes Specification</a> - Error code registry</li>
+</ul>
+
+          </div>
+        </section>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div class="container">
+      <p>&copy; 2026 DollhouseMCP Inc. d/b/a Dollhouse Research. MCP-AQL public draft documentation portal.</p>
+      <div class="footer-links">
+        <a href="../../docs/index.html">Docs Library</a>
+        <a href="../index.html">Repo-Synced Spec</a>
+        <a href="https://github.com/MCPAQL">MCPAQL Organization</a>
+        <a href="https://dollhouseresearch.com">Dollhouse Research</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../../js/search.js"></script>
+</body>
+</html>

--- a/public/spec/security/confirmation-tokens.html
+++ b/public/spec/security/confirmation-tokens.html
@@ -23,7 +23,7 @@
         </ul>
         <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
-          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <input id="site-search-input" data-search-input type="search" placeholder="Search MCP-AQL docs, spec pages, and adapter patterns...">
           <span class="search-count" data-search-count></span>
           <ul class="search-results" data-search-results hidden></ul>
         </form>
@@ -47,7 +47,7 @@
   <ul><li><a href="../adapter/danger-levels.html">Dangerous Operation Classification Specification</a></li><li><a href="../adapter/discovery-bundle.html">MCP Server Discovery Bundle</a></li><li><a href="../adapter/element-type.html">Adapter Element Type Specification</a></li><li><a href="../adapter/generator.html">Adapter Generator Specification</a></li><li><a href="../adapter/rate-limiting.html">Rate Limiting and Quota Management Specification</a></li><li><a href="../adapter/trust-levels.html">Trust Levels Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Security</h3>
-  <ul><li><a class="current" href="confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
+  <ul><li><a class="current" aria-current="page" href="confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Features</h3>
   <ul><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
@@ -700,6 +700,16 @@ identifier = 1*64(ALPHA / DIGIT / &quot;_&quot; / &quot;-&quot;)</code></pre>
 
           </div>
         </section>
+        <nav class="page-nav" aria-label="Page navigation">
+  <a class="page-nav-link prev" href="../adapter/trust-levels.html">
+    <span class="page-nav-eyebrow">Previous spec page</span>
+    <strong class="page-nav-label">Trust Levels Specification</strong>
+  </a>
+  <a class="page-nav-link next" href="execution-safety-loop.html">
+    <span class="page-nav-eyebrow">Next spec page</span>
+    <strong class="page-nav-label">Execution Safety Loop Specification</strong>
+  </a>
+</nav>
       </article>
     </div>
   </main>

--- a/public/spec/security/confirmation-tokens.html
+++ b/public/spec/security/confirmation-tokens.html
@@ -38,7 +38,7 @@
         <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
         <div class="docs-side-group">
   <h3>Core</h3>
-  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li></ul>
+  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li><li><a href="../repo/README.html">MCP-AQL Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Versions</h3>
   <ul><li><a href="../versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
@@ -56,7 +56,7 @@
   <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
-  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li></ul>
+  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li><li><a href="../repo/CHANGELOG.html">Changelog</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Architecture</h3>
   <ul><li><a href="../architecture/README.html">Architecture Documentation</a></li></ul>

--- a/public/spec/security/execution-safety-loop.html
+++ b/public/spec/security/execution-safety-loop.html
@@ -1,0 +1,944 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Informative Document: This is an informative specification that provides detailed guidance for the execution safety loop pattern defined normatively in Section 8.6 of the core specification. In case of conflict, the norm">
+  <title>MCP-AQL Spec | Execution Safety Loop Specification</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../../css/style.css">
+</head>
+<body>
+  <header>
+    <div class="container">
+      <nav>
+        <a class="logo" href="../../index.html"><span class="logo-mark"></span>MCP-AQL</a>
+        <ul class="nav-links">
+          <li><a href="../../index.html">Home</a></li>
+          <li><a href="../../docs/index.html">Docs</a></li>
+          <li><a href="../../launch-checklist.html">Launch Checklist</a></li>
+          <li><a href="../../apis/mcp-server.html">Adapter Patterns</a></li>
+        </ul>
+        <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
+          <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
+          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <span class="search-count" data-search-count></span>
+          <ul class="search-results" data-search-results hidden></ul>
+        </form>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <div class="container docs-shell">
+      <aside class="docs-side">
+        <h2>Repo-Synced Spec</h2>
+        <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
+        <div class="docs-side-group">
+  <h3>Core</h3>
+  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Versions</h3>
+  <ul><li><a href="../versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Adapter</h3>
+  <ul><li><a href="../adapter/danger-levels.html">Dangerous Operation Classification Specification</a></li><li><a href="../adapter/discovery-bundle.html">MCP Server Discovery Bundle</a></li><li><a href="../adapter/element-type.html">Adapter Element Type Specification</a></li><li><a href="../adapter/generator.html">Adapter Generator Specification</a></li><li><a href="../adapter/rate-limiting.html">Rate Limiting and Quota Management Specification</a></li><li><a href="../adapter/trust-levels.html">Trust Levels Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Security</h3>
+  <ul><li><a href="confirmation-tokens.html">Confirmation Token Specification</a></li><li><a class="current" href="execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Features</h3>
+  <ul><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Guides</h3>
+  <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Process</h3>
+  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Architecture</h3>
+  <ul><li><a href="../architecture/README.html">Architecture Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Research</h3>
+  <ul><li><a href="../research/mcp-vs-mcpaql-vs-a2a.html">Protocol Landscape: MCP vs MCP-AQL vs A2A</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Reference</h3>
+  <ul><li><a href="../reference/README.html">Reference Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>ADRs</h3>
+  <ul><li><a href="../adr/ADR-001-crude-pattern.html">ADR-001: CRUDE Pattern (Extending CRUD with Execute)</a></li><li><a href="../adr/ADR-002-graphql-style-input.html">ADR-002: GraphQL-Style Input Objects for Updates</a></li><li><a href="../adr/ADR-003-snake-case-parameters.html">ADR-003: snake_case Parameter Convention</a></li><li><a href="../adr/ADR-004-schema-driven-operations.html">ADR-004: Schema-Driven Operation Definitions</a></li><li><a href="../adr/ADR-005-introspection-system.html">ADR-005: GraphQL-Style Introspection System</a></li><li><a href="../adr/ADR-006-discriminated-responses.html">ADR-006: Discriminated Response Format</a></li><li><a href="../adr/index.html">Architecture Decision Records</a></li><li><a href="../adr/README.html">Architecture Decision Records</a></li></ul>
+</div>
+      </aside>
+
+      <article class="docs-main">
+        <section class="hero docs-hero">
+          <div class="hero-inner">
+            <span class="status-pill">REPO-SYNCED SPEC DOC</span>
+            <h1>Execution Safety Loop Specification</h1>
+            <p class="lede">Informative Document: This is an informative specification that provides detailed guidance for the execution safety loop pattern defined normatively in Section 8.6 of the core specification. In case of conflict, the norm</p>
+            <div class="spec-meta"><span class="state-chip live">Support document</span><span class="state-chip pending">Draft</span><span class="state-chip">1.0.0-draft</span><span class="state-chip">2026-02-25</span></div>
+            <p class="spec-source">Source: <a href="https://github.com/MCPAQL/spec/blob/main/docs/security/execution-safety-loop.md">spec/docs/security/execution-safety-loop.md</a></p>
+            <div class="hero-actions">
+              <a class="btn btn-primary" href="https://github.com/MCPAQL/spec/blob/main/docs/security/execution-safety-loop.md">Open Source Markdown</a>
+              <a class="btn btn-secondary" href="../index.html">Browse Full Spec Reference</a>
+            </div>
+          </div>
+        </section>
+
+        <section>
+          <div class="card spec-prose">
+            <p><strong>Version:</strong> 1.0.0-draft <strong>Status:</strong> Draft <strong>Last Updated:</strong> 2026-02-25</p>
+<blockquote>
+<p><strong>Informative Document:</strong> This is an informative specification that provides detailed guidance for the execution safety loop pattern defined normatively in <a href="../versions/v1.0.0-draft.html#86-execution-safety-loop">Section 8.6 of the core specification</a>. In case of conflict, the normative specification takes precedence.</p>
+</blockquote>
+<h2 id="abstract">Abstract</h2>
+<p>This document specifies the <strong>execution safety loop</strong> — an opt-in monitoring pattern that enables continuous safety evaluation of an LLM's intended actions across all connected MCP servers. It also defines the <strong>safety dongle</strong> deployment model, where a standalone MCP-AQL server functions as a universal safety layer without implementing any other MCP-AQL features.</p>
+<hr />
+<h2 id="table-of-contents">Table of Contents</h2>
+<ol type="1">
+<li><a href="#1-introduction">Introduction</a></li>
+<li><a href="#2-the-safety-dongle-deployment-model">The Safety Dongle Deployment Model</a></li>
+<li><a href="#3-the-execution-safety-loop">The Execution Safety Loop</a></li>
+<li><a href="#4-minimal-operation-surface">Minimal Operation Surface</a></li>
+<li><a href="#5-integration-with-gatekeeper">Integration with Gatekeeper</a></li>
+<li><a href="#6-integration-with-danger-zone">Integration with Danger Zone</a></li>
+<li><a href="#7-deployment-examples">Deployment Examples</a></li>
+<li><a href="#8-opting-out">Opting Out</a></li>
+<li><a href="#9-implementation-requirements">Implementation Requirements</a></li>
+</ol>
+<hr />
+<h2 id="1-introduction">1. Introduction</h2>
+<h3 id="11-purpose">1.1 Purpose</h3>
+<p>The execution safety loop addresses a fundamental challenge in LLM tool-calling environments: <strong>how do you enforce safety policies on an LLM's actions when those actions target multiple independent MCP servers?</strong></p>
+<p>Individual MCP servers can protect their own operations, but no single server has visibility into what the LLM is doing across all connected servers. The execution safety loop solves this by providing a central checkpoint that the LLM reports to before taking any action — regardless of which server handles the actual operation.</p>
+<h3 id="12-status">1.2 Status</h3>
+<p>The execution safety loop is an <strong>optional</strong> feature defined normatively in <a href="../versions/v1.0.0-draft.html#86-execution-safety-loop">Section 8.6 of the core specification</a>. This document provides informative guidance on deployment models, integration patterns, and implementation strategies.</p>
+<h3 id="13-core-concept">1.3 Core Concept</h3>
+<p>The execution safety loop is a protocol-level monitoring pattern:</p>
+<ol type="1">
+<li>The LLM plans an action (any tool call, file operation, shell command, etc.)</li>
+<li>The LLM reports its intent to a safety-enabled MCP-AQL server via <code>record_execution_step</code> with <code>nextActionHint</code></li>
+<li>The server evaluates the intent against its safety pipeline (Gatekeeper policies, Autonomy Evaluator, Danger Zone rules)</li>
+<li>The server returns an <code>AutonomyDirective</code> — go, pause, or hard stop</li>
+<li>The LLM respects the directive before proceeding</li>
+</ol>
+<p>This is distinct from the full agent lifecycle that a specific adapter (like DollhouseMCP) may implement. The safety loop is purely about monitoring and evaluating — it does not manage agent state, personas, elements, or any domain-specific functionality.</p>
+<h3 id="14-opt-in-design">1.4 Opt-In Design</h3>
+<p>The execution safety loop is entirely optional at every level:</p>
+<ul>
+<li><strong>Adapters</strong> choose whether to support it</li>
+<li><strong>Clients</strong> choose whether to enable it</li>
+<li><strong>Users</strong> can disable it at any time</li>
+</ul>
+<p>No adapter is required to implement the safety loop, and no client is required to use it. When disabled, the adapter operates normally without any safety enforcement overhead. See <a href="#8-opting-out">Section 8: Opting Out</a> for details.</p>
+<hr />
+<h2 id="2-the-safety-dongle-deployment-model">2. The Safety Dongle Deployment Model</h2>
+<h3 id="21-what-is-a-safety-dongle">2.1 What Is a Safety Dongle?</h3>
+<p>A safety dongle is a standalone MCP-AQL server whose sole purpose is safety enforcement. It has no domain functionality — it does not manage files, query databases, or interact with external services. It exists only to evaluate the LLM's intended actions and return go/no-go directives.</p>
+<p>The name "dongle" reflects the deployment model: you plug it in alongside your existing MCP servers, and it acts as a universal firewall for all tool calls in the session.</p>
+<h3 id="22-architecture">2.2 Architecture</h3>
+<pre><code>┌────────────────────────────────────────────────────────┐
+│  MCP Client (Claude, GPT, etc.)                        │
+│                                                        │
+│  LLM decides to take an action                         │
+│       │                                                │
+│       ▼                                                │
+│  1. Report intent to safety dongle                     │
+│     record_execution_step {                            │
+│       nextActionHint: &quot;calling write_file on server X&quot; │
+│     }                                                  │
+│       │                                                │
+│       ▼                                                │
+│  ┌──────────────────────────────────────────┐          │
+│  │  Safety Dongle (MCP-AQL Server)          │          │
+│  │                                          │          │
+│  │  Gatekeeper → Autonomy Evaluator →       │          │
+│  │  Danger Zone Enforcer                    │          │
+│  │                                          │          │
+│  │  Returns: AutonomyDirective              │          │
+│  │  { continue: true/false, factors: [...] }│          │
+│  └──────────────────────────────────────────┘          │
+│       │                                                │
+│       ▼                                                │
+│  2. If continue: execute the action on target server   │
+│     If !continue: pause, escalate, or abort            │
+│                                                        │
+│  ┌─────────┐  ┌─────────┐  ┌─────────┐               │
+│  │ MCP     │  │ MCP     │  │ MCP     │               │
+│  │ Server A│  │ Server B│  │ Server C│               │
+│  │ (files) │  │ (db)    │  │ (slack) │               │
+│  └─────────┘  └─────────┘  └─────────┘               │
+└────────────────────────────────────────────────────────┘</code></pre>
+<h3 id="23-what-the-dongle-does-not-do">2.3 What the Dongle Does NOT Do</h3>
+<p>A safety dongle in its minimal configuration:</p>
+<ul>
+<li><strong>Does not</strong> manage elements (personas, skills, templates, agents, memories)</li>
+<li><strong>Does not</strong> store or query domain data</li>
+<li><strong>Does not</strong> interact with external services beyond safety evaluation</li>
+<li><strong>Does not</strong> implement the full CRUDE pattern for domain operations</li>
+<li><strong>Does not</strong> require introspection of other servers' capabilities</li>
+</ul>
+<p>It is a purpose-built safety layer with a minimal operation surface.</p>
+<h3 id="24-relationship-to-full-mcp-aql-adapters">2.4 Relationship to Full MCP-AQL Adapters</h3>
+<p>The safety dongle and a full MCP-AQL adapter are both valid configurations of the same protocol. They differ only in scope:</p>
+<table>
+<thead>
+<tr>
+<th>Aspect</th>
+<th>Safety Dongle</th>
+<th>Full MCP-AQL Adapter</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Purpose</td>
+<td>Safety enforcement only</td>
+<td>Domain operations + safety</td>
+</tr>
+<tr>
+<td>Operations</td>
+<td>~7 (safety loop + introspection)</td>
+<td>Dozens (full CRUDE surface)</td>
+</tr>
+<tr>
+<td>Elements</td>
+<td>None</td>
+<td>Personas, skills, agents, etc.</td>
+</tr>
+<tr>
+<td>State</td>
+<td>Execution state + policies only</td>
+<td>Full domain state</td>
+</tr>
+<tr>
+<td>Endpoints used</td>
+<td>CREATE, EXECUTE, READ (subset)</td>
+<td>All five CRUDE endpoints</td>
+</tr>
+</tbody>
+</table>
+<p>A full MCP-AQL adapter MAY embed the safety loop directly — it does not need a separate dongle. The dongle model is for environments where safety enforcement is decoupled from the adapters performing the actual work.</p>
+<hr />
+<h2 id="3-the-execution-safety-loop">3. The Execution Safety Loop</h2>
+<h3 id="31-loop-protocol">3.1 Loop Protocol</h3>
+<p>The execution safety loop follows a simple protocol:</p>
+<pre><code>┌─────────────────────────────────────┐
+│                                     │
+│  ┌──────────┐                       │
+│  │  Plan    │  LLM determines       │
+│  │  action  │  next action          │
+│  └────┬─────┘                       │
+│       │                             │
+│       ▼                             │
+│  ┌──────────┐                       │
+│  │  Report  │  record_execution_step│
+│  │  intent  │  { nextActionHint,    │
+│  │          │    outcome? }         │
+│  └────┬─────┘                       │
+│       │                             │
+│       ▼                             │
+│  ┌──────────┐                       │
+│  │ Evaluate │  Gatekeeper +         │
+│  │          │  Autonomy Evaluator + │
+│  │          │  Danger Zone          │
+│  └────┬─────┘                       │
+│       │                             │
+│       ▼                             │
+│  ┌──────────┐    ┌──────────┐       │
+│  │ continue │───▶│  Act     │       │
+│  │ = true   │    │  (tool   │       │
+│  └──────────┘    │   call)  │       │
+│                  └────┬─────┘       │
+│       ┌───────────────┘             │
+│       │                             │
+│       ▼                             │
+│  ┌──────────┐    ┌──────────┐       │
+│  │ continue │───▶│  Pause / │       │
+│  │ = false  │    │  Escalate│       │
+│  └──────────┘    └──────────┘       │
+│                                     │
+└─────────────────────────────────────┘</code></pre>
+<p><strong>Lifecycle:</strong></p>
+<ol type="1">
+<li><strong>Start:</strong> <code>execute_agent</code> — initiates the safety loop (requires explicit approval)</li>
+<li><strong>Loop:</strong> <code>record_execution_step</code> — report each intended action, receive directive</li>
+<li><strong>End:</strong> <code>complete_execution</code> (success) or <code>abort_execution</code> (abnormal termination)</li>
+</ol>
+<h3 id="32-monitoring-scope">3.2 Monitoring Scope</h3>
+<p>The execution safety loop monitors <strong>all intended actions</strong>, not only MCP-AQL operations on the same adapter. This includes:</p>
+<ul>
+<li>Tool calls to any MCP server in the client session</li>
+<li>Tool calls to non-MCP-AQL MCP servers</li>
+<li>Built-in client capabilities (file I/O, shell access, web requests)</li>
+<li>Any operation that produces effects beyond the LLM's reasoning context</li>
+</ul>
+<p>This broad scope is what makes the safety dongle deployment model possible: the dongle does not need to understand or proxy the actual operations — it only needs to evaluate the LLM's description of what it intends to do.</p>
+<h3 id="33-the-record_execution_step-parameters">3.3 The <code>record_execution_step</code> Parameters</h3>
+<p>The <code>record_execution_step</code> operation accepts several parameters. The full parameter table is defined normatively in <a href="../versions/v1.0.0-draft.html#863-mandatory-action-reporting">Section 8.6.3 of the core specification</a>. The two most important fields are:</p>
+<ul>
+<li><strong><code>nextActionHint</code></strong> (MUST) — describes the intended next action for safety evaluation</li>
+<li><strong><code>outcome</code></strong> (SHOULD) — reports the result of the previous step (<code>"success"</code>, <code>"failure"</code>, or <code>"skipped"</code>), which drives Stage 2 of the Autonomy Evaluator pipeline (Section 8.7.2)</li>
+</ul>
+<p>The <code>nextActionHint</code> is a human-readable string describing the intended action with sufficient detail for safety evaluation.</p>
+<p><strong>Good <code>nextActionHint</code> examples:</strong></p>
+<div class="sourceCode" id="cb3"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb3-1"><a href="#cb3-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Specific tool call with target</span></span>
+<span id="cb3-2"><a href="#cb3-2" aria-hidden="true" tabindex="-1"></a><span class="st">&quot;calling write_file on project/config.json to update database URL&quot;</span></span>
+<span id="cb3-3"><a href="#cb3-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb3-4"><a href="#cb3-4" aria-hidden="true" tabindex="-1"></a><span class="co">// Shell command with detail</span></span>
+<span id="cb3-5"><a href="#cb3-5" aria-hidden="true" tabindex="-1"></a><span class="st">&quot;executing shell command: npm install express&quot;</span></span>
+<span id="cb3-6"><a href="#cb3-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb3-7"><a href="#cb3-7" aria-hidden="true" tabindex="-1"></a><span class="co">// Cross-server operation</span></span>
+<span id="cb3-8"><a href="#cb3-8" aria-hidden="true" tabindex="-1"></a><span class="st">&quot;sending message to #general channel via Slack MCP server&quot;</span></span>
+<span id="cb3-9"><a href="#cb3-9" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb3-10"><a href="#cb3-10" aria-hidden="true" tabindex="-1"></a><span class="co">// Destructive operation</span></span>
+<span id="cb3-11"><a href="#cb3-11" aria-hidden="true" tabindex="-1"></a><span class="st">&quot;deleting all records from staging_users table via database MCP server&quot;</span></span>
+<span id="cb3-12"><a href="#cb3-12" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb3-13"><a href="#cb3-13" aria-hidden="true" tabindex="-1"></a><span class="co">// File system operation</span></span>
+<span id="cb3-14"><a href="#cb3-14" aria-hidden="true" tabindex="-1"></a><span class="st">&quot;reading /etc/passwd to check user configuration&quot;</span></span></code></pre></div>
+<p><strong>Poor <code>nextActionHint</code> examples:</strong></p>
+<div class="sourceCode" id="cb4"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb4-1"><a href="#cb4-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Too vague — cannot evaluate risk</span></span>
+<span id="cb4-2"><a href="#cb4-2" aria-hidden="true" tabindex="-1"></a><span class="st">&quot;doing something&quot;</span></span>
+<span id="cb4-3"><a href="#cb4-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb4-4"><a href="#cb4-4" aria-hidden="true" tabindex="-1"></a><span class="co">// No target information</span></span>
+<span id="cb4-5"><a href="#cb4-5" aria-hidden="true" tabindex="-1"></a><span class="st">&quot;writing a file&quot;</span></span>
+<span id="cb4-6"><a href="#cb4-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb4-7"><a href="#cb4-7" aria-hidden="true" tabindex="-1"></a><span class="co">// Missing context for risk assessment</span></span>
+<span id="cb4-8"><a href="#cb4-8" aria-hidden="true" tabindex="-1"></a><span class="st">&quot;running a command&quot;</span></span></code></pre></div>
+<p>The quality of safety evaluation depends directly on the quality of the <code>nextActionHint</code>. LLM system prompts SHOULD instruct the model to provide specific, detailed action descriptions.</p>
+<h3 id="34-the-autonomydirective-response">3.4 The <code>AutonomyDirective</code> Response</h3>
+<p>Every <code>record_execution_step</code> call returns an <code>AutonomyDirective</code> indicating whether the LLM may proceed. See <a href="../versions/v1.0.0-draft.html#87-autonomy-evaluation">Section 8.7 of the core specification</a> for the full type definition.</p>
+<p>Key fields:</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Type</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>continue</code></td>
+<td>boolean</td>
+<td>Whether the LLM may proceed with the reported action</td>
+</tr>
+<tr>
+<td><code>factors</code></td>
+<td>string[]</td>
+<td>Human-readable explanations of the evaluation decision</td>
+</tr>
+<tr>
+<td><code>stopped</code></td>
+<td>boolean</td>
+<td>Whether the agent has been hard-blocked (Danger Zone)</td>
+</tr>
+<tr>
+<td><code>reason</code></td>
+<td>string</td>
+<td>Why the agent was paused or stopped</td>
+</tr>
+<tr>
+<td><code>stepsRemaining</code></td>
+<td>number</td>
+<td>Steps remaining before mandatory pause</td>
+</tr>
+<tr>
+<td><code>nextStepRisk</code></td>
+<td>SafetyTier</td>
+<td>Safety tier assigned to the reported action</td>
+</tr>
+<tr>
+<td><code>notifications</code></td>
+<td>AgentNotification[]</td>
+<td>Gatekeeper blocks, danger alerts, and other events</td>
+</tr>
+</tbody>
+</table>
+<p><strong>Decision tree:</strong></p>
+<ol type="1">
+<li>If <code>stopped === true</code> → <strong>Hard stop.</strong> Agent MUST cease all actions until unblocked via out-of-band verification.</li>
+<li>If <code>continue === false</code> → <strong>Pause.</strong> Agent MUST NOT proceed. Report the pause to the user or upstream system.</li>
+<li>If <code>continue === true</code> → <strong>Proceed.</strong> Agent MAY execute the reported action.</li>
+</ol>
+<hr />
+<h2 id="4-minimal-operation-surface">4. Minimal Operation Surface</h2>
+<h3 id="41-required-operations">4.1 Required Operations</h3>
+<p>A safety dongle implements a minimal set of operations:</p>
+<table>
+<thead>
+<tr>
+<th>Operation</th>
+<th>Endpoint</th>
+<th>Purpose</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>execute_agent</code></td>
+<td>EXECUTE</td>
+<td>Start the execution safety loop</td>
+</tr>
+<tr>
+<td><code>record_execution_step</code></td>
+<td>CREATE</td>
+<td>Report intended action, receive <code>AutonomyDirective</code></td>
+</tr>
+<tr>
+<td><code>complete_execution</code></td>
+<td>EXECUTE</td>
+<td>Signal normal completion of the safety loop</td>
+</tr>
+<tr>
+<td><code>abort_execution</code></td>
+<td>EXECUTE</td>
+<td>Signal abnormal termination</td>
+</tr>
+<tr>
+<td><code>confirm_operation</code></td>
+<td>EXECUTE</td>
+<td>Confirm Gatekeeper blocks or Autonomy Evaluator <code>confirm</code> tier pauses</td>
+</tr>
+<tr>
+<td><code>verify_challenge</code></td>
+<td>CREATE</td>
+<td>Submit out-of-band verification code (<code>verify</code> tier and Danger Zone)</td>
+</tr>
+<tr>
+<td><code>introspect</code></td>
+<td>READ</td>
+<td>Discover available operations and capabilities</td>
+</tr>
+</tbody>
+</table>
+<p>This is 7 operations across 3 endpoints — a fraction of a full MCP-AQL adapter's surface.</p>
+<h3 id="42-endpoint-classification">4.2 Endpoint Classification</h3>
+<p>The endpoint placement of these operations is critical to the permission architecture:</p>
+<table>
+<thead>
+<tr>
+<th>Endpoint</th>
+<th>Default Permission</th>
+<th>Operations</th>
+<th>Rationale</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>READ</td>
+<td><code>AUTO_APPROVE</code></td>
+<td><code>introspect</code></td>
+<td>Zero friction for discovery</td>
+</tr>
+<tr>
+<td>CREATE</td>
+<td><code>CONFIRM_SESSION</code></td>
+<td><code>record_execution_step</code>, <code>verify_challenge</code></td>
+<td>Approve once, then frictionless for the session</td>
+</tr>
+<tr>
+<td>EXECUTE</td>
+<td><code>CONFIRM_SINGLE_USE</code></td>
+<td><code>execute_agent</code>, <code>complete_execution</code>, <code>abort_execution</code>, <code>confirm_operation</code></td>
+<td>Each invocation requires explicit approval</td>
+</tr>
+</tbody>
+</table>
+<p>The key design decision: <code>record_execution_step</code> is on CREATE (not EXECUTE) because it runs on every loop cycle. If it were on EXECUTE, the client would need to either:</p>
+<ul>
+<li><strong>Auto-approve all EXECUTE operations</strong> — which also auto-approves <code>confirm_operation</code>, collapsing the Gatekeeper permission architecture</li>
+<li><strong>Manually approve every loop cycle</strong> — making the safety loop unusable in practice</li>
+</ul>
+<p>By placing it on CREATE with <code>CONFIRM_SESSION</code> semantics, the user approves it once at the start of the session, and subsequent calls are frictionless. Meanwhile, <code>confirm_operation</code> stays on EXECUTE with <code>CONFIRM_SINGLE_USE</code>, preserving the permission model.</p>
+<h3 id="43-permission-architecture">4.3 Permission Architecture</h3>
+<p>The CRUDE endpoint classification directly determines default friction levels:</p>
+<pre><code>READ (AUTO_APPROVE)
+  └── introspect           → Zero friction
+
+CREATE (CONFIRM_SESSION)
+  ├── record_execution_step → Approve once, then frictionless
+  └── verify_challenge      → Approve once, then frictionless
+
+EXECUTE (CONFIRM_SINGLE_USE)
+  ├── execute_agent         → Explicit approval each time
+  ├── complete_execution    → Explicit approval each time
+  ├── abort_execution       → Explicit approval each time
+  └── confirm_operation     → AUTO_APPROVE override (avoids &quot;confirm to confirm&quot; loop)</code></pre>
+<blockquote>
+<p><strong>Implementation Note:</strong> <code>confirm_operation</code> has an <code>AUTO_APPROVE</code> override despite being on the EXECUTE endpoint. This prevents an infinite confirmation loop where confirming an operation itself requires confirmation.</p>
+<p><strong>Security Note:</strong> Because <code>confirm_operation</code> is auto-approved, the LLM could theoretically call it to approve its own blocked operations (Gatekeeper blocks or Autonomy Evaluator <code>confirm</code> tier pauses) without human involvement. Implementations MUST prevent self-approval — the entity confirming an operation MUST NOT be the same agent that triggered the block. Server-side controls (caller identity validation, confirmation tokens bound to a human channel, or out-of-band confirmation delivery) are required. See <a href="../versions/v1.0.0-draft.html#873-agent-notification-system">Section 8.7.3</a> for the normative requirement.</p>
+</blockquote>
+<hr />
+<h2 id="5-integration-with-gatekeeper">5. Integration with Gatekeeper</h2>
+<h3 id="51-how-the-dongle-evaluates-actions">5.1 How the Dongle Evaluates Actions</h3>
+<p>The safety dongle uses the same <a href="gatekeeper.html">Gatekeeper</a> architecture as a full MCP-AQL adapter, but scoped to the execution safety loop:</p>
+<ol type="1">
+<li><strong>Layer 1 — Route Validation:</strong> Verifies the operation is called via the correct CRUDE endpoint</li>
+<li><strong>Layer 2 — Safety Tier:</strong> Evaluates the endpoint's permission characteristics</li>
+<li><strong>Layer 3 — Policy Evaluation:</strong> Checks <code>nextActionHint</code> against configured policies</li>
+<li><strong>Layer 4 — Confirmation:</strong> Issues confirmation tokens for operations requiring acknowledgment</li>
+</ol>
+<p>For the safety dongle, Layer 3 is the most important: it evaluates the LLM's stated intent against configurable patterns.</p>
+<h3 id="52-policy-model">5.2 Policy Model</h3>
+<p>Policies control which actions are allowed, denied, or require confirmation. Policies are matched against the <code>nextActionHint</code> string using glob patterns:</p>
+<div class="sourceCode" id="cb6"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb6-1"><a href="#cb6-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Example policy configuration</span></span>
+<span id="cb6-2"><a href="#cb6-2" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb6-3"><a href="#cb6-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">deny</span><span class="op">:</span> [</span>
+<span id="cb6-4"><a href="#cb6-4" aria-hidden="true" tabindex="-1"></a>    <span class="st">&quot;drop_*&quot;</span><span class="op">,</span>           <span class="co">// Block any drop operations</span></span>
+<span id="cb6-5"><a href="#cb6-5" aria-hidden="true" tabindex="-1"></a>    <span class="st">&quot;delete_all*&quot;</span><span class="op">,</span>      <span class="co">// Block bulk deletions</span></span>
+<span id="cb6-6"><a href="#cb6-6" aria-hidden="true" tabindex="-1"></a>    <span class="st">&quot;*_production*&quot;</span><span class="op">,</span>    <span class="co">// Block anything targeting production</span></span>
+<span id="cb6-7"><a href="#cb6-7" aria-hidden="true" tabindex="-1"></a>    <span class="st">&quot;rm -rf*&quot;</span>           <span class="co">// Block recursive force deletions</span></span>
+<span id="cb6-8"><a href="#cb6-8" aria-hidden="true" tabindex="-1"></a>  ]<span class="op">,</span></span>
+<span id="cb6-9"><a href="#cb6-9" aria-hidden="true" tabindex="-1"></a>  <span class="dt">requiresApproval</span><span class="op">:</span> [</span>
+<span id="cb6-10"><a href="#cb6-10" aria-hidden="true" tabindex="-1"></a>    <span class="st">&quot;delete_*&quot;</span><span class="op">,</span>         <span class="co">// Require approval for deletions</span></span>
+<span id="cb6-11"><a href="#cb6-11" aria-hidden="true" tabindex="-1"></a>    <span class="st">&quot;*force*&quot;</span><span class="op">,</span>          <span class="co">// Require approval for force operations</span></span>
+<span id="cb6-12"><a href="#cb6-12" aria-hidden="true" tabindex="-1"></a>    <span class="st">&quot;deploy_*&quot;</span><span class="op">,</span>         <span class="co">// Require approval for deployments</span></span>
+<span id="cb6-13"><a href="#cb6-13" aria-hidden="true" tabindex="-1"></a>    <span class="st">&quot;git push*&quot;</span>         <span class="co">// Require approval for git pushes</span></span>
+<span id="cb6-14"><a href="#cb6-14" aria-hidden="true" tabindex="-1"></a>  ]<span class="op">,</span></span>
+<span id="cb6-15"><a href="#cb6-15" aria-hidden="true" tabindex="-1"></a>  <span class="dt">autoApprove</span><span class="op">:</span> [</span>
+<span id="cb6-16"><a href="#cb6-16" aria-hidden="true" tabindex="-1"></a>    <span class="st">&quot;read_*&quot;</span><span class="op">,</span>           <span class="co">// Auto-approve reads</span></span>
+<span id="cb6-17"><a href="#cb6-17" aria-hidden="true" tabindex="-1"></a>    <span class="st">&quot;list_*&quot;</span><span class="op">,</span>           <span class="co">// Auto-approve listings</span></span>
+<span id="cb6-18"><a href="#cb6-18" aria-hidden="true" tabindex="-1"></a>    <span class="st">&quot;get_*&quot;</span><span class="op">,</span>            <span class="co">// Auto-approve getters</span></span>
+<span id="cb6-19"><a href="#cb6-19" aria-hidden="true" tabindex="-1"></a>    <span class="st">&quot;search_*&quot;</span>          <span class="co">// Auto-approve searches</span></span>
+<span id="cb6-20"><a href="#cb6-20" aria-hidden="true" tabindex="-1"></a>  ]</span>
+<span id="cb6-21"><a href="#cb6-21" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<p><strong>Resolution order:</strong> <code>deny</code> &gt; <code>requiresApproval</code> &gt; <code>autoApprove</code> &gt; default (evaluate via Autonomy Evaluator)</p>
+<h3 id="53-notification-system">5.3 Notification System</h3>
+<p>When the Gatekeeper blocks an operation or the Autonomy Evaluator pauses execution, notifications are included in the <code>AutonomyDirective</code> response:</p>
+<div class="sourceCode" id="cb7"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb7-1"><a href="#cb7-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb7-2"><a href="#cb7-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">continue</span><span class="op">:</span> <span class="kw">false</span><span class="op">,</span></span>
+<span id="cb7-3"><a href="#cb7-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">reason</span><span class="op">:</span> <span class="st">&quot;Action requires approval: delete_user&quot;</span><span class="op">,</span></span>
+<span id="cb7-4"><a href="#cb7-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">factors</span><span class="op">:</span> [<span class="st">&quot;Pattern match: delete_* requires approval&quot;</span>]<span class="op">,</span></span>
+<span id="cb7-5"><a href="#cb7-5" aria-hidden="true" tabindex="-1"></a>  <span class="dt">notifications</span><span class="op">:</span> [</span>
+<span id="cb7-6"><a href="#cb7-6" aria-hidden="true" tabindex="-1"></a>    {</span>
+<span id="cb7-7"><a href="#cb7-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">type</span><span class="op">:</span> <span class="st">&quot;permission_pending&quot;</span><span class="op">,</span></span>
+<span id="cb7-8"><a href="#cb7-8" aria-hidden="true" tabindex="-1"></a>      <span class="dt">message</span><span class="op">:</span> <span class="st">&quot;Operation &#39;delete_user&#39; requires confirmation&quot;</span><span class="op">,</span></span>
+<span id="cb7-9"><a href="#cb7-9" aria-hidden="true" tabindex="-1"></a>      <span class="dt">metadata</span><span class="op">:</span> {</span>
+<span id="cb7-10"><a href="#cb7-10" aria-hidden="true" tabindex="-1"></a>        <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;delete_user&quot;</span><span class="op">,</span></span>
+<span id="cb7-11"><a href="#cb7-11" aria-hidden="true" tabindex="-1"></a>        <span class="dt">level</span><span class="op">:</span> <span class="st">&quot;CONFIRM_SINGLE_USE&quot;</span></span>
+<span id="cb7-12"><a href="#cb7-12" aria-hidden="true" tabindex="-1"></a>      }<span class="op">,</span></span>
+<span id="cb7-13"><a href="#cb7-13" aria-hidden="true" tabindex="-1"></a>      <span class="dt">timestamp</span><span class="op">:</span> <span class="st">&quot;2026-02-25T14:30:00Z&quot;</span></span>
+<span id="cb7-14"><a href="#cb7-14" aria-hidden="true" tabindex="-1"></a>    }</span>
+<span id="cb7-15"><a href="#cb7-15" aria-hidden="true" tabindex="-1"></a>  ]</span>
+<span id="cb7-16"><a href="#cb7-16" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<p>Notification types:</p>
+<table>
+<thead>
+<tr>
+<th>Type</th>
+<th>Trigger</th>
+<th>Action Required</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>permission_pending</code></td>
+<td>Gatekeeper blocked an operation</td>
+<td>Call <code>confirm_operation</code> to approve</td>
+</tr>
+<tr>
+<td><code>autonomy_pause</code></td>
+<td>Autonomy Evaluator returned <code>continue: false</code></td>
+<td>For <code>confirm</code> tier: call <code>confirm_operation</code>; for <code>verify</code> tier: out-of-band <code>verify_challenge</code> (Section 6)</td>
+</tr>
+<tr>
+<td><code>danger_zone</code></td>
+<td>Hard block triggered (<code>danger_zone</code> tier or <code>deny</code> pattern)</td>
+<td>Out-of-band <code>verify_challenge</code> required (Section 6)</td>
+</tr>
+</tbody>
+</table>
+<p>The notification system is <strong>pull-based</strong>: notifications are included in <code>record_execution_step</code> responses. There is no push channel — the LLM must call <code>record_execution_step</code> to discover pending events. This aligns with the MCP protocol's request-response model.</p>
+<hr />
+<h2 id="6-integration-with-danger-zone">6. Integration with Danger Zone</h2>
+<h3 id="61-danger-level-escalation-during-execution">6.1 Danger Level Escalation During Execution</h3>
+<p>When the Autonomy Evaluator assigns a high risk score to a <code>nextActionHint</code>, the action escalates through safety tiers defined in the <a href="../adapter/danger-levels.html">Danger Levels specification</a>:</p>
+<table>
+<thead>
+<tr>
+<th>Risk Score</th>
+<th>Tier</th>
+<th>Behavior</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>0-30</td>
+<td><code>advisory</code></td>
+<td>Log and continue</td>
+</tr>
+<tr>
+<td>31-60</td>
+<td><code>confirm</code></td>
+<td>Pause for human review (<code>continue: false</code>)</td>
+</tr>
+<tr>
+<td>61-85</td>
+<td><code>verify</code></td>
+<td>Pause + out-of-band verification via <code>verify_challenge</code> (Section 8.8)</td>
+</tr>
+<tr>
+<td>86-100</td>
+<td><code>danger_zone</code></td>
+<td>Hard stop + out-of-band verification via <code>verify_challenge</code> (Section 8.8)</td>
+</tr>
+</tbody>
+</table>
+<h3 id="62-out-of-band-verification">6.2 Out-of-Band Verification</h3>
+<p>Both the <code>verify</code> and <code>danger_zone</code> tiers trigger out-of-band verification, but with different enforcement severity.</p>
+<p><strong>Danger Zone hard stop</strong> (<code>danger_zone</code> tier or <code>deny</code> pattern match):</p>
+<ol type="1">
+<li>The <code>AutonomyDirective</code> returns <code>stopped: true</code></li>
+<li>A verification challenge is generated with a cryptographically random code</li>
+<li>The code is displayed through a channel <strong>inaccessible to the AI</strong> (OS dialog, hardware token, SMS, etc.)</li>
+<li>The agent is blocked at the agent level until a human provides the correct code via <code>verify_challenge</code></li>
+<li>The block persists across server restarts</li>
+</ol>
+<p><strong>Verify tier pause</strong> (<code>verify</code> tier):</p>
+<ol type="1">
+<li>The <code>AutonomyDirective</code> returns <code>continue: false</code> (without <code>stopped: true</code>)</li>
+<li>A verification challenge is generated and displayed out-of-band (same as above)</li>
+<li>The agent is paused — subsequent <code>record_execution_step</code> calls return <code>continue: false</code> until verified</li>
+<li>Unlike Danger Zone blocks, verify pauses do not persist across restarts and do not prevent new executions</li>
+</ol>
+<p>See <a href="../versions/v1.0.0-draft.html#88-out-of-band-verification">Section 8.8 of the core specification</a> for the full out-of-band verification protocol.</p>
+<blockquote>
+<p><strong>Security Principle:</strong> The verification code MUST NOT appear in any MCP response, tool result, log accessible to the AI, or <code>_meta</code> field. The AI can only see the challenge ID — never the code itself. This ensures that even a prompt-injected LLM cannot self-verify.</p>
+</blockquote>
+<hr />
+<h2 id="7-deployment-examples">7. Deployment Examples</h2>
+<h3 id="71-minimal-safety-dongle">7.1 Minimal Safety Dongle</h3>
+<p>A standalone MCP-AQL server with no domain functionality:</p>
+<div class="sourceCode" id="cb8"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb8-1"><a href="#cb8-1" aria-hidden="true" tabindex="-1"></a><span class="co">// MCP client configuration</span></span>
+<span id="cb8-2"><a href="#cb8-2" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb8-3"><a href="#cb8-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">mcpServers</span><span class="op">:</span> {</span>
+<span id="cb8-4"><a href="#cb8-4" aria-hidden="true" tabindex="-1"></a>    <span class="co">// Safety dongle — evaluates all actions</span></span>
+<span id="cb8-5"><a href="#cb8-5" aria-hidden="true" tabindex="-1"></a>    <span class="st">&quot;safety&quot;</span><span class="op">:</span> {</span>
+<span id="cb8-6"><a href="#cb8-6" aria-hidden="true" tabindex="-1"></a>      <span class="dt">command</span><span class="op">:</span> <span class="st">&quot;mcpaql-safety-dongle&quot;</span><span class="op">,</span></span>
+<span id="cb8-7"><a href="#cb8-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">args</span><span class="op">:</span> [<span class="st">&quot;--policy&quot;</span><span class="op">,</span> <span class="st">&quot;./safety-policies.json&quot;</span>]</span>
+<span id="cb8-8"><a href="#cb8-8" aria-hidden="true" tabindex="-1"></a>    }<span class="op">,</span></span>
+<span id="cb8-9"><a href="#cb8-9" aria-hidden="true" tabindex="-1"></a>    <span class="co">// Domain servers — do the actual work</span></span>
+<span id="cb8-10"><a href="#cb8-10" aria-hidden="true" tabindex="-1"></a>    <span class="st">&quot;filesystem&quot;</span><span class="op">:</span> { <span class="dt">command</span><span class="op">:</span> <span class="st">&quot;mcp-filesystem&quot;</span><span class="op">,</span> <span class="dt">args</span><span class="op">:</span> [<span class="st">&quot;/workspace&quot;</span>] }<span class="op">,</span></span>
+<span id="cb8-11"><a href="#cb8-11" aria-hidden="true" tabindex="-1"></a>    <span class="st">&quot;database&quot;</span><span class="op">:</span> { <span class="dt">command</span><span class="op">:</span> <span class="st">&quot;mcp-postgres&quot;</span><span class="op">,</span> <span class="dt">args</span><span class="op">:</span> [<span class="st">&quot;--connection&quot;</span><span class="op">,</span> <span class="st">&quot;...&quot;</span>] }<span class="op">,</span></span>
+<span id="cb8-12"><a href="#cb8-12" aria-hidden="true" tabindex="-1"></a>    <span class="st">&quot;slack&quot;</span><span class="op">:</span> { <span class="dt">command</span><span class="op">:</span> <span class="st">&quot;mcp-slack&quot;</span><span class="op">,</span> <span class="dt">args</span><span class="op">:</span> [<span class="st">&quot;--token&quot;</span><span class="op">,</span> <span class="st">&quot;...&quot;</span>] }</span>
+<span id="cb8-13"><a href="#cb8-13" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb8-14"><a href="#cb8-14" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<p>The LLM's system prompt includes:</p>
+<pre><code>Before taking any action (tool call, file operation, shell command),
+you MUST report your intent to the safety server via
+record_execution_step with a detailed nextActionHint.
+Only proceed if the AutonomyDirective returns continue: true.</code></pre>
+<h3 id="72-safety-dongle--multiple-mcp-servers">7.2 Safety Dongle + Multiple MCP Servers</h3>
+<p>In a multi-server environment, the safety dongle monitors actions across all servers:</p>
+<pre><code>┌─────────────────────────────────────────────────┐
+│  MCP Client                                     │
+│                                                 │
+│  ┌─────────────┐                                │
+│  │ Safety      │ ◄── report ALL intended actions│
+│  │ Dongle      │ ──► go/no-go directives        │
+│  │ (MCP-AQL)   │                                │
+│  └─────────────┘                                │
+│                                                 │
+│  ┌──────┐ ┌──────┐ ┌──────┐ ┌──────┐           │
+│  │FS    │ │DB    │ │Slack │ │Git   │           │
+│  │Server│ │Server│ │Server│ │Server│           │
+│  └──────┘ └──────┘ └──────┘ └──────┘           │
+└─────────────────────────────────────────────────┘</code></pre>
+<p>The domain servers do not need to know about the safety dongle. They are standard MCP servers — the safety evaluation happens between the LLM and the dongle, before the LLM calls any tool on any server.</p>
+<h3 id="73-full-mcp-aql-adapter-with-embedded-safety">7.3 Full MCP-AQL Adapter with Embedded Safety</h3>
+<p>A full MCP-AQL adapter can embed the execution safety loop directly — no separate dongle needed:</p>
+<div class="sourceCode" id="cb11"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb11-1"><a href="#cb11-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Single adapter with full CRUDE surface + embedded safety</span></span>
+<span id="cb11-2"><a href="#cb11-2" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb11-3"><a href="#cb11-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">mcpServers</span><span class="op">:</span> {</span>
+<span id="cb11-4"><a href="#cb11-4" aria-hidden="true" tabindex="-1"></a>    <span class="st">&quot;dollhouse&quot;</span><span class="op">:</span> {</span>
+<span id="cb11-5"><a href="#cb11-5" aria-hidden="true" tabindex="-1"></a>      <span class="dt">command</span><span class="op">:</span> <span class="st">&quot;dollhouse-mcp&quot;</span><span class="op">,</span></span>
+<span id="cb11-6"><a href="#cb11-6" aria-hidden="true" tabindex="-1"></a>      <span class="dt">args</span><span class="op">:</span> [<span class="st">&quot;--safety-mode&quot;</span><span class="op">,</span> <span class="st">&quot;enforcing&quot;</span>]</span>
+<span id="cb11-7"><a href="#cb11-7" aria-hidden="true" tabindex="-1"></a>    }</span>
+<span id="cb11-8"><a href="#cb11-8" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb11-9"><a href="#cb11-9" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<p>In this model, the adapter handles both domain operations (elements, personas, agents) and safety enforcement (Gatekeeper, Autonomy Evaluator, Danger Zone) in the same server. The execution safety loop is just one feature among many.</p>
+<hr />
+<h2 id="8-opting-out">8. Opting Out</h2>
+<h3 id="81-when-to-disable">8.1 When to Disable</h3>
+<p>The execution safety loop may be unnecessary or undesirable in several scenarios:</p>
+<ul>
+<li><strong>Trusted environments:</strong> Development machines, sandboxed containers, or testing environments where safety enforcement adds friction without benefit</li>
+<li><strong>Performance-sensitive workloads:</strong> The loop adds latency to every action (one round-trip per tool call)</li>
+<li><strong>Simple automation:</strong> Scripts or pipelines where the action sequence is predetermined and does not need LLM-level safety evaluation</li>
+<li><strong>User preference:</strong> Some users may prefer to operate without safety constraints</li>
+</ul>
+<h3 id="82-how-to-disable">8.2 How to Disable</h3>
+<p>Adapters indicate their safety loop status via introspection:</p>
+<div class="sourceCode" id="cb12"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb12-1"><a href="#cb12-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Safety loop actively enforcing</span></span>
+<span id="cb12-2"><a href="#cb12-2" aria-hidden="true" tabindex="-1"></a>{ <span class="dt">capabilities</span><span class="op">:</span> { <span class="dt">execution_safety_loop</span><span class="op">:</span> <span class="st">&quot;enforcing&quot;</span> } }</span>
+<span id="cb12-3"><a href="#cb12-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb12-4"><a href="#cb12-4" aria-hidden="true" tabindex="-1"></a><span class="co">// Safety loop in monitoring mode (advisory only)</span></span>
+<span id="cb12-5"><a href="#cb12-5" aria-hidden="true" tabindex="-1"></a>{ <span class="dt">capabilities</span><span class="op">:</span> { <span class="dt">execution_safety_loop</span><span class="op">:</span> <span class="st">&quot;monitoring&quot;</span> } }</span>
+<span id="cb12-6"><a href="#cb12-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb12-7"><a href="#cb12-7" aria-hidden="true" tabindex="-1"></a><span class="co">// Safety loop logging only (no evaluation)</span></span>
+<span id="cb12-8"><a href="#cb12-8" aria-hidden="true" tabindex="-1"></a>{ <span class="dt">capabilities</span><span class="op">:</span> { <span class="dt">execution_safety_loop</span><span class="op">:</span> <span class="st">&quot;logging&quot;</span> } }</span>
+<span id="cb12-9"><a href="#cb12-9" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb12-10"><a href="#cb12-10" aria-hidden="true" tabindex="-1"></a><span class="co">// Safety loop supported but currently disabled</span></span>
+<span id="cb12-11"><a href="#cb12-11" aria-hidden="true" tabindex="-1"></a>{ <span class="dt">capabilities</span><span class="op">:</span> { <span class="dt">execution_safety_loop</span><span class="op">:</span> <span class="st">&quot;disabled&quot;</span> } }</span>
+<span id="cb12-12"><a href="#cb12-12" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb12-13"><a href="#cb12-13" aria-hidden="true" tabindex="-1"></a><span class="co">// Adapter does not support the safety loop (field omitted entirely)</span></span></code></pre></div>
+<p>Disabling is typically done via adapter configuration:</p>
+<div class="sourceCode" id="cb13"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb13-1"><a href="#cb13-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Adapter startup configuration</span></span>
+<span id="cb13-2"><a href="#cb13-2" aria-hidden="true" tabindex="-1"></a>{ <span class="dt">safetyLoop</span><span class="op">:</span> { <span class="dt">mode</span><span class="op">:</span> <span class="st">&quot;disabled&quot;</span> } }</span>
+<span id="cb13-3"><a href="#cb13-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb13-4"><a href="#cb13-4" aria-hidden="true" tabindex="-1"></a><span class="co">// Or via environment variable</span></span>
+<span id="cb13-5"><a href="#cb13-5" aria-hidden="true" tabindex="-1"></a><span class="co">// MCPAQL_SAFETY_LOOP=disabled</span></span></code></pre></div>
+<h3 id="83-partial-modes">8.3 Partial Modes</h3>
+<p>Between full enforcement and fully disabled, adapters MAY support intermediate modes:</p>
+<p><strong>Monitoring mode</strong> (<code>"monitoring"</code>):</p>
+<ul>
+<li>Actions are evaluated by the full safety pipeline</li>
+<li><code>AutonomyDirective</code> is returned with accurate <code>factors</code> and risk assessment</li>
+<li><code>continue</code> is always <code>true</code> — the directive is advisory, never blocking</li>
+<li><code>stopped</code> MUST NOT be set to <code>true</code></li>
+<li>Useful for: observing what the safety loop would block without actually blocking, gradual rollout, policy tuning</li>
+</ul>
+<p><strong>Logging mode</strong> (<code>"logging"</code>):</p>
+<ul>
+<li>Actions are recorded for audit purposes</li>
+<li>No evaluation occurs — the safety pipeline is not invoked</li>
+<li>Useful for: compliance auditing, post-incident analysis, establishing baseline action patterns</li>
+</ul>
+<hr />
+<h2 id="9-implementation-requirements">9. Implementation Requirements</h2>
+<p>This section provides a compliance checklist for adapters implementing the execution safety loop. Every requirement listed here corresponds to a normative MUST, SHOULD, or MAY in <a href="../versions/v1.0.0-draft.html">Sections 8.6–8.8 of the core specification</a>. See <a href="#94-normative-cross-reference">Section 9.4</a> for the complete mapping between normative sections and compliance bullets.</p>
+<h3 id="91-must-requirements">9.1 MUST Requirements</h3>
+<p>Adapters that support the execution safety loop:</p>
+<p><strong>Core Operations &amp; Introspection:</strong></p>
+<ul>
+<li>MUST document whether they support the execution safety loop via introspection (<a href="../versions/v1.0.0-draft.html#861-opt-in-activation">Section 8.6.1</a>)</li>
+<li>MUST clearly indicate via introspection whether safety enforcement is active or disabled (<a href="../versions/v1.0.0-draft.html#867-disabling-the-safety-loop">Section 8.6.7</a>)</li>
+<li>MUST implement <code>execute_agent</code>, <code>record_execution_step</code>, <code>complete_execution</code>, and <code>abort_execution</code> (<a href="../versions/v1.0.0-draft.html#862-enforcement-boundary-property">Section 8.6.2</a>)</li>
+<li>MUST place <code>record_execution_step</code> on the CREATE endpoint (<a href="../versions/v1.0.0-draft.html#854-reserved-operations">Section 8.5.4</a>)</li>
+<li>MUST place <code>execute_agent</code>, <code>complete_execution</code>, and <code>abort_execution</code> on the EXECUTE endpoint (<a href="../versions/v1.0.0-draft.html#854-reserved-operations">Section 8.5.4</a>)</li>
+</ul>
+<p><strong>AutonomyDirective Contract:</strong></p>
+<ul>
+<li>MUST return an <code>AutonomyDirective</code> on every <code>record_execution_step</code> call (<a href="../versions/v1.0.0-draft.html#871-the-autonomydirective-contract">Section 8.7.1</a>)</li>
+<li>MUST include <code>continue</code> and <code>factors</code> in every <code>AutonomyDirective</code> (<a href="../versions/v1.0.0-draft.html#871-the-autonomydirective-contract">Section 8.7.1</a>)</li>
+<li>MUST NOT allow agents to proceed after a stop directive (<code>stopped: true</code>) (<a href="../versions/v1.0.0-draft.html#864-continuous-enforcement">Section 8.6.4</a>)</li>
+<li>MUST NOT set <code>stopped: true</code> when operating in monitoring mode (<a href="../versions/v1.0.0-draft.html#864-continuous-enforcement">Section 8.6.4</a>)</li>
+<li>MUST return <code>stopped: true</code> in the <code>AutonomyDirective</code> for <code>danger_zone</code> tier and <code>deny</code> pattern triggers (<a href="../versions/v1.0.0-draft.html#881-trigger-conditions">Section 8.8.1</a>)</li>
+</ul>
+<p><strong>Step Limit:</strong></p>
+<ul>
+<li>MUST implement the Step Limit stage with a configurable <code>maxAutonomousSteps</code> threshold (<a href="../versions/v1.0.0-draft.html#875-minimum-viable-implementation">Section 8.7.5</a>)</li>
+</ul>
+<p><strong>Notifications &amp; Self-Approval:</strong></p>
+<ul>
+<li>MUST include a <code>danger_zone</code> notification broadcast to all executing agents when returning <code>stopped: true</code> (<a href="../versions/v1.0.0-draft.html#881-trigger-conditions">Section 8.8.1</a>)</li>
+<li>MUST include a <code>danger_zone</code> notification with <code>metadata.verificationId</code> for <code>danger_zone</code> tier and <code>deny</code> pattern challenges (<a href="../versions/v1.0.0-draft.html#882-challenge-protocol">Section 8.8.2</a>)</li>
+<li>MUST include an <code>autonomy_pause</code> notification with <code>metadata.verificationId</code> when issuing a <code>verify</code> tier challenge (<a href="../versions/v1.0.0-draft.html#882-challenge-protocol">Section 8.8.2</a>)</li>
+<li>MUST prevent self-approval — the entity confirming an operation MUST NOT be the same agent that triggered the block (<a href="../versions/v1.0.0-draft.html#873-agent-notification-system">Section 8.7.3</a>)</li>
+</ul>
+<p><strong>Out-of-Band Verification (when the adapter implements <code>verify</code> or <code>danger_zone</code> tier evaluation, or <code>deny</code> pattern matching):</strong></p>
+<ul>
+<li>MUST require out-of-band human verification when a <code>verify</code> or <code>danger_zone</code> safety tier is assigned, or when a <code>deny</code> pattern matches (<a href="../versions/v1.0.0-draft.html#88-out-of-band-verification">Section 8.8</a>)</li>
+<li>MUST generate verification codes with at least 128 bits of entropy from a cryptographically secure random source; codes MUST be cryptographically unpredictable (<a href="../versions/v1.0.0-draft.html#882-challenge-protocol">Section 8.8.2</a>)</li>
+<li>MUST display verification codes through a channel inaccessible to the AI agent — codes MUST NOT appear in any MCP response, tool result, <code>_meta</code> field, log, error message, or diagnostic output accessible to the AI, and MUST NOT be derivable from any information available to the AI (e.g., timestamps, sequential IDs) (<a href="../versions/v1.0.0-draft.html#882-challenge-protocol">Sections 8.8.2</a>, <a href="../versions/v1.0.0-draft.html#884-channel-separation-requirements">8.8.4</a>)</li>
+<li>MUST treat expired verification challenges as failed (<a href="../versions/v1.0.0-draft.html#882-challenge-protocol">Section 8.8.2</a>)</li>
+</ul>
+<p><strong>Blocking Semantics (when the adapter implements <code>stopped: true</code> behavior):</strong></p>
+<ul>
+<li>MUST reject all subsequent execution operations for a hard-blocked agent until unblocked via <code>verify_challenge</code> or admin override (<a href="../versions/v1.0.0-draft.html#883-blocking-semantics">Section 8.8.3</a>)</li>
+<li>MUST NOT allow an agent to bypass a hard block by starting a new execution — blocks apply at the agent level, not the execution level (<a href="../versions/v1.0.0-draft.html#883-blocking-semantics">Section 8.8.3</a>)</li>
+<li>MUST persist hard-blocked agent state across server restarts (file-based or database storage) (<a href="../versions/v1.0.0-draft.html#883-blocking-semantics">Section 8.8.3</a>)</li>
+</ul>
+<h3 id="92-should-requirements">9.2 SHOULD Requirements</h3>
+<p>Adapters that support the execution safety loop:</p>
+<p><strong>Evaluation Pipeline:</strong></p>
+<ul>
+<li>SHOULD evaluate actions through the multi-stage pipeline defined in <a href="../versions/v1.0.0-draft.html#872-evaluation-pipeline">Section 8.7.2</a></li>
+<li>SHOULD return <code>continue: false</code> with an appropriate reason when the step limit is exceeded (<a href="../versions/v1.0.0-draft.html#872-evaluation-pipeline">Section 8.7.2, Stage 1</a>)</li>
+<li>SHOULD document the default step limit via introspection (<a href="../versions/v1.0.0-draft.html#872-evaluation-pipeline">Section 8.7.2, Stage 1</a>)</li>
+<li>SHOULD evaluate the <code>outcome</code> field in <code>record_execution_step</code> calls and return <code>continue: false</code> on reported failures (<a href="../versions/v1.0.0-draft.html#872-evaluation-pipeline">Section 8.7.2, Stage 2</a>)</li>
+<li>SHOULD support configurable policy patterns (<code>deny</code>, <code>requiresApproval</code>, <code>autoApprove</code>) (<a href="../versions/v1.0.0-draft.html#872-evaluation-pipeline">Section 8.7.2, Stage 3</a>)</li>
+<li>SHOULD NOT allow agents to proceed after <code>continue: false</code> without human intervention (<a href="../versions/v1.0.0-draft.html#864-continuous-enforcement">Section 8.6.4</a>)</li>
+</ul>
+<p><strong>Operations:</strong></p>
+<ul>
+<li>SHOULD implement <code>confirm_operation</code> for Gatekeeper blocks and <code>confirm</code> tier pauses (<a href="../versions/v1.0.0-draft.html#873-agent-notification-system">Section 8.7.3</a>)</li>
+<li>SHOULD implement <code>verify_challenge</code> for <code>verify</code> tier pauses and Danger Zone unblocking (<a href="../versions/v1.0.0-draft.html#88-out-of-band-verification">Section 8.8</a>)</li>
+</ul>
+<p><strong>Configuration &amp; Introspection:</strong></p>
+<ul>
+<li>SHOULD expose the <code>execution_safety_loop</code> capability value in the introspection response (<a href="../versions/v1.0.0-draft.html#861-opt-in-activation">Section 8.6.1</a>)</li>
+<li>SHOULD make evaluation pipeline elements configurable per agent or per adapter (<a href="../versions/v1.0.0-draft.html#874-configurable-elements">Section 8.7.4</a>)</li>
+<li>SHOULD document default configuration and supported options via introspection (<a href="../versions/v1.0.0-draft.html#874-configurable-elements">Section 8.7.4</a>)</li>
+</ul>
+<p><strong>Notifications:</strong></p>
+<ul>
+<li>SHOULD include <code>notifications</code> in <code>AutonomyDirective</code> responses for non-hard-block events (note: <code>verify</code> tier <code>autonomy_pause</code> with <code>metadata.verificationId</code> and <code>danger_zone</code> notifications are MUST — see Section 9.1) (<a href="../versions/v1.0.0-draft.html#873-agent-notification-system">Section 8.7.3</a>)</li>
+</ul>
+<p><strong>Verify Tier Behavior:</strong></p>
+<ul>
+<li>SHOULD return <code>continue: false</code> with the pending challenge ID for subsequent <code>record_execution_step</code> calls while a <code>verify</code> challenge is pending (<a href="../versions/v1.0.0-draft.html#883-blocking-semantics">Section 8.8.3</a>)</li>
+<li>SHOULD re-evaluate actions normally when a <code>verify</code> challenge expires, generating a new challenge if the same action is reported again (<a href="../versions/v1.0.0-draft.html#883-blocking-semantics">Section 8.8.3</a>)</li>
+<li>SHOULD expire verification challenges after a configurable timeout (default: 5 minutes) (<a href="../versions/v1.0.0-draft.html#882-challenge-protocol">Section 8.8.2</a>)</li>
+</ul>
+<p><strong>Rate Limiting:</strong></p>
+<ul>
+<li>SHOULD rate-limit failed verification attempts (no more than 10 per 60-second window per agent) (<a href="../versions/v1.0.0-draft.html#885-rate-limiting">Section 8.8.5</a>)</li>
+<li>SHOULD reject subsequent verification attempts after the rate limit is exceeded (<a href="../versions/v1.0.0-draft.html#885-rate-limiting">Section 8.8.5</a>)</li>
+<li>SHOULD persist rate limit state across server restarts (<a href="../versions/v1.0.0-draft.html#885-rate-limiting">Section 8.8.5</a>)</li>
+<li>SHOULD trigger security audit events on failed verification attempts (<a href="../versions/v1.0.0-draft.html#885-rate-limiting">Section 8.8.5</a>)</li>
+</ul>
+<p><strong>Monitoring &amp; Audit:</strong></p>
+<ul>
+<li>SHOULD support the <code>"monitoring"</code> partial mode for gradual rollout (<a href="../versions/v1.0.0-draft.html#867-disabling-the-safety-loop">Section 8.6.7</a>)</li>
+</ul>
+<h3 id="93-may-requirements">9.3 MAY Requirements</h3>
+<p>Adapters that support the execution safety loop:</p>
+<ul>
+<li>MAY support the <code>"logging"</code> partial mode (<a href="../versions/v1.0.0-draft.html#867-disabling-the-safety-loop">Section 8.6.7</a>)</li>
+<li>MAY implement Safety Tier evaluation (Stage 4) using pattern matching, LLM-provided risk assessments, or adapter-specific heuristics for risk scoring (<a href="../versions/v1.0.0-draft.html#872-evaluation-pipeline">Section 8.7.2, Stage 4</a>)</li>
+<li>MAY support configurable risk tolerance thresholds (<code>conservative</code>, <code>moderate</code>, <code>aggressive</code>) (<a href="../versions/v1.0.0-draft.html#872-evaluation-pipeline">Section 8.7.2, Stage 5</a>)</li>
+<li>MAY apply progressive lockout (e.g., doubling the window duration) after repeated rate-limit violations (<a href="../versions/v1.0.0-draft.html#885-rate-limiting">Section 8.8.5</a>)</li>
+<li>MAY use OS dialogs, hardware tokens, SMS/email, or other display channels for presenting verification codes to operators (<a href="../versions/v1.0.0-draft.html#886-implementation-flexibility">Section 8.8.6</a>)</li>
+</ul>
+<h3 id="94-normative-cross-reference">9.4 Normative Cross-Reference</h3>
+<p>The following table maps each normative section to its corresponding Section 9 requirements, providing an audit trail for compliance verification.</p>
+<table>
+<thead>
+<tr>
+<th>Normative Section</th>
+<th>Key Requirements</th>
+<th>Section 9 Coverage</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>8.6.1 Opt-In Activation</td>
+<td>MUST document support; SHOULD expose capability value</td>
+<td>9.1 (introspection); 9.2 (capability value)</td>
+</tr>
+<tr>
+<td>8.6.2 Enforcement Boundary</td>
+<td>MUST report and evaluate all actions</td>
+<td>9.1 (operations, AutonomyDirective on every call)</td>
+</tr>
+<tr>
+<td>8.6.3 Action Reporting</td>
+<td>MUST/SHOULD/MAY parameter requirements</td>
+<td>9.1 (operations — parameter validation is part of implementing <code>record_execution_step</code>)</td>
+</tr>
+<tr>
+<td>8.6.4 Continuous Enforcement</td>
+<td>MUST NOT proceed after stop; SHOULD NOT after pause; MUST NOT <code>stopped</code> in monitoring</td>
+<td>9.1 (stop directive, monitoring mode); 9.2 (SHOULD NOT after pause)</td>
+</tr>
+<tr>
+<td>8.6.5 Non-Bypass Property</td>
+<td>Agent MUST NOT act outside loop</td>
+<td>Agent-side protocol obligation (not adapter-specific)</td>
+</tr>
+<tr>
+<td>8.6.6 Scope of Monitoring</td>
+<td>Monitors all actions (informative)</td>
+<td>Described in Sections 3.2, 2.2 of this document</td>
+</tr>
+<tr>
+<td>8.6.7 Disabling</td>
+<td>MAY disable; MUST indicate via introspection</td>
+<td>9.1 (introspection); 9.2 (monitoring); 9.3 (logging)</td>
+</tr>
+<tr>
+<td>8.7.1 AutonomyDirective</td>
+<td>MUST include <code>continue</code> + <code>factors</code></td>
+<td>9.1 (AutonomyDirective fields)</td>
+</tr>
+<tr>
+<td>8.7.2 Pipeline Stages 1–5</td>
+<td>MUST step limit; SHOULD stages 2–3; MAY stages 4–5</td>
+<td>9.1 (step limit MUST); 9.2 (stage 1 documentation SHOULDs, stages 2–3 SHOULDs); 9.3 (stages 4–5)</td>
+</tr>
+<tr>
+<td>8.7.3 Notifications</td>
+<td>MUST notification contents; MUST prevent self-approval</td>
+<td>9.1 (notifications, self-approval); 9.2 (non-hard-block notifications)</td>
+</tr>
+<tr>
+<td>8.7.4 Configurable Elements</td>
+<td>SHOULD configurable; SHOULD document</td>
+<td>9.2 (configuration, introspection)</td>
+</tr>
+<tr>
+<td>8.7.5 Minimum Viable</td>
+<td>MUST Step Limit; SHOULD Previous Outcome + Pattern Matching; MAY Safety Tier + Risk Tolerance</td>
+<td>9.1 (step limit); 9.2 (outcome, patterns); 9.3 (tier, tolerance)</td>
+</tr>
+<tr>
+<td>8.8 Introduction</td>
+<td>MUST require OOB for <code>verify</code>/<code>danger_zone</code></td>
+<td>9.1 (OOB verification)</td>
+</tr>
+<tr>
+<td>8.8.1 Trigger Conditions</td>
+<td>MUST <code>stopped: true</code> + <code>danger_zone</code> notification</td>
+<td>9.1 (<code>stopped: true</code>, notification broadcast)</td>
+</tr>
+<tr>
+<td>8.8.2 Challenge Protocol</td>
+<td>MUST entropy, display, notification, expiration</td>
+<td>9.1 (code generation, display, challenge ID, expiration); 9.2 (timeout)</td>
+</tr>
+<tr>
+<td>8.8.3 Blocking Semantics</td>
+<td>MUST reject, persist, no bypass; SHOULD verify behavior</td>
+<td>9.1 (blocking); 9.2 (verify tier)</td>
+</tr>
+<tr>
+<td>8.8.4 Channel Separation</td>
+<td>MUST NOT expose code (5 specific prohibitions)</td>
+<td>9.1 (display/channel separation — consolidated)</td>
+</tr>
+<tr>
+<td>8.8.5 Rate Limiting</td>
+<td>SHOULD rate-limit, persist, audit; MAY progressive lockout</td>
+<td>9.2 (rate limiting); 9.3 (lockout)</td>
+</tr>
+<tr>
+<td>8.8.6 Implementation Flexibility</td>
+<td>MAY any display channel</td>
+<td>9.3 (display channels)</td>
+</tr>
+</tbody>
+</table>
+<hr />
+<h2 id="related-specifications">Related Specifications</h2>
+<ul>
+<li><a href="../versions/v1.0.0-draft.html#86-execution-safety-loop">Core Specification — Section 8.6: Execution Safety Loop</a> — Normative requirements</li>
+<li><a href="../versions/v1.0.0-draft.html#87-autonomy-evaluation">Core Specification — Section 8.7: Autonomy Evaluation</a> — AutonomyDirective contract and evaluation pipeline</li>
+<li><a href="../versions/v1.0.0-draft.html#88-out-of-band-verification">Core Specification — Section 8.8: Out-of-Band Verification</a> — Out-of-band verification protocol (<code>verify</code> tier and Danger Zone)</li>
+<li><a href="gatekeeper.html">Gatekeeper Specification</a> — Multi-layer access control architecture</li>
+<li><a href="../adapter/danger-levels.html">Danger Levels Specification</a> — Risk classification and trust-to-danger gating</li>
+<li><a href="confirmation-tokens.html">Confirmation Tokens Specification</a> — Token protocol for operation confirmation</li>
+</ul>
+
+          </div>
+        </section>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div class="container">
+      <p>&copy; 2026 DollhouseMCP Inc. d/b/a Dollhouse Research. MCP-AQL public draft documentation portal.</p>
+      <div class="footer-links">
+        <a href="../../docs/index.html">Docs Library</a>
+        <a href="../index.html">Repo-Synced Spec</a>
+        <a href="https://github.com/MCPAQL">MCPAQL Organization</a>
+        <a href="https://dollhouseresearch.com">Dollhouse Research</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../../js/search.js"></script>
+</body>
+</html>

--- a/public/spec/security/execution-safety-loop.html
+++ b/public/spec/security/execution-safety-loop.html
@@ -23,7 +23,7 @@
         </ul>
         <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
-          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <input id="site-search-input" data-search-input type="search" placeholder="Search MCP-AQL docs, spec pages, and adapter patterns...">
           <span class="search-count" data-search-count></span>
           <ul class="search-results" data-search-results hidden></ul>
         </form>
@@ -47,7 +47,7 @@
   <ul><li><a href="../adapter/danger-levels.html">Dangerous Operation Classification Specification</a></li><li><a href="../adapter/discovery-bundle.html">MCP Server Discovery Bundle</a></li><li><a href="../adapter/element-type.html">Adapter Element Type Specification</a></li><li><a href="../adapter/generator.html">Adapter Generator Specification</a></li><li><a href="../adapter/rate-limiting.html">Rate Limiting and Quota Management Specification</a></li><li><a href="../adapter/trust-levels.html">Trust Levels Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Security</h3>
-  <ul><li><a href="confirmation-tokens.html">Confirmation Token Specification</a></li><li><a class="current" href="execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
+  <ul><li><a href="confirmation-tokens.html">Confirmation Token Specification</a></li><li><a class="current" aria-current="page" href="execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Features</h3>
   <ul><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
@@ -930,6 +930,16 @@ Only proceed if the AutonomyDirective returns continue: true.</code></pre>
 
           </div>
         </section>
+        <nav class="page-nav" aria-label="Page navigation">
+  <a class="page-nav-link prev" href="confirmation-tokens.html">
+    <span class="page-nav-eyebrow">Previous spec page</span>
+    <strong class="page-nav-label">Confirmation Token Specification</strong>
+  </a>
+  <a class="page-nav-link next" href="gatekeeper.html">
+    <span class="page-nav-eyebrow">Next spec page</span>
+    <strong class="page-nav-label">Security Model: Gatekeeper Specification</strong>
+  </a>
+</nav>
       </article>
     </div>
   </main>

--- a/public/spec/security/execution-safety-loop.html
+++ b/public/spec/security/execution-safety-loop.html
@@ -73,6 +73,13 @@
       </aside>
 
       <article class="docs-main">
+        <nav class="breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../../index.html">Home</a></li>
+            <li><a href="../index.html">Full Spec</a></li>
+            <li><span class="current">Execution Safety Loop Specification</span></li>
+          </ol>
+        </nav>
         <section class="hero docs-hero">
           <div class="hero-inner">
             <span class="status-pill">REPO-SYNCED SPEC DOC</span>

--- a/public/spec/security/execution-safety-loop.html
+++ b/public/spec/security/execution-safety-loop.html
@@ -38,7 +38,7 @@
         <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
         <div class="docs-side-group">
   <h3>Core</h3>
-  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li></ul>
+  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li><li><a href="../repo/README.html">MCP-AQL Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Versions</h3>
   <ul><li><a href="../versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
@@ -56,7 +56,7 @@
   <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
-  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li></ul>
+  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li><li><a href="../repo/CHANGELOG.html">Changelog</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Architecture</h3>
   <ul><li><a href="../architecture/README.html">Architecture Documentation</a></li></ul>

--- a/public/spec/security/gatekeeper.html
+++ b/public/spec/security/gatekeeper.html
@@ -73,6 +73,13 @@
       </aside>
 
       <article class="docs-main">
+        <nav class="breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../../index.html">Home</a></li>
+            <li><a href="../index.html">Full Spec</a></li>
+            <li><span class="current">Security Model: Gatekeeper Specification</span></li>
+          </ol>
+        </nav>
         <section class="hero docs-hero">
           <div class="hero-inner">
             <span class="status-pill">REPO-SYNCED SPEC DOC</span>

--- a/public/spec/security/gatekeeper.html
+++ b/public/spec/security/gatekeeper.html
@@ -1,0 +1,390 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="This document specifies an optional security model for MCP-AQL adapters, providing multi-layer access control, confirmation requirements, and audit capabilities.">
+  <title>MCP-AQL Spec | Security Model: Gatekeeper Specification</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../../css/style.css">
+</head>
+<body>
+  <header>
+    <div class="container">
+      <nav>
+        <a class="logo" href="../../index.html"><span class="logo-mark"></span>MCP-AQL</a>
+        <ul class="nav-links">
+          <li><a href="../../index.html">Home</a></li>
+          <li><a href="../../docs/index.html">Docs</a></li>
+          <li><a href="../../launch-checklist.html">Launch Checklist</a></li>
+          <li><a href="../../apis/mcp-server.html">Adapter Patterns</a></li>
+        </ul>
+        <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
+          <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
+          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <span class="search-count" data-search-count></span>
+          <ul class="search-results" data-search-results hidden></ul>
+        </form>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <div class="container docs-shell">
+      <aside class="docs-side">
+        <h2>Repo-Synced Spec</h2>
+        <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
+        <div class="docs-side-group">
+  <h3>Core</h3>
+  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Versions</h3>
+  <ul><li><a href="../versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Adapter</h3>
+  <ul><li><a href="../adapter/danger-levels.html">Dangerous Operation Classification Specification</a></li><li><a href="../adapter/discovery-bundle.html">MCP Server Discovery Bundle</a></li><li><a href="../adapter/element-type.html">Adapter Element Type Specification</a></li><li><a href="../adapter/generator.html">Adapter Generator Specification</a></li><li><a href="../adapter/rate-limiting.html">Rate Limiting and Quota Management Specification</a></li><li><a href="../adapter/trust-levels.html">Trust Levels Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Security</h3>
+  <ul><li><a href="confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a class="current" href="gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Features</h3>
+  <ul><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Guides</h3>
+  <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Process</h3>
+  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Architecture</h3>
+  <ul><li><a href="../architecture/README.html">Architecture Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Research</h3>
+  <ul><li><a href="../research/mcp-vs-mcpaql-vs-a2a.html">Protocol Landscape: MCP vs MCP-AQL vs A2A</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Reference</h3>
+  <ul><li><a href="../reference/README.html">Reference Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>ADRs</h3>
+  <ul><li><a href="../adr/ADR-001-crude-pattern.html">ADR-001: CRUDE Pattern (Extending CRUD with Execute)</a></li><li><a href="../adr/ADR-002-graphql-style-input.html">ADR-002: GraphQL-Style Input Objects for Updates</a></li><li><a href="../adr/ADR-003-snake-case-parameters.html">ADR-003: snake_case Parameter Convention</a></li><li><a href="../adr/ADR-004-schema-driven-operations.html">ADR-004: Schema-Driven Operation Definitions</a></li><li><a href="../adr/ADR-005-introspection-system.html">ADR-005: GraphQL-Style Introspection System</a></li><li><a href="../adr/ADR-006-discriminated-responses.html">ADR-006: Discriminated Response Format</a></li><li><a href="../adr/index.html">Architecture Decision Records</a></li><li><a href="../adr/README.html">Architecture Decision Records</a></li></ul>
+</div>
+      </aside>
+
+      <article class="docs-main">
+        <section class="hero docs-hero">
+          <div class="hero-inner">
+            <span class="status-pill">REPO-SYNCED SPEC DOC</span>
+            <h1>Security Model: Gatekeeper Specification</h1>
+            <p class="lede">This document specifies an optional security model for MCP-AQL adapters, providing multi-layer access control, confirmation requirements, and audit capabilities.</p>
+            <div class="spec-meta"><span class="state-chip live">Support document</span><span class="state-chip pending">Draft</span><span class="state-chip">1.0.0-draft</span><span class="state-chip">2026-01-14</span></div>
+            <p class="spec-source">Source: <a href="https://github.com/MCPAQL/spec/blob/main/docs/security/gatekeeper.md">spec/docs/security/gatekeeper.md</a></p>
+            <div class="hero-actions">
+              <a class="btn btn-primary" href="https://github.com/MCPAQL/spec/blob/main/docs/security/gatekeeper.md">Open Source Markdown</a>
+              <a class="btn btn-secondary" href="../index.html">Browse Full Spec Reference</a>
+            </div>
+          </div>
+        </section>
+
+        <section>
+          <div class="card spec-prose">
+            <p><strong>Version:</strong> 1.0.0-draft <strong>Status:</strong> Draft <strong>Last Updated:</strong> 2026-01-14</p>
+<h2 id="abstract">Abstract</h2>
+<p>This document specifies an optional security model for MCP-AQL adapters, providing multi-layer access control, confirmation requirements, and audit capabilities.</p>
+<hr />
+<h2 id="table-of-contents">Table of Contents</h2>
+<ol type="1">
+<li><a href="#1-introduction">Introduction</a></li>
+<li><a href="#2-security-layers">Security Layers</a></li>
+<li><a href="#3-permission-model">Permission Model</a></li>
+<li><a href="#4-confirmation-system">Confirmation System</a></li>
+<li><a href="#5-audit-logging">Audit Logging</a></li>
+<li><a href="#6-implementation-requirements">Implementation Requirements</a></li>
+</ol>
+<hr />
+<h2 id="1-introduction">1. Introduction</h2>
+<h3 id="11-purpose">1.1 Purpose</h3>
+<p>A security layer (called "Gatekeeper" in this specification) provides centralized security enforcement for MCP-AQL operations, ensuring:</p>
+<ul>
+<li><strong>Authorization</strong> - Operations are permitted for the caller</li>
+<li><strong>Safety classification</strong> - Operations categorized by risk</li>
+<li><strong>Confirmation gates</strong> - Destructive operations require acknowledgment</li>
+<li><strong>Audit trail</strong> - Security-relevant events are logged</li>
+</ul>
+<h3 id="12-status">1.2 Status</h3>
+<p>The Gatekeeper is an <strong>optional</strong> feature. Adapters MAY implement it based on their security requirements.</p>
+<h3 id="13-core-principle">1.3 Core Principle</h3>
+<blockquote>
+<p>"LLM instructions are suggestions. Adapter policies are enforcement."</p>
+</blockquote>
+<p>Security is enforced server-side by the adapter, not by client behavior. Clients cannot bypass security through endpoint selection or parameter manipulation.</p>
+<h3 id="14-relationship-to-the-execution-safety-loop">1.4 Relationship to the Execution Safety Loop</h3>
+<p>The Gatekeeper can operate as a standalone security layer for individual operations, or as part of the <a href="execution-safety-loop.html">Execution Safety Loop</a> — a continuous monitoring pattern where the LLM reports every intended action for safety evaluation. When deployed as a safety dongle (see <a href="execution-safety-loop.html#2-the-safety-dongle-deployment-model">Section 2 of the Execution Safety Loop specification</a>), the Gatekeeper evaluates <code>nextActionHint</code> strings against configured policies, providing go/no-go directives for actions across all connected MCP servers.</p>
+<hr />
+<h2 id="2-security-layers">2. Security Layers</h2>
+<h3 id="21-defense-in-depth">2.1 Defense in Depth</h3>
+<pre><code>┌────────────────────────────────────────────────────────┐
+│                    REQUEST                             │
+└────────────────────────┬───────────────────────────────┘
+                         ▼
+┌────────────────────────────────────────────────────────┐
+│  Layer 1: Route Validation                             │
+│  - Operation exists?                                   │
+│  - Correct endpoint (CRUDE mode)?                      │
+└────────────────────────┬───────────────────────────────┘
+                         ▼
+┌────────────────────────────────────────────────────────┐
+│  Layer 2: Safety Tier                                  │
+│  - Endpoint permissions (readOnly, destructive)        │
+└────────────────────────┬───────────────────────────────┘
+                         ▼
+┌────────────────────────────────────────────────────────┐
+│  Layer 3: Operation Policy                             │
+│  - Per-operation access rules                          │
+│  - Parameter-based restrictions                        │
+└────────────────────────┬───────────────────────────────┘
+                         ▼
+┌────────────────────────────────────────────────────────┐
+│  Layer 4: Confirmation                                 │
+│  - Destructive operation acknowledgment                │
+└────────────────────────┬───────────────────────────────┘
+                         ▼
+┌────────────────────────────────────────────────────────┐
+│                    EXECUTE                             │
+└────────────────────────────────────────────────────────┘</code></pre>
+<h3 id="22-layer-1-route-validation">2.2 Layer 1: Route Validation</h3>
+<p>Validates operation routing before any processing.</p>
+<p><strong>Checks:</strong></p>
+<ul>
+<li>Operation name is recognized</li>
+<li>Operation is sent to correct endpoint (CRUDE mode)</li>
+<li>Required parameters are present</li>
+</ul>
+<p><strong>Failure Response:</strong></p>
+<div class="sourceCode" id="cb2"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb2-2"><a href="#cb2-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">success</span><span class="op">:</span> <span class="kw">false</span><span class="op">,</span></span>
+<span id="cb2-3"><a href="#cb2-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">error</span><span class="op">:</span> <span class="st">&quot;Operation &#39;create_user&#39; must be called via mcp_aql_create, not mcp_aql_read&quot;</span></span>
+<span id="cb2-4"><a href="#cb2-4" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<h3 id="23-layer-2-safety-tier">2.3 Layer 2: Safety Tier</h3>
+<p>Applies endpoint-level safety classification.</p>
+<p><strong>Endpoint Safety Matrix:</strong></p>
+<table>
+<thead>
+<tr>
+<th>Endpoint</th>
+<th>readOnly</th>
+<th>destructive</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>CREATE</td>
+<td>false</td>
+<td>false</td>
+<td>Additive only</td>
+</tr>
+<tr>
+<td>READ</td>
+<td>true</td>
+<td>false</td>
+<td>No state changes</td>
+</tr>
+<tr>
+<td>UPDATE</td>
+<td>false</td>
+<td>true</td>
+<td>May overwrite data</td>
+</tr>
+<tr>
+<td>DELETE</td>
+<td>false</td>
+<td>true</td>
+<td>Removes data permanently</td>
+</tr>
+<tr>
+<td>EXECUTE</td>
+<td>false</td>
+<td>true</td>
+<td>May have external effects</td>
+</tr>
+</tbody>
+</table>
+<h3 id="24-layer-3-operation-policy">2.4 Layer 3: Operation Policy</h3>
+<p>Per-operation access control rules.</p>
+<p><strong>Policy Structure:</strong></p>
+<div class="sourceCode" id="cb3"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb3-1"><a href="#cb3-1" aria-hidden="true" tabindex="-1"></a><span class="kw">interface</span> OperationPolicy {</span>
+<span id="cb3-2"><a href="#cb3-2" aria-hidden="true" tabindex="-1"></a>  operation<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb3-3"><a href="#cb3-3" aria-hidden="true" tabindex="-1"></a>  permission<span class="op">:</span> Permission<span class="op">;</span></span>
+<span id="cb3-4"><a href="#cb3-4" aria-hidden="true" tabindex="-1"></a>  conditions<span class="op">?:</span> Condition[]<span class="op">;</span></span>
+<span id="cb3-5"><a href="#cb3-5" aria-hidden="true" tabindex="-1"></a>}</span>
+<span id="cb3-6"><a href="#cb3-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb3-7"><a href="#cb3-7" aria-hidden="true" tabindex="-1"></a><span class="kw">type</span> Permission <span class="op">=</span> <span class="st">&#39;allow&#39;</span> <span class="op">|</span> <span class="st">&#39;deny&#39;</span> <span class="op">|</span> <span class="st">&#39;confirm&#39;</span><span class="op">;</span></span></code></pre></div>
+<h3 id="25-layer-4-confirmation">2.5 Layer 4: Confirmation</h3>
+<p>Final gate for destructive operations.</p>
+<hr />
+<h2 id="3-permission-model">3. Permission Model</h2>
+<h3 id="31-permission-types">3.1 Permission Types</h3>
+<table>
+<thead>
+<tr>
+<th>Permission</th>
+<th>Behavior</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>allow</code></td>
+<td>Operation proceeds without additional checks</td>
+</tr>
+<tr>
+<td><code>deny</code></td>
+<td>Operation rejected with error</td>
+</tr>
+<tr>
+<td><code>confirm</code></td>
+<td>Operation requires explicit confirmation</td>
+</tr>
+</tbody>
+</table>
+<h3 id="32-permission-resolution">3.2 Permission Resolution</h3>
+<p>When multiple policies apply, most restrictive wins:</p>
+<pre><code>deny &gt; confirm &gt; allow</code></pre>
+<hr />
+<h2 id="4-confirmation-system">4. Confirmation System</h2>
+<p>This section provides an overview of the confirmation system. For detailed token generation, validation, and lifecycle requirements, see the <a href="confirmation-tokens.html">Confirmation Token Specification</a>.</p>
+<h3 id="41-confirmation-request">4.1 Confirmation Request</h3>
+<p>When confirmation is required:</p>
+<div class="sourceCode" id="cb5"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb5-1"><a href="#cb5-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb5-2"><a href="#cb5-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">success</span><span class="op">:</span> <span class="kw">false</span><span class="op">,</span></span>
+<span id="cb5-3"><a href="#cb5-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">error</span><span class="op">:</span> <span class="st">&quot;This operation requires confirmation&quot;</span><span class="op">,</span></span>
+<span id="cb5-4"><a href="#cb5-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">errorCode</span><span class="op">:</span> <span class="st">&quot;CONFIRMATION_REQUIRED&quot;</span><span class="op">,</span></span>
+<span id="cb5-5"><a href="#cb5-5" aria-hidden="true" tabindex="-1"></a>  <span class="dt">confirmation</span><span class="op">:</span> {</span>
+<span id="cb5-6"><a href="#cb5-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;delete_user&quot;</span><span class="op">,</span></span>
+<span id="cb5-7"><a href="#cb5-7" aria-hidden="true" tabindex="-1"></a>    <span class="dt">message</span><span class="op">:</span> <span class="st">&quot;Are you sure you want to delete user &#39;alice&#39;? This cannot be undone.&quot;</span><span class="op">,</span></span>
+<span id="cb5-8"><a href="#cb5-8" aria-hidden="true" tabindex="-1"></a>    <span class="dt">token</span><span class="op">:</span> <span class="st">&quot;conf_abc123&quot;</span></span>
+<span id="cb5-9"><a href="#cb5-9" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb5-10"><a href="#cb5-10" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<h3 id="42-confirming-operations">4.2 Confirming Operations</h3>
+<p>Client confirms by including the token:</p>
+<div class="sourceCode" id="cb6"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb6-1"><a href="#cb6-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb6-2"><a href="#cb6-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;delete_user&quot;</span><span class="op">,</span></span>
+<span id="cb6-3"><a href="#cb6-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> {</span>
+<span id="cb6-4"><a href="#cb6-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">user_id</span><span class="op">:</span> <span class="st">&quot;alice&quot;</span><span class="op">,</span></span>
+<span id="cb6-5"><a href="#cb6-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">_confirmation</span><span class="op">:</span> <span class="st">&quot;conf_abc123&quot;</span></span>
+<span id="cb6-6"><a href="#cb6-6" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb6-7"><a href="#cb6-7" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<h3 id="43-session-scoped-confirmations">4.3 Session-Scoped Confirmations</h3>
+<p>Confirmations MAY be cached per session (see <a href="../versions/v1.0.0-draft.html#23-session-lifecycle">Section 2.3</a> of the core specification):</p>
+<ul>
+<li>Confirmations expire after configurable timeout</li>
+<li>Confirmations are scoped to specific operation</li>
+<li>Session end (MCP connection termination) clears all confirmations</li>
+</ul>
+<hr />
+<h2 id="5-audit-logging">5. Audit Logging</h2>
+<h3 id="51-security-events">5.1 Security Events</h3>
+<p>Adapters implementing security SHOULD log:</p>
+<table>
+<thead>
+<tr>
+<th>Event</th>
+<th>Logged Data</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>OPERATION_DENIED</code></td>
+<td>Operation, reason</td>
+</tr>
+<tr>
+<td><code>CONFIRMATION_REQUIRED</code></td>
+<td>Operation, token</td>
+</tr>
+<tr>
+<td><code>CONFIRMATION_GRANTED</code></td>
+<td>Operation, token</td>
+</tr>
+</tbody>
+</table>
+<h3 id="52-audit-log-format">5.2 Audit Log Format</h3>
+<div class="sourceCode" id="cb7"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb7-1"><a href="#cb7-1" aria-hidden="true" tabindex="-1"></a><span class="kw">interface</span> AuditEntry {</span>
+<span id="cb7-2"><a href="#cb7-2" aria-hidden="true" tabindex="-1"></a>  timestamp<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb7-3"><a href="#cb7-3" aria-hidden="true" tabindex="-1"></a>  event<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb7-4"><a href="#cb7-4" aria-hidden="true" tabindex="-1"></a>  operation<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb7-5"><a href="#cb7-5" aria-hidden="true" tabindex="-1"></a>  endpoint<span class="op">:</span> CRUDEndpoint<span class="op">;</span></span>
+<span id="cb7-6"><a href="#cb7-6" aria-hidden="true" tabindex="-1"></a>  result<span class="op">:</span> <span class="st">&#39;allowed&#39;</span> <span class="op">|</span> <span class="st">&#39;denied&#39;</span> <span class="op">|</span> <span class="st">&#39;confirmed&#39;</span><span class="op">;</span></span>
+<span id="cb7-7"><a href="#cb7-7" aria-hidden="true" tabindex="-1"></a>  reason<span class="op">?:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb7-8"><a href="#cb7-8" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<hr />
+<h2 id="6-implementation-requirements">6. Implementation Requirements</h2>
+<h3 id="61-must-requirements">6.1 MUST Requirements</h3>
+<p>Adapters implementing security MUST:</p>
+<ol type="1">
+<li>Enforce endpoint routing validation</li>
+<li>Apply safety tier classifications</li>
+<li>Return proper error codes for security failures</li>
+<li>Protect against parameter manipulation</li>
+</ol>
+<h3 id="62-should-requirements">6.2 SHOULD Requirements</h3>
+<p>Adapters implementing security SHOULD:</p>
+<ol type="1">
+<li>Implement confirmation system for destructive operations</li>
+<li>Maintain audit logs</li>
+<li>Support policy configuration</li>
+</ol>
+<h3 id="63-may-requirements">6.3 MAY Requirements</h3>
+<p>Adapters implementing security MAY:</p>
+<ol type="1">
+<li>Support authenticated callers with different permissions</li>
+<li>Provide policy administration API</li>
+<li>Implement rate limiting</li>
+</ol>
+<hr />
+<h2 id="7-autonomy-evaluator-integration">7. Autonomy Evaluator Integration</h2>
+<p>When the Gatekeeper operates within the <a href="execution-safety-loop.html">Execution Safety Loop</a>, it integrates with the Autonomy Evaluator (Section 8.7 of the core spec) to provide continuous per-action safety evaluation:</p>
+<h3 id="71-gatekeeper-blocks-as-notifications">7.1 Gatekeeper Blocks as Notifications</h3>
+<p>When the Gatekeeper denies an operation during execution, the block is recorded and surfaced as a <code>permission_pending</code> notification in the next <code>AutonomyDirective</code> response. This allows bridge agents and remote interfaces to relay approval requests to human operators through their communication channel.</p>
+<h3 id="72-policy-evaluation-for-nextactionhint">7.2 Policy Evaluation for <code>nextActionHint</code></h3>
+<p>In safety dongle deployments, the Gatekeeper's Layer 3 (Operation Policy) evaluates <code>nextActionHint</code> strings against configured patterns rather than operation names. The same deny/confirm/allow semantics apply, but the input is the LLM's stated intent rather than a formal operation identifier.</p>
+<h3 id="73-confirmation-flow-during-execution">7.3 Confirmation Flow During Execution</h3>
+<p>When the Gatekeeper returns <code>CONFIRMATION_REQUIRED</code> during an execution safety loop:</p>
+<ol type="1">
+<li>The <code>AutonomyDirective</code> returns <code>continue: false</code> with a <code>permission_pending</code> notification</li>
+<li>The agent (or its bridge) presents the confirmation request to a human operator</li>
+<li>The human approves via <code>confirm_operation</code></li>
+<li>The next <code>record_execution_step</code> call clears the notification and evaluation continues</li>
+</ol>
+<hr />
+<h2 id="references">References</h2>
+<ul>
+<li><a href="../versions/v1.0.0-draft.html">MCP-AQL Specification</a></li>
+<li><a href="../crude-pattern.html">CRUDE Pattern Specification</a></li>
+<li><a href="confirmation-tokens.html">Confirmation Token Specification</a></li>
+<li><a href="execution-safety-loop.html">Execution Safety Loop Specification</a></li>
+<li><a href="../adapter/danger-levels.html">Danger Levels Specification</a></li>
+<li><a href="../operations.html">Operations Guide</a></li>
+</ul>
+
+          </div>
+        </section>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div class="container">
+      <p>&copy; 2026 DollhouseMCP Inc. d/b/a Dollhouse Research. MCP-AQL public draft documentation portal.</p>
+      <div class="footer-links">
+        <a href="../../docs/index.html">Docs Library</a>
+        <a href="../index.html">Repo-Synced Spec</a>
+        <a href="https://github.com/MCPAQL">MCPAQL Organization</a>
+        <a href="https://dollhouseresearch.com">Dollhouse Research</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../../js/search.js"></script>
+</body>
+</html>

--- a/public/spec/security/gatekeeper.html
+++ b/public/spec/security/gatekeeper.html
@@ -23,7 +23,7 @@
         </ul>
         <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
-          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <input id="site-search-input" data-search-input type="search" placeholder="Search MCP-AQL docs, spec pages, and adapter patterns...">
           <span class="search-count" data-search-count></span>
           <ul class="search-results" data-search-results hidden></ul>
         </form>
@@ -47,7 +47,7 @@
   <ul><li><a href="../adapter/danger-levels.html">Dangerous Operation Classification Specification</a></li><li><a href="../adapter/discovery-bundle.html">MCP Server Discovery Bundle</a></li><li><a href="../adapter/element-type.html">Adapter Element Type Specification</a></li><li><a href="../adapter/generator.html">Adapter Generator Specification</a></li><li><a href="../adapter/rate-limiting.html">Rate Limiting and Quota Management Specification</a></li><li><a href="../adapter/trust-levels.html">Trust Levels Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Security</h3>
-  <ul><li><a href="confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a class="current" href="gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
+  <ul><li><a href="confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a class="current" aria-current="page" href="gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Features</h3>
   <ul><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
@@ -376,6 +376,16 @@
 
           </div>
         </section>
+        <nav class="page-nav" aria-label="Page navigation">
+  <a class="page-nav-link prev" href="execution-safety-loop.html">
+    <span class="page-nav-eyebrow">Previous spec page</span>
+    <strong class="page-nav-label">Execution Safety Loop Specification</strong>
+  </a>
+  <a class="page-nav-link next" href="../features/field-selection.html">
+    <span class="page-nav-eyebrow">Next spec page</span>
+    <strong class="page-nav-label">Field Selection Specification</strong>
+  </a>
+</nav>
       </article>
     </div>
   </main>

--- a/public/spec/security/gatekeeper.html
+++ b/public/spec/security/gatekeeper.html
@@ -38,7 +38,7 @@
         <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
         <div class="docs-side-group">
   <h3>Core</h3>
-  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li></ul>
+  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li><li><a href="../repo/README.html">MCP-AQL Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Versions</h3>
   <ul><li><a href="../versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
@@ -56,7 +56,7 @@
   <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
-  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li></ul>
+  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li><li><a href="../repo/CHANGELOG.html">Changelog</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Architecture</h3>
   <ul><li><a href="../architecture/README.html">Architecture Documentation</a></li></ul>

--- a/public/spec/versions/v1.0.0-draft.html
+++ b/public/spec/versions/v1.0.0-draft.html
@@ -38,7 +38,7 @@
         <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
         <div class="docs-side-group">
   <h3>Core</h3>
-  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li></ul>
+  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li><li><a href="../repo/README.html">MCP-AQL Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Versions</h3>
   <ul><li><a class="current" href="v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
@@ -56,7 +56,7 @@
   <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
-  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li></ul>
+  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li><li><a href="../repo/CHANGELOG.html">Changelog</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Architecture</h3>
   <ul><li><a href="../architecture/README.html">Architecture Documentation</a></li></ul>

--- a/public/spec/versions/v1.0.0-draft.html
+++ b/public/spec/versions/v1.0.0-draft.html
@@ -1,0 +1,1826 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="MCP-AQL (Model Context Protocol - Advanced Agent API Adapter Query Language) is a protocol specification that consolidates multiple MCP tools into semantic CRUDE endpoints, providing significant token reduction while ena">
+  <title>MCP-AQL Spec | MCP-AQL Specification</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../../css/style.css">
+</head>
+<body>
+  <header>
+    <div class="container">
+      <nav>
+        <a class="logo" href="../../index.html"><span class="logo-mark"></span>MCP-AQL</a>
+        <ul class="nav-links">
+          <li><a href="../../index.html">Home</a></li>
+          <li><a href="../../docs/index.html">Docs</a></li>
+          <li><a href="../../launch-checklist.html">Launch Checklist</a></li>
+          <li><a href="../../apis/mcp-server.html">Adapter Patterns</a></li>
+        </ul>
+        <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
+          <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
+          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <span class="search-count" data-search-count></span>
+          <ul class="search-results" data-search-results hidden></ul>
+        </form>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <div class="container docs-shell">
+      <aside class="docs-side">
+        <h2>Repo-Synced Spec</h2>
+        <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
+        <div class="docs-side-group">
+  <h3>Core</h3>
+  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Versions</h3>
+  <ul><li><a class="current" href="v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Adapter</h3>
+  <ul><li><a href="../adapter/danger-levels.html">Dangerous Operation Classification Specification</a></li><li><a href="../adapter/discovery-bundle.html">MCP Server Discovery Bundle</a></li><li><a href="../adapter/element-type.html">Adapter Element Type Specification</a></li><li><a href="../adapter/generator.html">Adapter Generator Specification</a></li><li><a href="../adapter/rate-limiting.html">Rate Limiting and Quota Management Specification</a></li><li><a href="../adapter/trust-levels.html">Trust Levels Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Security</h3>
+  <ul><li><a href="../security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="../security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="../security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Features</h3>
+  <ul><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Guides</h3>
+  <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Process</h3>
+  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Architecture</h3>
+  <ul><li><a href="../architecture/README.html">Architecture Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Research</h3>
+  <ul><li><a href="../research/mcp-vs-mcpaql-vs-a2a.html">Protocol Landscape: MCP vs MCP-AQL vs A2A</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Reference</h3>
+  <ul><li><a href="../reference/README.html">Reference Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>ADRs</h3>
+  <ul><li><a href="../adr/ADR-001-crude-pattern.html">ADR-001: CRUDE Pattern (Extending CRUD with Execute)</a></li><li><a href="../adr/ADR-002-graphql-style-input.html">ADR-002: GraphQL-Style Input Objects for Updates</a></li><li><a href="../adr/ADR-003-snake-case-parameters.html">ADR-003: snake_case Parameter Convention</a></li><li><a href="../adr/ADR-004-schema-driven-operations.html">ADR-004: Schema-Driven Operation Definitions</a></li><li><a href="../adr/ADR-005-introspection-system.html">ADR-005: GraphQL-Style Introspection System</a></li><li><a href="../adr/ADR-006-discriminated-responses.html">ADR-006: Discriminated Response Format</a></li><li><a href="../adr/index.html">Architecture Decision Records</a></li><li><a href="../adr/README.html">Architecture Decision Records</a></li></ul>
+</div>
+      </aside>
+
+      <article class="docs-main">
+        <section class="hero docs-hero">
+          <div class="hero-inner">
+            <span class="status-pill">REPO-SYNCED SPEC DOC</span>
+            <h1>MCP-AQL Specification</h1>
+            <p class="lede">MCP-AQL (Model Context Protocol - Advanced Agent API Adapter Query Language) is a protocol specification that consolidates multiple MCP tools into semantic CRUDE endpoints, providing significant token reduction while ena</p>
+            <div class="spec-meta"><span class="state-chip live">Normative source</span><span class="state-chip pending">Draft</span><span class="state-chip">1.0.0-draft</span><span class="state-chip">2026-03-06</span></div>
+            <p class="spec-source">Source: <a href="https://github.com/MCPAQL/spec/blob/main/docs/versions/v1.0.0-draft.md">spec/docs/versions/v1.0.0-draft.md</a></p>
+            <div class="hero-actions">
+              <a class="btn btn-primary" href="https://github.com/MCPAQL/spec/blob/main/docs/versions/v1.0.0-draft.md">Open Source Markdown</a>
+              <a class="btn btn-secondary" href="../index.html">Browse Full Spec Reference</a>
+            </div>
+          </div>
+        </section>
+
+        <section>
+          <div class="card spec-prose">
+            <p><strong>Version:</strong> 1.0.0-draft <strong>Status:</strong> Draft <strong>Last Updated:</strong> 2026-03-06</p>
+<h2 id="abstract">Abstract</h2>
+<p>MCP-AQL (Model Context Protocol - Advanced Agent API Adapter Query Language) is a protocol specification that consolidates multiple MCP tools into semantic CRUDE endpoints, providing significant token reduction while enabling runtime operation discovery through introspection.</p>
+<h2 id="status-of-this-document">Status of This Document</h2>
+<p>This is the <strong>normative</strong> MCP-AQL specification. All conformance requirements (MUST, SHOULD, MAY) in this document are authoritative.</p>
+<p>Other documents in the <code>docs/</code> directory are <strong>informative</strong> and provide additional context, examples, and implementation guidance. In case of conflict between this specification and informative documents, this specification takes precedence.</p>
+<p>This is a draft specification subject to change. Feedback is welcome via the <a href="https://github.com/MCPAQL/spec">specification repository</a>.</p>
+<p>This draft is intended for preliminary public launch and ecosystem experimentation. It is not yet a final certification baseline.</p>
+<hr />
+<h2 id="table-of-contents">Table of Contents</h2>
+<ol type="1">
+<li><a href="#1-introduction">Introduction</a></li>
+<li><a href="#2-terminology">Terminology</a></li>
+<li><a href="#3-protocol-overview">Protocol Overview</a></li>
+<li><a href="#4-request-format">Request Format</a></li>
+<li><a href="#5-response-format">Response Format</a></li>
+<li><a href="#6-crude-endpoints">CRUDE Endpoints</a></li>
+<li><a href="#7-introspection">Introspection</a></li>
+<li><a href="#8-operation-classification">Operation Classification</a></li>
+<li><a href="#9-type-system">Type System</a></li>
+<li><a href="#10-conformance">Conformance</a></li>
+</ol>
+<hr />
+<h2 id="1-introduction">1. Introduction</h2>
+<h3 id="11-purpose">1.1 Purpose</h3>
+<p>MCP-AQL addresses the token efficiency challenge in LLM-MCP interactions. Traditional MCP implementations expose discrete tools, each requiring schema definition in the model's context. With many tools, this can consume significant tokens before any work begins.</p>
+<p>MCP-AQL consolidates operations into five semantic endpoints, reducing token overhead by approximately 85-96% while maintaining full functionality.</p>
+<h3 id="12-goals">1.2 Goals</h3>
+<ol type="1">
+<li><strong>Token Efficiency</strong> - Minimize context consumed by tool definitions</li>
+<li><strong>Semantic Clarity</strong> - Group operations by their effect on system state</li>
+<li><strong>Runtime Discovery</strong> - Enable operation discovery via introspection</li>
+<li><strong>Flexibility</strong> - Support multiple endpoint modes for different use cases</li>
+<li><strong>Genericity</strong> - Work with any domain, any backend, any operation set</li>
+</ol>
+<h3 id="13-scope">1.3 Scope</h3>
+<p>This specification defines:</p>
+<ul>
+<li>The CRUDE endpoint pattern</li>
+<li>Request and response formats</li>
+<li>The introspection system for operation discovery</li>
+<li>Operation classification guidelines</li>
+<li>Conformance requirements</li>
+</ul>
+<p>This specification does NOT define:</p>
+<ul>
+<li>Specific operations (adapters define their own)</li>
+<li>Domain-specific concepts (adapters define their own)</li>
+<li>Implementation architecture details</li>
+<li>Transport-layer concerns (handled by MCP)</li>
+</ul>
+<h3 id="14-relationship-to-adapters">1.4 Relationship to Adapters</h3>
+<p>MCP-AQL is a <strong>protocol layer</strong>, not an application. Adapters implement MCP-AQL to expose their domain-specific operations through the unified CRUDE interface. Each adapter:</p>
+<ul>
+<li>Defines its own operations</li>
+<li>Defines its own parameters</li>
+<li>Classifies operations into CRUDE endpoints</li>
+<li>Exposes operations via introspection</li>
+</ul>
+<hr />
+<h2 id="2-terminology">2. Terminology</h2>
+<h3 id="21-key-terms">2.1 Key Terms</h3>
+<p><strong>CRUDE Pattern</strong> : The five-endpoint pattern: Create, Read, Update, Delete, Execute</p>
+<p><strong>Operation</strong> : A specific action that an adapter provides (e.g., <code>create_user</code>, <code>run_report</code>, <code>search_documents</code>)</p>
+<p><strong>Endpoint</strong> : One of the five CRUDE categories to which operations are routed</p>
+<p><strong>Adapter</strong> : An MCP server that implements MCP-AQL to expose domain-specific operations</p>
+<p><strong>Introspection</strong> : The ability to query available operations and types at runtime</p>
+<p><strong>Resource</strong> : Any entity managed by an adapter (documents, users, configurations, workflows, etc.)</p>
+<h3 id="22-requirement-levels">2.2 Requirement Levels</h3>
+<p>The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in <a href="https://www.ietf.org/rfc/rfc2119.txt">RFC 2119</a>.</p>
+<h3 id="23-session-lifecycle">2.3 Session Lifecycle</h3>
+<h4 id="231-definition">2.3.1 Definition</h4>
+<p>An MCP-AQL <strong>session</strong> is the lifetime of a single MCP connection, beginning when the MCP <code>initialize</code> handshake completes successfully and ending when the connection terminates.</p>
+<h4 id="232-session-boundaries">2.3.2 Session Boundaries</h4>
+<table>
+<thead>
+<tr>
+<th>Event</th>
+<th>Session Impact</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>MCP <code>initialize</code> completes</td>
+<td>Session begins</td>
+</tr>
+<tr>
+<td>MCP <code>shutdown</code> received</td>
+<td>Session ends gracefully</td>
+</tr>
+<tr>
+<td>Transport disconnect</td>
+<td>Session ends abruptly</td>
+</tr>
+<tr>
+<td>Transport reconnect</td>
+<td>New session begins</td>
+</tr>
+</tbody>
+</table>
+<p>A session is strictly 1:1 with an MCP connection. If a transport disconnects and reconnects, the new connection is a new session — even if the same client reconnects immediately.</p>
+<h4 id="233-session-scoped-state">2.3.3 Session-Scoped State</h4>
+<p>The following are session-scoped and MUST NOT survive session termination:</p>
+<ul>
+<li>Confirmation tokens (default behavior per <a href="../security/confirmation-tokens.html#54-session-scoped-tokens">Section 5.4</a> of the Confirmation Token Specification; adapters MAY explicitly persist tokens across sessions)</li>
+<li>Cached introspection results</li>
+<li>In-progress EXECUTE operation context (pending state machine transitions)</li>
+<li>Warning deduplication state</li>
+</ul>
+<p>Adapters MUST invalidate all session-scoped state when a session ends, whether gracefully or abruptly. In-progress EXECUTE operations SHOULD transition to <code>failed</code> or <code>cancelled</code> as defined by the execution lifecycle (<a href="#84-execution-lifecycle">Section 8.4</a>).</p>
+<h4 id="234-cross-session-persistence">2.3.4 Cross-Session Persistence</h4>
+<p>The following MAY persist across sessions:</p>
+<ul>
+<li>Adapter configuration and operation schemas</li>
+<li>Stored resources and data managed by the adapter</li>
+<li>Audit logs and telemetry</li>
+<li>Completed execution results (terminal states)</li>
+</ul>
+<h4 id="235-session-identification">2.3.5 Session Identification</h4>
+<p>Adapters MAY track sessions using:</p>
+<ul>
+<li>MCP connection identifier (if provided by the transport)</li>
+<li>Internally generated session ID</li>
+<li>Client-provided metadata (via <code>_meta</code>) as a labeling hint</li>
+</ul>
+<p>Client-provided <code>_meta</code> values MUST be treated as labels for logging purposes only. Adapters MUST NOT use client-provided values as authoritative session identity for security decisions (e.g., token validation, access control).</p>
+<p>Session identifiers SHOULD be included in audit logs and error responses for debugging.</p>
+<blockquote>
+<p><strong>Implementation Note:</strong> MCP does not define a standard session identifier field. Adapters that need session tracking SHOULD generate their own identifier when the <code>initialize</code> handshake completes and include it in the <code>_protocol</code> metadata returned by introspection.</p>
+</blockquote>
+<hr />
+<h2 id="3-protocol-overview">3. Protocol Overview</h2>
+<h3 id="31-architecture">3.1 Architecture</h3>
+<pre><code>┌─────────────────────────────────────────────────────────────┐
+│                        MCP Client                           │
+│                     (LLM / Agent)                           │
+└─────────────────────────┬───────────────────────────────────┘
+                          │
+                          ▼
+┌─────────────────────────────────────────────────────────────┐
+│                     MCP-AQL Layer                           │
+│  ┌──────────────────────────────────────────────────────┐   │
+│  │              CRUDE Endpoints                         │   │
+│  │   CREATE │ READ │ UPDATE │ DELETE │ EXECUTE          │   │
+│  └──────────────────────────────────────────────────────┘   │
+│                          │                                  │
+│  ┌──────────────────────────────────────────────────────┐   │
+│  │              Operation Router                        │   │
+│  │   Routes operations to correct handlers              │   │
+│  └──────────────────────────────────────────────────────┘   │
+│                          │                                  │
+│  ┌──────────────────────────────────────────────────────┐   │
+│  │              Introspection System                    │   │
+│  │   Provides runtime operation discovery               │   │
+│  └──────────────────────────────────────────────────────┘   │
+└─────────────────────────────────────────────────────────────┘
+                          │
+                          ▼
+┌─────────────────────────────────────────────────────────────┐
+│                    Domain Backend                           │
+│         (Database, API, Service, File System, etc.)         │
+└─────────────────────────────────────────────────────────────┘</code></pre>
+<h3 id="32-request-flow">3.2 Request Flow</h3>
+<ol type="1">
+<li>Client sends request to MCP-AQL endpoint</li>
+<li>Router extracts <code>operation</code> field</li>
+<li>Router validates operation belongs to receiving endpoint</li>
+<li>Parameters are extracted and validated</li>
+<li>Handler executes operation</li>
+<li>Response returned to client</li>
+</ol>
+<h3 id="33-endpoint-modes">3.3 Endpoint Modes</h3>
+<p>MCP-AQL supports two operational modes:</p>
+<p><strong>CRUDE Mode (5 endpoints)</strong></p>
+<pre><code>mcp_aql_create   - CREATE operations
+mcp_aql_read     - READ operations
+mcp_aql_update   - UPDATE operations
+mcp_aql_delete   - DELETE operations
+mcp_aql_execute  - EXECUTE operations</code></pre>
+<p><strong>Single Mode (1 endpoint)</strong></p>
+<pre><code>mcp_aql - All operations through unified entry point</code></pre>
+<p>Implementations MUST support at least one mode. Implementations SHOULD support both.</p>
+<hr />
+<h2 id="4-request-format">4. Request Format</h2>
+<h3 id="41-standard-request-structure">4.1 Standard Request Structure</h3>
+<div class="sourceCode" id="cb4"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb4-1"><a href="#cb4-1" aria-hidden="true" tabindex="-1"></a><span class="kw">interface</span> OperationInput {</span>
+<span id="cb4-2"><a href="#cb4-2" aria-hidden="true" tabindex="-1"></a>  operation<span class="op">:</span> <span class="dt">string</span><span class="op">;</span>              <span class="co">// REQUIRED: Operation to perform</span></span>
+<span id="cb4-3"><a href="#cb4-3" aria-hidden="true" tabindex="-1"></a>  params<span class="op">?:</span> <span class="bu">Record</span><span class="op">&lt;</span><span class="dt">string</span><span class="op">,</span> <span class="dt">any</span><span class="op">&gt;;</span>   <span class="co">// OPTIONAL: Operation parameters</span></span>
+<span id="cb4-4"><a href="#cb4-4" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<h3 id="42-parameter-resolution">4.2 Parameter Resolution</h3>
+<p>Parameters MAY appear at multiple levels. Resolution follows this precedence:</p>
+<ol type="1">
+<li><code>params.&lt;parameter_name&gt;</code></li>
+<li>Top-level <code>&lt;parameter_name&gt;</code></li>
+</ol>
+<h3 id="43-parameter-naming">4.3 Parameter Naming</h3>
+<p>All public-facing parameters MUST use snake_case naming (matching the pattern <code>^[a-z][a-z0-9_]*$</code>) for consistency across adapters.</p>
+<blockquote>
+<p><strong>Terminology Note:</strong> The request field <code>params</code> (an object of key-value pairs) contains runtime parameter values. The introspection field <code>parameters</code> (an array of <code>ParameterInfo</code> entries) describes the accepted parameter definitions. The keys of <code>params</code> correspond to the <code>name</code> field of each entry in <code>parameters</code>.</p>
+</blockquote>
+<h3 id="44-request-examples">4.4 Request Examples</h3>
+<p><strong>Minimal Request:</strong></p>
+<div class="sourceCode" id="cb5"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb5-1"><a href="#cb5-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb5-2"><a href="#cb5-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;list_users&quot;</span></span>
+<span id="cb5-3"><a href="#cb5-3" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<p><strong>Request with Parameters:</strong></p>
+<div class="sourceCode" id="cb6"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb6-1"><a href="#cb6-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb6-2"><a href="#cb6-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;create_document&quot;</span><span class="fu">,</span></span>
+<span id="cb6-3"><a href="#cb6-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb6-4"><a href="#cb6-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;title&quot;</span><span class="fu">:</span> <span class="st">&quot;Quarterly Report&quot;</span><span class="fu">,</span></span>
+<span id="cb6-5"><a href="#cb6-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;content&quot;</span><span class="fu">:</span> <span class="st">&quot;...&quot;</span><span class="fu">,</span></span>
+<span id="cb6-6"><a href="#cb6-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;folder_id&quot;</span><span class="fu">:</span> <span class="st">&quot;folder_123&quot;</span></span>
+<span id="cb6-7"><a href="#cb6-7" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb6-8"><a href="#cb6-8" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<p><strong>Alternative Parameter Placement:</strong></p>
+<div class="sourceCode" id="cb7"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb7-1"><a href="#cb7-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb7-2"><a href="#cb7-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;get_user&quot;</span><span class="fu">,</span></span>
+<span id="cb7-3"><a href="#cb7-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;user_id&quot;</span><span class="fu">:</span> <span class="st">&quot;user_456&quot;</span></span>
+<span id="cb7-4"><a href="#cb7-4" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<h3 id="45-update-input-pattern">4.5 UPDATE Input Pattern</h3>
+<p>UPDATE operations MUST use a nested <code>input</code> object within <code>params</code> to contain all updateable fields. Identifier parameters (used to locate the resource) MUST remain at the <code>params</code> level.</p>
+<p><strong>Structure:</strong></p>
+<div class="sourceCode" id="cb8"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb8-1"><a href="#cb8-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb8-2"><a href="#cb8-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;update_resource&quot;</span><span class="fu">,</span></span>
+<span id="cb8-3"><a href="#cb8-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb8-4"><a href="#cb8-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;resource_id&quot;</span><span class="fu">:</span> <span class="st">&quot;res_123&quot;</span><span class="fu">,</span></span>
+<span id="cb8-5"><a href="#cb8-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;input&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb8-6"><a href="#cb8-6" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;title&quot;</span><span class="fu">:</span> <span class="st">&quot;New Title&quot;</span><span class="fu">,</span></span>
+<span id="cb8-7"><a href="#cb8-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;metadata&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb8-8"><a href="#cb8-8" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;priority&quot;</span><span class="fu">:</span> <span class="st">&quot;high&quot;</span></span>
+<span id="cb8-9"><a href="#cb8-9" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span></span>
+<span id="cb8-10"><a href="#cb8-10" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb8-11"><a href="#cb8-11" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb8-12"><a href="#cb8-12" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<h4 id="451-merge-semantics">4.5.1 Merge Semantics</h4>
+<p>When processing the <code>input</code> object, adapters MUST apply deep-merge semantics:</p>
+<ol type="1">
+<li><strong>Top-level fields</strong> in <code>input</code> replace existing values entirely</li>
+<li><strong>Nested objects</strong> merge recursively (keys present in <code>input</code> are updated; keys absent from <code>input</code> are preserved)</li>
+<li><strong>Arrays</strong> replace entirely (no element-level merging)</li>
+<li><strong>Explicit <code>null</code></strong> removes the field from the resource</li>
+</ol>
+<p><strong>Example — Deep Merge Behavior:</strong></p>
+<p>Given existing resource state:</p>
+<div class="sourceCode" id="cb9"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb9-1"><a href="#cb9-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb9-2"><a href="#cb9-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;title&quot;</span><span class="fu">:</span> <span class="st">&quot;Old Title&quot;</span><span class="fu">,</span></span>
+<span id="cb9-3"><a href="#cb9-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;metadata&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb9-4"><a href="#cb9-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;priority&quot;</span><span class="fu">:</span> <span class="st">&quot;low&quot;</span><span class="fu">,</span></span>
+<span id="cb9-5"><a href="#cb9-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;tags&quot;</span><span class="fu">:</span> <span class="ot">[</span><span class="st">&quot;draft&quot;</span><span class="ot">]</span><span class="fu">,</span></span>
+<span id="cb9-6"><a href="#cb9-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;author&quot;</span><span class="fu">:</span> <span class="st">&quot;alice&quot;</span></span>
+<span id="cb9-7"><a href="#cb9-7" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb9-8"><a href="#cb9-8" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<p>And update request:</p>
+<div class="sourceCode" id="cb10"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb10-1"><a href="#cb10-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb10-2"><a href="#cb10-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;update_resource&quot;</span><span class="fu">,</span></span>
+<span id="cb10-3"><a href="#cb10-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb10-4"><a href="#cb10-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;resource_id&quot;</span><span class="fu">:</span> <span class="st">&quot;res_123&quot;</span><span class="fu">,</span></span>
+<span id="cb10-5"><a href="#cb10-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;input&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb10-6"><a href="#cb10-6" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;title&quot;</span><span class="fu">:</span> <span class="st">&quot;New Title&quot;</span><span class="fu">,</span></span>
+<span id="cb10-7"><a href="#cb10-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;metadata&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb10-8"><a href="#cb10-8" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;priority&quot;</span><span class="fu">:</span> <span class="st">&quot;high&quot;</span><span class="fu">,</span></span>
+<span id="cb10-9"><a href="#cb10-9" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;tags&quot;</span><span class="fu">:</span> <span class="ot">[</span><span class="st">&quot;published&quot;</span><span class="ot">,</span> <span class="st">&quot;reviewed&quot;</span><span class="ot">]</span></span>
+<span id="cb10-10"><a href="#cb10-10" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span></span>
+<span id="cb10-11"><a href="#cb10-11" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb10-12"><a href="#cb10-12" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb10-13"><a href="#cb10-13" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<p>The resulting state MUST be:</p>
+<div class="sourceCode" id="cb11"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb11-1"><a href="#cb11-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb11-2"><a href="#cb11-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;title&quot;</span><span class="fu">:</span> <span class="st">&quot;New Title&quot;</span><span class="fu">,</span></span>
+<span id="cb11-3"><a href="#cb11-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;metadata&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb11-4"><a href="#cb11-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;priority&quot;</span><span class="fu">:</span> <span class="st">&quot;high&quot;</span><span class="fu">,</span></span>
+<span id="cb11-5"><a href="#cb11-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;tags&quot;</span><span class="fu">:</span> <span class="ot">[</span><span class="st">&quot;published&quot;</span><span class="ot">,</span> <span class="st">&quot;reviewed&quot;</span><span class="ot">]</span><span class="fu">,</span></span>
+<span id="cb11-6"><a href="#cb11-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;author&quot;</span><span class="fu">:</span> <span class="st">&quot;alice&quot;</span></span>
+<span id="cb11-7"><a href="#cb11-7" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb11-8"><a href="#cb11-8" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<ul>
+<li><code>title</code>: replaced (top-level field)</li>
+<li><code>metadata.priority</code>: replaced (present in input)</li>
+<li><code>metadata.tags</code>: replaced entirely (array)</li>
+<li><code>metadata.author</code>: preserved (absent from input)</li>
+</ul>
+<h4 id="452-field-removal">4.5.2 Field Removal</h4>
+<p>To remove a field, clients MUST set its value to <code>null</code>:</p>
+<div class="sourceCode" id="cb12"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb12-1"><a href="#cb12-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb12-2"><a href="#cb12-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;update_resource&quot;</span><span class="fu">,</span></span>
+<span id="cb12-3"><a href="#cb12-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb12-4"><a href="#cb12-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;resource_id&quot;</span><span class="fu">:</span> <span class="st">&quot;res_123&quot;</span><span class="fu">,</span></span>
+<span id="cb12-5"><a href="#cb12-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;input&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb12-6"><a href="#cb12-6" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;metadata&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb12-7"><a href="#cb12-7" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;deprecated_field&quot;</span><span class="fu">:</span> <span class="kw">null</span></span>
+<span id="cb12-8"><a href="#cb12-8" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span></span>
+<span id="cb12-9"><a href="#cb12-9" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb12-10"><a href="#cb12-10" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb12-11"><a href="#cb12-11" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<h4 id="453-validation">4.5.3 Validation</h4>
+<p>Adapters MUST validate the <code>input</code> object:</p>
+<ol type="1">
+<li>The <code>input</code> field MUST be present for UPDATE operations; adapters MUST reject requests missing <code>input</code> with a <code>VALIDATION_MISSING_PARAM</code> error</li>
+<li>The <code>input</code> field MUST be an object when present</li>
+<li>Fields within <code>input</code> MUST be validated against the resource schema</li>
+<li>Unknown fields within <code>input</code> SHOULD be rejected with a <code>VALIDATION_UNKNOWN_FIELD</code> error</li>
+<li>Identifier parameters MUST NOT appear inside <code>input</code></li>
+</ol>
+<p>See <a href="../adr/ADR-002-graphql-style-input.html">ADR-002: GraphQL-Style Input Objects</a> for design rationale.</p>
+<h3 id="46-unknown-parameter-handling">4.6 Unknown Parameter Handling</h3>
+<p>Adapters MUST reject requests containing parameters not defined in the operation schema.</p>
+<p>When an unknown parameter is detected, adapters MUST return a <code>VALIDATION_UNKNOWN_PARAM</code> error:</p>
+<div class="sourceCode" id="cb13"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb13-1"><a href="#cb13-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb13-2"><a href="#cb13-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb13-3"><a href="#cb13-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;error&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb13-4"><a href="#cb13-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;code&quot;</span><span class="fu">:</span> <span class="st">&quot;VALIDATION_UNKNOWN_PARAM&quot;</span><span class="fu">,</span></span>
+<span id="cb13-5"><a href="#cb13-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;Unknown parameter &#39;force_create&#39; for operation &#39;create_user&#39;&quot;</span><span class="fu">,</span></span>
+<span id="cb13-6"><a href="#cb13-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;details&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb13-7"><a href="#cb13-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;create_user&quot;</span><span class="fu">,</span></span>
+<span id="cb13-8"><a href="#cb13-8" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;unknown_params&quot;</span><span class="fu">:</span> <span class="ot">[</span><span class="st">&quot;force_create&quot;</span><span class="ot">,</span> <span class="st">&quot;admin_override&quot;</span><span class="ot">]</span><span class="fu">,</span></span>
+<span id="cb13-9"><a href="#cb13-9" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;valid_params&quot;</span><span class="fu">:</span> <span class="ot">[</span><span class="st">&quot;user_name&quot;</span><span class="ot">,</span> <span class="st">&quot;password&quot;</span><span class="ot">,</span> <span class="st">&quot;email&quot;</span><span class="ot">]</span></span>
+<span id="cb13-10"><a href="#cb13-10" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb13-11"><a href="#cb13-11" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb13-12"><a href="#cb13-12" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<p>This requirement:</p>
+<ul>
+<li>Prevents typos from silently failing</li>
+<li>Prevents LLM hallucination of non-existent parameters</li>
+<li>Provides actionable feedback for correction</li>
+</ul>
+<h4 id="461-scope">4.6.1 Scope</h4>
+<p>Unknown parameter validation applies to:</p>
+<ul>
+<li>Parameters within the <code>params</code> object</li>
+<li>Top-level parameters (when parameter resolution is enabled per Section 4.2)</li>
+</ul>
+<p>Unknown parameter validation does NOT apply to:</p>
+<ul>
+<li>Protocol-level fields (<code>operation</code>, <code>params</code>)</li>
+<li>Metadata fields prefixed with underscore (<code>_meta</code>, <code>_request_id</code>)</li>
+</ul>
+<h4 id="462-strict-mode-configuration">4.6.2 Strict Mode Configuration</h4>
+<p>Adapters MAY implement a <code>strict_mode</code> configuration option. When <code>strict_mode</code> is disabled (development environments only), adapters MAY log warnings for unknown parameters instead of rejecting the request.</p>
+<p>When <code>strict_mode</code> is enabled or not configured, the default behavior MUST be rejection.</p>
+<blockquote>
+<p><strong>Implementation Note:</strong> The <code>strict_mode</code> setting is considered implementation-internal configuration and is not exposed via introspection. Clients SHOULD always assume strict validation is enabled and not rely on lenient behavior.</p>
+</blockquote>
+<h3 id="47-data-types-and-encoding">4.7 Data Types and Encoding</h3>
+<p>This section defines data encoding requirements for interoperability across adapters.</p>
+<h4 id="471-character-encoding">4.7.1 Character Encoding</h4>
+<p>All text MUST be encoded as UTF-8. Adapters MUST reject requests containing invalid UTF-8 sequences with a <code>VALIDATION_INVALID_ENCODING</code> error.</p>
+<p><strong>Invalid UTF-8 sequences include:</strong></p>
+<ul>
+<li>Overlong encodings (e.g., using 2 bytes to encode a character that fits in 1)</li>
+<li>Invalid continuation bytes</li>
+<li>Truncated multi-byte sequences</li>
+<li>Surrogate code points (U+D800 to U+DFFF)</li>
+</ul>
+<p>Adapters SHOULD reject strings containing null bytes (U+0000) unless explicitly documented as supported for the parameter, as null bytes can cause issues in many languages and databases.</p>
+<h4 id="472-date-and-time">4.7.2 Date and Time</h4>
+<p>Dates and timestamps MUST use <a href="https://www.iso.org/iso-8601-date-and-time-format.html">ISO 8601</a> format:</p>
+<ul>
+<li><strong>Date only:</strong> <code>2026-02-04</code></li>
+<li><strong>Date-time (UTC):</strong> <code>2026-02-04T10:30:00Z</code></li>
+<li><strong>Date-time with offset:</strong> <code>2026-02-04T10:30:00+05:30</code></li>
+</ul>
+<p>Adapters SHOULD use UTC (Z suffix) for timestamps in responses. Adapters MUST document timezone handling for date-only values.</p>
+<h4 id="473-numbers">4.7.3 Numbers</h4>
+<p>Numeric values follow JSON number syntax (<a href="https://www.rfc-editor.org/rfc/rfc8259">RFC 8259</a>), which uses IEEE 754 double-precision floating-point:</p>
+<ul>
+<li><strong>Safe integer range:</strong> ±(2^53 - 1), i.e., ±9,007,199,254,740,991</li>
+<li><strong>Precision:</strong> Approximately 15-17 significant decimal digits</li>
+</ul>
+<p>For values requiring higher precision (e.g., financial amounts, large identifiers), adapters SHOULD use string representation:</p>
+<div class="sourceCode" id="cb14"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb14-1"><a href="#cb14-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb14-2"><a href="#cb14-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;amount&quot;</span><span class="fu">:</span> <span class="st">&quot;12345678901234567890&quot;</span><span class="fu">,</span></span>
+<span id="cb14-3"><a href="#cb14-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;amount_type&quot;</span><span class="fu">:</span> <span class="st">&quot;bigint&quot;</span></span>
+<span id="cb14-4"><a href="#cb14-4" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<blockquote>
+<p><strong>Note:</strong> The type indicator field name (e.g., <code>amount_type</code>) is adapter-specific. Adapters SHOULD document their conventions for distinguishing string-encoded numbers from regular strings.</p>
+</blockquote>
+<p>Adapters MUST document when string representation is required for numeric parameters.</p>
+<h4 id="474-binary-data">4.7.4 Binary Data</h4>
+<p>Binary data MUST be encoded as base64 (<a href="https://www.rfc-editor.org/rfc/rfc4648">RFC 4648</a>) with standard padding (<code>=</code> characters) and metadata:</p>
+<div class="sourceCode" id="cb15"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb15-1"><a href="#cb15-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb15-2"><a href="#cb15-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;file_content&quot;</span><span class="fu">:</span> <span class="st">&quot;SGVsbG8gV29ybGQ=&quot;</span><span class="fu">,</span></span>
+<span id="cb15-3"><a href="#cb15-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;file_encoding&quot;</span><span class="fu">:</span> <span class="st">&quot;base64&quot;</span><span class="fu">,</span></span>
+<span id="cb15-4"><a href="#cb15-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;file_mime_type&quot;</span><span class="fu">:</span> <span class="st">&quot;text/plain&quot;</span></span>
+<span id="cb15-5"><a href="#cb15-5" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<p>Adapters MAY support alternative binary handling (e.g., URL references, multipart) but MUST document this behavior via introspection.</p>
+<h4 id="475-payload-size-limits">4.7.5 Payload Size Limits</h4>
+<p>Adapters MUST enforce payload size limits to prevent resource exhaustion:</p>
+<table>
+<thead>
+<tr>
+<th>Limit</th>
+<th>Default</th>
+<th>Configurable Range</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Request payload</td>
+<td>1 MB</td>
+<td>64 KB – 10 MB</td>
+</tr>
+<tr>
+<td>Response payload</td>
+<td>10 MB</td>
+<td>1 MB – 100 MB</td>
+</tr>
+<tr>
+<td>Single string value</td>
+<td>1 MB</td>
+<td>64 KB – 10 MB</td>
+</tr>
+<tr>
+<td>Array elements</td>
+<td>10,000</td>
+<td>100 – 100,000</td>
+</tr>
+<tr>
+<td>Object nesting depth</td>
+<td>32 levels</td>
+<td>8 – 64 levels</td>
+</tr>
+</tbody>
+</table>
+<blockquote>
+<p><strong>Nesting depth counting:</strong> Depth counts the levels of nested objects or arrays. For example, <code>{"a": {"b": {"c": {}}}}</code> has a depth of 4. The root object counts as level 1.</p>
+</blockquote>
+<p>When a limit is exceeded, adapters MUST return a <code>VALIDATION_PAYLOAD_TOO_LARGE</code> error with details indicating which limit was exceeded.</p>
+<p>Adapters MUST document their configured limits via introspection or adapter documentation. Adapters SHOULD expose limits in protocol metadata (see Section 9.3.3) to enable client-side pre-validation:</p>
+<div class="sourceCode" id="cb16"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb16-1"><a href="#cb16-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb16-2"><a href="#cb16-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;_protocol&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb16-3"><a href="#cb16-3" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;limits&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb16-4"><a href="#cb16-4" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;max_request_size&quot;</span><span class="fu">:</span> <span class="dv">1048576</span><span class="fu">,</span></span>
+<span id="cb16-5"><a href="#cb16-5" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;max_response_size&quot;</span><span class="fu">:</span> <span class="dv">10485760</span><span class="fu">,</span></span>
+<span id="cb16-6"><a href="#cb16-6" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;max_string_length&quot;</span><span class="fu">:</span> <span class="dv">1048576</span><span class="fu">,</span></span>
+<span id="cb16-7"><a href="#cb16-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;max_array_elements&quot;</span><span class="fu">:</span> <span class="dv">10000</span><span class="fu">,</span></span>
+<span id="cb16-8"><a href="#cb16-8" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;max_nesting_depth&quot;</span><span class="fu">:</span> <span class="dv">32</span></span>
+<span id="cb16-9"><a href="#cb16-9" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb16-10"><a href="#cb16-10" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb16-11"><a href="#cb16-11" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<h4 id="476-null-handling">4.7.6 Null Handling</h4>
+<p>JSON <code>null</code> represents the absence of a value:</p>
+<ul>
+<li><strong>In requests:</strong> Omitting a field and explicitly setting it to <code>null</code> MAY have different semantics. See Section 4.5.2 for UPDATE operations where <code>null</code> removes fields.</li>
+<li><strong>In responses:</strong> <code>null</code> indicates the field exists but has no value.</li>
+</ul>
+<p>Adapters MUST document null semantics for parameters where the distinction matters.</p>
+<hr />
+<h2 id="5-response-format">5. Response Format</h2>
+<h3 id="51-discriminated-union">5.1 Discriminated Union</h3>
+<p>All operations return a discriminated union result:</p>
+<div class="sourceCode" id="cb17"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb17-1"><a href="#cb17-1" aria-hidden="true" tabindex="-1"></a><span class="kw">type</span> OperationResult <span class="op">=</span> OperationSuccess <span class="op">|</span> OperationFailure<span class="op">;</span></span>
+<span id="cb17-2"><a href="#cb17-2" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb17-3"><a href="#cb17-3" aria-hidden="true" tabindex="-1"></a><span class="kw">interface</span> OperationSuccess {</span>
+<span id="cb17-4"><a href="#cb17-4" aria-hidden="true" tabindex="-1"></a>  success<span class="op">:</span> <span class="kw">true</span><span class="op">;</span></span>
+<span id="cb17-5"><a href="#cb17-5" aria-hidden="true" tabindex="-1"></a>  data<span class="op">:</span> <span class="dt">any</span><span class="op">;</span>      <span class="co">// Operation-specific payload</span></span>
+<span id="cb17-6"><a href="#cb17-6" aria-hidden="true" tabindex="-1"></a>}</span>
+<span id="cb17-7"><a href="#cb17-7" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb17-8"><a href="#cb17-8" aria-hidden="true" tabindex="-1"></a><span class="kw">interface</span> OperationFailure {</span>
+<span id="cb17-9"><a href="#cb17-9" aria-hidden="true" tabindex="-1"></a>  success<span class="op">:</span> <span class="kw">false</span><span class="op">;</span></span>
+<span id="cb17-10"><a href="#cb17-10" aria-hidden="true" tabindex="-1"></a>  error<span class="op">:</span> ErrorDetail<span class="op">;</span></span>
+<span id="cb17-11"><a href="#cb17-11" aria-hidden="true" tabindex="-1"></a>}</span>
+<span id="cb17-12"><a href="#cb17-12" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb17-13"><a href="#cb17-13" aria-hidden="true" tabindex="-1"></a><span class="kw">interface</span> ErrorDetail {</span>
+<span id="cb17-14"><a href="#cb17-14" aria-hidden="true" tabindex="-1"></a>  code<span class="op">:</span> <span class="dt">string</span><span class="op">;</span>     <span class="co">// Machine-readable error code (e.g., &quot;VALIDATION_MISSING_PARAM&quot;)</span></span>
+<span id="cb17-15"><a href="#cb17-15" aria-hidden="true" tabindex="-1"></a>  message<span class="op">:</span> <span class="dt">string</span><span class="op">;</span>  <span class="co">// Human-readable error message</span></span>
+<span id="cb17-16"><a href="#cb17-16" aria-hidden="true" tabindex="-1"></a>  details<span class="op">?:</span> <span class="bu">Record</span><span class="op">&lt;</span><span class="dt">string</span><span class="op">,</span> <span class="dt">unknown</span><span class="op">&gt;;</span>  <span class="co">// Optional contextual information</span></span>
+<span id="cb17-17"><a href="#cb17-17" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<blockquote>
+<p><strong>Note:</strong> See <a href="../error-codes.html">Structured Error Codes Specification</a> for the complete error code taxonomy and usage guidelines.</p>
+</blockquote>
+<h3 id="52-success-response">5.2 Success Response</h3>
+<div class="sourceCode" id="cb18"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb18-1"><a href="#cb18-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb18-2"><a href="#cb18-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb18-3"><a href="#cb18-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;data&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb18-4"><a href="#cb18-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;id&quot;</span><span class="fu">:</span> <span class="st">&quot;doc_789&quot;</span><span class="fu">,</span></span>
+<span id="cb18-5"><a href="#cb18-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;title&quot;</span><span class="fu">:</span> <span class="st">&quot;Quarterly Report&quot;</span><span class="fu">,</span></span>
+<span id="cb18-6"><a href="#cb18-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;created_at&quot;</span><span class="fu">:</span> <span class="st">&quot;2024-01-15T10:30:00Z&quot;</span></span>
+<span id="cb18-7"><a href="#cb18-7" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb18-8"><a href="#cb18-8" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<h3 id="53-error-response">5.3 Error Response</h3>
+<div class="sourceCode" id="cb19"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb19-1"><a href="#cb19-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb19-2"><a href="#cb19-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb19-3"><a href="#cb19-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;error&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb19-4"><a href="#cb19-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;code&quot;</span><span class="fu">:</span> <span class="st">&quot;VALIDATION_MISSING_PARAM&quot;</span><span class="fu">,</span></span>
+<span id="cb19-5"><a href="#cb19-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;Missing required parameter &#39;title&#39; for operation &#39;create_document&#39;&quot;</span><span class="fu">,</span></span>
+<span id="cb19-6"><a href="#cb19-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;details&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb19-7"><a href="#cb19-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;param_name&quot;</span><span class="fu">:</span> <span class="st">&quot;title&quot;</span><span class="fu">,</span></span>
+<span id="cb19-8"><a href="#cb19-8" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;create_document&quot;</span></span>
+<span id="cb19-9"><a href="#cb19-9" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb19-10"><a href="#cb19-10" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb19-11"><a href="#cb19-11" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<hr />
+<h2 id="6-crude-endpoints">6. CRUDE Endpoints</h2>
+<h3 id="61-endpoint-summary">6.1 Endpoint Summary</h3>
+<table>
+<thead>
+<tr>
+<th>Endpoint</th>
+<th>Read-Only</th>
+<th>Destructive</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>CREATE</td>
+<td>false</td>
+<td>false</td>
+<td>Additive operations</td>
+</tr>
+<tr>
+<td>READ</td>
+<td>true</td>
+<td>false</td>
+<td>Query operations</td>
+</tr>
+<tr>
+<td>UPDATE</td>
+<td>false</td>
+<td>true</td>
+<td>Modification operations</td>
+</tr>
+<tr>
+<td>DELETE</td>
+<td>false</td>
+<td>true</td>
+<td>Removal operations</td>
+</tr>
+<tr>
+<td>EXECUTE</td>
+<td>false</td>
+<td>true</td>
+<td>Runtime lifecycle operations</td>
+</tr>
+</tbody>
+</table>
+<h3 id="62-operation-routing">6.2 Operation Routing</h3>
+<p>Each operation MUST be routed to exactly one endpoint based on its characteristics. Implementations MUST reject operations sent to incorrect endpoints in CRUDE mode.</p>
+<p>See <a href="../overview.html">Protocol Overview</a> for detailed endpoint definitions and classification guidelines.</p>
+<hr />
+<h2 id="7-introspection">7. Introspection</h2>
+<h3 id="71-purpose">7.1 Purpose</h3>
+<p>Introspection enables clients to discover available operations without parsing tool schemas, providing:</p>
+<ul>
+<li>On-demand operation discovery</li>
+<li>Parameter documentation</li>
+<li>Type information</li>
+<li>Usage examples</li>
+</ul>
+<h3 id="72-the-introspect-operation">7.2 The <code>introspect</code> Operation</h3>
+<p><strong>Endpoint:</strong> READ</p>
+<p>Every MCP-AQL adapter MUST implement the <code>introspect</code> operation.</p>
+<p><strong>Parameters:</strong> | Parameter | Type | Required | Description | |-----------|------|----------|-------------| | <code>query</code> | string | Yes | Query type: "operations" or "types" | | <code>name</code> | string | No | Specific item name for details |</p>
+<h3 id="73-query-types">7.3 Query Types</h3>
+<p><strong>List Operations:</strong></p>
+<div class="sourceCode" id="cb20"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb20-1"><a href="#cb20-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span> <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;introspect&quot;</span><span class="fu">,</span> <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;query&quot;</span><span class="fu">:</span> <span class="st">&quot;operations&quot;</span> <span class="fu">}</span> <span class="fu">}</span></span></code></pre></div>
+<p><strong>Operation Details:</strong></p>
+<div class="sourceCode" id="cb21"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb21-1"><a href="#cb21-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span> <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;introspect&quot;</span><span class="fu">,</span> <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;query&quot;</span><span class="fu">:</span> <span class="st">&quot;operations&quot;</span><span class="fu">,</span> <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;create_document&quot;</span> <span class="fu">}</span> <span class="fu">}</span></span></code></pre></div>
+<p><strong>List Types:</strong></p>
+<div class="sourceCode" id="cb22"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb22-1"><a href="#cb22-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span> <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;introspect&quot;</span><span class="fu">,</span> <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;query&quot;</span><span class="fu">:</span> <span class="st">&quot;types&quot;</span> <span class="fu">}</span> <span class="fu">}</span></span></code></pre></div>
+<p><strong>Type Details:</strong></p>
+<div class="sourceCode" id="cb23"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb23-1"><a href="#cb23-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span> <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;introspect&quot;</span><span class="fu">,</span> <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;query&quot;</span><span class="fu">:</span> <span class="st">&quot;types&quot;</span><span class="fu">,</span> <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;DocumentStatus&quot;</span> <span class="fu">}</span> <span class="fu">}</span></span></code></pre></div>
+<p>See <a href="../introspection.html">Introspection Specification</a> for detailed response structures.</p>
+<hr />
+<h2 id="8-operation-classification">8. Operation Classification</h2>
+<h3 id="81-classification-guidelines">8.1 Classification Guidelines</h3>
+<p>Adapters classify their operations into CRUDE endpoints based on characteristics:</p>
+<p><strong>CREATE</strong> - Operations that:</p>
+<ul>
+<li>Add new resources or state</li>
+<li>Do not remove or overwrite existing data</li>
+<li>Are non-destructive</li>
+</ul>
+<p><strong>READ</strong> - Operations that:</p>
+<ul>
+<li>Query or retrieve data</li>
+<li>Have no side effects on stored state</li>
+<li>Are safe to call repeatedly (idempotent)</li>
+</ul>
+<p><strong>UPDATE</strong> - Operations that:</p>
+<ul>
+<li>Modify existing resources</li>
+<li>Overwrite previous values</li>
+<li>Require the resource to exist</li>
+</ul>
+<p><strong>DELETE</strong> - Operations that:</p>
+<ul>
+<li>Remove resources permanently</li>
+<li>Are irreversible without backup</li>
+<li>May require confirmation</li>
+</ul>
+<p><strong>EXECUTE</strong> - Operations that:</p>
+<ul>
+<li>Manage runtime lifecycle (start, stop, monitor)</li>
+<li>Are non-idempotent (each call may create new state)</li>
+<li>May have external side effects</li>
+</ul>
+<h3 id="82-classification-examples">8.2 Classification Examples</h3>
+<table>
+<thead>
+<tr>
+<th>Operation</th>
+<th>Endpoint</th>
+<th>Rationale</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>create_user</code></td>
+<td>CREATE</td>
+<td>Adds new user</td>
+</tr>
+<tr>
+<td><code>upload_file</code></td>
+<td>CREATE</td>
+<td>Adds new file</td>
+</tr>
+<tr>
+<td><code>list_users</code></td>
+<td>READ</td>
+<td>Queries without modification</td>
+</tr>
+<tr>
+<td><code>search</code></td>
+<td>READ</td>
+<td>Queries without modification</td>
+</tr>
+<tr>
+<td><code>get_status</code></td>
+<td>READ</td>
+<td>Retrieves state</td>
+</tr>
+<tr>
+<td><code>update_profile</code></td>
+<td>UPDATE</td>
+<td>Modifies existing resource</td>
+</tr>
+<tr>
+<td><code>rename_file</code></td>
+<td>UPDATE</td>
+<td>Modifies existing resource</td>
+</tr>
+<tr>
+<td><code>delete_user</code></td>
+<td>DELETE</td>
+<td>Removes permanently</td>
+</tr>
+<tr>
+<td><code>purge_cache</code></td>
+<td>DELETE</td>
+<td>Removes data</td>
+</tr>
+<tr>
+<td><code>execute_job</code></td>
+<td>EXECUTE</td>
+<td>Starts runtime process</td>
+</tr>
+<tr>
+<td><code>cancel_task</code></td>
+<td>EXECUTE</td>
+<td>Lifecycle management</td>
+</tr>
+</tbody>
+</table>
+<h3 id="83-edge-cases">8.3 Edge Cases</h3>
+<p>When classification is ambiguous:</p>
+<ul>
+<li>Prefer READ if operation has no side effects</li>
+<li>Prefer CREATE over UPDATE if resource may not exist</li>
+<li>Prefer EXECUTE for operations with external effects</li>
+<li>Document reasoning in adapter specification</li>
+</ul>
+<h3 id="84-execution-lifecycle">8.4 Execution Lifecycle</h3>
+<p>EXECUTE operations that create or manage long-running processes SHOULD follow the standard execution lifecycle defined in this section.</p>
+<h4 id="841-core-states">8.4.1 Core States</h4>
+<table>
+<thead>
+<tr>
+<th>State</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>pending</code></td>
+<td>Execution created but not yet started</td>
+</tr>
+<tr>
+<td><code>running</code></td>
+<td>Execution actively processing</td>
+</tr>
+<tr>
+<td><code>completed</code></td>
+<td>Execution finished successfully</td>
+</tr>
+<tr>
+<td><code>failed</code></td>
+<td>Execution terminated with error</td>
+</tr>
+<tr>
+<td><code>cancelled</code></td>
+<td>Execution terminated by user request</td>
+</tr>
+</tbody>
+</table>
+<h4 id="842-state-transitions">8.4.2 State Transitions</h4>
+<pre><code>                              ┌───────────┐
+                              │ cancelled │
+                              └───────────┘
+                                    ▲
+                    cancel          │           cancel
+              ┌─────────────────────┼─────────────────────┐
+              │                     │                     │
+     ┌────────┴─┐             ┌─────┴────┐          ┌─────┴────┐
+     │ pending  │───start────▶│ running  │◄──retry──│  failed  │
+     └──────────┘             └────┬─────┘          └──────────┘
+                                   │                      ▲
+                                   │ success/error        │
+                                   ▼                      │
+                              ┌─────┴────┐                │
+                              │          │────────────────┘
+                              ▼          ▼
+                         ┌────────┐  ┌────────┐
+                         │completed│  │ failed │
+                         └────────┘  └────────┘
+                          (terminal)  (may retry)</code></pre>
+<p><strong>Terminal States:</strong> <code>completed</code>, <code>failed</code>, and <code>cancelled</code> are terminal states. Once an execution reaches a terminal state, it MUST NOT transition to any other state except for the optional <code>failed</code> → <code>running</code> retry transition when supported.</p>
+<p>Valid state transitions:</p>
+<ul>
+<li><code>pending</code> → <code>running</code> (start)</li>
+<li><code>pending</code> → <code>cancelled</code> (cancel before start)</li>
+<li><code>running</code> → <code>completed</code> (successful completion)</li>
+<li><code>running</code> → <code>failed</code> (error during execution)</li>
+<li><code>running</code> → <code>cancelled</code> (user cancellation)</li>
+<li><code>failed</code> → <code>running</code> (retry, if supported)</li>
+</ul>
+<h4 id="843-state-response-format">8.4.3 State Response Format</h4>
+<p>Operations that return execution state SHOULD include:</p>
+<div class="sourceCode" id="cb25"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb25-1"><a href="#cb25-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb25-2"><a href="#cb25-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;execution_id&quot;</span><span class="fu">:</span> <span class="st">&quot;exec_123&quot;</span><span class="fu">,</span></span>
+<span id="cb25-3"><a href="#cb25-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;status&quot;</span><span class="fu">:</span> <span class="st">&quot;running&quot;</span><span class="fu">,</span></span>
+<span id="cb25-4"><a href="#cb25-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;started_at&quot;</span><span class="fu">:</span> <span class="st">&quot;2026-02-04T10:00:00Z&quot;</span><span class="fu">,</span></span>
+<span id="cb25-5"><a href="#cb25-5" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;progress&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb25-6"><a href="#cb25-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;current&quot;</span><span class="fu">:</span> <span class="dv">45</span><span class="fu">,</span></span>
+<span id="cb25-7"><a href="#cb25-7" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;total&quot;</span><span class="fu">:</span> <span class="dv">100</span><span class="fu">,</span></span>
+<span id="cb25-8"><a href="#cb25-8" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;Processing step 5 of 10&quot;</span></span>
+<span id="cb25-9"><a href="#cb25-9" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb25-10"><a href="#cb25-10" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<p><strong>Required Fields:</strong> | Field | Type | Description | |-------|------|-------------| | <code>execution_id</code> | string | Unique identifier for the execution | | <code>status</code> | string | Current state (one of the core states) |</p>
+<p><strong>Optional Fields:</strong> | Field | Type | Description | |-------|------|-------------| | <code>started_at</code> | string (ISO 8601) | When execution started | | <code>finished_at</code> | string (ISO 8601) | When execution reached a terminal state | | <code>progress</code> | object | Progress information (see below) | | <code>error</code> | object | Error details if <code>status</code> is <code>failed</code> (see <a href="#53-error-response">Error Response Format</a>) |</p>
+<p><strong>Progress Object:</strong></p>
+<p>When <code>progress</code> is present, at least one of the following SHOULD be included:</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Type</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>percentage</code></td>
+<td>number</td>
+<td>Completion percentage (0-100) — use for determinate progress</td>
+</tr>
+<tr>
+<td><code>current</code> + <code>total</code></td>
+<td>number</td>
+<td>Current and total values — use when count information is available</td>
+</tr>
+<tr>
+<td><code>message</code></td>
+<td>string</td>
+<td>Human-readable status — use for indeterminate progress or additional context</td>
+</tr>
+</tbody>
+</table>
+<p><strong>Example — Completed Execution:</strong></p>
+<div class="sourceCode" id="cb26"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb26-1"><a href="#cb26-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb26-2"><a href="#cb26-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;execution_id&quot;</span><span class="fu">:</span> <span class="st">&quot;exec_123&quot;</span><span class="fu">,</span></span>
+<span id="cb26-3"><a href="#cb26-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;status&quot;</span><span class="fu">:</span> <span class="st">&quot;completed&quot;</span><span class="fu">,</span></span>
+<span id="cb26-4"><a href="#cb26-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;started_at&quot;</span><span class="fu">:</span> <span class="st">&quot;2026-02-04T10:00:00Z&quot;</span><span class="fu">,</span></span>
+<span id="cb26-5"><a href="#cb26-5" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;finished_at&quot;</span><span class="fu">:</span> <span class="st">&quot;2026-02-04T10:05:32Z&quot;</span></span>
+<span id="cb26-6"><a href="#cb26-6" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<p><strong>Example — Failed Execution:</strong></p>
+<div class="sourceCode" id="cb27"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb27-1"><a href="#cb27-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb27-2"><a href="#cb27-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;execution_id&quot;</span><span class="fu">:</span> <span class="st">&quot;exec_456&quot;</span><span class="fu">,</span></span>
+<span id="cb27-3"><a href="#cb27-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;status&quot;</span><span class="fu">:</span> <span class="st">&quot;failed&quot;</span><span class="fu">,</span></span>
+<span id="cb27-4"><a href="#cb27-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;started_at&quot;</span><span class="fu">:</span> <span class="st">&quot;2026-02-04T10:00:00Z&quot;</span><span class="fu">,</span></span>
+<span id="cb27-5"><a href="#cb27-5" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;finished_at&quot;</span><span class="fu">:</span> <span class="st">&quot;2026-02-04T10:02:15Z&quot;</span><span class="fu">,</span></span>
+<span id="cb27-6"><a href="#cb27-6" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;error&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb27-7"><a href="#cb27-7" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;code&quot;</span><span class="fu">:</span> <span class="st">&quot;INTERNAL_ERROR&quot;</span><span class="fu">,</span></span>
+<span id="cb27-8"><a href="#cb27-8" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;Connection timeout while processing&quot;</span><span class="fu">,</span></span>
+<span id="cb27-9"><a href="#cb27-9" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;details&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;step&quot;</span><span class="fu">:</span> <span class="st">&quot;data_fetch&quot;</span><span class="fu">,</span> <span class="dt">&quot;attempt&quot;</span><span class="fu">:</span> <span class="dv">3</span> <span class="fu">}</span></span>
+<span id="cb27-10"><a href="#cb27-10" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb27-11"><a href="#cb27-11" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<p><strong>Example — Cancelled Execution:</strong></p>
+<div class="sourceCode" id="cb28"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb28-1"><a href="#cb28-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb28-2"><a href="#cb28-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;execution_id&quot;</span><span class="fu">:</span> <span class="st">&quot;exec_789&quot;</span><span class="fu">,</span></span>
+<span id="cb28-3"><a href="#cb28-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;status&quot;</span><span class="fu">:</span> <span class="st">&quot;cancelled&quot;</span><span class="fu">,</span></span>
+<span id="cb28-4"><a href="#cb28-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;started_at&quot;</span><span class="fu">:</span> <span class="st">&quot;2026-02-04T10:00:00Z&quot;</span><span class="fu">,</span></span>
+<span id="cb28-5"><a href="#cb28-5" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;finished_at&quot;</span><span class="fu">:</span> <span class="st">&quot;2026-02-04T10:01:45Z&quot;</span><span class="fu">,</span></span>
+<span id="cb28-6"><a href="#cb28-6" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;progress&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb28-7"><a href="#cb28-7" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;percentage&quot;</span><span class="fu">:</span> <span class="dv">35</span><span class="fu">,</span></span>
+<span id="cb28-8"><a href="#cb28-8" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;Cancelled by user during data processing&quot;</span></span>
+<span id="cb28-9"><a href="#cb28-9" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb28-10"><a href="#cb28-10" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<h4 id="844-adapter-extensions">8.4.4 Adapter Extensions</h4>
+<p>Adapters MAY define additional states beyond the core set (e.g., <code>paused</code>, <code>queued</code>, <code>retrying</code>). When extending the state machine:</p>
+<ol type="1">
+<li>Custom states MUST be documented via introspection</li>
+<li>Custom states SHOULD map conceptually to core states for generic client compatibility</li>
+<li>Adapters MUST support transitions to <code>cancelled</code> from any non-terminal state</li>
+<li>Adapters SHOULD document which operations trigger each state transition</li>
+</ol>
+<p><strong>Example Extended State Mapping:</strong> | Adapter State | Maps To | Description | |---------------|---------|-------------| | <code>queued</code> | <code>pending</code> | Waiting in job queue | | <code>paused</code> | <code>running</code> | Temporarily suspended | | <code>retrying</code> | <code>running</code> | Automatic retry in progress |</p>
+<h4 id="845-introspection-support">8.4.5 Introspection Support</h4>
+<p>EXECUTE operations that manage lifecycle SHOULD expose their supported states via introspection. The <code>lifecycle</code> field in operation details indicates lifecycle support:</p>
+<div class="sourceCode" id="cb29"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb29-1"><a href="#cb29-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb29-2"><a href="#cb29-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb29-3"><a href="#cb29-3" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;execute_job&quot;</span><span class="fu">,</span></span>
+<span id="cb29-4"><a href="#cb29-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;endpoint&quot;</span><span class="fu">:</span> <span class="st">&quot;EXECUTE&quot;</span><span class="fu">,</span></span>
+<span id="cb29-5"><a href="#cb29-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;lifecycle&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb29-6"><a href="#cb29-6" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;states&quot;</span><span class="fu">:</span> <span class="ot">[</span><span class="st">&quot;pending&quot;</span><span class="ot">,</span> <span class="st">&quot;queued&quot;</span><span class="ot">,</span> <span class="st">&quot;running&quot;</span><span class="ot">,</span> <span class="st">&quot;completed&quot;</span><span class="ot">,</span> <span class="st">&quot;failed&quot;</span><span class="ot">,</span> <span class="st">&quot;cancelled&quot;</span><span class="ot">]</span><span class="fu">,</span></span>
+<span id="cb29-7"><a href="#cb29-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;supports_cancel&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb29-8"><a href="#cb29-8" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;supports_retry&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb29-9"><a href="#cb29-9" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;progress_reporting&quot;</span><span class="fu">:</span> <span class="kw">true</span></span>
+<span id="cb29-10"><a href="#cb29-10" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb29-11"><a href="#cb29-11" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb29-12"><a href="#cb29-12" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<p>See <a href="../introspection.html">Introspection Specification</a> for the complete schema.</p>
+<h3 id="85-operation-naming-grammar">8.5 Operation Naming Grammar</h3>
+<h4 id="851-canonical-verbs">8.5.1 Canonical Verbs</h4>
+<p>Each endpoint has one or more canonical verbs that SHOULD be used for standard operations:</p>
+<table>
+<thead>
+<tr>
+<th>Endpoint</th>
+<th>Canonical Verb</th>
+<th>Usage</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>CREATE</td>
+<td><code>create</code></td>
+<td>Creating new resources</td>
+</tr>
+<tr>
+<td>READ</td>
+<td><code>get</code> (single), <code>list</code> (multiple)</td>
+<td>Retrieving resources</td>
+</tr>
+<tr>
+<td>UPDATE</td>
+<td><code>update</code></td>
+<td>Modifying existing resources</td>
+</tr>
+<tr>
+<td>DELETE</td>
+<td><code>delete</code></td>
+<td>Removing resources</td>
+</tr>
+<tr>
+<td>EXECUTE</td>
+<td><code>execute</code> (initiate), <code>cancel</code> (terminate)</td>
+<td>Lifecycle operations</td>
+</tr>
+</tbody>
+</table>
+<p><code>cancel</code> covers both aborting a pending/queued operation and halting a currently running one. Adapters that need to distinguish these cases MAY use additional verbs (e.g., <code>stop</code>) alongside <code>cancel</code>.</p>
+<p>Using canonical verbs improves cross-adapter consistency, enabling LLMs to predict operation names without requiring introspection for every adapter.</p>
+<p>For developers familiar with REST conventions, the following mapping provides context:</p>
+<table>
+<thead>
+<tr>
+<th>Canonical Verb</th>
+<th>Typical HTTP Method</th>
+<th>Semantics</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>create</code></td>
+<td>POST</td>
+<td>Add new resource</td>
+</tr>
+<tr>
+<td><code>get</code> / <code>list</code></td>
+<td>GET</td>
+<td>Retrieve resource(s)</td>
+</tr>
+<tr>
+<td><code>update</code></td>
+<td>PUT / PATCH</td>
+<td>Modify resource</td>
+</tr>
+<tr>
+<td><code>delete</code></td>
+<td>DELETE</td>
+<td>Remove resource</td>
+</tr>
+<tr>
+<td><code>execute</code> / <code>cancel</code></td>
+<td>POST</td>
+<td>Lifecycle control</td>
+</tr>
+</tbody>
+</table>
+<h4 id="852-operation-name-format">8.5.2 Operation Name Format</h4>
+<p>Operation names MUST use snake_case naming (a lowercase letter followed by lowercase letters, digits, and underscores), matching the schema pattern <code>^[a-z][a-z0-9_]*$</code>. Operations SHOULD follow the pattern: <code>{verb}_{resource}</code></p>
+<p>Examples:</p>
+<ul>
+<li><code>create_user</code> (not <code>add_user</code>)</li>
+<li><code>get_document</code> (not <code>fetch_document</code>)</li>
+<li><code>list_items</code> (not <code>find_items</code>)</li>
+<li><code>update_profile</code> (not <code>edit_profile</code>)</li>
+<li><code>delete_account</code> (not <code>remove_account</code>)</li>
+<li><code>execute_workflow</code> (not <code>run_workflow</code>)</li>
+</ul>
+<p>Operations that act on the system as a whole (rather than a specific resource) MAY omit the resource suffix (e.g., <code>introspect</code>).</p>
+<h4 id="853-when-to-use-non-canonical-verbs">8.5.3 When to Use Non-Canonical Verbs</h4>
+<p>Non-canonical verbs MAY be used when:</p>
+<ol type="1">
+<li>The operation has domain-specific semantics (e.g., <code>upload_file</code> vs <code>create_file</code> when the operation involves binary transfer)</li>
+<li>The canonical verb would be misleading (e.g., <code>search</code> implies query semantics that <code>list</code> does not)</li>
+<li>Industry convention strongly favors a different verb (e.g., <code>import</code>/<code>export</code>)</li>
+</ol>
+<p>When using non-canonical verbs, adapters SHOULD:</p>
+<ul>
+<li>Document the rationale in the operation description</li>
+<li>Note the canonical equivalent in the operation description (e.g., "Similar to <code>create</code>, but handles binary upload")</li>
+</ul>
+<h4 id="854-reserved-operations">8.5.4 Reserved Operations</h4>
+<p>The following operation names are reserved for protocol use and MUST NOT be used by adapters for other purposes:</p>
+<table>
+<thead>
+<tr>
+<th>Operation</th>
+<th>Endpoint</th>
+<th>Purpose</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>introspect</code></td>
+<td>READ</td>
+<td>Protocol introspection (Section 7)</td>
+</tr>
+<tr>
+<td><code>execute_agent</code></td>
+<td>EXECUTE</td>
+<td>Start execution safety loop (Section 8.6)</td>
+</tr>
+<tr>
+<td><code>record_execution_step</code></td>
+<td>CREATE</td>
+<td>Report intended action for safety evaluation (Section 8.6)</td>
+</tr>
+<tr>
+<td><code>complete_execution</code></td>
+<td>EXECUTE</td>
+<td>Signal normal execution completion (Section 8.6)</td>
+</tr>
+<tr>
+<td><code>abort_execution</code></td>
+<td>EXECUTE</td>
+<td>Signal abnormal execution termination (Section 8.6)</td>
+</tr>
+<tr>
+<td><code>confirm_operation</code></td>
+<td>EXECUTE</td>
+<td>Confirm a Gatekeeper-blocked operation or Autonomy Evaluator <code>confirm</code> tier pause (Section 8.7.3)</td>
+</tr>
+<tr>
+<td><code>verify_challenge</code></td>
+<td>CREATE</td>
+<td>Submit out-of-band verification code (Section 8.8)</td>
+</tr>
+</tbody>
+</table>
+<p>Adapters MUST NOT define custom operations with these names for other purposes. Future specification versions MAY reserve additional operation names.</p>
+<h3 id="86-execution-safety-loop">8.6 Execution Safety Loop</h3>
+<p>The execution safety loop is an opt-in enforcement pattern that provides continuous safety evaluation of an agent's intended actions during execution. When active, it turns the execute lifecycle (Section 8.4) into a monitored enforcement boundary rather than a simple state tracker.</p>
+<blockquote>
+<p><strong>Terminology Note:</strong> The "execution safety loop" is distinct from the full agent lifecycle that a specific adapter may implement. The safety loop is a protocol-level monitoring pattern; agent lifecycle management (personas, elements, state) is an adapter concern.</p>
+<p><strong>Forward Reference:</strong> This section references the Autonomy Evaluator (Section 8.7) and Out-of-Band Verification (Section 8.8), which are defined as companion sections. The <code>AutonomyDirective</code> response type is formally defined in Section 8.7.1.</p>
+</blockquote>
+<h4 id="861-opt-in-activation">8.6.1 Opt-In Activation</h4>
+<p>The execution safety loop is an OPTIONAL feature. Adapters MAY support it, and clients MAY choose to enable it.</p>
+<ul>
+<li>When not enabled, the adapter operates normally without safety enforcement overhead</li>
+<li>Activation is explicit — via <code>execute_agent</code> to start a monitored execution, or via adapter configuration to enable safety-loop mode</li>
+<li>Adapters MUST document whether they support the execution safety loop via introspection</li>
+</ul>
+<p>Adapters that support the execution safety loop SHOULD expose this capability in their introspection response:</p>
+<div class="sourceCode" id="cb30"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb30-1"><a href="#cb30-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb30-2"><a href="#cb30-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;capabilities&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb30-3"><a href="#cb30-3" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;execution_safety_loop&quot;</span><span class="fu">:</span> <span class="st">&quot;enforcing&quot;</span></span>
+<span id="cb30-4"><a href="#cb30-4" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb30-5"><a href="#cb30-5" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<p>Valid values for <code>execution_safety_loop</code>:</p>
+<table>
+<thead>
+<tr>
+<th>Value</th>
+<th>Meaning</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>"enforcing"</code></td>
+<td>Full enforcement — actions are evaluated and directives are authoritative</td>
+</tr>
+<tr>
+<td><code>"monitoring"</code></td>
+<td>Actions are evaluated but <code>continue</code> is always <code>true</code> (advisory only)</td>
+</tr>
+<tr>
+<td><code>"logging"</code></td>
+<td>Actions are recorded for audit purposes without evaluation</td>
+</tr>
+<tr>
+<td><code>"disabled"</code></td>
+<td>Safety loop is supported but currently disabled</td>
+</tr>
+</tbody>
+</table>
+<h4 id="862-enforcement-boundary-property">8.6.2 Enforcement Boundary Property</h4>
+<p>When the execution safety loop is active, it establishes a <strong>mandatory enforcement boundary</strong>: all intended actions MUST be reported before execution, and all reports MUST be evaluated before the agent proceeds.</p>
+<p>The enforcement chain:</p>
+<ol type="1">
+<li>An agent starts via <code>execute_agent</code>, which requires explicit approval (one-time gate)</li>
+<li>The agent is now running inside the execution safety loop</li>
+<li>Every action the agent intends to take MUST be reported via <code>record_execution_step</code> with <code>nextActionHint</code></li>
+<li>Each report is evaluated by the adapter's safety pipeline (Gatekeeper, Autonomy Evaluator, Danger Zone — see Sections 8.7, 8.8)</li>
+<li>The evaluation returns an <code>AutonomyDirective</code> (Section 8.7.1) indicating whether the agent may proceed</li>
+<li>The loop continues until <code>complete_execution</code> or <code>abort_execution</code></li>
+</ol>
+<p>The initial <code>execute_agent</code> approval grants <strong>monitored trust</strong>, not blanket trust. The approval starts continuous per-action evaluation.</p>
+<p>Between <code>execute_agent</code> approval and the first <code>record_execution_step</code> call, the agent MAY perform internal reasoning (planning, context gathering) but MUST NOT take any externally-visible action. The first action with external effects MUST be reported before execution.</p>
+<p>The loop terminates via <code>complete_execution</code> (normal success) or <code>abort_execution</code> (abnormal termination, e.g., after a stop directive or user cancellation).</p>
+<h4 id="863-mandatory-action-reporting">8.6.3 Mandatory Action Reporting</h4>
+<p>When the execution safety loop is active, agents MUST report all intended actions through <code>record_execution_step</code> with a <code>nextActionHint</code> describing the planned action. Actions taken without reporting are a protocol violation.</p>
+<p>A reportable action is any operation that causes effects beyond the agent's internal reasoning:</p>
+<ul>
+<li>Tool calls to any MCP server (including other adapters)</li>
+<li>File system operations (read, write, delete)</li>
+<li>Shell command execution</li>
+<li>Network requests to external services</li>
+<li>Database queries or mutations</li>
+<li>State changes in any connected system</li>
+</ul>
+<p>The <code>record_execution_step</code> operation accepts the following parameters:</p>
+<table>
+<thead>
+<tr>
+<th>Parameter</th>
+<th>Type</th>
+<th>Required</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>element_name</code></td>
+<td>string</td>
+<td>MUST</td>
+<td>The agent reporting the step</td>
+</tr>
+<tr>
+<td><code>stepDescription</code></td>
+<td>string</td>
+<td>SHOULD</td>
+<td>Description of the action just completed</td>
+</tr>
+<tr>
+<td><code>outcome</code></td>
+<td>string</td>
+<td>SHOULD</td>
+<td>Result of the previous step: <code>"success"</code>, <code>"failure"</code>, or <code>"skipped"</code></td>
+</tr>
+<tr>
+<td><code>nextActionHint</code></td>
+<td>string</td>
+<td>MUST</td>
+<td>Description of the intended next action</td>
+</tr>
+<tr>
+<td><code>findings</code></td>
+<td>string</td>
+<td>MAY</td>
+<td>Data or observations from the completed step</td>
+</tr>
+</tbody>
+</table>
+<p>The <code>nextActionHint</code> field MUST be a human-readable string describing the intended action with sufficient detail for safety evaluation. Examples:</p>
+<ul>
+<li><code>"calling write_file on project/config.json to update database URL"</code></li>
+<li><code>"executing shell command: npm install express"</code></li>
+<li><code>"sending message to #general channel via Slack MCP server"</code></li>
+</ul>
+<h4 id="864-continuous-enforcement">8.6.4 Continuous Enforcement</h4>
+<p>Every <code>record_execution_step</code> call is an evaluation checkpoint. The response includes an <code>AutonomyDirective</code> (Section 8.7.1) that is authoritative:</p>
+<ul>
+<li>When <code>continue</code> is <code>true</code>, the agent MAY proceed with the reported action</li>
+<li>When <code>continue</code> is <code>false</code>, the agent MUST NOT proceed. The agent SHOULD report the pause to the user or upstream system</li>
+<li>When <code>stopped</code> is <code>true</code>, the agent has been hard-blocked (Section 8.8). The agent MUST cease all actions until unblocked via out-of-band verification</li>
+</ul>
+<p>Implementations MUST NOT allow agents to proceed after a stop directive. Implementations SHOULD NOT allow agents to proceed after <code>continue: false</code> without human intervention.</p>
+<p>In monitoring mode (<code>"monitoring"</code>), <code>continue</code> is always <code>true</code> and <code>stopped</code> MUST NOT be set to <code>true</code>. Monitoring mode is advisory only — it evaluates and logs but does not block. In logging mode (<code>"logging"</code>), no evaluation occurs and no directive fields are authoritative.</p>
+<h4 id="865-non-bypass-property">8.6.5 Non-Bypass Property</h4>
+<p>If an agent is executing through the execution safety loop, it MUST NOT perform actions outside the reported loop. This property is essential to the safety model:</p>
+<ul>
+<li>The agent MUST NOT call tools on other MCP servers without first reporting intent via <code>record_execution_step</code></li>
+<li>The agent MUST NOT take file system or shell actions without reporting</li>
+<li>If the agent acts without reporting, it is a protocol violation</li>
+</ul>
+<blockquote>
+<p><strong>Implementation Note:</strong> This property is enforced cooperatively — the agent (typically an LLM following system prompt instructions) must be instructed to check in with the safety loop before every action. The protocol defines the contract; the client integration enforces it.</p>
+</blockquote>
+<h4 id="866-scope-of-monitoring">8.6.6 Scope of Monitoring</h4>
+<p>The execution safety loop monitors ALL intended actions, not only MCP-AQL operations on the same adapter. This includes:</p>
+<ul>
+<li>Tool calls to other MCP servers in the same client session</li>
+<li>Tool calls to non-MCP-AQL MCP servers</li>
+<li>Built-in client capabilities (file I/O, shell access, web requests)</li>
+<li>Any operation that produces effects beyond the agent's reasoning context</li>
+</ul>
+<p>This broad scope is what makes the safety dongle deployment model possible: a standalone MCP-AQL server can function as a universal safety layer for all tool calls in a client session, regardless of which server handles the actual operation.</p>
+<h4 id="867-disabling-the-safety-loop">8.6.7 Disabling the Safety Loop</h4>
+<p>Clients or adapter configuration MAY disable the execution safety loop entirely. When disabled:</p>
+<ul>
+<li>The execution lifecycle operations (<code>execute_agent</code>, <code>record_execution_step</code>, <code>complete_execution</code>, <code>abort_execution</code>) are either unavailable or operate as no-op progress tracking without safety enforcement</li>
+<li>No <code>AutonomyDirective</code> evaluation occurs</li>
+<li>No action reporting is required</li>
+</ul>
+<p>The adapter MUST clearly indicate via introspection whether safety enforcement is active or disabled:</p>
+<div class="sourceCode" id="cb31"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb31-1"><a href="#cb31-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb31-2"><a href="#cb31-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;capabilities&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb31-3"><a href="#cb31-3" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;execution_safety_loop&quot;</span><span class="fu">:</span> <span class="st">&quot;disabled&quot;</span></span>
+<span id="cb31-4"><a href="#cb31-4" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb31-5"><a href="#cb31-5" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<h3 id="87-autonomy-evaluation">8.7 Autonomy Evaluation</h3>
+<p>When the execution safety loop is active, every <code>record_execution_step</code> call triggers an autonomy evaluation. This section defines the evaluation pipeline and the <code>AutonomyDirective</code> response contract.</p>
+<h4 id="871-the-autonomydirective-contract">8.7.1 The AutonomyDirective Contract</h4>
+<p>The <code>AutonomyDirective</code> is returned as part of the <code>record_execution_step</code> response. It is the authoritative signal for whether the agent may proceed.</p>
+<div class="sourceCode" id="cb32"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb32-1"><a href="#cb32-1" aria-hidden="true" tabindex="-1"></a><span class="kw">interface</span> AutonomyDirective {</span>
+<span id="cb32-2"><a href="#cb32-2" aria-hidden="true" tabindex="-1"></a>  <span class="cf">continue</span><span class="op">:</span> <span class="dt">boolean</span><span class="op">;</span>              <span class="co">// Whether the agent may proceed</span></span>
+<span id="cb32-3"><a href="#cb32-3" aria-hidden="true" tabindex="-1"></a>  factors<span class="op">:</span> <span class="dt">string</span>[]<span class="op">;</span>              <span class="co">// Human-readable decision factors</span></span>
+<span id="cb32-4"><a href="#cb32-4" aria-hidden="true" tabindex="-1"></a>  stopped<span class="op">?:</span> <span class="dt">boolean</span><span class="op">;</span>              <span class="co">// True if hard-blocked (Section 8.8)</span></span>
+<span id="cb32-5"><a href="#cb32-5" aria-hidden="true" tabindex="-1"></a>  reason<span class="op">?:</span> <span class="dt">string</span><span class="op">;</span>                <span class="co">// Why paused or stopped</span></span>
+<span id="cb32-6"><a href="#cb32-6" aria-hidden="true" tabindex="-1"></a>  stepsRemaining<span class="op">?:</span> <span class="dt">number</span><span class="op">;</span>        <span class="co">// Steps before mandatory pause</span></span>
+<span id="cb32-7"><a href="#cb32-7" aria-hidden="true" tabindex="-1"></a>  nextStepRisk<span class="op">?:</span> SafetyTier<span class="op">;</span>      <span class="co">// Risk tier of the evaluated action</span></span>
+<span id="cb32-8"><a href="#cb32-8" aria-hidden="true" tabindex="-1"></a>  notifications<span class="op">?:</span> AgentNotification[]<span class="op">;</span> <span class="co">// Pending events (Section 8.7.3)</span></span>
+<span id="cb32-9"><a href="#cb32-9" aria-hidden="true" tabindex="-1"></a>}</span>
+<span id="cb32-10"><a href="#cb32-10" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb32-11"><a href="#cb32-11" aria-hidden="true" tabindex="-1"></a><span class="kw">type</span> SafetyTier <span class="op">=</span> <span class="st">&quot;advisory&quot;</span> <span class="op">|</span> <span class="st">&quot;confirm&quot;</span> <span class="op">|</span> <span class="st">&quot;verify&quot;</span> <span class="op">|</span> <span class="st">&quot;danger_zone&quot;</span><span class="op">;</span></span></code></pre></div>
+<p>Implementations MUST include <code>continue</code> and <code>factors</code> in every <code>AutonomyDirective</code>. All other fields are OPTIONAL except where specific sections impose MUST requirements (see Sections 8.8.1 and 8.8.2 for mandatory <code>notifications</code> in <code>verify</code> tier, <code>danger_zone</code> tier, and <code>deny</code> pattern scenarios).</p>
+<h4 id="872-evaluation-pipeline">8.7.2 Evaluation Pipeline</h4>
+<p>Implementations SHOULD evaluate actions through a multi-stage pipeline. The stages are evaluated in order; the first stage that triggers a pause or stop ends the evaluation:</p>
+<p><strong>Stage 1 — Step Limit Check:</strong></p>
+<p>Compares the current step count against a configurable <code>maxAutonomousSteps</code> threshold.</p>
+<ul>
+<li>When the step count exceeds the limit, the evaluator SHOULD return <code>continue: false</code> with <code>reason: "Step limit exceeded"</code></li>
+<li>The default limit is implementation-defined but SHOULD be documented via introspection</li>
+<li>Implementations MUST support configuring the step limit</li>
+</ul>
+<p><strong>Stage 2 — Previous Step Outcome:</strong></p>
+<p>If the <code>outcome</code> field of the current <code>record_execution_step</code> call reports <code>"failure"</code>, the evaluator SHOULD return <code>continue: false</code>.</p>
+<ul>
+<li>Pausing after failure prevents cascading errors from autonomous recovery attempts</li>
+<li>The agent SHOULD report the failure to the user or upstream system before retrying</li>
+<li>If <code>outcome</code> is omitted, this stage is skipped</li>
+</ul>
+<p><strong>Stage 3 — Action Pattern Matching:</strong></p>
+<p>Matches the <code>nextActionHint</code> string against configurable glob patterns:</p>
+<ul>
+<li><code>deny</code> patterns → <code>continue: false</code>, <code>stopped: true</code> (triggers out-of-band verification — Section 8.8)</li>
+<li><code>requiresApproval</code> patterns → <code>continue: false</code> (human review needed)</li>
+<li><code>autoApprove</code> patterns → <code>continue: true</code> (skip remaining stages)</li>
+<li>Resolution order: <code>deny</code> &gt; <code>requiresApproval</code> &gt; <code>autoApprove</code></li>
+<li>Unmatched actions fall through to Stage 4</li>
+</ul>
+<p>Pattern examples:</p>
+<div class="sourceCode" id="cb33"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb33-1"><a href="#cb33-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb33-2"><a href="#cb33-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">deny</span><span class="op">:</span> [<span class="st">&quot;drop_*&quot;</span><span class="op">,</span> <span class="st">&quot;delete_all*&quot;</span><span class="op">,</span> <span class="st">&quot;rm -rf*&quot;</span>]<span class="op">,</span></span>
+<span id="cb33-3"><a href="#cb33-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">requiresApproval</span><span class="op">:</span> [<span class="st">&quot;delete_*&quot;</span><span class="op">,</span> <span class="st">&quot;*force*&quot;</span><span class="op">,</span> <span class="st">&quot;deploy_*&quot;</span><span class="op">,</span> <span class="st">&quot;git push*&quot;</span>]<span class="op">,</span></span>
+<span id="cb33-4"><a href="#cb33-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">autoApprove</span><span class="op">:</span> [<span class="st">&quot;read_*&quot;</span><span class="op">,</span> <span class="st">&quot;list_*&quot;</span><span class="op">,</span> <span class="st">&quot;get_*&quot;</span><span class="op">,</span> <span class="st">&quot;search_*&quot;</span>]</span>
+<span id="cb33-5"><a href="#cb33-5" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<p><strong>Stage 4 — Safety Tier Evaluation:</strong></p>
+<p>Assigns a risk score (0-100) to the action and maps it to a safety tier:</p>
+<table>
+<thead>
+<tr>
+<th>Risk Score</th>
+<th>Tier</th>
+<th>Default Behavior</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>0-30</td>
+<td><code>advisory</code></td>
+<td>Continue (log only)</td>
+</tr>
+<tr>
+<td>31-60</td>
+<td><code>confirm</code></td>
+<td>Pause for human review via <code>confirm_operation</code></td>
+</tr>
+<tr>
+<td>61-85</td>
+<td><code>verify</code></td>
+<td>Pause + out-of-band verification via <code>verify_challenge</code> (Section 8.8)</td>
+</tr>
+<tr>
+<td>86-100</td>
+<td><code>danger_zone</code></td>
+<td>Hard stop + out-of-band verification via <code>verify_challenge</code> (Section 8.8)</td>
+</tr>
+</tbody>
+</table>
+<p>The <code>verify</code> and <code>danger_zone</code> tiers both use the out-of-band verification protocol defined in Section 8.8. The difference is enforcement severity: <code>verify</code> sets <code>continue: false</code> (pause — the agent may resume after verification), while <code>danger_zone</code> sets <code>stopped: true</code> (hard block — the agent is blocked at the agent level until verified).</p>
+<p>Risk scoring MAY use pattern matching against known dangerous operations, LLM-provided risk assessments, or adapter-specific heuristics.</p>
+<p><strong>Stage 5 — Risk Tolerance Threshold:</strong></p>
+<p>Compares the risk score against the agent's configured tolerance:</p>
+<table>
+<thead>
+<tr>
+<th>Tolerance</th>
+<th>Threshold</th>
+<th>Behavior</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>conservative</code></td>
+<td>25</td>
+<td>Pause for any risk above 25</td>
+</tr>
+<tr>
+<td><code>moderate</code></td>
+<td>50</td>
+<td>Pause for risk above 50 (default)</td>
+</tr>
+<tr>
+<td><code>aggressive</code></td>
+<td>75</td>
+<td>Pause only for high risk above 75</td>
+</tr>
+</tbody>
+</table>
+<p>Actions with risk scores below the threshold in the <code>advisory</code> tier MAY proceed without pausing.</p>
+<h4 id="873-agent-notification-system">8.7.3 Agent Notification System</h4>
+<p>Notifications inform the agent of events that occurred since the last <code>record_execution_step</code> call. They are included in the <code>AutonomyDirective</code> response.</p>
+<div class="sourceCode" id="cb34"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb34-1"><a href="#cb34-1" aria-hidden="true" tabindex="-1"></a><span class="kw">interface</span> AgentNotification {</span>
+<span id="cb34-2"><a href="#cb34-2" aria-hidden="true" tabindex="-1"></a>  type<span class="op">:</span> NotificationType<span class="op">;</span></span>
+<span id="cb34-3"><a href="#cb34-3" aria-hidden="true" tabindex="-1"></a>  message<span class="op">:</span> <span class="dt">string</span><span class="op">;</span>               <span class="co">// Human-readable description</span></span>
+<span id="cb34-4"><a href="#cb34-4" aria-hidden="true" tabindex="-1"></a>  metadata<span class="op">?:</span> {</span>
+<span id="cb34-5"><a href="#cb34-5" aria-hidden="true" tabindex="-1"></a>    operation<span class="op">?:</span> <span class="dt">string</span><span class="op">;</span>          <span class="co">// Operation that triggered the event</span></span>
+<span id="cb34-6"><a href="#cb34-6" aria-hidden="true" tabindex="-1"></a>    reason<span class="op">?:</span> <span class="dt">string</span><span class="op">;</span>             <span class="co">// Detailed reason</span></span>
+<span id="cb34-7"><a href="#cb34-7" aria-hidden="true" tabindex="-1"></a>    level<span class="op">?:</span> <span class="dt">string</span><span class="op">;</span>              <span class="co">// Permission level that caused the block</span></span>
+<span id="cb34-8"><a href="#cb34-8" aria-hidden="true" tabindex="-1"></a>    verificationId<span class="op">?:</span> <span class="dt">string</span><span class="op">;</span>     <span class="co">// For verify and danger_zone challenges</span></span>
+<span id="cb34-9"><a href="#cb34-9" aria-hidden="true" tabindex="-1"></a>  }<span class="op">;</span></span>
+<span id="cb34-10"><a href="#cb34-10" aria-hidden="true" tabindex="-1"></a>  timestamp<span class="op">:</span> <span class="dt">string</span><span class="op">;</span>             <span class="co">// ISO 8601</span></span>
+<span id="cb34-11"><a href="#cb34-11" aria-hidden="true" tabindex="-1"></a>}</span>
+<span id="cb34-12"><a href="#cb34-12" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb34-13"><a href="#cb34-13" aria-hidden="true" tabindex="-1"></a><span class="kw">type</span> NotificationType <span class="op">=</span></span>
+<span id="cb34-14"><a href="#cb34-14" aria-hidden="true" tabindex="-1"></a>  <span class="op">|</span> <span class="st">&quot;permission_pending&quot;</span>    <span class="co">// Gatekeeper blocked an operation</span></span>
+<span id="cb34-15"><a href="#cb34-15" aria-hidden="true" tabindex="-1"></a>  <span class="op">|</span> <span class="st">&quot;autonomy_pause&quot;</span>        <span class="co">// Autonomy Evaluator paused execution</span></span>
+<span id="cb34-16"><a href="#cb34-16" aria-hidden="true" tabindex="-1"></a>  <span class="op">|</span> <span class="st">&quot;danger_zone&quot;</span>           <span class="co">// Danger Zone hard block (system-wide broadcast)</span></span>
+<span id="cb34-17"><a href="#cb34-17" aria-hidden="true" tabindex="-1"></a>  <span class="op">|</span> <span class="st">&quot;status&quot;</span>                <span class="co">// Informational status update</span></span>
+<span id="cb34-18"><a href="#cb34-18" aria-hidden="true" tabindex="-1"></a>  <span class="op">|</span> <span class="st">&quot;error&quot;</span><span class="op">;</span>                <span class="co">// Error condition</span></span></code></pre></div>
+<p><strong>Notification sources:</strong></p>
+<ul>
+<li><strong><code>permission_pending</code>:</strong> Generated when the Gatekeeper denies an operation that requires confirmation. Cleared when <code>confirm_operation</code> is called with a valid confirmation token for the blocked operation. Failed or invalid confirmation attempts do not clear the notification.</li>
+<li><strong><code>autonomy_pause</code>:</strong> Generated when the Autonomy Evaluator returns <code>continue: false</code>. Provides the reason and contributing factors. For <code>confirm</code> tier pauses, cleared when <code>confirm_operation</code> is called for the paused action. For <code>verify</code> tier pauses, MUST include <code>verificationId</code> in metadata; cleared when <code>verify_challenge</code> succeeds for the associated challenge ID or the challenge expires.</li>
+<li><strong><code>danger_zone</code>:</strong> Broadcast to ALL executing agents (including the affected agent) when any agent triggers a hard block (<code>danger_zone</code> tier or <code>deny</code> pattern match). MUST include the <code>verificationId</code> for the affected agent. Cleared when the blocked agent is unblocked via successful <code>verify_challenge</code> or admin override.</li>
+</ul>
+<p>The notification system is <strong>pull-based</strong>: notifications accumulate between <code>record_execution_step</code> calls and are delivered in the response. There is no push channel.</p>
+<p><strong>Self-Approval Prevention:</strong> When <code>permission_pending</code> notifications expose the blocked operation name, the executing agent could attempt to call <code>confirm_operation</code> to approve its own blocked operations. Implementations MUST prevent self-approval — the entity confirming an operation MUST NOT be the same agent that triggered the block. Server-side controls such as caller identity validation, confirmation tokens bound to a human-only channel, or out-of-band confirmation delivery satisfy this requirement.</p>
+<h4 id="874-configurable-elements">8.7.4 Configurable Elements</h4>
+<p>The following elements of the evaluation pipeline SHOULD be configurable per agent or per adapter:</p>
+<table>
+<thead>
+<tr>
+<th>Element</th>
+<th>Type</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>maxAutonomousSteps</code></td>
+<td>number</td>
+<td>Maximum steps before mandatory pause</td>
+</tr>
+<tr>
+<td><code>riskTolerance</code></td>
+<td>string</td>
+<td><code>"conservative"</code>, <code>"moderate"</code>, or <code>"aggressive"</code></td>
+</tr>
+<tr>
+<td><code>deny</code></td>
+<td>string[]</td>
+<td>Glob patterns that trigger hard block and out-of-band verification (Section 8.8)</td>
+</tr>
+<tr>
+<td><code>requiresApproval</code></td>
+<td>string[]</td>
+<td>Glob patterns that always require human review</td>
+</tr>
+<tr>
+<td><code>autoApprove</code></td>
+<td>string[]</td>
+<td>Glob patterns that bypass evaluation</td>
+</tr>
+</tbody>
+</table>
+<p>Adapters SHOULD document their default configuration and supported configuration options via introspection.</p>
+<h4 id="875-minimum-viable-implementation">8.7.5 Minimum Viable Implementation</h4>
+<p>Not all stages of the evaluation pipeline are equally important. The following defines the minimum requirements:</p>
+<table>
+<thead>
+<tr>
+<th>Stage</th>
+<th>Requirement</th>
+<th>Rationale</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Step Limit</td>
+<td>MUST</td>
+<td>Prevents runaway autonomous execution</td>
+</tr>
+<tr>
+<td>Previous Outcome</td>
+<td>SHOULD</td>
+<td>Prevents cascading failures</td>
+</tr>
+<tr>
+<td>Pattern Matching</td>
+<td>SHOULD</td>
+<td>Primary safety control mechanism</td>
+</tr>
+<tr>
+<td>Safety Tier</td>
+<td>MAY</td>
+<td>Requires risk scoring capability</td>
+</tr>
+<tr>
+<td>Risk Tolerance</td>
+<td>MAY</td>
+<td>Depends on Safety Tier implementation</td>
+</tr>
+</tbody>
+</table>
+<p>An implementation that supports only the Step Limit stage (with a configurable limit and hard pause at the threshold) is a conformant minimum viable implementation.</p>
+<h3 id="88-out-of-band-verification">8.8 Out-of-Band Verification</h3>
+<p>When the Autonomy Evaluator assigns a <code>verify</code> or <code>danger_zone</code> safety tier (Section 8.7.2, Stage 4), the system MUST require out-of-band human verification before the agent may proceed. Out-of-band verification requires a human to provide a verification code through a channel that the AI cannot access, creating cryptographic proof that a human reviewed and approved the action. The <code>verify</code> tier pauses the agent; the <code>danger_zone</code> tier hard-blocks it.</p>
+<h4 id="881-trigger-conditions">8.8.1 Trigger Conditions</h4>
+<p>Out-of-band verification is triggered when:</p>
+<ul>
+<li>The safety tier evaluation assigns <code>verify</code> (risk score 61-85) or <code>danger_zone</code> (risk score 86-100), OR</li>
+<li>The <code>nextActionHint</code> matches a hard-block (<code>deny</code>) pattern configured in the adapter (Section 8.7.2, Stage 3)</li>
+</ul>
+<p>For <code>danger_zone</code> and <code>deny</code> pattern triggers, the <code>AutonomyDirective</code> MUST return <code>stopped: true</code> and MUST include a <code>danger_zone</code> notification broadcast to all executing agents. For <code>verify</code> triggers, the <code>AutonomyDirective</code> returns <code>continue: false</code> (pause) without <code>stopped: true</code> — the agent is paused but not permanently blocked.</p>
+<h4 id="882-challenge-protocol">8.8.2 Challenge Protocol</h4>
+<p>The verification protocol follows these steps:</p>
+<p><strong>1. Challenge Generation:</strong></p>
+<ul>
+<li>The adapter generates a verification code with at least 128 bits of entropy from a cryptographically secure random source</li>
+<li>The adapter generates a unique challenge ID (UUID v4 recommended)</li>
+<li>The code MUST be cryptographically unpredictable (not sequential, not time-based)</li>
+</ul>
+<p><strong>2. Out-of-Band Display:</strong></p>
+<ul>
+<li>The verification code MUST be displayed through a channel inaccessible to the AI agent</li>
+<li>The code MUST NOT appear in any MCP response, tool result, <code>_meta</code> field, or log accessible to the AI</li>
+<li>Valid display channels include (but are not limited to):
+<ul>
+<li>OS-native dialogs (AppleScript on macOS, zenity on Linux, PowerShell on Windows)</li>
+<li>Hardware security tokens</li>
+<li>SMS or email to a registered operator</li>
+<li>Dedicated security dashboard</li>
+</ul></li>
+<li>The AI agent receives only the challenge ID and a human-readable prompt — never the code itself</li>
+<li>The initial <code>AutonomyDirective</code> MUST include the challenge ID via a notification: <code>autonomy_pause</code> with <code>metadata.verificationId</code> for <code>verify</code> tier, or <code>danger_zone</code> with <code>metadata.verificationId</code> for <code>danger_zone</code> tier and <code>deny</code> pattern matches</li>
+</ul>
+<p><strong>3. Verification:</strong></p>
+<ul>
+<li>The human provides the code via the <code>verify_challenge</code> operation with the challenge ID and code</li>
+<li>On successful verification, the blocked agent is unblocked and execution may resume</li>
+<li>On failed verification, the code is invalidated (one-time use)</li>
+</ul>
+<p><strong>4. Expiration:</strong></p>
+<ul>
+<li>Verification challenges SHOULD expire after a configurable timeout (default: 5 minutes)</li>
+<li>Expired challenges MUST be treated as failed</li>
+</ul>
+<h4 id="883-blocking-semantics">8.8.3 Blocking Semantics</h4>
+<p>When an agent is hard-blocked by any event that sets <code>stopped: true</code> (a <code>danger_zone</code> safety tier assignment, a <code>deny</code> pattern match, or equivalent adapter-specific trigger):</p>
+<ul>
+<li>The <code>AutonomyDirective</code> returns <code>stopped: true</code></li>
+<li>All subsequent execution operations for the blocked agent MUST be rejected until unblocked</li>
+<li>The blocked state MUST persist across server restarts (file-based or database storage)</li>
+<li>Only successful verification via <code>verify_challenge</code> or an explicit admin override can unblock the agent</li>
+</ul>
+<p>Adapters MUST NOT allow an agent to bypass a hard block by starting a new execution. The block is applied at the agent level, not the execution level.</p>
+<p>For <code>verify</code> tier challenges (where <code>stopped</code> is not <code>true</code>), the agent is paused rather than blocked. While a <code>verify</code> challenge is pending, subsequent <code>record_execution_step</code> calls for the same agent SHOULD return <code>continue: false</code> with the pending challenge ID in the reason field, until the challenge is completed or expires. Unlike hard blocks, <code>verify</code> pauses do not persist across server restarts and do not prevent starting new executions. When a <code>verify</code> challenge expires, the pause is lifted and subsequent <code>record_execution_step</code> calls SHOULD re-evaluate the action normally — if the same action is reported again, a new challenge is generated.</p>
+<h4 id="884-channel-separation-requirements">8.8.4 Channel Separation Requirements</h4>
+<p>The security of out-of-band verification depends entirely on channel separation. The verification code:</p>
+<ul>
+<li>MUST NOT appear in any MCP tool response or result</li>
+<li>MUST NOT appear in any <code>_meta</code> field of an MCP response</li>
+<li>MUST NOT be logged in any location accessible to the AI agent</li>
+<li>MUST NOT be included in error messages, debug output, or diagnostic information accessible to the AI</li>
+<li>MUST NOT be derivable from any information available to the AI (e.g., timestamps, sequential IDs)</li>
+</ul>
+<blockquote>
+<p><strong>Security Principle:</strong> Even a fully prompt-injected LLM that has been instructed to bypass safety checks cannot complete out-of-band verification, because the code exists only in a channel the LLM cannot observe.</p>
+</blockquote>
+<h4 id="885-rate-limiting">8.8.5 Rate Limiting</h4>
+<p>Failed verification attempts SHOULD be rate-limited to prevent brute-force attacks:</p>
+<ul>
+<li>Implementations SHOULD allow no more than 10 failed attempts per 60-second window per agent</li>
+<li>After exceeding the rate limit, subsequent verification attempts SHOULD be rejected with an appropriate error</li>
+<li>The failure counter resets after the window expires (sliding or fixed window); however, implementations MAY apply progressive lockout (e.g., doubling the window duration) after repeated rate-limit violations</li>
+<li>Rate limit state SHOULD persist across server restarts</li>
+<li>Failed verification attempts SHOULD trigger security audit events</li>
+</ul>
+<h4 id="886-implementation-flexibility">8.8.6 Implementation Flexibility</h4>
+<p>This specification defines the <strong>verification protocol</strong>, not the display mechanism. Implementations MAY use any display channel that satisfies the channel separation requirements (Section 8.8.4):</p>
+<table>
+<thead>
+<tr>
+<th>Channel</th>
+<th>Platform</th>
+<th>Notes</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>OS dialog</td>
+<td>Desktop</td>
+<td>AppleScript, zenity, PowerShell</td>
+</tr>
+<tr>
+<td>Hardware token</td>
+<td>Any</td>
+<td>Physical device with display</td>
+</tr>
+<tr>
+<td>SMS/Email</td>
+<td>Any</td>
+<td>Requires operator contact info</td>
+</tr>
+<tr>
+<td>Security dashboard</td>
+<td>Web</td>
+<td>Dedicated approval interface</td>
+</tr>
+<tr>
+<td>Mobile push notification</td>
+<td>Any</td>
+<td>Requires companion app</td>
+</tr>
+</tbody>
+</table>
+<p>The only requirement is that the channel is inaccessible to the AI agent performing the action.</p>
+<hr />
+<h2 id="9-type-system">9. Type System</h2>
+<h3 id="91-protocol-types">9.1 Protocol Types</h3>
+<p>MCP-AQL defines these protocol-level types:</p>
+<p><strong>EndpointCategory</strong> (enum)</p>
+<pre><code>CREATE | READ | UPDATE | DELETE | EXECUTE</code></pre>
+<p><strong>OperationResult</strong> (union)</p>
+<pre><code>OperationSuccess | OperationFailure</code></pre>
+<p>See <a href="#appendix-d-json-schemas">Appendix D: JSON Schemas</a> for formal schema definitions.</p>
+<h3 id="92-adapter-types">9.2 Adapter Types</h3>
+<p>Adapters define their own domain-specific types, which MUST be discoverable via the <code>introspect</code> operation with <code>query: "types"</code>.</p>
+<h3 id="93-request-concurrency">9.3 Request Concurrency</h3>
+<p>MCP allows request pipelining, enabling clients to send multiple requests without waiting for responses. MCP-AQL defines ordering guarantees for batch operations (see <a href="../operations.html">Operations Reference</a> Section 7) but does not mandate ordering for concurrent independent requests.</p>
+<h4 id="931-concurrency-requirements">9.3.1 Concurrency Requirements</h4>
+<p>Adapters MUST document their concurrency behavior. The following concurrency categories are defined:</p>
+<table>
+<thead>
+<tr>
+<th>Category</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>serialized</code></td>
+<td>All requests processed sequentially in arrival order</td>
+</tr>
+<tr>
+<td><code>read-concurrent</code></td>
+<td>READ operations may execute concurrently; writes serialized</td>
+</tr>
+<tr>
+<td><code>fully-concurrent</code></td>
+<td>All operations may execute concurrently</td>
+</tr>
+<tr>
+<td><code>resource-locked</code></td>
+<td>Concurrent on different resources; serialized per resource</td>
+</tr>
+</tbody>
+</table>
+<h4 id="932-state-modifying-operations">9.3.2 State-Modifying Operations</h4>
+<p>Adapters supporting concurrent state modification SHOULD implement optimistic concurrency control:</p>
+<ol type="1">
+<li><strong>ETag/Version Response:</strong> Include <code>_etag</code> or <code>_version</code> field in responses for mutable resources</li>
+<li><strong>Precondition Request:</strong> Accept <code>if_match</code> parameter for conditional updates</li>
+<li><strong>Conflict Detection:</strong> Return <code>CONFLICT_VERSION_MISMATCH</code> error when precondition fails</li>
+</ol>
+<p><strong>Example response with version:</strong></p>
+<div class="sourceCode" id="cb37"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb37-1"><a href="#cb37-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb37-2"><a href="#cb37-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb37-3"><a href="#cb37-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;data&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb37-4"><a href="#cb37-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;id&quot;</span><span class="fu">:</span> <span class="st">&quot;doc_123&quot;</span><span class="fu">,</span></span>
+<span id="cb37-5"><a href="#cb37-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;title&quot;</span><span class="fu">:</span> <span class="st">&quot;My Document&quot;</span><span class="fu">,</span></span>
+<span id="cb37-6"><a href="#cb37-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;_etag&quot;</span><span class="fu">:</span> <span class="st">&quot;W/</span><span class="ch">\&quot;</span><span class="st">a1b2c3d4</span><span class="ch">\&quot;</span><span class="st">&quot;</span></span>
+<span id="cb37-7"><a href="#cb37-7" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb37-8"><a href="#cb37-8" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<p><strong>Example conditional update:</strong></p>
+<div class="sourceCode" id="cb38"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb38-1"><a href="#cb38-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb38-2"><a href="#cb38-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;update_document&quot;</span><span class="fu">,</span></span>
+<span id="cb38-3"><a href="#cb38-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb38-4"><a href="#cb38-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;id&quot;</span><span class="fu">:</span> <span class="st">&quot;doc_123&quot;</span><span class="fu">,</span></span>
+<span id="cb38-5"><a href="#cb38-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;title&quot;</span><span class="fu">:</span> <span class="st">&quot;Updated Title&quot;</span><span class="fu">,</span></span>
+<span id="cb38-6"><a href="#cb38-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;if_match&quot;</span><span class="fu">:</span> <span class="st">&quot;W/</span><span class="ch">\&quot;</span><span class="st">a1b2c3d4</span><span class="ch">\&quot;</span><span class="st">&quot;</span></span>
+<span id="cb38-7"><a href="#cb38-7" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb38-8"><a href="#cb38-8" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<h4 id="933-concurrency-metadata">9.3.3 Concurrency Metadata</h4>
+<p>Adapters MAY expose concurrency behavior via introspection in protocol metadata:</p>
+<div class="sourceCode" id="cb39"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb39-1"><a href="#cb39-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb39-2"><a href="#cb39-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;_protocol&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb39-3"><a href="#cb39-3" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;concurrency&quot;</span><span class="fu">:</span> <span class="st">&quot;resource-locked&quot;</span><span class="fu">,</span></span>
+<span id="cb39-4"><a href="#cb39-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;supports_etag&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb39-5"><a href="#cb39-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;max_concurrent_requests&quot;</span><span class="fu">:</span> <span class="dv">10</span></span>
+<span id="cb39-6"><a href="#cb39-6" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb39-7"><a href="#cb39-7" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<hr />
+<h2 id="10-conformance">10. Conformance</h2>
+<h3 id="101-conformance-levels">10.1 Conformance Levels</h3>
+<p><strong>Level 1: Basic Conformance</strong></p>
+<ul>
+<li>MUST support at least one endpoint mode (CRUDE or Single)</li>
+<li>MUST implement the <code>introspect</code> operation</li>
+<li>MUST use standard request/response formats</li>
+<li>MUST classify operations correctly into CRUDE endpoints</li>
+<li>MUST reject operations sent to wrong endpoints (CRUDE mode)</li>
+</ul>
+<p><strong>Level 2: Full Conformance</strong></p>
+<ul>
+<li>MUST meet Level 1 requirements</li>
+<li>MUST support both CRUDE and Single endpoint modes</li>
+<li>MUST pass the conformance test suite</li>
+<li>SHOULD implement field selection</li>
+<li>SHOULD implement batch operations</li>
+</ul>
+<h3 id="102-claiming-conformance">10.2 Claiming Conformance</h3>
+<p>Implementations claiming MCP-AQL conformance MUST:</p>
+<ol type="1">
+<li>State their conformance level</li>
+<li>Document their operations via introspection</li>
+<li>Document any extensions</li>
+</ol>
+<h3 id="103-extensions">10.3 Extensions</h3>
+<p>Implementations MAY extend MCP-AQL with additional:</p>
+<ul>
+<li>Features (field selection, batch operations, etc.)</li>
+<li>Response metadata fields</li>
+</ul>
+<p>Extensions MUST be documented and MUST NOT conflict with core specification behavior.</p>
+<hr />
+<h2 id="appendix-a-token-efficiency">Appendix A: Token Efficiency</h2>
+<h3 id="a1-measured-token-costs">A.1 Measured Token Costs</h3>
+<table>
+<thead>
+<tr>
+<th>Configuration</th>
+<th>Tools</th>
+<th>Tokens</th>
+<th>Reduction</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Discrete Tools</td>
+<td>50+</td>
+<td>~29,600</td>
+<td>Baseline</td>
+</tr>
+<tr>
+<td>CRUDE Mode</td>
+<td>5</td>
+<td>~4,300</td>
+<td>~85%</td>
+</tr>
+<tr>
+<td>Single Mode</td>
+<td>1</td>
+<td>~1,100</td>
+<td>~96%</td>
+</tr>
+</tbody>
+</table>
+<h3 id="a2-introspection-pattern">A.2 Introspection Pattern</h3>
+<pre><code>Total context for 10 operations with introspection:
+- Tool registration: ~1,100 tokens
+- 10 × introspect calls: ~1,500 tokens
+- Total: ~2,600 tokens (vs ~29,600 baseline)</code></pre>
+<hr />
+<h2 id="appendix-b-references">Appendix B: References</h2>
+<h3 id="core-documentation">Core Documentation</h3>
+<ul>
+<li><a href="../overview.html">Protocol Overview</a></li>
+<li><a href="../operations.html">Operations Reference</a></li>
+<li><a href="../endpoint-modes.html">Endpoint Modes</a></li>
+<li><a href="../mcp-integration.html">MCP Integration</a></li>
+<li><a href="../introspection.html">Introspection Specification</a></li>
+<li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li>
+<li><a href="../adapter/element-type.html">Adapter Element Type Specification</a></li>
+</ul>
+<h3 id="implementation-documentation">Implementation Documentation</h3>
+<ul>
+<li><a href="https://github.com/MCPAQL/mcpaql-adapter/blob/develop/docs/architecture/overview.md">Architecture Overview</a> (in mcpaql-adapter repo)</li>
+<li><a href="https://github.com/MCPAQL/mcpaql-adapter/blob/develop/docs/architecture/runtime.md">Universal Adapter Runtime</a> (in mcpaql-adapter repo)</li>
+<li><a href="https://github.com/MCPAQL/mcpaql-adapter/blob/develop/docs/architecture/plugin-system.md">Plugin System Implementation</a> (in mcpaql-adapter repo)</li>
+<li><a href="https://github.com/MCPAQL/mcpaql-adapter/blob/develop/docs/guides/development.md">Development Guide</a> (in mcpaql-adapter repo)</li>
+</ul>
+<h3 id="examples">Examples</h3>
+<ul>
+<li><a href="https://github.com/MCPAQL/examples/blob/develop/adapters/github-api-adapter.md">GitHub API Adapter</a> (in examples repo)</li>
+</ul>
+<h3 id="guides">Guides</h3>
+<ul>
+<li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li>
+</ul>
+<h3 id="process--decision-records">Process &amp; Decision Records</h3>
+<ul>
+<li><a href="../adr/index.html">Architecture Decision Records</a></li>
+</ul>
+<h3 id="external-references">External References</h3>
+<ul>
+<li><a href="https://spec.modelcontextprotocol.io/">Model Context Protocol Specification</a> (note: may be unreachable)</li>
+<li><a href="https://www.ietf.org/rfc/rfc2119.txt">RFC 2119 - Key words for use in RFCs</a></li>
+</ul>
+<hr />
+<h2 id="appendix-c-change-log">Appendix C: Change Log</h2>
+<table>
+<thead>
+<tr>
+<th>Version</th>
+<th>Date</th>
+<th>Changes</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>1.0.0-draft</td>
+<td>2026-01-05</td>
+<td>Initial draft specification</td>
+</tr>
+<tr>
+<td>1.0.0-draft</td>
+<td>2026-01-14</td>
+<td>Revised to be adapter-agnostic</td>
+</tr>
+<tr>
+<td>1.0.0-draft</td>
+<td>2026-01-16</td>
+<td>Added schema references, updated documentation links, renamed EndpointCategory</td>
+</tr>
+</tbody>
+</table>
+<hr />
+<h2 id="appendix-d-json-schemas">Appendix D: JSON Schemas</h2>
+<p>Formal JSON Schema definitions are provided for validation:</p>
+<table>
+<thead>
+<tr>
+<th>Schema</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a href="https://github.com/MCPAQL/spec/blob/main/schemas/operation-input.schema.json">operation-input.schema.json</a></td>
+<td>Request format validation</td>
+</tr>
+<tr>
+<td><a href="https://github.com/MCPAQL/spec/blob/main/schemas/operation-result.schema.json">operation-result.schema.json</a></td>
+<td>Response format validation</td>
+</tr>
+<tr>
+<td><a href="https://github.com/MCPAQL/spec/blob/main/schemas/introspection-response.schema.json">introspection-response.schema.json</a></td>
+<td>Introspection response validation</td>
+</tr>
+<tr>
+<td><a href="https://github.com/MCPAQL/spec/blob/main/schemas/danger-level.schema.json">danger-level.schema.json</a></td>
+<td>Operation danger classification</td>
+</tr>
+</tbody>
+</table>
+<p>Schemas use JSON Schema 2020-12 draft and are normative for this specification.</p>
+
+          </div>
+        </section>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div class="container">
+      <p>&copy; 2026 DollhouseMCP Inc. d/b/a Dollhouse Research. MCP-AQL public draft documentation portal.</p>
+      <div class="footer-links">
+        <a href="../../docs/index.html">Docs Library</a>
+        <a href="../index.html">Repo-Synced Spec</a>
+        <a href="https://github.com/MCPAQL">MCPAQL Organization</a>
+        <a href="https://dollhouseresearch.com">Dollhouse Research</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../../js/search.js"></script>
+</body>
+</html>

--- a/public/spec/versions/v1.0.0-draft.html
+++ b/public/spec/versions/v1.0.0-draft.html
@@ -73,6 +73,13 @@
       </aside>
 
       <article class="docs-main">
+        <nav class="breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../../index.html">Home</a></li>
+            <li><a href="../index.html">Full Spec</a></li>
+            <li><span class="current">MCP-AQL Specification</span></li>
+          </ol>
+        </nav>
         <section class="hero docs-hero">
           <div class="hero-inner">
             <span class="status-pill">REPO-SYNCED SPEC DOC</span>

--- a/public/spec/versions/v1.0.0-draft.html
+++ b/public/spec/versions/v1.0.0-draft.html
@@ -23,7 +23,7 @@
         </ul>
         <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
-          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <input id="site-search-input" data-search-input type="search" placeholder="Search MCP-AQL docs, spec pages, and adapter patterns...">
           <span class="search-count" data-search-count></span>
           <ul class="search-results" data-search-results hidden></ul>
         </form>
@@ -41,7 +41,7 @@
   <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li><li><a href="../repo/README.html">MCP-AQL Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Versions</h3>
-  <ul><li><a class="current" href="v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
+  <ul><li><a class="current" aria-current="page" href="v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Adapter</h3>
   <ul><li><a href="../adapter/danger-levels.html">Dangerous Operation Classification Specification</a></li><li><a href="../adapter/discovery-bundle.html">MCP Server Discovery Bundle</a></li><li><a href="../adapter/element-type.html">Adapter Element Type Specification</a></li><li><a href="../adapter/generator.html">Adapter Generator Specification</a></li><li><a href="../adapter/rate-limiting.html">Rate Limiting and Quota Management Specification</a></li><li><a href="../adapter/trust-levels.html">Trust Levels Specification</a></li></ul>
@@ -1812,6 +1812,16 @@ mcp_aql_execute  - EXECUTE operations</code></pre>
 
           </div>
         </section>
+        <nav class="page-nav" aria-label="Page navigation">
+  <a class="page-nav-link prev" href="../repo/README.html">
+    <span class="page-nav-eyebrow">Previous spec page</span>
+    <strong class="page-nav-label">MCP-AQL Specification</strong>
+  </a>
+  <a class="page-nav-link next" href="../adapter/danger-levels.html">
+    <span class="page-nav-eyebrow">Next spec page</span>
+    <strong class="page-nav-label">Dangerous Operation Classification Specification</strong>
+  </a>
+</nav>
       </article>
     </div>
   </main>

--- a/scripts/generate-spec-docs.mjs
+++ b/scripts/generate-spec-docs.mjs
@@ -1,0 +1,645 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const siteRoot = path.resolve(__dirname, "..");
+const publicRoot = path.join(siteRoot, "public");
+const outputRoot = path.join(publicRoot, "spec");
+const searchBasePath = path.join(siteRoot, "source", "search-index.base.json");
+
+const args = process.argv.slice(2);
+const isCheck = args.includes("--check");
+const specDirArgIndex = args.indexOf("--spec-dir");
+const specRoot = path.resolve(
+  siteRoot,
+  specDirArgIndex >= 0 && args[specDirArgIndex + 1] ? args[specDirArgIndex + 1] : "../spec"
+);
+const specDocsRoot = path.join(specRoot, "docs");
+
+const categoryOrder = [
+  "Core",
+  "Versions",
+  "Adapter",
+  "Security",
+  "Features",
+  "Guides",
+  "Process",
+  "Architecture",
+  "Research",
+  "Reference",
+  "ADRs"
+];
+
+if (!fs.existsSync(specDocsRoot)) {
+  console.error(`Spec docs directory not found: ${specDocsRoot}`);
+  process.exit(1);
+}
+
+assertPandoc();
+
+const docs = collectDocs(specDocsRoot).map((sourceFile) => {
+  const sourceRel = path.relative(specDocsRoot, sourceFile).replace(/\\/g, "/");
+  const outputRel = `spec/${sourceRel.replace(/\.md$/i, ".html")}`;
+  const markdown = fs.readFileSync(sourceFile, "utf8");
+  const { body, metadata } = splitFrontMatter(markdown);
+  const title = extractTitle(body, sourceRel, metadata);
+  const status = extractField(body, "Status", metadata);
+  const version = extractField(body, "Version", metadata);
+  const lastUpdated = extractField(body, "Last Updated", metadata);
+  const summary = extractSummary(body, title);
+  const category = categoryFor(sourceRel);
+  const scopeLabel = sourceRel.startsWith("versions/") ? "Normative source" : "Support document";
+
+  return {
+    sourceFile,
+    sourceRel,
+    outputRel,
+    markdown,
+    title,
+    status,
+    version,
+    lastUpdated,
+    summary,
+    category,
+    scopeLabel
+  };
+});
+
+const navGroups = buildNavGroups(docs);
+let changedFiles = 0;
+
+for (const doc of docs) {
+  const fragment = renderMarkdown(doc.markdown);
+  const html = wrapSpecDocPage({
+    doc,
+    navGroups,
+    bodyHtml: rewriteLinks(stripFirstHeading(fragment), doc.sourceRel, doc.outputRel)
+  });
+  changedFiles += writeFile(path.join(publicRoot, doc.outputRel), html);
+}
+
+const specIndexHtml = wrapSpecIndexPage(navGroups);
+changedFiles += writeFile(path.join(outputRoot, "index.html"), specIndexHtml);
+
+const baseSearchEntries = JSON.parse(fs.readFileSync(searchBasePath, "utf8"));
+const generatedSearchEntries = docs.map((doc) => ({
+  title: `Spec: ${doc.title}`,
+  url: `/${doc.outputRel}`,
+  excerpt: doc.summary,
+  keywords: buildKeywords(doc)
+}));
+
+const mergedSearch = [...baseSearchEntries, {
+  title: "Repo-Synced Spec Reference",
+  url: "/spec/index.html",
+  excerpt: "Full website-hosted mirror of the MCP-AQL spec docs generated from the spec repository source.",
+  keywords: ["spec mirror", "repo synced", "full docs", "reference", "generated"]
+}, ...generatedSearchEntries];
+
+changedFiles += writeFile(
+  path.join(publicRoot, "data", "search-index.json"),
+  `${JSON.stringify(mergedSearch, null, 2)}\n`
+);
+
+if (isCheck && changedFiles > 0) {
+  console.error("Generated spec docs are out of date. Run `npm run generate:spec-docs`.");
+  process.exit(1);
+}
+
+console.log(`${isCheck ? "Checked" : "Generated"} ${docs.length} spec doc pages.`);
+
+function assertPandoc() {
+  try {
+    execFileSync("pandoc", ["--version"], { stdio: "ignore" });
+  } catch (error) {
+    console.error("pandoc is required to generate the repo-synced spec pages.");
+    process.exit(1);
+  }
+}
+
+function collectDocs(rootDir) {
+  const files = [];
+
+  walk(rootDir);
+
+  return files.sort((left, right) => left.localeCompare(right));
+
+  function walk(dir) {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const absolute = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (absolute.includes(`${path.sep}agent${path.sep}development`)) {
+          continue;
+        }
+        walk(absolute);
+        continue;
+      }
+
+      if (!entry.isFile() || !entry.name.endsWith(".md")) {
+        continue;
+      }
+
+      const rel = path.relative(rootDir, absolute).replace(/\\/g, "/");
+      if (rel.startsWith("agent/development/")) {
+        continue;
+      }
+      files.push(absolute);
+    }
+  }
+}
+
+function extractTitle(markdown, sourceRel, metadata = {}) {
+  if (metadata.title) {
+    return metadata.title.trim();
+  }
+
+  let inCodeFence = false;
+  for (const line of markdown.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (trimmed.startsWith("```")) {
+      inCodeFence = !inCodeFence;
+      continue;
+    }
+
+    if (!inCodeFence && /^#\s+/.test(trimmed)) {
+      return trimmed.replace(/^#\s+/, "").trim();
+    }
+  }
+
+  return sourceRel
+    .replace(/\.md$/i, "")
+    .split("/")
+    .pop()
+    .replace(/[-_]/g, " ")
+    .replace(/\b\w/g, (value) => value.toUpperCase());
+}
+
+function extractField(markdown, label, metadata = {}) {
+  const normalizedKey = label.toLowerCase().replace(/\s+/g, "_");
+  if (metadata[normalizedKey]) {
+    return metadata[normalizedKey].trim();
+  }
+
+  const expression = new RegExp(`^\\*\\*${escapeRegExp(label)}:\\*\\*\\s+(.+)$`, "m");
+  const match = markdown.match(expression);
+  return match ? match[1].trim() : "";
+}
+
+function extractSummary(markdown, title) {
+  const lines = markdown.split(/\r?\n/);
+  let inCodeFence = false;
+  let skipToc = false;
+  const paragraph = [];
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+
+    if (trimmed.startsWith("```")) {
+      inCodeFence = !inCodeFence;
+      continue;
+    }
+
+    if (inCodeFence) {
+      continue;
+    }
+
+    if (trimmed === "## Table of Contents") {
+      skipToc = true;
+      continue;
+    }
+
+    if (skipToc) {
+      if (trimmed === "---") {
+        skipToc = false;
+      }
+      continue;
+    }
+
+    if (!trimmed) {
+      if (paragraph.length) {
+        break;
+      }
+      continue;
+    }
+
+    if (
+      /^\*\*(Version|Status|Last Updated):\*\*/.test(trimmed) ||
+      /^[a-z_]+:\s+.+$/i.test(trimmed) ||
+      /^[-*+]\s+/.test(trimmed) ||
+      /^\d+\.\s+/.test(trimmed) ||
+      /^#{1,6}\s+/.test(trimmed) ||
+      /^\|/.test(trimmed)
+    ) {
+      continue;
+    }
+
+    paragraph.push(trimmed.replace(/^>\s?/, ""));
+  }
+
+  if (!paragraph.length) {
+    return title;
+  }
+
+  return stripMarkdown(paragraph.join(" ")).slice(0, 220);
+}
+
+function renderMarkdown(markdown) {
+  return execFileSync(
+    "pandoc",
+    ["--from=gfm", "--to=html5", "--wrap=none"],
+    {
+      input: markdown,
+      encoding: "utf8",
+      maxBuffer: 16 * 1024 * 1024
+    }
+  );
+}
+
+function stripFirstHeading(html) {
+  return html.replace(/^<h1[^>]*>[\s\S]*?<\/h1>\n?/, "");
+}
+
+function rewriteLinks(html, currentSourceRel, currentOutputRel) {
+  return html.replace(/\b(href|src)="([^"]+)"/g, (fullMatch, attribute, target) => {
+    return `${attribute}="${resolveTarget(target, currentSourceRel, currentOutputRel)}"`;
+  });
+}
+
+function resolveTarget(target, currentSourceRel, currentOutputRel) {
+  if (!target || target.startsWith("#") || /^[a-z]+:/i.test(target) || target.startsWith("/")) {
+    return target;
+  }
+
+  const [rawPath, hash = ""] = target.split("#");
+  const anchor = hash ? `#${hash}` : "";
+  const specRelativeTarget = path
+    .normalize(path.join("docs", path.dirname(currentSourceRel), rawPath))
+    .replace(/\\/g, "/");
+  const absoluteTarget = path.join(specRoot, specRelativeTarget);
+
+  if (rawPath.endsWith(".md") && specRelativeTarget.startsWith("docs/") && fs.existsSync(absoluteTarget)) {
+    const docsRelative = specRelativeTarget.replace(/^docs\//, "");
+    const targetOutputRel = `spec/${docsRelative.replace(/\.md$/i, ".html")}`;
+    const relativeUrl = path.relative(path.dirname(currentOutputRel), targetOutputRel).replace(/\\/g, "/");
+    return `${relativeUrl || path.basename(targetOutputRel)}${anchor}`;
+  }
+
+  if (rawPath.endsWith(".md")) {
+    return `https://github.com/MCPAQL/spec/blob/main/${specRelativeTarget}${anchor}`;
+  }
+
+  return `https://github.com/MCPAQL/spec/blob/main/${specRelativeTarget}${anchor}`;
+}
+
+function buildNavGroups(docs) {
+  const grouped = new Map();
+  for (const category of categoryOrder) {
+    grouped.set(category, []);
+  }
+
+  for (const doc of docs) {
+    if (!grouped.has(doc.category)) {
+      grouped.set(doc.category, []);
+    }
+    grouped.get(doc.category).push(doc);
+  }
+
+  return Array.from(grouped.entries())
+    .map(([category, entries]) => ({ category, entries }))
+    .filter((group) => group.entries.length > 0);
+}
+
+function wrapSpecDocPage({ doc, navGroups, bodyHtml }) {
+  const navHtml = renderNavGroups(navGroups, doc.outputRel);
+  const sourceUrl = `https://github.com/MCPAQL/spec/blob/main/docs/${doc.sourceRel}`;
+  const metaBits = [
+    `<span class="state-chip live">${escapeHtml(doc.scopeLabel)}</span>`,
+    doc.status ? `<span class="state-chip pending">${escapeHtml(doc.status)}</span>` : "",
+    doc.version ? `<span class="state-chip">${escapeHtml(doc.version)}</span>` : "",
+    doc.lastUpdated ? `<span class="state-chip">${escapeHtml(doc.lastUpdated)}</span>` : ""
+  ].filter(Boolean).join("");
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="${escapeHtml(doc.summary)}">
+  <title>MCP-AQL Spec | ${escapeHtml(doc.title)}</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="${relativeAssetPath(doc.outputRel, "css/style.css")}">
+</head>
+<body>
+  <header>
+    <div class="container">
+      <nav>
+        <a class="logo" href="${relativePathFromDoc(doc.outputRel, "index.html")}"><span class="logo-mark"></span>MCP-AQL</a>
+        <ul class="nav-links">
+          <li><a href="${relativePathFromDoc(doc.outputRel, "index.html")}">Home</a></li>
+          <li><a href="${relativePathFromDoc(doc.outputRel, "docs/index.html")}">Docs</a></li>
+          <li><a href="${relativePathFromDoc(doc.outputRel, "launch-checklist.html")}">Launch Checklist</a></li>
+          <li><a href="${relativePathFromDoc(doc.outputRel, "apis/mcp-server.html")}">Adapter Patterns</a></li>
+        </ul>
+        <form class="site-search" data-search-form data-index-url="${relativePathFromDoc(doc.outputRel, "data/search-index.json")}" role="search">
+          <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
+          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <span class="search-count" data-search-count></span>
+          <ul class="search-results" data-search-results hidden></ul>
+        </form>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <div class="container docs-shell">
+      <aside class="docs-side">
+        <h2>Repo-Synced Spec</h2>
+        <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
+        ${navHtml}
+      </aside>
+
+      <article class="docs-main">
+        <section class="hero docs-hero">
+          <div class="hero-inner">
+            <span class="status-pill">REPO-SYNCED SPEC DOC</span>
+            <h1>${escapeHtml(doc.title)}</h1>
+            <p class="lede">${escapeHtml(doc.summary)}</p>
+            <div class="spec-meta">${metaBits}</div>
+            <p class="spec-source">Source: <a href="${sourceUrl}">${escapeHtml(`spec/docs/${doc.sourceRel}`)}</a></p>
+            <div class="hero-actions">
+              <a class="btn btn-primary" href="${sourceUrl}">Open Source Markdown</a>
+              <a class="btn btn-secondary" href="${relativePathFromDoc(doc.outputRel, "spec/index.html")}">Browse Full Spec Reference</a>
+            </div>
+          </div>
+        </section>
+
+        <section>
+          <div class="card spec-prose">
+            ${bodyHtml}
+          </div>
+        </section>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div class="container">
+      <p>&copy; 2026 DollhouseMCP Inc. d/b/a Dollhouse Research. MCP-AQL public draft documentation portal.</p>
+      <div class="footer-links">
+        <a href="${relativePathFromDoc(doc.outputRel, "docs/index.html")}">Docs Library</a>
+        <a href="${relativePathFromDoc(doc.outputRel, "spec/index.html")}">Repo-Synced Spec</a>
+        <a href="https://github.com/MCPAQL">MCPAQL Organization</a>
+        <a href="https://dollhouseresearch.com">Dollhouse Research</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="${relativeAssetPath(doc.outputRel, "js/search.js")}"></script>
+</body>
+</html>
+`;
+}
+
+function wrapSpecIndexPage(navGroups) {
+  const sections = navGroups.map((group) => {
+    const cards = group.entries.map((doc) => {
+      return `<article class="card">
+  <h3>${escapeHtml(doc.title)}</h3>
+  <p>${escapeHtml(doc.summary)}</p>
+  <div class="spec-meta">
+    <span class="state-chip live">${escapeHtml(doc.scopeLabel)}</span>
+    ${doc.status ? `<span class="state-chip pending">${escapeHtml(doc.status)}</span>` : ""}
+  </div>
+  <a href="${relativePathWithinPublic("spec/index.html", doc.outputRel)}">Open Page</a>
+</article>`;
+    }).join("\n");
+
+    return `<section>
+  <h2 class="section-title">${escapeHtml(group.category)}</h2>
+  <div class="grid cols-3 spec-index-grid">
+    ${cards}
+  </div>
+</section>`;
+  }).join("\n");
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Repo-synced full MCP-AQL spec reference generated from the specification repository.">
+  <title>MCP-AQL Spec | Full Reference</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../css/style.css">
+</head>
+<body>
+  <header>
+    <div class="container">
+      <nav>
+        <a class="logo" href="../index.html"><span class="logo-mark"></span>MCP-AQL</a>
+        <ul class="nav-links">
+          <li><a href="../index.html">Home</a></li>
+          <li><a href="../docs/index.html">Docs</a></li>
+          <li><a href="../launch-checklist.html">Launch Checklist</a></li>
+          <li><a href="../apis/mcp-server.html">Adapter Patterns</a></li>
+        </ul>
+        <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
+          <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
+          <input id="site-search-input" data-search-input type="search" placeholder="Search full spec reference...">
+          <span class="search-count" data-search-count></span>
+          <ul class="search-results" data-search-results hidden></ul>
+        </form>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <div class="container">
+      <section class="hero">
+        <div class="hero-inner">
+          <span class="status-pill">REPO-SYNCED SPEC REFERENCE</span>
+          <h1>The deeper protocol docs now live on the website too</h1>
+          <p class="lede">
+            These pages are generated from <code>MCPAQL/spec/docs</code> so the public site can carry the full protocol and adapter material,
+            not just summaries and links back to GitHub.
+          </p>
+          <div class="hero-actions">
+            <a class="btn btn-primary" href="versions/v1.0.0-draft.html">Read The Normative Draft</a>
+            <a class="btn btn-secondary" href="../docs/index.html">Back To Docs Library</a>
+          </div>
+        </div>
+      </section>
+
+      <section>
+        <h2 class="section-title">How To Use This Section</h2>
+        <div class="card">
+          <ul>
+            <li>Use the summary pages in <a href="../docs/index.html">Docs Library</a> for orientation and launch framing.</li>
+            <li>Use this repo-synced reference for the fuller spec text hosted directly on the website.</li>
+            <li>In case of conflict, the versioned draft under <code>versions/</code> remains the normative source.</li>
+          </ul>
+        </div>
+      </section>
+
+      ${sections}
+    </div>
+  </main>
+
+  <footer>
+    <div class="container">
+      <p>&copy; 2026 DollhouseMCP Inc. d/b/a Dollhouse Research. MCP-AQL public draft documentation portal.</p>
+      <div class="footer-links">
+        <a href="../docs/index.html">Docs Library</a>
+        <a href="https://github.com/MCPAQL/spec">Spec Repository</a>
+        <a href="https://github.com/MCPAQL">MCPAQL Organization</a>
+        <a href="https://dollhouseresearch.com">Dollhouse Research</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../js/search.js"></script>
+</body>
+</html>
+`;
+}
+
+function renderNavGroups(navGroups, currentOutputRel) {
+  return navGroups.map((group) => {
+    const links = group.entries.map((entry) => {
+      const href = relativePathWithinPublic(currentOutputRel, entry.outputRel);
+      const currentClass = entry.outputRel === currentOutputRel ? " class=\"current\"" : "";
+      return `<li><a${currentClass} href="${href}">${escapeHtml(entry.title)}</a></li>`;
+    }).join("");
+
+    return `<div class="docs-side-group">
+  <h3>${escapeHtml(group.category)}</h3>
+  <ul>${links}</ul>
+</div>`;
+  }).join("");
+}
+
+function buildKeywords(doc) {
+  const pathWords = doc.sourceRel
+    .replace(/\.md$/i, "")
+    .split(/[\/\-]/)
+    .map((value) => value.toLowerCase())
+    .filter(Boolean);
+
+  const titleWords = doc.title
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter(Boolean);
+
+  return Array.from(new Set([doc.category.toLowerCase(), "spec", ...pathWords, ...titleWords])).slice(0, 12);
+}
+
+function relativeAssetPath(currentOutputRel, assetRelFromPublic) {
+  return relativePathWithinPublic(currentOutputRel, assetRelFromPublic);
+}
+
+function relativePathFromDoc(currentOutputRel, publicRel) {
+  return relativePathWithinPublic(currentOutputRel, publicRel);
+}
+
+function relativePathWithinPublic(fromRel, toRel) {
+  const relative = path.relative(path.dirname(fromRel), toRel).replace(/\\/g, "/");
+  return relative || path.basename(toRel);
+}
+
+function writeFile(targetPath, content) {
+  const existing = fs.existsSync(targetPath) ? fs.readFileSync(targetPath, "utf8") : null;
+  if (existing === content) {
+    return 0;
+  }
+
+  if (!isCheck) {
+    fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+    fs.writeFileSync(targetPath, content);
+  }
+
+  return 1;
+}
+
+function categoryFor(sourceRel) {
+  const firstSegment = sourceRel.split("/")[0];
+  const mapping = new Map([
+    ["overview.md", "Core"],
+    ["crude-pattern.md", "Core"],
+    ["endpoint-modes.md", "Core"],
+    ["introspection.md", "Core"],
+    ["operations.md", "Core"],
+    ["error-codes.md", "Core"],
+    ["conformance-testing.md", "Core"],
+    ["plugin-contracts.md", "Core"],
+    ["versions", "Versions"],
+    ["adapter", "Adapter"],
+    ["security", "Security"],
+    ["features", "Features"],
+    ["guides", "Guides"],
+    ["process", "Process"],
+    ["architecture", "Architecture"],
+    ["research", "Research"],
+    ["reference", "Reference"],
+    ["adr", "ADRs"]
+  ]);
+
+  return mapping.get(firstSegment) || mapping.get(path.basename(sourceRel)) || "Core";
+}
+
+function stripMarkdown(value) {
+  return value
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+    .replace(/`([^`]+)`/g, "$1")
+    .replace(/\*\*([^*]+)\*\*/g, "$1")
+    .replace(/\*([^*]+)\*/g, "$1")
+    .replace(/[_#>]/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function splitFrontMatter(markdown) {
+  if (!markdown.startsWith("---\n")) {
+    return { metadata: {}, body: markdown };
+  }
+
+  const endIndex = markdown.indexOf("\n---\n", 4);
+  if (endIndex < 0) {
+    return { metadata: {}, body: markdown };
+  }
+
+  const rawFrontMatter = markdown.slice(4, endIndex);
+  const body = markdown.slice(endIndex + 5);
+  const metadata = {};
+
+  for (const line of rawFrontMatter.split(/\r?\n/)) {
+    const match = line.match(/^([A-Za-z0-9_-]+):\s*(.+)$/);
+    if (!match) {
+      continue;
+    }
+
+    metadata[match[1].trim().toLowerCase()] = match[2].trim().replace(/^["']|["']$/g, "");
+  }
+
+  return { metadata, body };
+}
+
+function escapeHtml(value) {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/scripts/generate-spec-docs.mjs
+++ b/scripts/generate-spec-docs.mjs
@@ -20,6 +20,20 @@ const specRoot = path.resolve(
   specDirArgIndex >= 0 && args[specDirArgIndex + 1] ? args[specDirArgIndex + 1] : "../spec"
 );
 const specDocsRoot = path.join(specRoot, "docs");
+const extraSources = [
+  {
+    sourceRepoRel: "README.md",
+    outputRel: "spec/repo/README.html",
+    category: "Core",
+    scopeLabel: "Repository source"
+  },
+  {
+    sourceRepoRel: "CHANGELOG.md",
+    outputRel: "spec/repo/CHANGELOG.html",
+    category: "Process",
+    scopeLabel: "Repository source"
+  }
+];
 
 const categoryOrder = [
   "Core",
@@ -42,34 +56,36 @@ if (!fs.existsSync(specDocsRoot)) {
 
 assertPandoc();
 
-const docs = collectDocs(specDocsRoot).map((sourceFile) => {
-  const sourceRel = path.relative(specDocsRoot, sourceFile).replace(/\\/g, "/");
-  const outputRel = `spec/${sourceRel.replace(/\.md$/i, ".html")}`;
-  const markdown = fs.readFileSync(sourceFile, "utf8");
-  const { body, metadata } = splitFrontMatter(markdown);
-  const title = extractTitle(body, sourceRel, metadata);
-  const status = extractField(body, "Status", metadata);
-  const version = extractField(body, "Version", metadata);
-  const lastUpdated = extractField(body, "Last Updated", metadata);
-  const summary = extractSummary(body, title);
-  const category = categoryFor(sourceRel);
-  const scopeLabel = sourceRel.startsWith("versions/") ? "Normative source" : "Support document";
+const docs = [
+  ...collectDocs(specDocsRoot).map((sourceFile) => {
+    const sourceRel = path.relative(specDocsRoot, sourceFile).replace(/\\/g, "/");
+    return createDocRecord({
+      sourceFile,
+      sourceRepoRel: `docs/${sourceRel}`,
+      outputRel: `spec/${sourceRel.replace(/\.md$/i, ".html")}`,
+      category: categoryFor(sourceRel),
+      scopeLabel: sourceRel.startsWith("versions/") ? "Normative source" : "Support document"
+    });
+  }),
+  ...extraSources
+    .map((source) => {
+      const sourceFile = path.join(specRoot, source.sourceRepoRel);
+      if (!fs.existsSync(sourceFile)) {
+        return null;
+      }
 
-  return {
-    sourceFile,
-    sourceRel,
-    outputRel,
-    markdown,
-    title,
-    status,
-    version,
-    lastUpdated,
-    summary,
-    category,
-    scopeLabel
-  };
-});
+      return createDocRecord({
+        sourceFile,
+        sourceRepoRel: source.sourceRepoRel,
+        outputRel: source.outputRel,
+        category: source.category,
+        scopeLabel: source.scopeLabel
+      });
+    })
+    .filter(Boolean)
+];
 
+const docLookup = new Map(docs.map((doc) => [doc.sourceRepoRel, doc.outputRel]));
 const navGroups = buildNavGroups(docs);
 let changedFiles = 0;
 
@@ -78,7 +94,7 @@ for (const doc of docs) {
   const html = wrapSpecDocPage({
     doc,
     navGroups,
-    bodyHtml: rewriteLinks(stripFirstHeading(fragment), doc.sourceRel, doc.outputRel)
+    bodyHtml: rewriteLinks(stripFirstHeading(fragment), doc.sourceRepoRel, doc.outputRel, docLookup)
   });
   changedFiles += writeFile(path.join(publicRoot, doc.outputRel), html);
 }
@@ -94,12 +110,16 @@ const generatedSearchEntries = docs.map((doc) => ({
   keywords: buildKeywords(doc)
 }));
 
-const mergedSearch = [...baseSearchEntries, {
-  title: "Repo-Synced Spec Reference",
-  url: "/spec/index.html",
-  excerpt: "Full website-hosted mirror of the MCP-AQL spec docs generated from the spec repository source.",
-  keywords: ["spec mirror", "repo synced", "full docs", "reference", "generated"]
-}, ...generatedSearchEntries];
+const mergedSearch = [
+  ...baseSearchEntries,
+  {
+    title: "Repo-Synced Spec Reference",
+    url: "/spec/index.html",
+    excerpt: "Full website-hosted mirror of the MCP-AQL spec docs generated from the spec repository source.",
+    keywords: ["spec mirror", "repo synced", "full docs", "reference", "generated"]
+  },
+  ...generatedSearchEntries
+];
 
 changedFiles += writeFile(
   path.join(publicRoot, "data", "search-index.json"),
@@ -112,6 +132,30 @@ if (isCheck && changedFiles > 0) {
 }
 
 console.log(`${isCheck ? "Checked" : "Generated"} ${docs.length} spec doc pages.`);
+
+function createDocRecord({ sourceFile, sourceRepoRel, outputRel, category, scopeLabel }) {
+  const markdown = fs.readFileSync(sourceFile, "utf8");
+  const { body, metadata } = splitFrontMatter(markdown);
+  const title = extractTitle(body, sourceRepoRel, metadata);
+  const status = extractField(body, "Status", metadata);
+  const version = extractField(body, "Version", metadata);
+  const lastUpdated = extractField(body, "Last Updated", metadata);
+  const summary = extractSummary(body, title);
+
+  return {
+    sourceFile,
+    sourceRepoRel,
+    outputRel,
+    markdown,
+    title,
+    status,
+    version,
+    lastUpdated,
+    summary,
+    category,
+    scopeLabel
+  };
+}
 
 function assertPandoc() {
   try {
@@ -264,36 +308,35 @@ function stripFirstHeading(html) {
   return html.replace(/^<h1[^>]*>[\s\S]*?<\/h1>\n?/, "");
 }
 
-function rewriteLinks(html, currentSourceRel, currentOutputRel) {
+function rewriteLinks(html, currentSourceRepoRel, currentOutputRel, docLookup) {
   return html.replace(/\b(href|src)="([^"]+)"/g, (fullMatch, attribute, target) => {
-    return `${attribute}="${resolveTarget(target, currentSourceRel, currentOutputRel)}"`;
+    return `${attribute}="${resolveTarget(target, currentSourceRepoRel, currentOutputRel, docLookup)}"`;
   });
 }
 
-function resolveTarget(target, currentSourceRel, currentOutputRel) {
+function resolveTarget(target, currentSourceRepoRel, currentOutputRel, docLookup) {
   if (!target || target.startsWith("#") || /^[a-z]+:/i.test(target) || target.startsWith("/")) {
     return target;
   }
 
   const [rawPath, hash = ""] = target.split("#");
   const anchor = hash ? `#${hash}` : "";
-  const specRelativeTarget = path
-    .normalize(path.join("docs", path.dirname(currentSourceRel), rawPath))
+  const repoRelativeTarget = path
+    .normalize(path.join(path.dirname(currentSourceRepoRel), rawPath))
     .replace(/\\/g, "/");
-  const absoluteTarget = path.join(specRoot, specRelativeTarget);
+  const absoluteTarget = path.join(specRoot, repoRelativeTarget);
 
-  if (rawPath.endsWith(".md") && specRelativeTarget.startsWith("docs/") && fs.existsSync(absoluteTarget)) {
-    const docsRelative = specRelativeTarget.replace(/^docs\//, "");
-    const targetOutputRel = `spec/${docsRelative.replace(/\.md$/i, ".html")}`;
+  if (rawPath.endsWith(".md") && docLookup.has(repoRelativeTarget)) {
+    const targetOutputRel = docLookup.get(repoRelativeTarget);
     const relativeUrl = path.relative(path.dirname(currentOutputRel), targetOutputRel).replace(/\\/g, "/");
     return `${relativeUrl || path.basename(targetOutputRel)}${anchor}`;
   }
 
-  if (rawPath.endsWith(".md")) {
-    return `https://github.com/MCPAQL/spec/blob/main/${specRelativeTarget}${anchor}`;
+  if (rawPath.endsWith(".md") && fs.existsSync(absoluteTarget)) {
+    return `https://github.com/MCPAQL/spec/blob/main/${repoRelativeTarget}${anchor}`;
   }
 
-  return `https://github.com/MCPAQL/spec/blob/main/${specRelativeTarget}${anchor}`;
+  return `https://github.com/MCPAQL/spec/blob/main/${repoRelativeTarget}${anchor}`;
 }
 
 function buildNavGroups(docs) {
@@ -316,7 +359,7 @@ function buildNavGroups(docs) {
 
 function wrapSpecDocPage({ doc, navGroups, bodyHtml }) {
   const navHtml = renderNavGroups(navGroups, doc.outputRel);
-  const sourceUrl = `https://github.com/MCPAQL/spec/blob/main/docs/${doc.sourceRel}`;
+  const sourceUrl = `https://github.com/MCPAQL/spec/blob/main/${doc.sourceRepoRel}`;
   const metaBits = [
     `<span class="state-chip live">${escapeHtml(doc.scopeLabel)}</span>`,
     doc.status ? `<span class="state-chip pending">${escapeHtml(doc.status)}</span>` : "",
@@ -372,7 +415,7 @@ function wrapSpecDocPage({ doc, navGroups, bodyHtml }) {
             <h1>${escapeHtml(doc.title)}</h1>
             <p class="lede">${escapeHtml(doc.summary)}</p>
             <div class="spec-meta">${metaBits}</div>
-            <p class="spec-source">Source: <a href="${sourceUrl}">${escapeHtml(`spec/docs/${doc.sourceRel}`)}</a></p>
+            <p class="spec-source">Source: <a href="${sourceUrl}">${escapeHtml(`spec/${doc.sourceRepoRel}`)}</a></p>
             <div class="hero-actions">
               <a class="btn btn-primary" href="${sourceUrl}">Open Source Markdown</a>
               <a class="btn btn-secondary" href="${relativePathFromDoc(doc.outputRel, "spec/index.html")}">Browse Full Spec Reference</a>
@@ -410,14 +453,15 @@ function wrapSpecDocPage({ doc, navGroups, bodyHtml }) {
 function wrapSpecIndexPage(navGroups) {
   const sections = navGroups.map((group) => {
     const cards = group.entries.map((doc) => {
+      const href = relativePathWithinPublic("spec/index.html", doc.outputRel);
       return `<article class="card">
-  <h3>${escapeHtml(doc.title)}</h3>
+  <h3><a href="${href}">${escapeHtml(doc.title)}</a></h3>
   <p>${escapeHtml(doc.summary)}</p>
   <div class="spec-meta">
     <span class="state-chip live">${escapeHtml(doc.scopeLabel)}</span>
     ${doc.status ? `<span class="state-chip pending">${escapeHtml(doc.status)}</span>` : ""}
   </div>
-  <a href="${relativePathWithinPublic("spec/index.html", doc.outputRel)}">Open Page</a>
+  <a href="${href}">Open Page</a>
 </article>`;
     }).join("\n");
 
@@ -469,7 +513,7 @@ function wrapSpecIndexPage(navGroups) {
           <span class="status-pill">REPO-SYNCED SPEC REFERENCE</span>
           <h1>The deeper protocol docs now live on the website too</h1>
           <p class="lede">
-            These pages are generated from <code>MCPAQL/spec/docs</code> so the public site can carry the full protocol and adapter material,
+            These pages are generated from <code>MCPAQL/spec</code> so the public site can carry the full protocol and adapter material,
             not just summaries and links back to GitHub.
           </p>
           <div class="hero-actions">
@@ -528,7 +572,7 @@ function renderNavGroups(navGroups, currentOutputRel) {
 }
 
 function buildKeywords(doc) {
-  const pathWords = doc.sourceRel
+  const pathWords = doc.sourceRepoRel
     .replace(/\.md$/i, "")
     .split(/[\/\-]/)
     .map((value) => value.toLowerCase())

--- a/scripts/generate-spec-docs.mjs
+++ b/scripts/generate-spec-docs.mjs
@@ -409,6 +409,13 @@ function wrapSpecDocPage({ doc, navGroups, bodyHtml }) {
       </aside>
 
       <article class="docs-main">
+        <nav class="breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="${relativePathFromDoc(doc.outputRel, "index.html")}">Home</a></li>
+            <li><a href="${relativePathFromDoc(doc.outputRel, "spec/index.html")}">Full Spec</a></li>
+            <li><span class="current">${escapeHtml(doc.title)}</span></li>
+          </ol>
+        </nav>
         <section class="hero docs-hero">
           <div class="hero-inner">
             <span class="status-pill">REPO-SYNCED SPEC DOC</span>
@@ -508,6 +515,12 @@ function wrapSpecIndexPage(navGroups) {
 
   <main>
     <div class="container">
+      <nav class="breadcrumbs" aria-label="Breadcrumb">
+        <ol>
+          <li><a href="../index.html">Home</a></li>
+          <li><span class="current">Full Spec</span></li>
+        </ol>
+      </nav>
       <section class="hero">
         <div class="hero-inner">
           <span class="status-pill">REPO-SYNCED SPEC REFERENCE</span>

--- a/scripts/generate-spec-docs.mjs
+++ b/scripts/generate-spec-docs.mjs
@@ -87,6 +87,7 @@ const docs = [
 
 const docLookup = new Map(docs.map((doc) => [doc.sourceRepoRel, doc.outputRel]));
 const navGroups = buildNavGroups(docs);
+const navSequence = navGroups.flatMap((group) => group.entries);
 let changedFiles = 0;
 
 for (const doc of docs) {
@@ -94,6 +95,7 @@ for (const doc of docs) {
   const html = wrapSpecDocPage({
     doc,
     navGroups,
+    navSequence,
     bodyHtml: rewriteLinks(stripFirstHeading(fragment), doc.sourceRepoRel, doc.outputRel, docLookup)
   });
   changedFiles += writeFile(path.join(publicRoot, doc.outputRel), html);
@@ -357,8 +359,9 @@ function buildNavGroups(docs) {
     .filter((group) => group.entries.length > 0);
 }
 
-function wrapSpecDocPage({ doc, navGroups, bodyHtml }) {
+function wrapSpecDocPage({ doc, navGroups, navSequence, bodyHtml }) {
   const navHtml = renderNavGroups(navGroups, doc.outputRel);
+  const pageNavHtml = renderSpecPageNav(doc, navSequence);
   const sourceUrl = `https://github.com/MCPAQL/spec/blob/main/${doc.sourceRepoRel}`;
   const metaBits = [
     `<span class="state-chip live">${escapeHtml(doc.scopeLabel)}</span>`,
@@ -392,7 +395,7 @@ function wrapSpecDocPage({ doc, navGroups, bodyHtml }) {
         </ul>
         <form class="site-search" data-search-form data-index-url="${relativePathFromDoc(doc.outputRel, "data/search-index.json")}" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
-          <input id="site-search-input" data-search-input type="search" placeholder="Search repo-synced spec docs...">
+          <input id="site-search-input" data-search-input type="search" placeholder="Search MCP-AQL docs, spec pages, and adapter patterns...">
           <span class="search-count" data-search-count></span>
           <ul class="search-results" data-search-results hidden></ul>
         </form>
@@ -435,6 +438,7 @@ function wrapSpecDocPage({ doc, navGroups, bodyHtml }) {
             ${bodyHtml}
           </div>
         </section>
+        ${pageNavHtml}
       </article>
     </div>
   </main>
@@ -505,7 +509,7 @@ function wrapSpecIndexPage(navGroups) {
         </ul>
         <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
-          <input id="site-search-input" data-search-input type="search" placeholder="Search full spec reference...">
+          <input id="site-search-input" data-search-input type="search" placeholder="Search MCP-AQL docs, spec pages, and adapter patterns...">
           <span class="search-count" data-search-count></span>
           <ul class="search-results" data-search-results hidden></ul>
         </form>
@@ -573,8 +577,8 @@ function renderNavGroups(navGroups, currentOutputRel) {
   return navGroups.map((group) => {
     const links = group.entries.map((entry) => {
       const href = relativePathWithinPublic(currentOutputRel, entry.outputRel);
-      const currentClass = entry.outputRel === currentOutputRel ? " class=\"current\"" : "";
-      return `<li><a${currentClass} href="${href}">${escapeHtml(entry.title)}</a></li>`;
+      const currentAttr = entry.outputRel === currentOutputRel ? " class=\"current\" aria-current=\"page\"" : "";
+      return `<li><a${currentAttr} href="${href}">${escapeHtml(entry.title)}</a></li>`;
     }).join("");
 
     return `<div class="docs-side-group">
@@ -582,6 +586,47 @@ function renderNavGroups(navGroups, currentOutputRel) {
   <ul>${links}</ul>
 </div>`;
   }).join("");
+}
+
+function renderSpecPageNav(doc, navSequence) {
+  const currentIndex = navSequence.findIndex((entry) => entry.outputRel === doc.outputRel);
+  const previousDoc = currentIndex > 0 ? navSequence[currentIndex - 1] : null;
+  const nextDoc = currentIndex >= 0 && currentIndex < navSequence.length - 1 ? navSequence[currentIndex + 1] : null;
+
+  return renderPageNav({
+    previous: previousDoc ? {
+      href: relativePathWithinPublic(doc.outputRel, previousDoc.outputRel),
+      eyebrow: "Previous spec page",
+      label: previousDoc.title
+    } : {
+      href: relativePathFromDoc(doc.outputRel, "spec/index.html"),
+      eyebrow: "Reference overview",
+      label: "Full Spec Reference"
+    },
+    next: nextDoc ? {
+      href: relativePathWithinPublic(doc.outputRel, nextDoc.outputRel),
+      eyebrow: "Next spec page",
+      label: nextDoc.title
+    } : {
+      href: relativePathFromDoc(doc.outputRel, "spec/index.html"),
+      eyebrow: "Back to index",
+      label: "Full Spec Reference"
+    }
+  });
+}
+
+function renderPageNav({ previous, next }) {
+  return `<nav class="page-nav" aria-label="Page navigation">
+  ${renderPageNavLink(previous, "prev")}
+  ${renderPageNavLink(next, "next")}
+</nav>`;
+}
+
+function renderPageNavLink(entry, direction) {
+  return `<a class="page-nav-link ${direction}" href="${entry.href}">
+    <span class="page-nav-eyebrow">${escapeHtml(entry.eyebrow)}</span>
+    <strong class="page-nav-label">${escapeHtml(entry.label)}</strong>
+  </a>`;
 }
 
 function buildKeywords(doc) {

--- a/source/search-index.base.json
+++ b/source/search-index.base.json
@@ -1,0 +1,128 @@
+[
+  {
+    "title": "MCP-AQL Portal Home",
+    "url": "/index.html",
+    "excerpt": "Public draft portal overview, launch posture, repository map, and start-here navigation.",
+    "keywords": ["home", "overview", "public draft", "portal", "launch"]
+  },
+  {
+    "title": "Docs Library",
+    "url": "/docs/index.html",
+    "excerpt": "Structured documentation map for normative spec, implementation guidance, examples, tooling, and governance.",
+    "keywords": ["docs", "documentation", "library", "spec map", "reference"]
+  },
+  {
+    "title": "Getting Started",
+    "url": "/docs/getting-started.html",
+    "excerpt": "Quick-start overview of MCP-AQL, token efficiency, request shape, and reading order for the draft.",
+    "keywords": ["getting started", "overview", "quickstart", "token efficiency", "intro"]
+  },
+  {
+    "title": "Protocol Core",
+    "url": "/docs/protocol-core.html",
+    "excerpt": "Normative foundations: CRUDE model, endpoint modes, request and response contracts, introspection, and operation routing.",
+    "keywords": ["crude", "single mode", "request", "response", "introspect", "operation"]
+  },
+  {
+    "title": "Error Model",
+    "url": "/docs/error-model.html",
+    "excerpt": "Structured error envelopes, machine-readable codes, and the current draft work to align error surfaces.",
+    "keywords": ["error", "structured error", "code", "message", "details", "issue 199"]
+  },
+  {
+    "title": "Security Model",
+    "url": "/docs/security-model.html",
+    "excerpt": "Gatekeeper trust levels, danger handling, confirmation token flows, and execution safety boundaries.",
+    "keywords": ["security", "gatekeeper", "danger", "confirmation token", "trust", "safety"]
+  },
+  {
+    "title": "Conformance And Validation",
+    "url": "/docs/conformance.html",
+    "excerpt": "Current conformance requirements, validation scope, and planned validator tooling for implementers.",
+    "keywords": ["conformance", "validator", "validation", "testing", "compliance", "on-spec"]
+  },
+  {
+    "title": "Adapter Contracts",
+    "url": "/docs/adapter-contracts.html",
+    "excerpt": "Adapter schema, plugin contracts, generator outputs, and implementation expectations across the MCP-AQL stack.",
+    "keywords": ["adapter contracts", "plugin", "element type", "generator", "schema", "runtime"]
+  },
+  {
+    "title": "Implementation Profiles",
+    "url": "/docs/implementation-profiles.html",
+    "excerpt": "Canonical protocol vs practical profile boundaries across spec, adapter runtime, examples, and production references.",
+    "keywords": ["profile", "dollhouse", "reference", "adapter", "runtime", "implementation"]
+  },
+  {
+    "title": "Roadmap",
+    "url": "/docs/roadmap.html",
+    "excerpt": "Protocol and ecosystem roadmap with current execution focus and phased delivery tracks.",
+    "keywords": ["roadmap", "phase", "launch", "readiness", "ecosystem", "timeline"]
+  },
+  {
+    "title": "Release Notes",
+    "url": "/docs/release-notes.html",
+    "excerpt": "Recent draft changes and launch-relevant notes distilled from the MCP-AQL specification changelog.",
+    "keywords": ["release notes", "changelog", "draft changes", "launch", "issue 194"]
+  },
+  {
+    "title": "Launch Checklist",
+    "url": "/launch-checklist.html",
+    "excerpt": "Public-facing preliminary launch checklist for readiness visibility and scope control.",
+    "keywords": ["launch", "checklist", "readiness", "public draft"]
+  },
+  {
+    "title": "MCP Server Adapter Pattern",
+    "url": "/apis/mcp-server.html",
+    "excerpt": "Draft guidance for adapting MCP servers to MCP-AQL through introspection and CRUDE operation mapping.",
+    "keywords": ["mcp server", "adapter pattern", "mapping", "introspection"]
+  },
+  {
+    "title": "Operating System Adapter Pattern",
+    "url": "/apis/operating-system.html",
+    "excerpt": "Draft guidance for operating-system integrations with permission and safety-aware boundaries.",
+    "keywords": ["operating system", "permissions", "local operations", "safety"]
+  },
+  {
+    "title": "Application Adapter Pattern",
+    "url": "/apis/application.html",
+    "excerpt": "Draft guidance for desktop and application API integration into MCP-AQL contracts.",
+    "keywords": ["application", "desktop", "app api", "integration"]
+  },
+  {
+    "title": "Cloud Service Adapter Pattern",
+    "url": "/apis/cloud-service.html",
+    "excerpt": "Draft guidance for cloud API adaptation, rate limits, and resilient operation handling.",
+    "keywords": ["cloud", "service", "rate limit", "external api"]
+  },
+  {
+    "title": "Website Adapter Pattern",
+    "url": "/apis/website.html",
+    "excerpt": "Draft guidance for website-facing integrations and retrieval/action patterns.",
+    "keywords": ["website", "web", "retrieval", "action"]
+  },
+  {
+    "title": "Spec Repository",
+    "url": "https://github.com/MCPAQL/spec",
+    "excerpt": "Canonical source for normative protocol text, schemas, and versioned specification draft.",
+    "keywords": ["spec", "normative", "schema", "version", "protocol"]
+  },
+  {
+    "title": "Adapter Runtime Repository",
+    "url": "https://github.com/MCPAQL/mcpaql-adapter",
+    "excerpt": "Reference implementation guidance for schema-driven dispatch and plugin runtime architecture.",
+    "keywords": ["runtime", "plugin", "dispatch", "implementation"]
+  },
+  {
+    "title": "Examples Repository",
+    "url": "https://github.com/MCPAQL/examples",
+    "excerpt": "Reference adapter examples demonstrating practical API adaptation patterns.",
+    "keywords": ["examples", "reference adapters", "sample"]
+  },
+  {
+    "title": "Tools Repository",
+    "url": "https://github.com/MCPAQL/tools",
+    "excerpt": "Planned conformance and on-spec validator tooling for MCP-AQL implementations.",
+    "keywords": ["tools", "validator", "conformance cli", "on-spec"]
+  }
+]


### PR DESCRIPTION
## Summary
- add repo hygiene items for the website repo: CODEOWNERS, issue templates, PR template, contribution guidance, and dedicated link/Lighthouse workflows
- expand the public docs surface with getting started, error model, adapter contracts, and release notes pages
- update home, docs index, launch checklist, roadmap, and search data so the site reflects the current MCP-AQL spec draft and live backlog issues

## Testing
- validated the search index JSON
- loaded updated pages locally via a preview server and checked navigation for the new docs pages

## Issue status
- closes #4
- closes #5
- closes #6
- closes #7
- advances #2 and #3, but branch protection and any final shared preview/deployment policy still need GitHub-side admin configuration