### PR TITLE
fix: polish docs page navigation

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -720,6 +720,10 @@ footer {
   grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
+.docs-main > .page-nav {
+  margin-top: 1.2rem;
+}
+
 .page-nav-link {
   background: rgba(255, 255, 255, 0.82);
   border: 1px solid var(--line);

--- a/public/docs/adapter-contracts.html
+++ b/public/docs/adapter-contracts.html
@@ -71,6 +71,17 @@
           </div>
         </section>
 
+        <nav class="page-nav" aria-label="Page navigation">
+          <a class="page-nav-link prev" href="conformance.html">
+            <span class="page-nav-eyebrow">Previous page</span>
+            <strong class="page-nav-label">Conformance</strong>
+          </a>
+          <a class="page-nav-link next" href="implementation-profiles.html">
+            <span class="page-nav-eyebrow">Next page</span>
+            <strong class="page-nav-label">Implementation Profiles</strong>
+          </a>
+        </nav>
+
         <section class="topic-bridge">
           <h2 class="sr-only">Related reading</h2>
           <div class="grid cols-2">
@@ -155,16 +166,6 @@
             </article>
           </div>
         </section>
-        <nav class="page-nav" aria-label="Page navigation">
-          <a class="page-nav-link prev" href="conformance.html">
-            <span class="page-nav-eyebrow">Previous page</span>
-            <strong class="page-nav-label">Conformance</strong>
-          </a>
-          <a class="page-nav-link next" href="implementation-profiles.html">
-            <span class="page-nav-eyebrow">Next page</span>
-            <strong class="page-nav-label">Implementation Profiles</strong>
-          </a>
-        </nav>
       </article>
     </div>
   </main>

--- a/public/docs/conformance.html
+++ b/public/docs/conformance.html
@@ -71,6 +71,17 @@
           </div>
         </section>
 
+        <nav class="page-nav" aria-label="Page navigation">
+          <a class="page-nav-link prev" href="security-model.html">
+            <span class="page-nav-eyebrow">Previous page</span>
+            <strong class="page-nav-label">Security Model</strong>
+          </a>
+          <a class="page-nav-link next" href="adapter-contracts.html">
+            <span class="page-nav-eyebrow">Next page</span>
+            <strong class="page-nav-label">Adapter Contracts</strong>
+          </a>
+        </nav>
+
         <section class="topic-bridge">
           <h2 class="sr-only">Related reading</h2>
           <div class="grid cols-2">
@@ -172,16 +183,6 @@
             </ul>
           </div>
         </section>
-        <nav class="page-nav" aria-label="Page navigation">
-          <a class="page-nav-link prev" href="security-model.html">
-            <span class="page-nav-eyebrow">Previous page</span>
-            <strong class="page-nav-label">Security Model</strong>
-          </a>
-          <a class="page-nav-link next" href="adapter-contracts.html">
-            <span class="page-nav-eyebrow">Next page</span>
-            <strong class="page-nav-label">Adapter Contracts</strong>
-          </a>
-        </nav>
       </article>
     </div>
   </main>

--- a/public/docs/error-model.html
+++ b/public/docs/error-model.html
@@ -71,6 +71,17 @@
           </div>
         </section>
 
+        <nav class="page-nav" aria-label="Page navigation">
+          <a class="page-nav-link prev" href="protocol-core.html">
+            <span class="page-nav-eyebrow">Previous page</span>
+            <strong class="page-nav-label">Protocol Core</strong>
+          </a>
+          <a class="page-nav-link next" href="security-model.html">
+            <span class="page-nav-eyebrow">Next page</span>
+            <strong class="page-nav-label">Security Model</strong>
+          </a>
+        </nav>
+
         <section class="topic-bridge">
           <h2 class="sr-only">Related reading</h2>
           <div class="grid cols-2">
@@ -157,16 +168,6 @@
             response envelope requirements, and implementation-facing schemas.
           </p>
         </section>
-        <nav class="page-nav" aria-label="Page navigation">
-          <a class="page-nav-link prev" href="protocol-core.html">
-            <span class="page-nav-eyebrow">Previous page</span>
-            <strong class="page-nav-label">Protocol Core</strong>
-          </a>
-          <a class="page-nav-link next" href="security-model.html">
-            <span class="page-nav-eyebrow">Next page</span>
-            <strong class="page-nav-label">Security Model</strong>
-          </a>
-        </nav>
       </article>
     </div>
   </main>

--- a/public/docs/getting-started.html
+++ b/public/docs/getting-started.html
@@ -71,6 +71,17 @@
           </div>
         </section>
 
+        <nav class="page-nav" aria-label="Page navigation">
+          <a class="page-nav-link prev" href="index.html">
+            <span class="page-nav-eyebrow">Previous page</span>
+            <strong class="page-nav-label">Docs Library</strong>
+          </a>
+          <a class="page-nav-link next" href="protocol-core.html">
+            <span class="page-nav-eyebrow">Next page</span>
+            <strong class="page-nav-label">Protocol Core</strong>
+          </a>
+        </nav>
+
         <section class="topic-bridge">
           <h2 class="sr-only">Related reading</h2>
           <div class="grid cols-2">
@@ -163,16 +174,6 @@
             </ol>
           </div>
         </section>
-        <nav class="page-nav" aria-label="Page navigation">
-          <a class="page-nav-link prev" href="index.html">
-            <span class="page-nav-eyebrow">Previous page</span>
-            <strong class="page-nav-label">Docs Library</strong>
-          </a>
-          <a class="page-nav-link next" href="protocol-core.html">
-            <span class="page-nav-eyebrow">Next page</span>
-            <strong class="page-nav-label">Protocol Core</strong>
-          </a>
-        </nav>
       </article>
     </div>
   </main>

--- a/public/docs/implementation-profiles.html
+++ b/public/docs/implementation-profiles.html
@@ -71,6 +71,17 @@
           </div>
         </section>
 
+        <nav class="page-nav" aria-label="Page navigation">
+          <a class="page-nav-link prev" href="adapter-contracts.html">
+            <span class="page-nav-eyebrow">Previous page</span>
+            <strong class="page-nav-label">Adapter Contracts</strong>
+          </a>
+          <a class="page-nav-link next" href="roadmap.html">
+            <span class="page-nav-eyebrow">Next page</span>
+            <strong class="page-nav-label">Roadmap</strong>
+          </a>
+        </nav>
+
         <section class="topic-bridge">
           <h2 class="sr-only">Related reading</h2>
           <div class="grid cols-2">
@@ -189,16 +200,6 @@
             </article>
           </div>
         </section>
-        <nav class="page-nav" aria-label="Page navigation">
-          <a class="page-nav-link prev" href="adapter-contracts.html">
-            <span class="page-nav-eyebrow">Previous page</span>
-            <strong class="page-nav-label">Adapter Contracts</strong>
-          </a>
-          <a class="page-nav-link next" href="roadmap.html">
-            <span class="page-nav-eyebrow">Next page</span>
-            <strong class="page-nav-label">Roadmap</strong>
-          </a>
-        </nav>
       </article>
     </div>
   </main>

--- a/public/docs/protocol-core.html
+++ b/public/docs/protocol-core.html
@@ -71,6 +71,17 @@
           </div>
         </section>
 
+        <nav class="page-nav" aria-label="Page navigation">
+          <a class="page-nav-link prev" href="getting-started.html">
+            <span class="page-nav-eyebrow">Previous page</span>
+            <strong class="page-nav-label">Getting Started</strong>
+          </a>
+          <a class="page-nav-link next" href="error-model.html">
+            <span class="page-nav-eyebrow">Next page</span>
+            <strong class="page-nav-label">Error Model</strong>
+          </a>
+        </nav>
+
         <section class="topic-bridge">
           <h2 class="sr-only">Related reading</h2>
           <div class="grid cols-2">
@@ -235,16 +246,6 @@ mcp_aql_execute</pre>
             </article>
           </div>
         </section>
-        <nav class="page-nav" aria-label="Page navigation">
-          <a class="page-nav-link prev" href="getting-started.html">
-            <span class="page-nav-eyebrow">Previous page</span>
-            <strong class="page-nav-label">Getting Started</strong>
-          </a>
-          <a class="page-nav-link next" href="error-model.html">
-            <span class="page-nav-eyebrow">Next page</span>
-            <strong class="page-nav-label">Error Model</strong>
-          </a>
-        </nav>
       </article>
     </div>
   </main>

--- a/public/docs/release-notes.html
+++ b/public/docs/release-notes.html
@@ -71,6 +71,17 @@
           </div>
         </section>
 
+        <nav class="page-nav" aria-label="Page navigation">
+          <a class="page-nav-link prev" href="roadmap.html">
+            <span class="page-nav-eyebrow">Previous page</span>
+            <strong class="page-nav-label">Roadmap</strong>
+          </a>
+          <a class="page-nav-link next" href="../spec/index.html">
+            <span class="page-nav-eyebrow">Next page</span>
+            <strong class="page-nav-label">Full Spec Reference</strong>
+          </a>
+        </nav>
+
         <section class="topic-bridge">
           <h2 class="sr-only">Related reading</h2>
           <div class="grid cols-2">
@@ -134,16 +145,6 @@
             </article>
           </div>
         </section>
-        <nav class="page-nav" aria-label="Page navigation">
-          <a class="page-nav-link prev" href="roadmap.html">
-            <span class="page-nav-eyebrow">Previous page</span>
-            <strong class="page-nav-label">Roadmap</strong>
-          </a>
-          <a class="page-nav-link next" href="../spec/index.html">
-            <span class="page-nav-eyebrow">Next page</span>
-            <strong class="page-nav-label">Full Spec Reference</strong>
-          </a>
-        </nav>
       </article>
     </div>
   </main>

--- a/public/docs/roadmap.html
+++ b/public/docs/roadmap.html
@@ -72,6 +72,17 @@
           </div>
         </section>
 
+        <nav class="page-nav" aria-label="Page navigation">
+          <a class="page-nav-link prev" href="implementation-profiles.html">
+            <span class="page-nav-eyebrow">Previous page</span>
+            <strong class="page-nav-label">Implementation Profiles</strong>
+          </a>
+          <a class="page-nav-link next" href="release-notes.html">
+            <span class="page-nav-eyebrow">Next page</span>
+            <strong class="page-nav-label">Release Notes</strong>
+          </a>
+        </nav>
+
         <section class="topic-bridge">
           <h2 class="sr-only">Related reading</h2>
           <div class="grid cols-2">
@@ -204,16 +215,6 @@
             </p>
           </div>
         </section>
-        <nav class="page-nav" aria-label="Page navigation">
-          <a class="page-nav-link prev" href="implementation-profiles.html">
-            <span class="page-nav-eyebrow">Previous page</span>
-            <strong class="page-nav-label">Implementation Profiles</strong>
-          </a>
-          <a class="page-nav-link next" href="release-notes.html">
-            <span class="page-nav-eyebrow">Next page</span>
-            <strong class="page-nav-label">Release Notes</strong>
-          </a>
-        </nav>
       </article>
     </div>
   </main>

--- a/public/docs/security-model.html
+++ b/public/docs/security-model.html
@@ -72,6 +72,17 @@
           </div>
         </section>
 
+        <nav class="page-nav" aria-label="Page navigation">
+          <a class="page-nav-link prev" href="error-model.html">
+            <span class="page-nav-eyebrow">Previous page</span>
+            <strong class="page-nav-label">Error Model</strong>
+          </a>
+          <a class="page-nav-link next" href="conformance.html">
+            <span class="page-nav-eyebrow">Next page</span>
+            <strong class="page-nav-label">Conformance</strong>
+          </a>
+        </nav>
+
         <section class="topic-bridge">
           <h2 class="sr-only">Related reading</h2>
           <div class="grid cols-2">
@@ -170,16 +181,6 @@
             </ul>
           </div>
         </section>
-        <nav class="page-nav" aria-label="Page navigation">
-          <a class="page-nav-link prev" href="error-model.html">
-            <span class="page-nav-eyebrow">Previous page</span>
-            <strong class="page-nav-label">Error Model</strong>
-          </a>
-          <a class="page-nav-link next" href="conformance.html">
-            <span class="page-nav-eyebrow">Next page</span>
-            <strong class="page-nav-label">Conformance</strong>
-          </a>
-        </nav>
       </article>
     </div>
   </main>

--- a/public/js/search.js
+++ b/public/js/search.js
@@ -195,6 +195,45 @@
     });
   }
 
