### PR TITLE
feat: add adapter patterns hub

### DIFF
--- a/public/apis/application.html
+++ b/public/apis/application.html
@@ -19,7 +19,7 @@
           <li><a href="../index.html">Home</a></li>
           <li><a href="../docs/index.html">Docs</a></li>
           <li><a href="../launch-checklist.html">Launch Checklist</a></li>
-          <li><a href="mcp-server.html">Adapter Patterns</a></li>
+          <li><a href="index.html">Adapter Patterns</a></li>
         </ul>
         <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
@@ -35,8 +35,9 @@
     <div class="container docs-shell">
       <aside class="docs-side">
         <h2>Adapter Patterns</h2>
-        <p class="docs-side-note">Conceptual integration profiles that connect the protocol rules to common target-system shapes.</p>
+        <p class="docs-side-note">Use the overview to orient first, then compare the child pages to see how contract shape and safety posture change by target system.</p>
         <ul>
+          <li><a href="index.html">Overview</a></li>
           <li><a href="mcp-server.html">MCP Server</a></li>
           <li><a class="current" aria-current="page" href="application.html">Application</a></li>
           <li><a href="cloud-service.html">Cloud Service</a></li>
@@ -49,8 +50,7 @@
         <nav class="breadcrumbs" aria-label="Breadcrumb">
           <ol>
             <li><a href="../index.html">Home</a></li>
-            <li><a href="../docs/index.html">Docs</a></li>
-            <li><a href="mcp-server.html">Adapter Patterns</a></li>
+            <li><a href="index.html">Adapter Patterns</a></li>
             <li><span class="current">Application</span></li>
           </ol>
         </nav>
@@ -89,6 +89,28 @@
                 <li><a href="cloud-service.html">Cloud Service</a></li>
                 <li><a href="operating-system.html">Operating System</a></li>
                 <li><a href="website.html">Website / Web API</a></li>
+              </ul>
+            </article>
+          </div>
+        </section>
+
+        <section>
+          <h2 class="section-title">When this pattern fits</h2>
+          <div class="grid cols-2">
+            <article class="card">
+              <h3>Best fit</h3>
+              <ul>
+                <li>The source system is a product or application surface with many user-facing actions.</li>
+                <li>You need stable operation names over a feature area that evolves quickly.</li>
+                <li>Validation, discoverability, and side-effect labeling matter more than mirroring transport details directly.</li>
+              </ul>
+            </article>
+            <article class="card">
+              <h3>Watch for</h3>
+              <ul>
+                <li>Action names that reflect UI wording instead of durable operation semantics.</li>
+                <li>Large opaque payloads that hide parameter meaning from introspection and clients.</li>
+                <li>Retry and idempotency assumptions that are real in practice but unstated in the contract.</li>
               </ul>
             </article>
           </div>

--- a/public/apis/cloud-service.html
+++ b/public/apis/cloud-service.html
@@ -19,7 +19,7 @@
           <li><a href="../index.html">Home</a></li>
           <li><a href="../docs/index.html">Docs</a></li>
           <li><a href="../launch-checklist.html">Launch Checklist</a></li>
-          <li><a href="mcp-server.html">Adapter Patterns</a></li>
+          <li><a href="index.html">Adapter Patterns</a></li>
         </ul>
         <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
@@ -35,8 +35,9 @@
     <div class="container docs-shell">
       <aside class="docs-side">
         <h2>Adapter Patterns</h2>
-        <p class="docs-side-note">Conceptual integration profiles that connect the protocol rules to common target-system shapes.</p>
+        <p class="docs-side-note">Use the overview to orient first, then compare the child pages to see how contract shape and safety posture change by target system.</p>
         <ul>
+          <li><a href="index.html">Overview</a></li>
           <li><a href="mcp-server.html">MCP Server</a></li>
           <li><a href="application.html">Application</a></li>
           <li><a class="current" aria-current="page" href="cloud-service.html">Cloud Service</a></li>
@@ -49,8 +50,7 @@
         <nav class="breadcrumbs" aria-label="Breadcrumb">
           <ol>
             <li><a href="../index.html">Home</a></li>
-            <li><a href="../docs/index.html">Docs</a></li>
-            <li><a href="mcp-server.html">Adapter Patterns</a></li>
+            <li><a href="index.html">Adapter Patterns</a></li>
             <li><span class="current">Cloud Service</span></li>
           </ol>
         </nav>
@@ -89,6 +89,28 @@
                 <li><a href="application.html">Application</a></li>
                 <li><a href="operating-system.html">Operating System</a></li>
                 <li><a href="website.html">Website / Web API</a></li>
+              </ul>
+            </article>
+          </div>
+        </section>
+
+        <section>
+          <h2 class="section-title">When this pattern fits</h2>
+          <div class="grid cols-2">
+            <article class="card">
+              <h3>Best fit</h3>
+              <ul>
+                <li>The source system is a remote API where quotas, retries, and pagination shape the user experience.</li>
+                <li>You need a contract that normalizes provider transport details into stable operations.</li>
+                <li>Structured errors and explicit rate-limit posture are central design concerns.</li>
+              </ul>
+            </article>
+            <article class="card">
+              <h3>Watch for</h3>
+              <ul>
+                <li>Provider-specific failures leaking through without clean protocol-level mapping.</li>
+                <li>Read-heavy list operations that need pagination and field-selection discipline.</li>
+                <li>Batch or fan-out behavior that can amplify cost or exhaust quotas unexpectedly.</li>
               </ul>
             </article>
           </div>