+  function mountPageNavigationShortcuts() {
+    const nav = document.querySelector(".page-nav");
+    if (!nav) return;
+
+    const prevLink = nav.querySelector(".page-nav-link.prev");
+    const nextLink = nav.querySelector(".page-nav-link.next");
+
+    document.addEventListener("keydown", function (event) {
+      const active = document.activeElement;
+      const isEditable = active && (
+        active.tagName === "INPUT" ||
+        active.tagName === "TEXTAREA" ||
+        active.tagName === "SELECT" ||
+        active.isContentEditable
+      );
+      const selection = window.getSelection && window.getSelection();
+
+      if (
+        event.defaultPrevented ||
+        event.altKey ||
+        event.ctrlKey ||
+        event.metaKey ||
+        event.shiftKey ||
+        isEditable ||
+        (selection && selection.type === "Range")
+      ) {
+        return;
+      }
+
+      if (event.key === "ArrowLeft" && prevLink) {
+        event.preventDefault();
+        window.location.href = prevLink.href;
+      } else if (event.key === "ArrowRight" && nextLink) {
+        event.preventDefault();
+        window.location.href = nextLink.href;
+      }
+    });
+  }
+
   function mountSearchPage() {
     const page = document.querySelector("[data-search-page]");
     if (!page) return;
@@ -257,5 +296,6 @@
   document.addEventListener("DOMContentLoaded", function () {
     document.querySelectorAll("[data-search-form]").forEach(mountSearch);
     mountSearchPage();
+    mountPageNavigationShortcuts();
   });
 })();