--- a/public/apis/index.html
+++ b/public/apis/index.html
@@ -1,0 +1,166 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Browse MCP-AQL adapter patterns across MCP servers, applications, cloud services, operating systems, and website-facing integrations.">
+  <title>Adapter Patterns | MCP-AQL</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../css/style.css">
+</head>
+<body>
+  <header>
+    <div class="container">
+      <nav>
+        <a class="logo" href="../index.html"><span class="logo-mark"></span>MCP-AQL</a>
+        <ul class="nav-links">
+          <li><a href="../index.html">Home</a></li>
+          <li><a href="../docs/index.html">Docs</a></li>
+          <li><a href="../launch-checklist.html">Launch Checklist</a></li>
+          <li><a href="index.html">Adapter Patterns</a></li>
+        </ul>
+        <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
+          <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
+          <input id="site-search-input" data-search-input type="search" placeholder="Search MCP-AQL docs, spec pages, and adapter patterns...">
+          <span class="search-count" data-search-count></span>
+          <ul class="search-results" data-search-results hidden></ul>
+        </form>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <div class="container docs-shell">
+      <aside class="docs-side">
+        <h2>Adapter Patterns</h2>
+        <p class="docs-side-note">Choose the closest target-system shape first, then use the child pages to understand which contract and safety decisions matter most.</p>
+        <ul>
+          <li><a class="current" aria-current="page" href="index.html">Overview</a></li>
+          <li><a href="mcp-server.html">MCP Server</a></li>
+          <li><a href="application.html">Application</a></li>
+          <li><a href="cloud-service.html">Cloud Service</a></li>
+          <li><a href="operating-system.html">Operating System</a></li>
+          <li><a href="website.html">Website / Web API</a></li>
+        </ul>
+      </aside>
+
+      <article class="docs-main">
+        <nav class="breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../index.html">Home</a></li>
+            <li><span class="current">Adapter Patterns</span></li>
+          </ol>
+        </nav>
+
+        <section class="hero docs-hero api-hero">
+          <div class="hero-inner">
+            <span class="status-pill">IMPLEMENTATION GUIDANCE</span>
+            <h1>Adapter patterns are where the protocol meets the target system</h1>
+            <p class="lede">
+              These pages are the browse-first guide to how MCP-AQL changes shape across different environments.
+              The formal rules still live in the spec and contract docs, but the pattern pages help implementers choose the right modeling, safety, and runtime posture before they drop into the details.
+            </p>
+            <div class="hero-actions">
+              <a class="btn btn-primary" href="../docs/adapter-contracts.html">Adapter Contracts</a>
+              <a class="btn btn-secondary" href="../docs/implementation-profiles.html">Implementation Profiles</a>
+              <a class="btn btn-secondary" href="../spec/mcp-integration.html">MCP Integration Spec</a>
+            </div>
+          </div>
+        </section>
+
+        <section class="topic-bridge">
+          <h2 class="sr-only">Related reading</h2>
+          <div class="grid cols-2">
+            <article class="card">
+              <h3>What this section is for</h3>
+              <p>Use this hub when you know you need adapter guidance, but you have not yet decided which target-system shape best matches the thing you are adapting.</p>
+              <ul>
+                <li>Start here to compare the major environment types quickly.</li>
+                <li>Use the child pages for environment-specific caveats and examples.</li>
+                <li>Cross-check each decision against the website-hosted spec pages instead of bouncing back to repo Markdown.</li>
+              </ul>
+            </article>
+            <article class="card">
+              <h3>How to read it alongside the spec</h3>
+              <p>The pattern pages are implementation-facing guidance, not normative rules. They narrow the problem and then route you to the correct spec material.</p>
+              <ul>
+                <li><a href="../docs/adapter-contracts.html">Adapter Contracts</a></li>
+                <li><a href="../docs/security-model.html">Security Model</a></li>
+                <li><a href="../spec/operations.html">Operations Specification</a></li>
+                <li><a href="../spec/adapter/element-type.html">Adapter Element Type Specification</a></li>
+              </ul>
+            </article>
+          </div>
+        </section>
+
+        <section>
+          <h2 class="section-title">Pattern Library</h2>
+          <p class="section-subtitle">Pick the closest environment first. The child pages are there to turn that choice into better contract and runtime decisions.</p>
+          <div class="grid cols-2">
+            <article class="card">
+              <h3><a class="card-title-link" href="mcp-server.html">MCP Server</a></h3>
+              <span class="state-chip live">Primary protocol fit</span>
+              <p>For native MCP tool surfaces that need introspection-preserving consolidation into CRUDE or single-mode MCP-AQL operations.</p>
+            </article>
+            <article class="card">
+              <h3><a class="card-title-link" href="application.html">Application</a></h3>
+              <span class="state-chip pending">Product API fit</span>
+              <p>For desktop, mobile, and product-function surfaces where user-facing actions need a clearer operation contract.</p>
+            </article>
+            <article class="card">
+              <h3><a class="card-title-link" href="cloud-service.html">Cloud Service</a></h3>
+              <span class="state-chip pending">External API fit</span>
+              <p>For remote APIs where quotas, retries, pagination, and provider failure semantics shape the adapter design.</p>
+            </article>
+            <article class="card">
+              <h3><a class="card-title-link" href="operating-system.html">Operating System</a></h3>
+              <span class="state-chip pending">Local execution fit</span>
+              <p>For file, process, and system-level operations where permission, confirmation, and policy controls must be explicit.</p>
+            </article>
+            <article class="card">
+              <h3><a class="card-title-link" href="website.html">Website / Web API</a></h3>
+              <span class="state-chip pending">Web workflow fit</span>
+              <p>For retrieval-heavy or action-heavy web flows where scraping, APIs, navigation, and side effects can overlap.</p>
+            </article>
+          </div>
+        </section>
+
+        <section>
+          <h2 class="section-title">Cross-Cutting Questions</h2>
+          <div class="grid cols-3">
+            <article class="card">
+              <h3>What is being adapted?</h3>
+              <p>Name the real upstream surface clearly: tools, app actions, cloud endpoints, local system operations, or website flows.</p>
+            </article>
+            <article class="card">
+              <h3>Where is the safety boundary?</h3>
+              <p>The right pattern often turns on where cost, permissions, confirmation, or destructive behavior actually lives.</p>
+            </article>
+            <article class="card">
+              <h3>Which spec pages matter most?</h3>
+              <p>The hub helps answer that question early so implementers can go deeper with less wandering and less duplication.</p>
+            </article>
+          </div>
+        </section>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div class="container">
+      <p>&copy; 2026 DollhouseMCP Inc. d/b/a Dollhouse Research. MCP-AQL public draft documentation portal.</p>
+      <div class="footer-links">
+        <a href="../docs/index.html">Documentation Library</a>
+        <a href="../index.html">Portal Home</a>
+        <a href="https://github.com/MCPAQL">MCPAQL Organization</a>
+        <a href="https://dollhouseresearch.com">Dollhouse Research</a>
+        <a href="https://github.com/DollhouseMCP/mcp-server">DollhouseMCP Production Profile</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../js/search.js"></script>
+</body>
+</html>

--- a/public/apis/mcp-server.html
+++ b/public/apis/mcp-server.html
@@ -19,7 +19,7 @@
           <li><a href="../index.html">Home</a></li>
           <li><a href="../docs/index.html">Docs</a></li>
           <li><a href="../launch-checklist.html">Launch Checklist</a></li>
-          <li><a href="mcp-server.html">Adapter Patterns</a></li>
+          <li><a href="index.html">Adapter Patterns</a></li>
         </ul>
         <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
@@ -35,8 +35,9 @@
     <div class="container docs-shell">
       <aside class="docs-side">
         <h2>Adapter Patterns</h2>
-        <p class="docs-side-note">Conceptual integration profiles that connect the protocol rules to common target-system shapes.</p>
+        <p class="docs-side-note">Use the overview to orient first, then compare the child pages to see how contract shape and safety posture change by target system.</p>
         <ul>
+          <li><a href="index.html">Overview</a></li>
           <li><a class="current" aria-current="page" href="mcp-server.html">MCP Server</a></li>
           <li><a href="application.html">Application</a></li>
           <li><a href="cloud-service.html">Cloud Service</a></li>
@@ -49,8 +50,8 @@
         <nav class="breadcrumbs" aria-label="Breadcrumb">
           <ol>
             <li><a href="../index.html">Home</a></li>
-            <li><a href="../docs/index.html">Docs</a></li>
-            <li><span class="current">MCP Server Pattern</span></li>
+            <li><a href="index.html">Adapter Patterns</a></li>
+            <li><span class="current">MCP Server</span></li>
           </ol>
         </nav>
 
@@ -90,6 +91,28 @@
                 <li><a href="cloud-service.html">Cloud Services</a></li>
                 <li><a href="operating-system.html">Operating System Flows</a></li>
                 <li><a href="website.html">Website / Web API Flows</a></li>
+              </ul>
+            </article>
+          </div>
+        </section>
+
+        <section>
+          <h2 class="section-title">When this pattern fits</h2>
+          <div class="grid cols-2">
+            <article class="card">
+              <h3>Best fit</h3>
+              <ul>
+                <li>The upstream system already exposes MCP tools or tool-like operations.</li>
+                <li>You want runtime discovery to remain central instead of freezing a large static tool surface.</li>
+                <li>You need a clear path from interrogated MCP behavior into a spec-aligned adapter contract.</li>
+              </ul>
+            </article>
+            <article class="card">
+              <h3>Watch for</h3>
+              <ul>
+                <li>Operation naming or parameter drift between upstream descriptions and adapter output.</li>
+                <li>Tools with unclear side effects that need better CREATE, UPDATE, DELETE, or EXECUTE classification.</li>
+                <li>Discovery artifacts that can fall out of sync with the normative draft if generation is loose.</li>
               </ul>
             </article>
           </div>

--- a/public/apis/operating-system.html
+++ b/public/apis/operating-system.html
@@ -19,7 +19,7 @@
           <li><a href="../index.html">Home</a></li>
           <li><a href="../docs/index.html">Docs</a></li>
           <li><a href="../launch-checklist.html">Launch Checklist</a></li>
-          <li><a href="mcp-server.html">Adapter Patterns</a></li>
+          <li><a href="index.html">Adapter Patterns</a></li>
         </ul>
         <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
@@ -35,8 +35,9 @@
     <div class="container docs-shell">
       <aside class="docs-side">
         <h2>Adapter Patterns</h2>
-        <p class="docs-side-note">Conceptual integration profiles that connect the protocol rules to common target-system shapes.</p>
+        <p class="docs-side-note">Use the overview to orient first, then compare the child pages to see how contract shape and safety posture change by target system.</p>
         <ul>
+          <li><a href="index.html">Overview</a></li>
           <li><a href="mcp-server.html">MCP Server</a></li>
           <li><a href="application.html">Application</a></li>
           <li><a href="cloud-service.html">Cloud Service</a></li>
@@ -49,8 +50,7 @@
         <nav class="breadcrumbs" aria-label="Breadcrumb">
           <ol>
             <li><a href="../index.html">Home</a></li>
-            <li><a href="../docs/index.html">Docs</a></li>
-            <li><a href="mcp-server.html">Adapter Patterns</a></li>
+            <li><a href="index.html">Adapter Patterns</a></li>
             <li><span class="current">Operating System</span></li>
           </ol>
         </nav>
@@ -89,6 +89,28 @@
                 <li><a href="application.html">Application</a></li>
                 <li><a href="cloud-service.html">Cloud Service</a></li>
                 <li><a href="website.html">Website / Web API</a></li>
+              </ul>
+            </article>
+          </div>
+        </section>
+
+        <section>
+          <h2 class="section-title">When this pattern fits</h2>
+          <div class="grid cols-2">
+            <article class="card">
+              <h3>Best fit</h3>
+              <ul>
+                <li>The adapter exposes local files, processes, or other system-level capabilities.</li>
+                <li>You need explicit distinctions between read-only queries, state-changing actions, and true execution flows.</li>
+                <li>Permissions, confirmations, and auditability are part of the product requirement, not optional add-ons.</li>
+              </ul>
+            </article>
+            <article class="card">
+              <h3>Watch for</h3>
+              <ul>
+                <li>Destructive or execute-capable operations that are too easy to trigger accidentally.</li>
+                <li>Insufficient scoping on file-system or process queries that can cause runaway work.</li>
+                <li>Security models that rely on labels instead of machine-readable policy signals.</li>
               </ul>
             </article>
           </div>

--- a/public/apis/website.html
+++ b/public/apis/website.html
@@ -19,7 +19,7 @@
           <li><a href="../index.html">Home</a></li>
           <li><a href="../docs/index.html">Docs</a></li>
           <li><a href="../launch-checklist.html">Launch Checklist</a></li>
-          <li><a href="mcp-server.html">Adapter Patterns</a></li>
+          <li><a href="index.html">Adapter Patterns</a></li>
         </ul>
         <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
@@ -35,8 +35,9 @@
     <div class="container docs-shell">
       <aside class="docs-side">
         <h2>Adapter Patterns</h2>
-        <p class="docs-side-note">Conceptual integration profiles that connect the protocol rules to common target-system shapes.</p>
+        <p class="docs-side-note">Use the overview to orient first, then compare the child pages to see how contract shape and safety posture change by target system.</p>
         <ul>
+          <li><a href="index.html">Overview</a></li>
           <li><a href="mcp-server.html">MCP Server</a></li>
           <li><a href="application.html">Application</a></li>
           <li><a href="cloud-service.html">Cloud Service</a></li>
@@ -49,8 +50,7 @@
         <nav class="breadcrumbs" aria-label="Breadcrumb">
           <ol>
             <li><a href="../index.html">Home</a></li>
-            <li><a href="../docs/index.html">Docs</a></li>
-            <li><a href="mcp-server.html">Adapter Patterns</a></li>
+            <li><a href="index.html">Adapter Patterns</a></li>
             <li><span class="current">Website / Web API</span></li>
           </ol>
         </nav>
@@ -89,6 +89,28 @@
                 <li><a href="application.html">Application</a></li>
                 <li><a href="cloud-service.html">Cloud Service</a></li>
                 <li><a href="operating-system.html">Operating System</a></li>
+              </ul>
+            </article>
+          </div>
+        </section>
+
+        <section>
+          <h2 class="section-title">When this pattern fits</h2>
+          <div class="grid cols-2">
+            <article class="card">
+              <h3>Best fit</h3>
+              <ul>
+                <li>The source surface mixes retrieval, parsing, and action execution across web pages or HTTP-facing APIs.</li>
+                <li>You want a stable contract above browser automation, scraping, or site-specific workflow code.</li>
+                <li>Field selection and clear read versus execute boundaries are important for cost and safety.</li>
+              </ul>
+            </article>
+            <article class="card">
+              <h3>Watch for</h3>
+              <ul>
+                <li>Read flows and state-changing actions being blurred into one generic operation surface.</li>
+                <li>Fragile selectors or page-specific assumptions leaking into operation semantics.</li>
+                <li>HTTP, page, and workflow failures that need better structured error normalization.</li>
               </ul>
             </article>
           </div>

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -303,6 +303,11 @@ section {
   margin-top: 2.4rem;
 }
 