--- a/public/spec/index.html
+++ b/public/spec/index.html
@@ -75,7 +75,6 @@
     <span class="state-chip live">Support document</span>
     <span class="state-chip pending">Draft</span>
   </div>
-  <a href="conformance-testing.html">Open Page</a>
 </article>
 <article class="card">
   <h3><a href="crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></h3>
@@ -84,7 +83,6 @@
     <span class="state-chip live">Support document</span>
     <span class="state-chip pending">Draft</span>
   </div>
-  <a href="crude-pattern.html">Open Page</a>
 </article>
 <article class="card">
   <h3><a href="endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></h3>
@@ -93,7 +91,6 @@
     <span class="state-chip live">Support document</span>
     <span class="state-chip pending">Draft</span>
   </div>
-  <a href="endpoint-modes.html">Open Page</a>
 </article>
 <article class="card">
   <h3><a href="error-codes.html">Structured Error Codes Specification</a></h3>
@@ -102,7 +99,6 @@
     <span class="state-chip live">Support document</span>
     <span class="state-chip pending">Draft (MVP)</span>
   </div>
-  <a href="error-codes.html">Open Page</a>
 </article>
 <article class="card">
   <h3><a href="introspection.html">MCP-AQL Introspection Specification</a></h3>
@@ -111,7 +107,6 @@
     <span class="state-chip live">Support document</span>
     <span class="state-chip pending">Draft</span>
   </div>