+main > .container > section:not(.hero) {
+  contain-intrinsic-size: 1px 520px;
+  content-visibility: auto;
+}
+
 .hero {
   background: linear-gradient(130deg, #ffffff 0%, #f4f8ff 55%, #ecfeff 100%);
   border: 1px solid var(--line);

--- a/public/data/search-index.json
+++ b/public/data/search-index.json
@@ -150,6 +150,18 @@
     ]
   },
   {
+    "title": "Adapter Patterns",
+    "url": "/apis/index.html",
+    "excerpt": "Top-level guide to MCP-AQL adapter patterns across MCP servers, applications, cloud services, operating systems, and website-facing workflows.",
+    "keywords": [
+      "adapter patterns",
+      "pattern hub",
+      "integration",
+      "implementation guidance",
+      "apis"
+    ]
+  },
+  {
     "title": "MCP Server Adapter Pattern",
     "url": "/apis/mcp-server.html",
     "excerpt": "Draft guidance for adapting MCP servers to MCP-AQL through introspection and CRUDE operation mapping.",
@@ -196,10 +208,11 @@
   {
     "title": "Website Adapter Pattern",
     "url": "/apis/website.html",
-    "excerpt": "Draft guidance for website-facing integrations and retrieval/action patterns.",
+    "excerpt": "Draft guidance for website and web API integrations, including retrieval/action patterns and structured web workflows.",
     "keywords": [
       "website",
       "web",
+      "web api",
       "retrieval",
       "action"
     ]

--- a/public/docs/adapter-contracts.html
+++ b/public/docs/adapter-contracts.html
@@ -19,7 +19,7 @@
           <li><a href="../index.html">Home</a></li>
           <li><a href="index.html">Docs</a></li>
           <li><a href="../launch-checklist.html">Launch Checklist</a></li>
-          <li><a href="../apis/mcp-server.html">Adapter Patterns</a></li>
+          <li><a href="../apis/index.html">Adapter Patterns</a></li>
         </ul>
         <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>

--- a/public/docs/conformance.html
+++ b/public/docs/conformance.html
@@ -19,7 +19,7 @@
           <li><a href="../index.html">Home</a></li>
           <li><a href="index.html">Docs</a></li>
           <li><a href="../launch-checklist.html">Launch Checklist</a></li>
-          <li><a href="../apis/mcp-server.html">Adapter Patterns</a></li>
+          <li><a href="../apis/index.html">Adapter Patterns</a></li>
         </ul>
         <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>

--- a/public/docs/error-model.html
+++ b/public/docs/error-model.html
@@ -19,7 +19,7 @@
           <li><a href="../index.html">Home</a></li>
           <li><a href="index.html">Docs</a></li>
           <li><a href="../launch-checklist.html">Launch Checklist</a></li>
-          <li><a href="../apis/mcp-server.html">Adapter Patterns</a></li>
+          <li><a href="../apis/index.html">Adapter Patterns</a></li>
         </ul>
         <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>

--- a/public/docs/getting-started.html
+++ b/public/docs/getting-started.html
@@ -19,7 +19,7 @@
           <li><a href="../index.html">Home</a></li>
           <li><a href="index.html">Docs</a></li>
           <li><a href="../launch-checklist.html">Launch Checklist</a></li>
-          <li><a href="../apis/mcp-server.html">Adapter Patterns</a></li>
+          <li><a href="../apis/index.html">Adapter Patterns</a></li>
         </ul>
         <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>

--- a/public/docs/implementation-profiles.html
+++ b/public/docs/implementation-profiles.html
@@ -19,7 +19,7 @@
           <li><a href="../index.html">Home</a></li>
           <li><a href="index.html">Docs</a></li>
           <li><a href="../launch-checklist.html">Launch Checklist</a></li>
-          <li><a href="../apis/mcp-server.html">Adapter Patterns</a></li>
+          <li><a href="../apis/index.html">Adapter Patterns</a></li>
         </ul>
         <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>

--- a/public/docs/index.html
+++ b/public/docs/index.html
@@ -19,7 +19,7 @@
           <li><a href="../index.html">Home</a></li>
           <li><a href="index.html">Docs</a></li>
           <li><a href="../launch-checklist.html">Launch Checklist</a></li>
-          <li><a href="../apis/mcp-server.html">Adapter Patterns</a></li>
+          <li><a href="../apis/index.html">Adapter Patterns</a></li>
         </ul>
         <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>

--- a/public/docs/protocol-core.html
+++ b/public/docs/protocol-core.html
@@ -19,7 +19,7 @@
           <li><a href="../index.html">Home</a></li>
           <li><a href="index.html">Docs</a></li>
           <li><a href="../launch-checklist.html">Launch Checklist</a></li>
-          <li><a href="../apis/mcp-server.html">Adapter Patterns</a></li>
+          <li><a href="../apis/index.html">Adapter Patterns</a></li>
         </ul>
         <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>

--- a/public/docs/release-notes.html
+++ b/public/docs/release-notes.html
@@ -19,7 +19,7 @@
           <li><a href="../index.html">Home</a></li>
           <li><a href="index.html">Docs</a></li>
           <li><a href="../launch-checklist.html">Launch Checklist</a></li>
-          <li><a href="../apis/mcp-server.html">Adapter Patterns</a></li>
+          <li><a href="../apis/index.html">Adapter Patterns</a></li>
         </ul>
         <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>

--- a/public/docs/roadmap.html
+++ b/public/docs/roadmap.html
@@ -19,7 +19,7 @@
           <li><a href="../index.html">Home</a></li>
           <li><a href="index.html">Docs</a></li>
           <li><a href="../launch-checklist.html">Launch Checklist</a></li>
-          <li><a href="../apis/mcp-server.html">Adapter Patterns</a></li>
+          <li><a href="../apis/index.html">Adapter Patterns</a></li>
         </ul>
         <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>

--- a/public/docs/security-model.html
+++ b/public/docs/security-model.html
@@ -19,7 +19,7 @@
           <li><a href="../index.html">Home</a></li>
           <li><a href="index.html">Docs</a></li>
           <li><a href="../launch-checklist.html">Launch Checklist</a></li>
-          <li><a href="../apis/mcp-server.html">Adapter Patterns</a></li>
+          <li><a href="../apis/index.html">Adapter Patterns</a></li>
         </ul>
         <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>

--- a/public/index.html
+++ b/public/index.html
@@ -19,7 +19,7 @@
           <li><a href="index.html">Home</a></li>
           <li><a href="docs/index.html">Docs</a></li>
           <li><a href="launch-checklist.html">Launch Checklist</a></li>
-          <li><a href="apis/mcp-server.html">Adapter Patterns</a></li>
+          <li><a href="apis/index.html">Adapter Patterns</a></li>
         </ul>
         <form class="site-search" data-search-form data-index-url="data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
@@ -233,8 +233,9 @@
 
       <section>
         <h2 class="section-title">Adapter Pattern Pages</h2>
-        <p class="section-subtitle">Pattern pages remain draft guidance until concrete public adapters are published.</p>
+        <p class="section-subtitle">Start from the adapter-pattern hub, then move into the specific environment pages that match the target system you are adapting.</p>
         <div class="grid cols-3">
+          <a class="card" href="apis/index.html"><h3>Adapter Patterns Overview</h3><span class="state-chip live">Start here</span><p>Top-level guide to choosing the right target-system pattern before diving into the child pages.</p></a>
           <a class="card" href="apis/mcp-server.html"><h3>MCP Server Pattern</h3><span class="state-chip pending">Draft guidance</span><p>Native MCP server consolidation patterns.</p></a>
           <a class="card" href="apis/operating-system.html"><h3>Operating System Pattern</h3><span class="state-chip pending">Draft guidance</span><p>Permission-aware local execution boundaries.</p></a>
           <a class="card" href="apis/application.html"><h3>Application Pattern</h3><span class="state-chip pending">Draft guidance</span><p>Application APIs mapped into semantic operations.</p></a>

--- a/public/launch-checklist.html
+++ b/public/launch-checklist.html
@@ -19,7 +19,7 @@
           <li><a href="index.html">Home</a></li>
           <li><a href="docs/index.html">Docs</a></li>
           <li><a href="launch-checklist.html">Launch Checklist</a></li>
-          <li><a href="apis/mcp-server.html">Adapter Patterns</a></li>
+          <li><a href="apis/index.html">Adapter Patterns</a></li>
         </ul>
         <form class="site-search" data-search-form data-index-url="data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>

--- a/public/search.html
+++ b/public/search.html
@@ -18,8 +18,8 @@
         <ul class="nav-links">
           <li><a href="index.html">Home</a></li>
           <li><a href="docs/index.html">Docs</a></li>
-          <li><a href="spec/index.html">Full Spec</a></li>
           <li><a href="launch-checklist.html">Launch Checklist</a></li>
+          <li><a href="apis/index.html">Adapter Patterns</a></li>
         </ul>
         <form class="site-search" data-search-form data-index-url="data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>

--- a/public/spec/README.html
+++ b/public/spec/README.html
@@ -19,7 +19,7 @@
           <li><a href="../index.html">Home</a></li>
           <li><a href="../docs/index.html">Docs</a></li>
           <li><a href="../launch-checklist.html">Launch Checklist</a></li>
-          <li><a href="../apis/mcp-server.html">Adapter Patterns</a></li>
+          <li><a href="../apis/index.html">Adapter Patterns</a></li>
         </ul>
         <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>

--- a/public/spec/adapter/danger-levels.html
+++ b/public/spec/adapter/danger-levels.html
@@ -19,7 +19,7 @@
           <li><a href="../../index.html">Home</a></li>
           <li><a href="../../docs/index.html">Docs</a></li>
           <li><a href="../../launch-checklist.html">Launch Checklist</a></li>
-          <li><a href="../../apis/mcp-server.html">Adapter Patterns</a></li>
+          <li><a href="../../apis/index.html">Adapter Patterns</a></li>
         </ul>
         <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>

--- a/public/spec/adapter/discovery-bundle.html
+++ b/public/spec/adapter/discovery-bundle.html
@@ -19,7 +19,7 @@
           <li><a href="../../index.html">Home</a></li>
           <li><a href="../../docs/index.html">Docs</a></li>
           <li><a href="../../launch-checklist.html">Launch Checklist</a></li>
-          <li><a href="../../apis/mcp-server.html">Adapter Patterns</a></li>
+          <li><a href="../../apis/index.html">Adapter Patterns</a></li>
         </ul>
         <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>

--- a/public/spec/adapter/element-type.html
+++ b/public/spec/adapter/element-type.html
@@ -19,7 +19,7 @@
           <li><a href="../../index.html">Home</a></li>
           <li><a href="../../docs/index.html">Docs</a></li>
           <li><a href="../../launch-checklist.html">Launch Checklist</a></li>
-          <li><a href="../../apis/mcp-server.html">Adapter Patterns</a></li>
+          <li><a href="../../apis/index.html">Adapter Patterns</a></li>
         </ul>
         <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>

--- a/public/spec/adapter/generator.html
+++ b/public/spec/adapter/generator.html
@@ -19,7 +19,7 @@
           <li><a href="../../index.html">Home</a></li>
           <li><a href="../../docs/index.html">Docs</a></li>
           <li><a href="../../launch-checklist.html">Launch Checklist</a></li>
-          <li><a href="../../apis/mcp-server.html">Adapter Patterns</a></li>
+          <li><a href="../../apis/index.html">Adapter Patterns</a></li>
         </ul>
         <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>

--- a/public/spec/adapter/rate-limiting.html
+++ b/public/spec/adapter/rate-limiting.html
@@ -19,7 +19,7 @@
           <li><a href="../../index.html">Home</a></li>
           <li><a href="../../docs/index.html">Docs</a></li>
           <li><a href="../../launch-checklist.html">Launch Checklist</a></li>
-          <li><a href="../../apis/mcp-server.html">Adapter Patterns</a></li>
+          <li><a href="../../apis/index.html">Adapter Patterns</a></li>
         </ul>
         <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>

--- a/public/spec/adapter/trust-levels.html
+++ b/public/spec/adapter/trust-levels.html
@@ -19,7 +19,7 @@
           <li><a href="../../index.html">Home</a></li>
           <li><a href="../../docs/index.html">Docs</a></li>
           <li><a href="../../launch-checklist.html">Launch Checklist</a></li>
-          <li><a href="../../apis/mcp-server.html">Adapter Patterns</a></li>
+          <li><a href="../../apis/index.html">Adapter Patterns</a></li>
         </ul>
         <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>

--- a/public/spec/adr/ADR-001-crude-pattern.html
+++ b/public/spec/adr/ADR-001-crude-pattern.html
@@ -19,7 +19,7 @@
           <li><a href="../../index.html">Home</a></li>
           <li><a href="../../docs/index.html">Docs</a></li>
           <li><a href="../../launch-checklist.html">Launch Checklist</a></li>
-          <li><a href="../../apis/mcp-server.html">Adapter Patterns</a></li>
+          <li><a href="../../apis/index.html">Adapter Patterns</a></li>
         </ul>
         <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>

--- a/public/spec/adr/ADR-002-graphql-style-input.html
+++ b/public/spec/adr/ADR-002-graphql-style-input.html
@@ -19,7 +19,7 @@
           <li><a href="../../index.html">Home</a></li>
           <li><a href="../../docs/index.html">Docs</a></li>
           <li><a href="../../launch-checklist.html">Launch Checklist</a></li>
-          <li><a href="../../apis/mcp-server.html">Adapter Patterns</a></li>
+          <li><a href="../../apis/index.html">Adapter Patterns</a></li>
         </ul>
         <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>

--- a/public/spec/adr/ADR-003-snake-case-parameters.html
+++ b/public/spec/adr/ADR-003-snake-case-parameters.html
@@ -19,7 +19,7 @@
           <li><a href="../../index.html">Home</a></li>
           <li><a href="../../docs/index.html">Docs</a></li>
           <li><a href="../../launch-checklist.html">Launch Checklist</a></li>
-          <li><a href="../../apis/mcp-server.html">Adapter Patterns</a></li>
+          <li><a href="../../apis/index.html">Adapter Patterns</a></li>
         </ul>
         <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>

--- a/public/spec/adr/ADR-004-schema-driven-operations.html
+++ b/public/spec/adr/ADR-004-schema-driven-operations.html
@@ -19,7 +19,7 @@
           <li><a href="../../index.html">Home</a></li>
           <li><a href="../../docs/index.html">Docs</a></li>
           <li><a href="../../launch-checklist.html">Launch Checklist</a></li>
-          <li><a href="../../apis/mcp-server.html">Adapter Patterns</a></li>
+          <li><a href="../../apis/index.html">Adapter Patterns</a></li>
         </ul>
         <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>

--- a/public/spec/adr/ADR-005-introspection-system.html
+++ b/public/spec/adr/ADR-005-introspection-system.html
@@ -19,7 +19,7 @@
           <li><a href="../../index.html">Home</a></li>
           <li><a href="../../docs/index.html">Docs</a></li>
           <li><a href="../../launch-checklist.html">Launch Checklist</a></li>
-          <li><a href="../../apis/mcp-server.html">Adapter Patterns</a></li>
+          <li><a href="../../apis/index.html">Adapter Patterns</a></li>
         </ul>
         <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>

--- a/public/spec/adr/ADR-006-discriminated-responses.html
+++ b/public/spec/adr/ADR-006-discriminated-responses.html
@@ -19,7 +19,7 @@
           <li><a href="../../index.html">Home</a></li>
           <li><a href="../../docs/index.html">Docs</a></li>
           <li><a href="../../launch-checklist.html">Launch Checklist</a></li>
-          <li><a href="../../apis/mcp-server.html">Adapter Patterns</a></li>
+          <li><a href="../../apis/index.html">Adapter Patterns</a></li>
         </ul>
         <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>

--- a/public/spec/adr/README.html
+++ b/public/spec/adr/README.html
@@ -19,7 +19,7 @@
           <li><a href="../../index.html">Home</a></li>
           <li><a href="../../docs/index.html">Docs</a></li>
           <li><a href="../../launch-checklist.html">Launch Checklist</a></li>
-          <li><a href="../../apis/mcp-server.html">Adapter Patterns</a></li>
+          <li><a href="../../apis/index.html">Adapter Patterns</a></li>
         </ul>
         <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>

--- a/public/spec/adr/index.html
+++ b/public/spec/adr/index.html
@@ -19,7 +19,7 @@
           <li><a href="../../index.html">Home</a></li>
           <li><a href="../../docs/index.html">Docs</a></li>
           <li><a href="../../launch-checklist.html">Launch Checklist</a></li>
-          <li><a href="../../apis/mcp-server.html">Adapter Patterns</a></li>
+          <li><a href="../../apis/index.html">Adapter Patterns</a></li>
         </ul>
         <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>

--- a/public/spec/architecture/README.html
+++ b/public/spec/architecture/README.html
@@ -19,7 +19,7 @@
           <li><a href="../../index.html">Home</a></li>
           <li><a href="../../docs/index.html">Docs</a></li>
           <li><a href="../../launch-checklist.html">Launch Checklist</a></li>
-          <li><a href="../../apis/mcp-server.html">Adapter Patterns</a></li>
+          <li><a href="../../apis/index.html">Adapter Patterns</a></li>
         </ul>
         <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>

--- a/public/spec/conformance-testing.html
+++ b/public/spec/conformance-testing.html
@@ -19,7 +19,7 @@
           <li><a href="../index.html">Home</a></li>
           <li><a href="../docs/index.html">Docs</a></li>
           <li><a href="../launch-checklist.html">Launch Checklist</a></li>
-          <li><a href="../apis/mcp-server.html">Adapter Patterns</a></li>
+          <li><a href="../apis/index.html">Adapter Patterns</a></li>
         </ul>
         <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>

--- a/public/spec/crude-pattern.html
+++ b/public/spec/crude-pattern.html
@@ -19,7 +19,7 @@
           <li><a href="../index.html">Home</a></li>
           <li><a href="../docs/index.html">Docs</a></li>
           <li><a href="../launch-checklist.html">Launch Checklist</a></li>
-          <li><a href="../apis/mcp-server.html">Adapter Patterns</a></li>
+          <li><a href="../apis/index.html">Adapter Patterns</a></li>
         </ul>
         <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>

--- a/public/spec/endpoint-modes.html
+++ b/public/spec/endpoint-modes.html
@@ -19,7 +19,7 @@
           <li><a href="../index.html">Home</a></li>
           <li><a href="../docs/index.html">Docs</a></li>
           <li><a href="../launch-checklist.html">Launch Checklist</a></li>
-          <li><a href="../apis/mcp-server.html">Adapter Patterns</a></li>
+          <li><a href="../apis/index.html">Adapter Patterns</a></li>
         </ul>
         <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>

--- a/public/spec/error-codes.html
+++ b/public/spec/error-codes.html
@@ -19,7 +19,7 @@
           <li><a href="../index.html">Home</a></li>
           <li><a href="../docs/index.html">Docs</a></li>
           <li><a href="../launch-checklist.html">Launch Checklist</a></li>
-          <li><a href="../apis/mcp-server.html">Adapter Patterns</a></li>
+          <li><a href="../apis/index.html">Adapter Patterns</a></li>
         </ul>
         <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>

--- a/public/spec/features/field-selection.html
+++ b/public/spec/features/field-selection.html
@@ -19,7 +19,7 @@
           <li><a href="../../index.html">Home</a></li>
           <li><a href="../../docs/index.html">Docs</a></li>
           <li><a href="../../launch-checklist.html">Launch Checklist</a></li>
-          <li><a href="../../apis/mcp-server.html">Adapter Patterns</a></li>
+          <li><a href="../../apis/index.html">Adapter Patterns</a></li>
         </ul>
         <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>

--- a/public/spec/features/pagination.html
+++ b/public/spec/features/pagination.html
@@ -19,7 +19,7 @@
           <li><a href="../../index.html">Home</a></li>
           <li><a href="../../docs/index.html">Docs</a></li>
           <li><a href="../../launch-checklist.html">Launch Checklist</a></li>
-          <li><a href="../../apis/mcp-server.html">Adapter Patterns</a></li>
+          <li><a href="../../apis/index.html">Adapter Patterns</a></li>
         </ul>
         <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>

--- a/public/spec/features/warnings.html
+++ b/public/spec/features/warnings.html
@@ -19,7 +19,7 @@
           <li><a href="../../index.html">Home</a></li>
           <li><a href="../../docs/index.html">Docs</a></li>
           <li><a href="../../launch-checklist.html">Launch Checklist</a></li>
-          <li><a href="../../apis/mcp-server.html">Adapter Patterns</a></li>
+          <li><a href="../../apis/index.html">Adapter Patterns</a></li>
         </ul>
         <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>

--- a/public/spec/guides/README.html
+++ b/public/spec/guides/README.html
@@ -19,7 +19,7 @@
           <li><a href="../../index.html">Home</a></li>
           <li><a href="../../docs/index.html">Docs</a></li>
           <li><a href="../../launch-checklist.html">Launch Checklist</a></li>
-          <li><a href="../../apis/mcp-server.html">Adapter Patterns</a></li>
+          <li><a href="../../apis/index.html">Adapter Patterns</a></li>
         </ul>
         <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>

--- a/public/spec/guides/protocol-comparison.html
+++ b/public/spec/guides/protocol-comparison.html
@@ -19,7 +19,7 @@
           <li><a href="../../index.html">Home</a></li>
           <li><a href="../../docs/index.html">Docs</a></li>
           <li><a href="../../launch-checklist.html">Launch Checklist</a></li>
-          <li><a href="../../apis/mcp-server.html">Adapter Patterns</a></li>
+          <li><a href="../../apis/index.html">Adapter Patterns</a></li>
         </ul>
         <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>

--- a/public/spec/index.html
+++ b/public/spec/index.html
@@ -19,7 +19,7 @@
           <li><a href="../index.html">Home</a></li>
           <li><a href="../docs/index.html">Docs</a></li>
           <li><a href="../launch-checklist.html">Launch Checklist</a></li>
-          <li><a href="../apis/mcp-server.html">Adapter Patterns</a></li>
+          <li><a href="../apis/index.html">Adapter Patterns</a></li>
         </ul>
         <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>

--- a/public/spec/introspection.html
+++ b/public/spec/introspection.html
@@ -19,7 +19,7 @@
           <li><a href="../index.html">Home</a></li>
           <li><a href="../docs/index.html">Docs</a></li>
           <li><a href="../launch-checklist.html">Launch Checklist</a></li>
-          <li><a href="../apis/mcp-server.html">Adapter Patterns</a></li>
+          <li><a href="../apis/index.html">Adapter Patterns</a></li>
         </ul>
         <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>

--- a/public/spec/licensing-options.html
+++ b/public/spec/licensing-options.html
@@ -19,7 +19,7 @@
           <li><a href="../index.html">Home</a></li>
           <li><a href="../docs/index.html">Docs</a></li>
           <li><a href="../launch-checklist.html">Launch Checklist</a></li>
-          <li><a href="../apis/mcp-server.html">Adapter Patterns</a></li>
+          <li><a href="../apis/index.html">Adapter Patterns</a></li>
         </ul>
         <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>

--- a/public/spec/mcp-integration.html
+++ b/public/spec/mcp-integration.html
@@ -19,7 +19,7 @@
           <li><a href="../index.html">Home</a></li>
           <li><a href="../docs/index.html">Docs</a></li>
           <li><a href="../launch-checklist.html">Launch Checklist</a></li>
-          <li><a href="../apis/mcp-server.html">Adapter Patterns</a></li>
+          <li><a href="../apis/index.html">Adapter Patterns</a></li>
         </ul>
         <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>

--- a/public/spec/operations.html
+++ b/public/spec/operations.html
@@ -19,7 +19,7 @@
           <li><a href="../index.html">Home</a></li>
           <li><a href="../docs/index.html">Docs</a></li>
           <li><a href="../launch-checklist.html">Launch Checklist</a></li>
-          <li><a href="../apis/mcp-server.html">Adapter Patterns</a></li>
+          <li><a href="../apis/index.html">Adapter Patterns</a></li>
         </ul>
         <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>

--- a/public/spec/overview.html
+++ b/public/spec/overview.html
@@ -19,7 +19,7 @@
           <li><a href="../index.html">Home</a></li>
           <li><a href="../docs/index.html">Docs</a></li>
           <li><a href="../launch-checklist.html">Launch Checklist</a></li>
-          <li><a href="../apis/mcp-server.html">Adapter Patterns</a></li>
+          <li><a href="../apis/index.html">Adapter Patterns</a></li>
         </ul>
         <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>

--- a/public/spec/plugin-contracts.html
+++ b/public/spec/plugin-contracts.html
@@ -19,7 +19,7 @@
           <li><a href="../index.html">Home</a></li>
           <li><a href="../docs/index.html">Docs</a></li>
           <li><a href="../launch-checklist.html">Launch Checklist</a></li>
-          <li><a href="../apis/mcp-server.html">Adapter Patterns</a></li>
+          <li><a href="../apis/index.html">Adapter Patterns</a></li>
         </ul>
         <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>

--- a/public/spec/process/breaking-changes.html
+++ b/public/spec/process/breaking-changes.html
@@ -19,7 +19,7 @@
           <li><a href="../../index.html">Home</a></li>
           <li><a href="../../docs/index.html">Docs</a></li>
           <li><a href="../../launch-checklist.html">Launch Checklist</a></li>
-          <li><a href="../../apis/mcp-server.html">Adapter Patterns</a></li>
+          <li><a href="../../apis/index.html">Adapter Patterns</a></li>
         </ul>
         <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>

--- a/public/spec/process/preliminary-public-launch-checklist.html
+++ b/public/spec/process/preliminary-public-launch-checklist.html
@@ -19,7 +19,7 @@
           <li><a href="../../index.html">Home</a></li>
           <li><a href="../../docs/index.html">Docs</a></li>
           <li><a href="../../launch-checklist.html">Launch Checklist</a></li>
-          <li><a href="../../apis/mcp-server.html">Adapter Patterns</a></li>
+          <li><a href="../../apis/index.html">Adapter Patterns</a></li>
         </ul>
         <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>

--- a/public/spec/process/rfc-process.html
+++ b/public/spec/process/rfc-process.html
@@ -19,7 +19,7 @@
           <li><a href="../../index.html">Home</a></li>
           <li><a href="../../docs/index.html">Docs</a></li>
           <li><a href="../../launch-checklist.html">Launch Checklist</a></li>
-          <li><a href="../../apis/mcp-server.html">Adapter Patterns</a></li>
+          <li><a href="../../apis/index.html">Adapter Patterns</a></li>
         </ul>
         <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>

--- a/public/spec/process/versioning.html
+++ b/public/spec/process/versioning.html
@@ -19,7 +19,7 @@
           <li><a href="../../index.html">Home</a></li>
           <li><a href="../../docs/index.html">Docs</a></li>
           <li><a href="../../launch-checklist.html">Launch Checklist</a></li>
-          <li><a href="../../apis/mcp-server.html">Adapter Patterns</a></li>
+          <li><a href="../../apis/index.html">Adapter Patterns</a></li>
         </ul>
         <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>

--- a/public/spec/reference/README.html
+++ b/public/spec/reference/README.html
@@ -19,7 +19,7 @@
           <li><a href="../../index.html">Home</a></li>
           <li><a href="../../docs/index.html">Docs</a></li>
           <li><a href="../../launch-checklist.html">Launch Checklist</a></li>
-          <li><a href="../../apis/mcp-server.html">Adapter Patterns</a></li>
+          <li><a href="../../apis/index.html">Adapter Patterns</a></li>
         </ul>
         <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>

--- a/public/spec/repo/CHANGELOG.html
+++ b/public/spec/repo/CHANGELOG.html
@@ -19,7 +19,7 @@
           <li><a href="../../index.html">Home</a></li>
           <li><a href="../../docs/index.html">Docs</a></li>
           <li><a href="../../launch-checklist.html">Launch Checklist</a></li>
-          <li><a href="../../apis/mcp-server.html">Adapter Patterns</a></li>
+          <li><a href="../../apis/index.html">Adapter Patterns</a></li>
         </ul>
         <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>

--- a/public/spec/repo/README.html
+++ b/public/spec/repo/README.html
@@ -19,7 +19,7 @@
           <li><a href="../../index.html">Home</a></li>
           <li><a href="../../docs/index.html">Docs</a></li>
           <li><a href="../../launch-checklist.html">Launch Checklist</a></li>
-          <li><a href="../../apis/mcp-server.html">Adapter Patterns</a></li>
+          <li><a href="../../apis/index.html">Adapter Patterns</a></li>
         </ul>
         <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>

--- a/public/spec/research/mcp-vs-mcpaql-vs-a2a.html
+++ b/public/spec/research/mcp-vs-mcpaql-vs-a2a.html
@@ -19,7 +19,7 @@
           <li><a href="../../index.html">Home</a></li>
           <li><a href="../../docs/index.html">Docs</a></li>
           <li><a href="../../launch-checklist.html">Launch Checklist</a></li>
-          <li><a href="../../apis/mcp-server.html">Adapter Patterns</a></li>
+          <li><a href="../../apis/index.html">Adapter Patterns</a></li>
         </ul>
         <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>

--- a/public/spec/security/confirmation-tokens.html
+++ b/public/spec/security/confirmation-tokens.html
@@ -19,7 +19,7 @@
           <li><a href="../../index.html">Home</a></li>
           <li><a href="../../docs/index.html">Docs</a></li>
           <li><a href="../../launch-checklist.html">Launch Checklist</a></li>
-          <li><a href="../../apis/mcp-server.html">Adapter Patterns</a></li>
+          <li><a href="../../apis/index.html">Adapter Patterns</a></li>
         </ul>
         <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>

--- a/public/spec/security/execution-safety-loop.html
+++ b/public/spec/security/execution-safety-loop.html
@@ -19,7 +19,7 @@
           <li><a href="../../index.html">Home</a></li>
           <li><a href="../../docs/index.html">Docs</a></li>
           <li><a href="../../launch-checklist.html">Launch Checklist</a></li>
-          <li><a href="../../apis/mcp-server.html">Adapter Patterns</a></li>
+          <li><a href="../../apis/index.html">Adapter Patterns</a></li>
         </ul>
         <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>

--- a/public/spec/security/gatekeeper.html
+++ b/public/spec/security/gatekeeper.html
@@ -19,7 +19,7 @@
           <li><a href="../../index.html">Home</a></li>
           <li><a href="../../docs/index.html">Docs</a></li>
           <li><a href="../../launch-checklist.html">Launch Checklist</a></li>
-          <li><a href="../../apis/mcp-server.html">Adapter Patterns</a></li>
+          <li><a href="../../apis/index.html">Adapter Patterns</a></li>
         </ul>
         <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>

--- a/public/spec/versions/v1.0.0-draft.html
+++ b/public/spec/versions/v1.0.0-draft.html
@@ -19,7 +19,7 @@
           <li><a href="../../index.html">Home</a></li>
           <li><a href="../../docs/index.html">Docs</a></li>
           <li><a href="../../launch-checklist.html">Launch Checklist</a></li>
-          <li><a href="../../apis/mcp-server.html">Adapter Patterns</a></li>
+          <li><a href="../../apis/index.html">Adapter Patterns</a></li>
         </ul>
         <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>

--- a/scripts/generate-spec-docs.mjs
+++ b/scripts/generate-spec-docs.mjs
@@ -391,7 +391,7 @@ function wrapSpecDocPage({ doc, navGroups, navSequence, bodyHtml }) {
           <li><a href="${relativePathFromDoc(doc.outputRel, "index.html")}">Home</a></li>
           <li><a href="${relativePathFromDoc(doc.outputRel, "docs/index.html")}">Docs</a></li>
           <li><a href="${relativePathFromDoc(doc.outputRel, "launch-checklist.html")}">Launch Checklist</a></li>
-          <li><a href="${relativePathFromDoc(doc.outputRel, "apis/mcp-server.html")}">Adapter Patterns</a></li>
+          <li><a href="${relativePathFromDoc(doc.outputRel, "apis/index.html")}">Adapter Patterns</a></li>
         </ul>
         <form class="site-search" data-search-form data-index-url="${relativePathFromDoc(doc.outputRel, "data/search-index.json")}" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
@@ -505,7 +505,7 @@ function wrapSpecIndexPage(navGroups) {
           <li><a href="../index.html">Home</a></li>
           <li><a href="../docs/index.html">Docs</a></li>
           <li><a href="../launch-checklist.html">Launch Checklist</a></li>
-          <li><a href="../apis/mcp-server.html">Adapter Patterns</a></li>
+          <li><a href="../apis/index.html">Adapter Patterns</a></li>
         </ul>
         <form class="site-search" data-search-form data-index-url="../data/search-index.json" role="search">
           <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>

--- a/source/search-index.base.json
+++ b/source/search-index.base.json
@@ -72,6 +72,12 @@
     "keywords": ["launch", "checklist", "readiness", "public draft"]
   },
   {
+    "title": "Adapter Patterns",
+    "url": "/apis/index.html",
+    "excerpt": "Top-level guide to MCP-AQL adapter patterns across MCP servers, applications, cloud services, operating systems, and website-facing workflows.",
+    "keywords": ["adapter patterns", "pattern hub", "integration", "implementation guidance", "apis"]
+  },
+  {
     "title": "MCP Server Adapter Pattern",
     "url": "/apis/mcp-server.html",
     "excerpt": "Draft guidance for adapting MCP servers to MCP-AQL through introspection and CRUDE operation mapping.",
@@ -98,8 +104,8 @@
   {
     "title": "Website Adapter Pattern",
     "url": "/apis/website.html",
-    "excerpt": "Draft guidance for website-facing integrations and retrieval/action patterns.",
-    "keywords": ["website", "web", "retrieval", "action"]
+    "excerpt": "Draft guidance for website and web API integrations, including retrieval/action patterns and structured web workflows.",
+    "keywords": ["website", "web", "web api", "retrieval", "action"]
   },
   {
     "title": "Spec Repository",


### PR DESCRIPTION
## Summary
- add a true top-level Adapter Patterns landing page under `public/apis/index.html`
- repoint global nav, homepage entry points, search surfaces, and generated spec pages to the new hub
- update the child adapter pages so they sit under the hub in breadcrumbs and sidebar nav, with stronger fit/caveat guidance per pattern

Closes #12.

## Verification
- npm run generate:spec-docs
- npm run generate:spec-docs:check
- node --check scripts/generate-spec-docs.mjs
- node --check public/js/search.js