-  <a href="introspection.html">Open Page</a>
 </article>
 <article class="card">
   <h3><a href="licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></h3>
@@ -120,7 +115,6 @@
     <span class="state-chip live">Support document</span>
     
   </div>
-  <a href="licensing-options.html">Open Page</a>
 </article>
 <article class="card">
   <h3><a href="mcp-integration.html">MCP Integration Specification</a></h3>
@@ -129,7 +123,6 @@
     <span class="state-chip live">Support document</span>
     <span class="state-chip pending">Draft</span>
   </div>
-  <a href="mcp-integration.html">Open Page</a>
 </article>
 <article class="card">
   <h3><a href="operations.html">MCP-AQL Operations Specification</a></h3>
@@ -138,7 +131,6 @@
     <span class="state-chip live">Support document</span>
     <span class="state-chip pending">Draft</span>
   </div>
-  <a href="operations.html">Open Page</a>
 </article>
 <article class="card">
   <h3><a href="overview.html">MCP-AQL Protocol Overview</a></h3>
@@ -147,7 +139,6 @@
     <span class="state-chip live">Support document</span>
     
   </div>
-  <a href="overview.html">Open Page</a>
 </article>
 <article class="card">
   <h3><a href="plugin-contracts.html">Plugin Interface Contracts</a></h3>
@@ -156,7 +147,6 @@
     <span class="state-chip live">Support document</span>
     <span class="state-chip pending">Draft (MVP)</span>
   </div>
-  <a href="plugin-contracts.html">Open Page</a>
 </article>
 <article class="card">
   <h3><a href="README.html">MCP-AQL Specification Documentation</a></h3>
@@ -165,7 +155,6 @@
     <span class="state-chip live">Support document</span>
     
   </div>
-  <a href="README.html">Open Page</a>
 </article>
 <article class="card">
   <h3><a href="repo/README.html">MCP-AQL Specification</a></h3>
@@ -174,7 +163,6 @@
     <span class="state-chip live">Repository source</span>
     
   </div>
-  <a href="repo/README.html">Open Page</a>
 </article>
   </div>
 </section>
@@ -188,7 +176,6 @@
     <span class="state-chip live">Normative source</span>
     <span class="state-chip pending">Draft</span>
   </div>
-  <a href="versions/v1.0.0-draft.html">Open Page</a>
 </article>
   </div>
 </section>
@@ -202,7 +189,6 @@
     <span class="state-chip live">Support document</span>
     <span class="state-chip pending">Draft</span>
   </div>
-  <a href="adapter/danger-levels.html">Open Page</a>
 </article>
 <article class="card">
   <h3><a href="adapter/discovery-bundle.html">MCP Server Discovery Bundle</a></h3>
@@ -211,7 +197,6 @@
     <span class="state-chip live">Support document</span>
     <span class="state-chip pending">Draft</span>
   </div>
-  <a href="adapter/discovery-bundle.html">Open Page</a>
 </article>
 <article class="card">
   <h3><a href="adapter/element-type.html">Adapter Element Type Specification</a></h3>
@@ -220,7 +205,6 @@
     <span class="state-chip live">Support document</span>
     <span class="state-chip pending">Draft (MVP)</span>
   </div>
-  <a href="adapter/element-type.html">Open Page</a>
 </article>
 <article class="card">
   <h3><a href="adapter/generator.html">Adapter Generator Specification</a></h3>
@@ -229,7 +213,6 @@
     <span class="state-chip live">Support document</span>
     <span class="state-chip pending">Draft</span>
   </div>
-  <a href="adapter/generator.html">Open Page</a>
 </article>
 <article class="card">
   <h3><a href="adapter/rate-limiting.html">Rate Limiting and Quota Management Specification</a></h3>
@@ -238,7 +221,6 @@
     <span class="state-chip live">Support document</span>
     <span class="state-chip pending">Draft</span>
   </div>
-  <a href="adapter/rate-limiting.html">Open Page</a>
 </article>
 <article class="card">
   <h3><a href="adapter/trust-levels.html">Trust Levels Specification</a></h3>
@@ -247,7 +229,6 @@
     <span class="state-chip live">Support document</span>
     <span class="state-chip pending">Draft</span>
   </div>
-  <a href="adapter/trust-levels.html">Open Page</a>
 </article>
   </div>
 </section>
@@ -261,7 +242,6 @@
     <span class="state-chip live">Support document</span>
     <span class="state-chip pending">Draft</span>
   </div>
-  <a href="security/confirmation-tokens.html">Open Page</a>
 </article>
 <article class="card">
   <h3><a href="security/execution-safety-loop.html">Execution Safety Loop Specification</a></h3>
@@ -270,7 +250,6 @@
     <span class="state-chip live">Support document</span>
     <span class="state-chip pending">Draft</span>
   </div>
-  <a href="security/execution-safety-loop.html">Open Page</a>
 </article>
 <article class="card">
   <h3><a href="security/gatekeeper.html">Security Model: Gatekeeper Specification</a></h3>
@@ -279,7 +258,6 @@
     <span class="state-chip live">Support document</span>
     <span class="state-chip pending">Draft</span>
   </div>
-  <a href="security/gatekeeper.html">Open Page</a>
 </article>
   </div>
 </section>
@@ -293,7 +271,6 @@
     <span class="state-chip live">Support document</span>
     <span class="state-chip pending">Draft</span>
   </div>
-  <a href="features/field-selection.html">Open Page</a>
 </article>
 <article class="card">
   <h3><a href="features/pagination.html">Cursor-Based Pagination Specification</a></h3>
@@ -302,7 +279,6 @@
     <span class="state-chip live">Support document</span>
     <span class="state-chip pending">Draft</span>
   </div>
-  <a href="features/pagination.html">Open Page</a>
 </article>
 <article class="card">
   <h3><a href="features/warnings.html">Warnings Array Specification</a></h3>
@@ -311,7 +287,6 @@
     <span class="state-chip live">Support document</span>
     <span class="state-chip pending">Draft</span>
   </div>
-  <a href="features/warnings.html">Open Page</a>
 </article>
   </div>
 </section>
@@ -325,7 +300,6 @@
     <span class="state-chip live">Support document</span>
     <span class="state-chip pending">draft</span>
   </div>
-  <a href="guides/protocol-comparison.html">Open Page</a>
 </article>
 <article class="card">
   <h3><a href="guides/README.html">Developer Guides</a></h3>
@@ -334,7 +308,6 @@
     <span class="state-chip live">Support document</span>
     
   </div>
-  <a href="guides/README.html">Open Page</a>
 </article>
   </div>
 </section>
@@ -348,7 +321,6 @@
     <span class="state-chip live">Support document</span>
     <span class="state-chip pending">Draft</span>
   </div>
-  <a href="process/breaking-changes.html">Open Page</a>
 </article>
 <article class="card">
   <h3><a href="process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></h3>
@@ -357,7 +329,6 @@
     <span class="state-chip live">Support document</span>
     <span class="state-chip pending">Working</span>
   </div>
-  <a href="process/preliminary-public-launch-checklist.html">Open Page</a>
 </article>
 <article class="card">
   <h3><a href="process/rfc-process.html">RFC Process for MCP-AQL Specification</a></h3>
@@ -366,7 +337,6 @@
     <span class="state-chip live">Support document</span>
     <span class="state-chip pending">Active</span>
   </div>
-  <a href="process/rfc-process.html">Open Page</a>
 </article>
 <article class="card">
   <h3><a href="process/versioning.html">Versioning Strategy</a></h3>
@@ -375,7 +345,6 @@
     <span class="state-chip live">Support document</span>
     <span class="state-chip pending">draft</span>
   </div>
-  <a href="process/versioning.html">Open Page</a>
 </article>
 <article class="card">
   <h3><a href="repo/CHANGELOG.html">Changelog</a></h3>
@@ -384,7 +353,6 @@
     <span class="state-chip live">Repository source</span>
     
   </div>
-  <a href="repo/CHANGELOG.html">Open Page</a>
 </article>
   </div>
 </section>
@@ -398,7 +366,6 @@
     <span class="state-chip live">Support document</span>
     
   </div>
-  <a href="architecture/README.html">Open Page</a>
 </article>
   </div>
 </section>
@@ -412,7 +379,6 @@
     <span class="state-chip live">Support document</span>
     <span class="state-chip pending">research</span>
   </div>
-  <a href="research/mcp-vs-mcpaql-vs-a2a.html">Open Page</a>
 </article>
   </div>
 </section>
@@ -426,7 +392,6 @@
     <span class="state-chip live">Support document</span>
     
   </div>
-  <a href="reference/README.html">Open Page</a>
 </article>
   </div>
 </section>
@@ -440,7 +405,6 @@
     <span class="state-chip live">Support document</span>
     <span class="state-chip pending">Accepted</span>
   </div>
-  <a href="adr/ADR-001-crude-pattern.html">Open Page</a>
 </article>
 <article class="card">
   <h3><a href="adr/ADR-002-graphql-style-input.html">ADR-002: GraphQL-Style Input Objects for Updates</a></h3>
@@ -449,7 +413,6 @@
     <span class="state-chip live">Support document</span>
     <span class="state-chip pending">Accepted</span>
   </div>
-  <a href="adr/ADR-002-graphql-style-input.html">Open Page</a>
 </article>
 <article class="card">
   <h3><a href="adr/ADR-003-snake-case-parameters.html">ADR-003: snake_case Parameter Convention</a></h3>
@@ -458,7 +421,6 @@
     <span class="state-chip live">Support document</span>
     <span class="state-chip pending">Accepted</span>
   </div>
-  <a href="adr/ADR-003-snake-case-parameters.html">Open Page</a>
 </article>
 <article class="card">
   <h3><a href="adr/ADR-004-schema-driven-operations.html">ADR-004: Schema-Driven Operation Definitions</a></h3>
@@ -467,7 +429,6 @@
     <span class="state-chip live">Support document</span>
     <span class="state-chip pending">Accepted</span>
   </div>
-  <a href="adr/ADR-004-schema-driven-operations.html">Open Page</a>
 </article>
 <article class="card">
   <h3><a href="adr/ADR-005-introspection-system.html">ADR-005: GraphQL-Style Introspection System</a></h3>
@@ -476,7 +437,6 @@
     <span class="state-chip live">Support document</span>
     <span class="state-chip pending">Accepted</span>
   </div>
-  <a href="adr/ADR-005-introspection-system.html">Open Page</a>
 </article>
 <article class="card">
   <h3><a href="adr/ADR-006-discriminated-responses.html">ADR-006: Discriminated Response Format</a></h3>
@@ -485,7 +445,6 @@
     <span class="state-chip live">Support document</span>
     <span class="state-chip pending">Accepted</span>
   </div>
-  <a href="adr/ADR-006-discriminated-responses.html">Open Page</a>
 </article>
 <article class="card">
   <h3><a href="adr/index.html">Architecture Decision Records</a></h3>
@@ -494,7 +453,6 @@
     <span class="state-chip live">Support document</span>
     <span class="state-chip pending">Accepted | Proposed | Deprecated | Superseded</span>
   </div>
-  <a href="adr/index.html">Open Page</a>
 </article>
 <article class="card">
   <h3><a href="adr/README.html">Architecture Decision Records</a></h3>
@@ -503,7 +461,6 @@
     <span class="state-chip live">Support document</span>
     
   </div>
-  <a href="adr/README.html">Open Page</a>
 </article>
   </div>
 </section>

--- a/scripts/generate-spec-docs.mjs
+++ b/scripts/generate-spec-docs.mjs
@@ -472,7 +472,6 @@ function wrapSpecIndexPage(navGroups) {
     <span class="state-chip live">${escapeHtml(doc.scopeLabel)}</span>
     ${doc.status ? `<span class="state-chip pending">${escapeHtml(doc.status)}</span>` : ""}
   </div>
-  <a href="${href}">Open Page</a>
 </article>`;
     }).join("\n");
 


### PR DESCRIPTION
## Summary
- move docs previous/next navigation below the hero instead of the page footer
- add left/right keyboard shortcuts for docs page navigation without hijacking form inputs
- remove redundant Open Page links from the generated full spec index cards

## Verification
- npm run generate:spec-docs
- node --check public/js/search.js
- node --check scripts/generate-spec-docs.mjs