### PR TITLE
feat: sharpen website story and protocol summaries

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -742,6 +742,10 @@ footer {
   grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
+.code-example-stack {
+  grid-template-columns: 1fr;
+}
+
 .docs-main > .page-nav {
   margin-top: 1.2rem;
 }

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -599,6 +599,23 @@ h1 {
   padding: 0.95rem;
 }
 
+.code-box[data-code-language] {
+  padding-top: 2rem;
+  position: relative;
+}
+
+.code-box[data-code-language]::before {
+  color: #93c5fd;
+  content: attr(data-code-language);
+  font-size: 0.72rem;
+  font-weight: 700;
+  left: 0.95rem;
+  letter-spacing: 0.05em;
+  position: absolute;
+  text-transform: uppercase;
+  top: 0.7rem;
+}
+
 .repo-list a {
   display: inline-flex;
   font-weight: 600;

--- a/public/docs/error-model.html
+++ b/public/docs/error-model.html
@@ -123,7 +123,7 @@
 
         <section>
           <h2 class="section-title" id="canonical-response-envelope">Canonical response envelope</h2>
-          <div class="grid cols-2">
+          <div class="grid code-example-stack">
             <article class="card">
               <h3>Success</h3>
               <pre class="code-box" data-code-language="json">{
@@ -215,7 +215,7 @@
 
         <section>
           <h2 class="section-title" id="concrete-error-examples">Concrete error examples</h2>
-          <div class="grid cols-2">
+          <div class="grid code-example-stack">
             <article class="card">
               <h3>Validation error</h3>
               <pre class="code-box" data-code-language="json">{

--- a/public/docs/error-model.html
+++ b/public/docs/error-model.html
@@ -90,7 +90,7 @@
               <p class="page-toc-intro">Use the outline to move through longer pages without losing your place.</p>
             </div>
             <ol class="page-toc-list" data-page-toc-list>
-              <li class="page-toc-item level-2"><a href="#canonical-response-envelope" data-toc-target="canonical-response-envelope">Canonical response envelope</a></li><li class="page-toc-item level-2"><a href="#why-the-code-field-matters" data-toc-target="why-the-code-field-matters">Why the code field matters</a></li><li class="page-toc-item level-2"><a href="#current-draft-focus" data-toc-target="current-draft-focus">Current draft focus</a></li>
+              <li class="page-toc-item level-2"><a href="#canonical-response-envelope" data-toc-target="canonical-response-envelope">Canonical response envelope</a></li><li class="page-toc-item level-2"><a href="#error-code-registry" data-toc-target="error-code-registry">MVP error code registry</a></li><li class="page-toc-item level-2"><a href="#why-the-code-field-matters" data-toc-target="why-the-code-field-matters">Why the code field matters</a></li><li class="page-toc-item level-2"><a href="#concrete-error-examples" data-toc-target="concrete-error-examples">Concrete error examples</a></li><li class="page-toc-item level-2"><a href="#client-handling-guidance" data-toc-target="client-handling-guidance">Client handling guidance</a></li><li class="page-toc-item level-2"><a href="#adapter-error-mapping" data-toc-target="adapter-error-mapping">How adapter-specific failures map in</a></li><li class="page-toc-item level-2"><a href="#current-draft-focus" data-toc-target="current-draft-focus">Current draft focus</a></li>
             </ol>
           </div>
         </section>
@@ -126,14 +126,14 @@
           <div class="grid cols-2">
             <article class="card">
               <h3>Success</h3>
-              <pre class="code-box">{
+              <pre class="code-box" data-code-language="json">{
   "success": true,
   "data": { ... }
 }</pre>
             </article>
             <article class="card">
               <h3>Failure</h3>
-              <pre class="code-box">{
+              <pre class="code-box" data-code-language="json">{
   "success": false,
   "error": {
     "code": "VALIDATION_MISSING_PARAM",
@@ -145,6 +145,63 @@
         </section>
 
         <section>
+          <h2 class="section-title" id="error-code-registry">MVP error code registry</h2>
+          <div class="card table-card">
+            <table class="data-table">
+              <thead>
+                <tr>
+                  <th>Code</th>
+                  <th>Category</th>
+                  <th>Meaning</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td><code>VALIDATION_MISSING_PARAM</code></td>
+                  <td>Validation</td>
+                  <td>Required parameter not provided</td>
+                </tr>
+                <tr>
+                  <td><code>VALIDATION_INVALID_TYPE</code></td>
+                  <td>Validation</td>
+                  <td>Parameter value does not match the expected type</td>
+                </tr>
+                <tr>
+                  <td><code>VALIDATION_UNKNOWN_PARAM</code></td>
+                  <td>Validation</td>
+                  <td>Request contains a parameter outside the declared schema</td>
+                </tr>
+                <tr>
+                  <td><code>NOT_FOUND_OPERATION</code></td>
+                  <td>Not Found</td>
+                  <td>Requested operation does not exist</td>
+                </tr>
+                <tr>
+                  <td><code>NOT_FOUND_RESOURCE</code></td>
+                  <td>Not Found</td>
+                  <td>Target resource does not exist</td>
+                </tr>
+                <tr>
+                  <td><code>PERMISSION_DENIED</code></td>
+                  <td>Permission</td>
+                  <td>Caller lacks the required authorization</td>
+                </tr>
+                <tr>
+                  <td><code>CONFIRMATION_REQUIRED</code></td>
+                  <td>Permission</td>
+                  <td>Operation is denied pending explicit confirmation</td>
+                </tr>
+                <tr>
+                  <td><code>INTERNAL_ERROR</code></td>
+                  <td>Internal</td>
+                  <td>Unexpected server or adapter failure</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <section>
           <h2 class="section-title" id="why-the-code-field-matters">Why the code field matters</h2>
           <div class="card">
             <ul>
@@ -152,6 +209,106 @@
               <li>Adapters can map target-system failures into a predictable registry.</li>
               <li>Monitoring and analytics can group failures by category instead of message text.</li>
               <li>Localized or rewritten human messages do not break programmatic recovery.</li>
+            </ul>
+          </div>
+        </section>
+
+        <section>
+          <h2 class="section-title" id="concrete-error-examples">Concrete error examples</h2>
+          <div class="grid cols-2">
+            <article class="card">
+              <h3>Validation error</h3>
+              <pre class="code-box" data-code-language="json">{
+  "success": false,
+  "error": {
+    "code": "VALIDATION_MISSING_PARAM",
+    "message": "Missing required parameter 'owner'",
+    "details": {
+      "param_name": "owner"
+    }
+  }
+}</pre>
+            </article>
+            <article class="card">
+              <h3>Not-found error</h3>
+              <pre class="code-box" data-code-language="json">{
+  "success": false,
+  "error": {
+    "code": "NOT_FOUND_RESOURCE",
+    "message": "Repository 'acme/widgets' not found",
+    "details": {
+      "resource_type": "repository",
+      "resource_id": "acme/widgets"
+    }
+  }
+}</pre>
+            </article>
+            <article class="card">
+              <h3>Permission error</h3>
+              <pre class="code-box" data-code-language="json">{
+  "success": false,
+  "error": {
+    "code": "PERMISSION_DENIED",
+    "message": "Operation 'delete_user' is not allowed for this caller",
+    "details": {
+      "operation": "delete_user"
+    }
+  }
+}</pre>
+            </article>
+            <article class="card">
+              <h3>Internal error</h3>
+              <pre class="code-box" data-code-language="json">{
+  "success": false,
+  "error": {
+    "code": "INTERNAL_ERROR",
+    "message": "Unexpected adapter failure",
+    "details": {
+      "request_id": "req_7f1d"
+    }
+  }
+}</pre>
+            </article>
+          </div>
+        </section>
+
+        <section>
+          <h2 class="section-title" id="client-handling-guidance">Client handling guidance</h2>
+          <div class="grid cols-2">
+            <article class="card">
+              <h3>Branch on <code>error.code</code></h3>
+              <p>
+                Use the code for programmatic behavior: retry policy, UI state, escalation path, and whether a client should fix the request
+                or stop execution entirely.
+              </p>
+              <ul>
+                <li><code>VALIDATION_*</code>: repair the request</li>
+                <li><code>NOT_FOUND_*</code>: stop or ask the user to choose another target</li>
+                <li><code>PERMISSION_*</code>: request credentials or confirmation</li>
+                <li><code>INTERNAL_*</code>: surface a server-side fault and preserve request context</li>
+              </ul>
+            </article>
+            <article class="card">
+              <h3>Display <code>error.message</code> to humans</h3>
+              <p>
+                The message is for logs, dashboards, and human-visible explanations. It can be localized or rewritten without breaking the
+                client's recovery logic because the recovery key is the code.
+              </p>
+            </article>
+          </div>
+        </section>
+
+        <section>
+          <h2 class="section-title" id="adapter-error-mapping">How adapter-specific failures map in</h2>
+          <div class="card">
+            <p>
+              Adapters do not expose raw target-system failures as their public contract. They translate them into the MCP-AQL registry and
+              preserve target-specific context in <code>error.details</code> when it helps recovery.
+            </p>
+            <ul>
+              <li>Target API 404s should map to <code>NOT_FOUND_RESOURCE</code></li>
+              <li>Target permission failures should map to <code>PERMISSION_DENIED</code> or <code>CONFIRMATION_REQUIRED</code></li>
+              <li>Unexpected downstream failures should map to <code>INTERNAL_ERROR</code> with request context preserved in <code>details</code></li>
             </ul>
           </div>
         </section>

--- a/public/docs/getting-started.html
+++ b/public/docs/getting-started.html
@@ -100,7 +100,7 @@
           <div class="grid cols-2">
             <article class="card">
               <h3>Go Deeper In The Full Spec</h3>
-              <p>Use the website-hosted source pages when you want the actual protocol text instead of the onboarding summary.</p>
+              <p>Read the canonical protocol text here on the site when you want the full normative detail behind this overview.</p>
               <ul>
                 <li><a href="../spec/repo/README.html">Spec README</a></li>
                 <li><a href="../spec/overview.html">Protocol Overview</a></li>
@@ -110,7 +110,7 @@
             </article>
             <article class="card">
               <h3>Keep Moving Through The Library</h3>
-              <p>Once the framing is clear, the next useful stops are the rules pages and the launch-readiness views.</p>
+              <p>Continue into the core rules, structured response model, and security controls that shape real implementations.</p>
               <ul>
                 <li><a href="protocol-core.html">Protocol Core</a></li>
                 <li><a href="error-model.html">Error Model</a></li>

--- a/public/docs/getting-started.html
+++ b/public/docs/getting-started.html
@@ -135,7 +135,7 @@
 
         <section>
           <h2 class="section-title" id="why-teams-look-at-it">The semantics gap MCP-AQL closes</h2>
-          <div class="grid cols-2">
+          <div class="grid code-example-stack">
             <article class="card">
               <h3>What plain MCP leaves open</h3>
               <p>
@@ -228,7 +228,7 @@
 
         <section>
           <h2 class="section-title" id="quick-start-request-shape">Quick-start request shape</h2>
-          <div class="grid cols-2">
+          <div class="grid code-example-stack">
             <article class="card">
               <h3>Discover operations</h3>
               <pre class="code-box" data-code-language="json">{
@@ -254,7 +254,7 @@
 
         <section>
           <h2 class="section-title" id="end-to-end-walkthrough">End-to-end walkthrough</h2>
-          <div class="grid cols-2">
+          <div class="grid code-example-stack">
             <article class="card">
               <h3>1. Discover operations</h3>
               <pre class="code-box" data-code-language="json">{

--- a/public/docs/getting-started.html
+++ b/public/docs/getting-started.html
@@ -61,8 +61,8 @@
             <span class="status-pill">GETTING STARTED</span>
             <h1>What MCP-AQL is, why it exists, and what to read first</h1>
             <p class="lede">
-              MCP-AQL consolidates many discrete MCP tools into a small semantic endpoint surface while preserving runtime discovery.
-              The result is less registration overhead, clearer routing, and a more scalable contract for agent-driven systems.
+              MCP-AQL keeps MCP transport but adds something MCP itself does not provide: built-in semantic classification. Clients can tell
+              whether they are looking at a read, mutation, deletion, or execution flow from the endpoint itself instead of guessing from prose.
             </p>
             <div class="hero-actions">
               <a class="btn btn-primary" href="../spec/repo/README.html">Spec README</a>
@@ -90,7 +90,7 @@
               <p class="page-toc-intro">Use the outline to move through longer pages without losing your place.</p>
             </div>
             <ol class="page-toc-list" data-page-toc-list>
-              <li class="page-toc-item level-2"><a href="#the-one-paragraph-version" data-toc-target="the-one-paragraph-version">The one-paragraph version</a></li><li class="page-toc-item level-2"><a href="#why-teams-look-at-it" data-toc-target="why-teams-look-at-it">Why teams look at it</a></li><li class="page-toc-item level-2"><a href="#quick-start-request-shape" data-toc-target="quick-start-request-shape">Quick-start request shape</a></li><li class="page-toc-item level-2"><a href="#suggested-reading-order" data-toc-target="suggested-reading-order">Suggested reading order</a></li>
+              <li class="page-toc-item level-2"><a href="#the-one-paragraph-version" data-toc-target="the-one-paragraph-version">The one-paragraph version</a></li><li class="page-toc-item level-2"><a href="#why-teams-look-at-it" data-toc-target="why-teams-look-at-it">The semantics gap MCP-AQL closes</a></li><li class="page-toc-item level-2"><a href="#token-efficiency-story" data-toc-target="token-efficiency-story">Token efficiency story</a></li><li class="page-toc-item level-2"><a href="#why-introspection-matters" data-toc-target="why-introspection-matters">Why introspection matters</a></li><li class="page-toc-item level-2"><a href="#quick-start-request-shape" data-toc-target="quick-start-request-shape">Quick-start request shape</a></li><li class="page-toc-item level-2"><a href="#end-to-end-walkthrough" data-toc-target="end-to-end-walkthrough">End-to-end walkthrough</a></li><li class="page-toc-item level-2"><a href="#how-this-differs" data-toc-target="how-this-differs">How this differs from familiar systems</a></li><li class="page-toc-item level-2"><a href="#suggested-reading-order" data-toc-target="suggested-reading-order">Suggested reading order</a></li>
             </ol>
           </div>
         </section>
@@ -126,26 +126,102 @@
           <div class="card">
             <p>
               MCP-AQL is a protocol specification and implementation toolkit for exposing adapter operations through either five CRUDE endpoints
-              or a single routed endpoint. It keeps <code>introspect</code> mandatory, treats the versioned spec as canonical, and positions
-              production profiles like DollhouseMCP as practical references rather than the definition of the protocol.
+              or a single routed endpoint. It keeps <code>introspect</code> mandatory, makes operation intent structural at the endpoint layer,
+              treats the versioned spec as canonical, and positions production profiles like DollhouseMCP as practical references rather than the
+              definition of the protocol.
             </p>
           </div>
         </section>
 
         <section>
-          <h2 class="section-title" id="why-teams-look-at-it">Why teams look at it</h2>
+          <h2 class="section-title" id="why-teams-look-at-it">The semantics gap MCP-AQL closes</h2>
+          <div class="grid cols-2">
+            <article class="card">
+              <h3>What plain MCP leaves open</h3>
+              <p>
+                MCP standardizes how tools register and how calls are made, but it does not encode what an operation means. A harmless query and
+                a destructive deletion share the same structural shape, so the only signal about intent is free-text description.
+              </p>
+              <pre class="code-box" data-code-language="json">{
+  "name": "get_user",
+  "description": "Return a user record"
+}
+
+{
+  "name": "drop_database",
+  "description": "Delete the production database"
+}</pre>
+            </article>
+            <article class="card">
+              <h3>What MCP-AQL adds</h3>
+              <p>
+                MCP-AQL makes intent structural. Routing an operation through <code>READ</code> declares it side-effect-free. Routing through
+                <code>DELETE</code> declares it destructive. That makes safety classification available to clients, LLMs, and policy systems
+                without parsing descriptions or guessing from naming conventions.
+              </p>
+              <ul>
+                <li><code>READ</code> means safe query semantics</li>
+                <li><code>DELETE</code> means destructive intent is explicit</li>
+                <li><code>EXECUTE</code> means lifecycle or side-effectful runtime flow</li>
+              </ul>
+            </article>
+          </div>
+        </section>
+
+        <section>
+          <h2 class="section-title" id="token-efficiency-story">Token efficiency story</h2>
+          <div class="card table-card">
+            <table class="data-table">
+              <thead>
+                <tr>
+                  <th>Mode</th>
+                  <th>Tool definitions</th>
+                  <th>Approximate token cost</th>
+                  <th>Reduction</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Discrete tools (50+)</td>
+                  <td>Every tool definition loaded up front</td>
+                  <td>~30,000 tokens</td>
+                  <td>Baseline</td>
+                </tr>
+                <tr>
+                  <td>CRUDE mode (5 endpoints)</td>
+                  <td>Semantic endpoints plus runtime discovery</td>
+                  <td>~4,500 tokens</td>
+                  <td>~85%</td>
+                </tr>
+                <tr>
+                  <td>Single mode (1 endpoint)</td>
+                  <td>One routed endpoint plus runtime discovery</td>
+                  <td>~1,100 tokens</td>
+                  <td>~96%</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <p class="callout">
+            The introspection spec models the on-demand path even more sharply: around <strong>29,600 upfront tokens</strong> for discrete tools
+            versus around <strong>2,600 total</strong> for MCP-AQL plus introspection across ten operations.
+          </p>
+        </section>
+
+        <section>
+          <h2 class="section-title" id="why-introspection-matters">Why introspection matters</h2>
           <div class="grid cols-3">
             <article class="card">
-              <h3>Lower token overhead</h3>
-              <p>Instead of loading dozens of tool definitions, clients can register five semantic endpoints or one unified endpoint.</p>
+              <h3>Discovery becomes demand-driven</h3>
+              <p>Instead of loading every tool schema at connection time, clients can ask only for the operations and parameter details they need right now.</p>
             </article>
             <article class="card">
-              <h3>Runtime discovery</h3>
-              <p>Clients discover operations, parameters, and types on demand with <code>introspect</code>.</p>
+              <h3>Introspection is first-class</h3>
+              <p><code>introspect</code> is mandatory, so runtime discovery is part of protocol behavior rather than an optional convenience layer.</p>
             </article>
             <article class="card">
-              <h3>Better public contracts</h3>
-              <p>CRUDE classification, structured responses, and spec-linked docs make compatibility claims easier to inspect.</p>
+              <h3>Token savings stay explainable</h3>
+              <p>The reduction is not magic. It comes from moving capability discovery from up-front schema bulk into small runtime lookups.</p>
             </article>
           </div>
         </section>
@@ -155,14 +231,14 @@
           <div class="grid cols-2">
             <article class="card">
               <h3>Discover operations</h3>
-              <pre class="code-box">{
+              <pre class="code-box" data-code-language="json">{
   "operation": "introspect",
   "params": { "query": "operations" }
 }</pre>
             </article>
             <article class="card">
               <h3>Call a discovered operation</h3>
-              <pre class="code-box">{
+              <pre class="code-box" data-code-language="json">{
   "operation": "create_user",
   "params": {
     "email": "alice@example.com",
@@ -177,11 +253,145 @@
         </section>
 
         <section>
+          <h2 class="section-title" id="end-to-end-walkthrough">End-to-end walkthrough</h2>
+          <div class="grid cols-2">
+            <article class="card">
+              <h3>1. Discover operations</h3>
+              <pre class="code-box" data-code-language="json">{
+  "operation": "introspect",
+  "params": { "query": "operations" }
+}
+
+{
+  "success": true,
+  "data": {
+    "operations": [
+      { "name": "get_user", "endpoint": "read" },
+      { "name": "create_user", "endpoint": "create" },
+      { "name": "delete_user", "endpoint": "delete" }
+    ]
+  }
+}</pre>
+            </article>
+            <article class="card">
+              <h3>2. Read safely</h3>
+              <pre class="code-box" data-code-language="json">{
+  "operation": "get_user",
+  "params": { "user_id": "user_123" }
+}
+
+{
+  "success": true,
+  "data": {
+    "id": "user_123",
+    "email": "alice@example.com",
+    "name": "Alice"
+  }
+}</pre>
+            </article>
+            <article class="card">
+              <h3>3. Create state</h3>
+              <pre class="code-box" data-code-language="json">{
+  "operation": "create_user",
+  "params": {
+    "email": "alice@example.com",
+    "name": "Alice"
+  }
+}
+
+{
+  "success": true,
+  "data": {
+    "id": "user_123",
+    "created": true
+  }
+}</pre>
+            </article>
+            <article class="card">
+              <h3>4. Handle malformed input</h3>
+              <pre class="code-box" data-code-language="json">{
+  "operation": "get_user",
+  "params": {}
+}
+
+{
+  "success": false,
+  "error": {
+    "code": "VALIDATION_MISSING_PARAM",
+    "message": "Missing required parameter 'user_id'",
+    "details": {
+      "param_name": "user_id"
+    }
+  }
+}</pre>
+            </article>
+            <article class="card">
+              <h3>5. Ask for confirmation before delete</h3>
+              <pre class="code-box" data-code-language="json">{
+  "operation": "delete_user",
+  "params": { "user_id": "user_123" }
+}
+
+{
+  "success": false,
+  "error": {
+    "code": "CONFIRMATION_REQUIRED",
+    "message": "This operation requires confirmation",
+    "details": {
+      "danger_level": "destructive",
+      "confirmation_token": "conf_abc123xyz"
+    }
+  }
+}</pre>
+            </article>
+            <article class="card">
+              <h3>6. Retry with the confirmation token</h3>
+              <pre class="code-box" data-code-language="json">{
+  "operation": "delete_user",
+  "params": {
+    "user_id": "user_123",
+    "_confirmation": "conf_abc123xyz"
+  }
+}
+
+{
+  "success": true,
+  "data": {
+    "deleted": true
+  }
+}</pre>
+            </article>
+          </div>
+          <p class="callout">
+            The same logical flow works in CRUDE mode or single-endpoint mode. What changes is the transport surface, not the operation contract,
+            introspection model, or structured response envelope.
+          </p>
+        </section>
+
+        <section>
+          <h2 class="section-title" id="how-this-differs">How this differs from familiar systems</h2>
+          <div class="grid cols-3">
+            <article class="card">
+              <h3>MCP</h3>
+              <p>MCP-AQL is layered on MCP transport. The difference is semantic endpoints, runtime discovery, and built-in safety classification.</p>
+            </article>
+            <article class="card">
+              <h3>GraphQL</h3>
+              <p>Both consolidate discovery behind a query layer, but GraphQL requires an SDL and type system while MCP-AQL reuses MCP transport.</p>
+            </article>
+            <article class="card">
+              <h3>REST</h3>
+              <p>REST uses HTTP verbs for semantics. MCP-AQL applies a similar principle to the MCP tool layer, where HTTP verbs do not exist.</p>
+            </article>
+          </div>
+        </section>
+
+        <section>
           <h2 class="section-title" id="suggested-reading-order">Suggested reading order</h2>
           <div class="card">
             <ol>
               <li>Read the <a href="../spec/versions/v1.0.0-draft.html">versioned draft</a> for the canonical rules.</li>
-              <li>Use <a href="protocol-core.html">Protocol Core</a> for routing, request shape, and endpoint semantics.</li>
+              <li>Use <a href="protocol-core.html">Protocol Core</a> for routing, request shape, endpoint semantics, and the MCP-versus-MCP-AQL contrast.</li>
               <li>Use <a href="error-model.html">Error Model</a> and <a href="security-model.html">Security Model</a> for operational expectations.</li>
               <li>Use <a href="conformance.html">Conformance</a> and <a href="../launch-checklist.html">Launch Checklist</a> to understand current draft maturity.</li>
             </ol>

--- a/public/docs/protocol-core.html
+++ b/public/docs/protocol-core.html
@@ -253,8 +253,10 @@ mcp_aql_execute</pre>
             <article class="card">
               <h3>Why it changes the economics</h3>
               <p>
-                MCP clients often learn everything up front by loading tool definitions at connection time. MCP-AQL keeps the endpoint surface tiny
-                and moves operation discovery into <code>introspect</code>, so the client only pays for the details it actually needs.
+                MCP-AQL keeps the public endpoint surface small and makes runtime discovery part of the protocol through
+                <code>introspect</code>. That means the protocol does not require a large up-front tool-definition payload in order to begin
+                operating. Some MCP clients may already choose to load tools progressively, but that is client-specific behavior; MCP-AQL
+                makes on-demand discovery available in a client-agnostic way as long as the client speaks MCP.
               </p>
               <ul>
                 <li><a href="../spec/introspection.html">Introspection specification</a></li>

--- a/public/docs/protocol-core.html
+++ b/public/docs/protocol-core.html
@@ -255,8 +255,9 @@ mcp_aql_execute</pre>
               <p>
                 MCP-AQL keeps the public endpoint surface small and makes runtime discovery part of the protocol through
                 <code>introspect</code>. That means the protocol does not require a large up-front tool-definition payload in order to begin
-                operating. Some MCP clients may already choose to load tools progressively, but that is client-specific behavior; MCP-AQL
-                makes on-demand discovery available in a client-agnostic way as long as the client speaks MCP.
+                operating. Some MCP clients already have progressive loading, but the benefit depends on which client you are using.
+                MCP-AQL makes on-demand discovery available in a client-agnostic way, so the practical benefit carries across MCP-speaking
+                clients instead of depending on a particular client implementation.
               </p>
               <ul>
                 <li><a href="../spec/introspection.html">Introspection specification</a></li>

--- a/public/docs/protocol-core.html
+++ b/public/docs/protocol-core.html
@@ -204,7 +204,7 @@
 
         <section>
           <h2 class="section-title" id="endpoint-modes">Endpoint Modes</h2>
-          <div class="grid cols-2">
+          <div class="grid code-example-stack">
             <article class="card">
               <h3>CRUDE Mode (5 endpoints)</h3>
               <p>Semantic separation by operation effect category. Maximizes explicit routing intent.</p>
@@ -224,7 +224,7 @@ mcp_aql_execute</pre>
 
         <section>
           <h2 class="section-title" id="request-and-response-contract">Request And Response Contract</h2>
-          <div class="grid cols-2">
+          <div class="grid code-example-stack">
             <article class="card">
               <h3>Request Shape</h3>
               <pre class="code-box" data-code-language="json">{
@@ -249,7 +249,7 @@ mcp_aql_execute</pre>
 
         <section>
           <h2 class="section-title" id="runtime-discovery">Runtime Discovery</h2>
-          <div class="grid cols-2">
+          <div class="grid code-example-stack">
             <article class="card">
               <h3>Why it changes the economics</h3>
               <p>

--- a/public/docs/protocol-core.html
+++ b/public/docs/protocol-core.html
@@ -100,7 +100,7 @@
           <div class="grid cols-2">
             <article class="card">
               <h3>Go Deeper In The Full Spec</h3>
-              <p>This summary is the fast map. These pages carry the fuller protocol requirements and supporting detail.</p>
+              <p>These pages contain the full protocol requirements, supporting detail, and normative references behind this summary.</p>
               <ul>
                 <li><a href="../spec/versions/v1.0.0-draft.html">Normative Draft</a></li>
                 <li><a href="../spec/crude-pattern.html">CRUDE Pattern</a></li>
@@ -110,7 +110,7 @@
             </article>
             <article class="card">
               <h3>Related Summary Pages</h3>
-              <p>These summary pages help connect the core semantics to safety, errors, and launch posture.</p>
+              <p>Read the companion summaries for onboarding context, error handling, and safety behavior.</p>
               <ul>
                 <li><a href="getting-started.html">Getting Started</a></li>
                 <li><a href="error-model.html">Error Model</a></li>

--- a/public/docs/protocol-core.html
+++ b/public/docs/protocol-core.html
@@ -90,7 +90,7 @@
               <p class="page-toc-intro">Use the outline to move through longer pages without losing your place.</p>
             </div>
             <ol class="page-toc-list" data-page-toc-list>
-              <li class="page-toc-item level-2"><a href="#protocol-scope" data-toc-target="protocol-scope">Protocol Scope</a></li><li class="page-toc-item level-2"><a href="#crude-endpoint-model" data-toc-target="crude-endpoint-model">CRUDE Endpoint Model</a></li><li class="page-toc-item level-2"><a href="#endpoint-modes" data-toc-target="endpoint-modes">Endpoint Modes</a></li><li class="page-toc-item level-2"><a href="#request-and-response-contract" data-toc-target="request-and-response-contract">Request And Response Contract</a></li><li class="page-toc-item level-2"><a href="#runtime-discovery" data-toc-target="runtime-discovery">Runtime Discovery</a></li><li class="page-toc-item level-2"><a href="#operational-rules-readers-usually-miss" data-toc-target="operational-rules-readers-usually-miss">Operational rules readers usually miss</a></li>
+              <li class="page-toc-item level-2"><a href="#protocol-scope" data-toc-target="protocol-scope">Protocol Scope</a></li><li class="page-toc-item level-2"><a href="#why-semantic-endpoints-matter" data-toc-target="why-semantic-endpoints-matter">Why semantic endpoints matter</a></li><li class="page-toc-item level-2"><a href="#crude-endpoint-model" data-toc-target="crude-endpoint-model">CRUDE Endpoint Model</a></li><li class="page-toc-item level-2"><a href="#endpoint-modes" data-toc-target="endpoint-modes">Endpoint Modes</a></li><li class="page-toc-item level-2"><a href="#request-and-response-contract" data-toc-target="request-and-response-contract">Request And Response Contract</a></li><li class="page-toc-item level-2"><a href="#runtime-discovery" data-toc-target="runtime-discovery">Runtime Discovery</a></li><li class="page-toc-item level-2"><a href="#operational-rules-readers-usually-miss" data-toc-target="operational-rules-readers-usually-miss">Operational rules readers usually miss</a></li>
             </ol>
           </div>
         </section>
@@ -134,6 +134,30 @@
               <li>Adapter-specific operations: declared by each implementation</li>
             </ul>
           </div>
+        </section>
+
+        <section>
+          <h2 class="section-title" id="why-semantic-endpoints-matter">Why semantic endpoints matter</h2>
+          <div class="grid cols-2">
+            <article class="card">
+              <h3>MCP tool calls are structurally flat</h3>
+              <p>
+                In plain MCP, all tools share the same call shape. A reader, client, or policy system cannot reliably distinguish
+                <code>get_user</code> from <code>drop_database</code> without inspecting descriptions and guessing from naming.
+              </p>
+            </article>
+            <article class="card">
+              <h3>MCP-AQL makes intent structural</h3>
+              <p>
+                In MCP-AQL, the endpoint is part of the contract. <code>READ</code> declares side-effect-free behavior,
+                <code>DELETE</code> declares destructive intent, and <code>EXECUTE</code> declares a lifecycle or stateful flow.
+              </p>
+            </article>
+          </div>
+          <p class="callout">
+            The CRUDE model is not just an organizational convenience. It gives clients, LLMs, and policy systems protocol-level safety
+            hints without relying on author-written descriptions.
+          </p>
         </section>
 
         <section>
@@ -184,7 +208,7 @@
             <article class="card">
               <h3>CRUDE Mode (5 endpoints)</h3>
               <p>Semantic separation by operation effect category. Maximizes explicit routing intent.</p>
-              <pre class="code-box">mcp_aql_create
+              <pre class="code-box" data-code-language="text">mcp_aql_create
 mcp_aql_read
 mcp_aql_update
 mcp_aql_delete
@@ -193,7 +217,7 @@ mcp_aql_execute</pre>
             <article class="card">
               <h3>Single Mode (1 endpoint)</h3>
               <p>One entrypoint for all operations, with internal routing based on operation metadata.</p>
-              <pre class="code-box">mcp_aql</pre>
+              <pre class="code-box" data-code-language="text">mcp_aql</pre>
             </article>
           </div>
         </section>
@@ -203,7 +227,7 @@ mcp_aql_execute</pre>
           <div class="grid cols-2">
             <article class="card">
               <h3>Request Shape</h3>
-              <pre class="code-box">{
+              <pre class="code-box" data-code-language="json">{
   "operation": "introspect",
   "params": { "query": "operations" }
 }</pre>
@@ -214,7 +238,7 @@ mcp_aql_execute</pre>
             </article>
             <article class="card">
               <h3>Response Shape</h3>
-              <pre class="code-box">{ "success": true,  "data": { ... } }
+              <pre class="code-box" data-code-language="json">{ "success": true,  "data": { ... } }
 { "success": false, "error": { ... } }</pre>
               <p>
                 Conforming implementations use discriminated response unions so clients can branch behavior predictably.
@@ -225,16 +249,38 @@ mcp_aql_execute</pre>
 
         <section>
           <h2 class="section-title" id="runtime-discovery">Runtime Discovery</h2>
-          <div class="card">
-            <p>
-              The introspection system is required for runtime capability discovery and is central to reducing up-front tool-definition token load.
-              Clients query operations, parameters, and element types on demand instead of loading static schema sprawl into context.
-            </p>
-            <ul>
-              <li><a href="../spec/introspection.html">Introspection specification</a></li>
-              <li><a href="../spec/operations.html">Operation design guide</a></li>
-              <li><a href="../spec/error-codes.html">Structured error model</a></li>
-            </ul>
+          <div class="grid cols-2">
+            <article class="card">
+              <h3>Why it changes the economics</h3>
+              <p>
+                MCP clients often learn everything up front by loading tool definitions at connection time. MCP-AQL keeps the endpoint surface tiny
+                and moves operation discovery into <code>introspect</code>, so the client only pays for the details it actually needs.
+              </p>
+              <ul>
+                <li><a href="../spec/introspection.html">Introspection specification</a></li>
+                <li><a href="../spec/operations.html">Operation design guide</a></li>
+                <li><a href="../spec/error-codes.html">Structured error model</a></li>
+              </ul>
+            </article>
+            <article class="card">
+              <h3>Typical discovery path</h3>
+              <pre class="code-box" data-code-language="json">{
+  "operation": "introspect",
+  "params": { "query": "operations" }
+}
+
+{
+  "operation": "introspect",
+  "params": {
+    "query": "operations",
+    "name": "create_user"
+  }
+}</pre>
+              <p>
+                The spec models this pattern as about <strong>50 tokens</strong> to list operations and about <strong>100 tokens</strong>
+                to fetch the details for one relevant operation.
+              </p>
+            </article>
           </div>
         </section>
 

--- a/public/docs/security-model.html
+++ b/public/docs/security-model.html
@@ -208,7 +208,7 @@
 
         <section>
           <h2 class="section-title" id="confirmation-token-flow">Confirmation token flow</h2>
-          <div class="grid cols-2">
+          <div class="grid code-example-stack">
             <article class="card">
               <h3>Request and required confirmation response</h3>
               <pre class="code-box" data-code-language="json">{
@@ -252,7 +252,7 @@
 
         <section>
           <h2 class="section-title" id="execution-safety-loop">Execution Safety Loop</h2>
-          <div class="grid cols-2">
+          <div class="grid code-example-stack">
             <article class="card">
               <h3>What it means for agents</h3>
               <p>

--- a/public/docs/security-model.html
+++ b/public/docs/security-model.html
@@ -62,7 +62,7 @@
             <h1>Trust And Safety Controls</h1>
             <p class="lede">
               MCP-AQL security is designed around operation risk, trust-level mediation, and explicit confirmation for dangerous actions.
-              This page maps the current security model used in draft protocol and practical profiles.
+              This page explains how the draft protocol handles approval paths, danger tiers, and safe execution behavior.
             </p>
             <div class="hero-actions">
               <a class="btn btn-primary" href="../spec/security/gatekeeper.html">Gatekeeper Spec</a>

--- a/public/docs/security-model.html
+++ b/public/docs/security-model.html
@@ -91,7 +91,7 @@
               <p class="page-toc-intro">Use the outline to move through longer pages without losing your place.</p>
             </div>
             <ol class="page-toc-list" data-page-toc-list>
-              <li class="page-toc-item level-2"><a href="#trust-level-mediation" data-toc-target="trust-level-mediation">Trust-Level Mediation</a></li><li class="page-toc-item level-2"><a href="#danger-classification" data-toc-target="danger-classification">Danger Classification</a></li><li class="page-toc-item level-2"><a href="#execution-safety-loop" data-toc-target="execution-safety-loop">Execution Safety Loop</a></li><li class="page-toc-item level-2"><a href="#open-security-hardening-tracks" data-toc-target="open-security-hardening-tracks">Open Security Hardening Tracks</a></li><li class="page-toc-item level-2"><a href="#source-documents-behind-this-summary" data-toc-target="source-documents-behind-this-summary">Source documents behind this summary</a></li>
+              <li class="page-toc-item level-2"><a href="#trust-level-mediation" data-toc-target="trust-level-mediation">Trust-Level Mediation</a></li><li class="page-toc-item level-2"><a href="#danger-classification" data-toc-target="danger-classification">Danger Classification</a></li><li class="page-toc-item level-2"><a href="#confirmation-token-flow" data-toc-target="confirmation-token-flow">Confirmation token flow</a></li><li class="page-toc-item level-2"><a href="#execution-safety-loop" data-toc-target="execution-safety-loop">Execution Safety Loop</a></li><li class="page-toc-item level-2"><a href="#open-security-hardening-tracks" data-toc-target="open-security-hardening-tracks">Open Security Hardening Tracks</a></li><li class="page-toc-item level-2"><a href="#source-documents-behind-this-summary" data-toc-target="source-documents-behind-this-summary">Source documents behind this summary</a></li>
             </ol>
           </div>
         </section>
@@ -124,16 +124,27 @@
 
         <section>
           <h2 class="section-title" id="trust-level-mediation">Trust-Level Mediation</h2>
-          <div class="card">
-            <p>
-              Implementations classify requester trust and apply policy gates before operation dispatch. The exact trust taxonomy is adapter-defined,
-              but the enforcement pattern is protocol-aligned: low-trust contexts default toward read-only or restricted mutations.
-            </p>
-            <ul>
-              <li>Trust-level checks happen before execution</li>
-              <li>Dangerous operations require stronger policy context</li>
-              <li>Policies should be introspectable where feasible</li>
-            </ul>
+          <div class="grid cols-2">
+            <article class="card">
+              <h3>What it means in practice</h3>
+              <p>
+                Implementations classify requester trust and apply policy gates before operation dispatch. The exact trust taxonomy is
+                adapter-defined, but the enforcement pattern is consistent: low-trust contexts default toward safe reads, while higher-trust
+                contexts can unlock mutations or execution flows.
+              </p>
+              <ul>
+                <li>Trust-level checks happen before execution</li>
+                <li>Dangerous operations require stronger policy context</li>
+                <li>Policies should be introspectable where feasible</li>
+              </ul>
+            </article>
+            <article class="card">
+              <h3>Typical mediation outcome</h3>
+              <p>
+                A validated user might be allowed to call <code>list_files</code> and <code>update_profile</code>, but blocked from
+                <code>bulk_delete</code> until stronger review, confirmation, or out-of-band verification is available.
+              </p>
+            </article>
           </div>
         </section>
 
@@ -141,30 +152,122 @@
           <h2 class="section-title" id="danger-classification">Danger Classification</h2>
           <div class="grid cols-2">
             <article class="card">
-              <h3>Operation Risk Labels</h3>
+              <h3>Operation risk labels</h3>
               <p>
                 Operations can be tagged by danger class to support UI and agent policy decisions. Draft specification work tracks stronger
                 requirements for danger metadata alignment with runtime surfaces.
               </p>
             </article>
             <article class="card">
-              <h3>Confirmation Handshake</h3>
+              <h3>Why the labels matter</h3>
               <p>
-                For destructive or high-impact operations, adapters can require a confirmation token round-trip so intent is explicit and auditable.
+                Danger labels are the bridge between semantics and policy. They help an agent distinguish advisory actions from ones that must
+                pause for approval or trigger hard-stop verification.
               </p>
+            </article>
+          </div>
+          <div class="card table-card">
+            <table class="data-table">
+              <thead>
+                <tr>
+                  <th>Danger level</th>
+                  <th>Example operation</th>
+                  <th>Likely safety tier</th>
+                  <th>Expected behavior</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td><code>safe</code></td>
+                  <td><code>list_files</code></td>
+                  <td><code>advisory</code></td>
+                  <td>No intervention beyond normal logging</td>
+                </tr>
+                <tr>
+                  <td><code>destructive</code></td>
+                  <td><code>delete_account</code></td>
+                  <td><code>confirm</code></td>
+                  <td>Pause and require an approval path</td>
+                </tr>
+                <tr>
+                  <td><code>dangerous</code></td>
+                  <td><code>bulk_delete</code></td>
+                  <td><code>verify</code></td>
+                  <td>Mandatory pause plus stronger verification</td>
+                </tr>
+                <tr>
+                  <td><code>forbidden</code></td>
+                  <td><code>drop_database</code></td>
+                  <td><code>danger_zone</code></td>
+                  <td>Hard stop with out-of-band verification</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <section>
+          <h2 class="section-title" id="confirmation-token-flow">Confirmation token flow</h2>
+          <div class="grid cols-2">
+            <article class="card">
+              <h3>Request and required confirmation response</h3>
+              <pre class="code-box" data-code-language="json">{
+  "operation": "delete_repo",
+  "params": {
+    "owner": "acme",
+    "repo": "widgets"
+  }
+}
+
+{
+  "success": false,
+  "error": {
+    "code": "CONFIRMATION_REQUIRED",
+    "message": "This operation requires confirmation",
+    "details": {
+      "danger_level": "destructive",
+      "confirmation_message": "Delete repository 'acme/widgets'?",
+      "confirmation_token": "conf_abc123xyz"
+    }
+  }
+}</pre>
+            </article>
+            <article class="card">
+              <h3>Confirmed retry</h3>
+              <p>
+                The client retries the same operation with the issued token. That keeps the first denial machine-readable and makes the second
+                request an explicit act of confirmation.
+              </p>
+              <pre class="code-box" data-code-language="json">{
+  "operation": "delete_repo",
+  "params": {
+    "owner": "acme",
+    "repo": "widgets",
+    "_confirmation": "conf_abc123xyz"
+  }
+}</pre>
             </article>
           </div>
         </section>
 
         <section>
           <h2 class="section-title" id="execution-safety-loop">Execution Safety Loop</h2>
-          <div class="card">
-            <p>
-              Stateful execute flows must support lifecycle controls (start, continue, complete, abort) and maintain safe transitions.
-              Session-bound controls should prevent stale token reuse or operation drift across disconnected contexts.
-            </p>
-            <pre class="code-box">execute_agent -> record_execution_step -> continue_execution
+          <div class="grid cols-2">
+            <article class="card">
+              <h3>What it means for agents</h3>
+              <p>
+                The execution safety loop means actions are evaluated before they happen, not merely logged afterward. An agent reports intent,
+                receives an autonomy decision, and only proceeds when the current step is allowed.
+              </p>
+            </article>
+            <article class="card">
+              <h3>Lifecycle shape</h3>
+              <pre class="code-box" data-code-language="text">execute_agent -> record_execution_step -> continue_execution
                  \-> pause/confirm -> complete_execution or abort_execution</pre>
+              <p>
+                Session-bound controls prevent stale confirmation tokens, unexpected operation drift, and hidden escalation during long-running execution.
+              </p>
+            </article>
           </div>
         </section>
 

--- a/public/index.html
+++ b/public/index.html
@@ -51,7 +51,7 @@
       </section>
 
       <section>
-        <h2 class="section-title">Why People Stop And Read</h2>
+        <h2 class="section-title">Why MCP-AQL Matters</h2>
         <p class="section-subtitle">
           The public story is not just that MCP-AQL organizes operations neatly. It closes MCP's semantics gap, keeps discovery runtime-driven,
           and gives clients enough structure to reason about safety without guessing from prose.
@@ -126,7 +126,7 @@
       </section>
 
       <section>
-        <h2 class="section-title">Start Here</h2>
+        <h2 class="section-title">Getting Started</h2>
         <p class="section-subtitle">
           If you are new to MCP-AQL, this sequence gets you from protocol overview to launch reality without repo spelunking.
         </p>

--- a/public/index.html
+++ b/public/index.html
@@ -53,8 +53,8 @@
       <section>
         <h2 class="section-title">Why MCP-AQL Matters</h2>
         <p class="section-subtitle">
-          The public story is not just that MCP-AQL organizes operations neatly. It closes MCP's semantics gap, keeps discovery runtime-driven,
-          and gives clients enough structure to reason about safety without guessing from prose.
+          MCP-AQL makes operation intent visible at the protocol layer, keeps discovery runtime-driven, and gives clients enough structure
+          to reason about safety without guessing from prose.
         </p>
         <div class="grid cols-3">
           <article class="card">
@@ -128,7 +128,7 @@
       <section>
         <h2 class="section-title">Getting Started</h2>
         <p class="section-subtitle">
-          If you are new to MCP-AQL, this sequence gets you from protocol overview to launch reality without repo spelunking.
+          Start here for the shortest path from the core idea to the draft spec, operational rules, and current launch posture.
         </p>
         <div class="grid cols-3">
           <article class="card">
@@ -164,7 +164,7 @@
 
       <section>
         <h2 class="section-title">Protocol Coverage</h2>
-        <p class="section-subtitle">Website coverage is organized to mirror how production protocol sites are typically navigated: core, security, validation, implementation, ecosystem.</p>
+        <p class="section-subtitle">Explore the protocol by core behavior, safety model, validation surface, implementation guidance, and ecosystem reference material.</p>
         <div class="grid cols-2">
           <article class="card">
             <h3>Core Protocol Surface</h3>
@@ -218,7 +218,7 @@
 
       <section>
         <h2 class="section-title">How MCP-AQL Differs From Familiar Patterns</h2>
-        <p class="section-subtitle">The protocol should answer the obvious comparison question directly instead of making readers infer it from the spec tree.</p>
+        <p class="section-subtitle">See where MCP-AQL aligns with familiar patterns, and where its semantic routing and runtime discovery make it different.</p>
         <div class="grid cols-3">
           <article class="card">
             <h3>MCP</h3>
@@ -249,7 +249,7 @@
 
       <section>
         <h2 class="section-title">Full Website-Hosted Spec Reference</h2>
-        <p class="section-subtitle">The public site now has a repo-synced spec layer generated from the canonical docs, so readers can stay on the website for the deeper protocol material too.</p>
+        <p class="section-subtitle">Read the canonical spec material on-site, with the same navigation and search used across the rest of the documentation portal.</p>
         <div class="grid cols-2">
           <article class="card">
             <h3>What changed</h3>
@@ -272,7 +272,7 @@
 
       <section>
         <h2 class="section-title">Reference Adapter Docs On-Site</h2>
-        <p class="section-subtitle">The implementation architecture is mirrored onto the website too, so adapter guidance now has a real runtime reference behind it.</p>
+        <p class="section-subtitle">Reference adapter architecture, runtime, testing, and ADR material are available on-site alongside the protocol docs.</p>
         <div class="grid cols-2">
           <article class="card">
             <h3>What changed</h3>
@@ -295,7 +295,7 @@
 
       <section>
         <h2 class="section-title">Current Draft Blockers</h2>
-        <p class="section-subtitle">The website is explicit about the live spec issues that still shape launch messaging.</p>
+        <p class="section-subtitle">These live spec issues still shape compatibility claims, launch language, and what the public draft can promise today.</p>
         <div class="grid cols-2">
           <article class="card">
             <h3>Phase-1 launch gate issues</h3>
@@ -319,7 +319,7 @@
 
       <section>
         <h2 class="section-title">Repository Map</h2>
-        <p class="section-subtitle">Each repository has a distinct role in launch readiness. The website summarizes and links all of them in one public path.</p>
+        <p class="section-subtitle">Each repository has a specific role in the protocol, reference implementations, tooling, and launch readiness work.</p>
         <div class="grid cols-3 repo-list">
           <article class="card">
             <h3>spec</h3>

--- a/public/index.html
+++ b/public/index.html
@@ -36,11 +36,10 @@
       <section class="hero">
         <div class="hero-inner">
           <span class="status-pill">PRELIMINARY PUBLIC DRAFT</span>
-          <h1>MCP transport tells clients how to call tools, not what those tools mean</h1>
+          <h1>MCP-AQL tells AI clients what operations mean, not just how to call them</h1>
           <p class="lede">
-            MCP defines registration and invocation shape, but it does not make semantic intent structural. A client cannot reliably
-            tell a safe read from a destructive delete without parsing tool descriptions. MCP-AQL adds semantic routing on top of
-            MCP transport, making operation intent explicit at the endpoint level while cutting tool-definition token overhead by about 85-96%.
+            MCP-AQL adds semantic routing on top of MCP transport, so operation intent is explicit at the protocol layer instead of buried in tool descriptions.
+            Clients can distinguish safe reads from destructive deletes by endpoint alone, while cutting tool-definition token overhead by about 85-96%.
           </p>
           <div class="hero-actions">
             <a class="btn btn-primary" href="docs/getting-started.html">Start With The Quick Path</a>

--- a/public/index.html
+++ b/public/index.html
@@ -36,10 +36,11 @@
       <section class="hero">
         <div class="hero-inner">
           <span class="status-pill">PRELIMINARY PUBLIC DRAFT</span>
-          <h1>MCP-AQL documentation that tracks the draft spec as it exists today</h1>
+          <h1>MCP transport tells clients how to call tools, not what those tools mean</h1>
           <p class="lede">
-            This site is the browse-first public surface for MCP-AQL: what the protocol is, how it routes operations,
-            how it handles safety and errors, what counts as draft-compatible today, and what remains open in the live spec backlog.
+            MCP defines registration and invocation shape, but it does not make semantic intent structural. A client cannot reliably
+            tell a safe read from a destructive delete without parsing tool descriptions. MCP-AQL adds semantic routing on top of
+            MCP transport, making operation intent explicit at the endpoint level while cutting tool-definition token overhead by about 85-96%.
           </p>
           <div class="hero-actions">
             <a class="btn btn-primary" href="docs/getting-started.html">Start With The Quick Path</a>
@@ -51,6 +52,81 @@
       </section>
 
       <section>
+        <h2 class="section-title">Why People Stop And Read</h2>
+        <p class="section-subtitle">
+          The public story is not just that MCP-AQL organizes operations neatly. It closes MCP's semantics gap, keeps discovery runtime-driven,
+          and gives clients enough structure to reason about safety without guessing from prose.
+        </p>
+        <div class="grid cols-3">
+          <article class="card">
+            <h3>MCP's semantics gap</h3>
+            <p>
+              In plain MCP, <code>get_user</code> and <code>drop_database</code> are structurally identical. The only clue about safety
+              or intent is the human-written description field.
+            </p>
+          </article>
+          <article class="card">
+            <h3>Semantic routing in MCP-AQL</h3>
+            <p>
+              In MCP-AQL, routing an operation to <code>READ</code> guarantees side-effect-free intent, while routing to
+              <code>DELETE</code> declares destructive intent at the protocol layer.
+            </p>
+          </article>
+          <article class="card">
+            <h3>Policy and agent benefit</h3>
+            <p>
+              Clients, LLMs, and policy systems can make decisions from the endpoint alone instead of burning tokens trying to infer
+              behavior from descriptive text.
+            </p>
+          </article>
+        </div>
+      </section>
+
+      <section>
+        <h2 class="section-title">Token Efficiency In One View</h2>
+        <p class="section-subtitle">
+          The fastest way to understand why the protocol exists is to look at the registration footprint. MCP-AQL moves capability discovery
+          to runtime, so clients do not pay the full schema cost up front for operations they may never use.
+        </p>
+        <div class="card table-card">
+          <table class="data-table">
+            <thead>
+              <tr>
+                <th>Configuration</th>
+                <th>Approximate token cost</th>
+                <th>Reduction</th>
+                <th>What the client gets</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Discrete tools (50+)</td>
+                <td>~30,000 tokens</td>
+                <td>Baseline</td>
+                <td>Every tool definition loaded up front</td>
+              </tr>
+              <tr>
+                <td>CRUDE mode (5 endpoints)</td>
+                <td>~4,500 tokens</td>
+                <td>~85%</td>
+                <td>Semantic endpoints plus runtime discovery</td>
+              </tr>
+              <tr>
+                <td>Single mode (1 endpoint)</td>
+                <td>~1,100 tokens</td>
+                <td>~96%</td>
+                <td>One routed entrypoint plus runtime discovery</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="callout">
+          The deeper discovery math lives in the spec too: the introspection guide models a typical path dropping from about
+          <strong>29,600 tokens</strong> for discrete tools to about <strong>2,600 total</strong> for MCP-AQL plus on-demand introspection over ten operations.
+        </p>
+      </section>
+
+      <section>
         <h2 class="section-title">Start Here</h2>
         <p class="section-subtitle">
           If you are new to MCP-AQL, this sequence gets you from protocol overview to launch reality without repo spelunking.
@@ -58,17 +134,17 @@
         <div class="grid cols-3">
           <article class="card">
             <h3>1. Understand The Model</h3>
-            <p>Start with the short overview, token-efficiency story, and quick-start request shape before dropping into the full draft.</p>
+            <p>Start with the semantics gap, token-efficiency story, and introspection-first request flow before dropping into the full draft.</p>
             <ul>
               <li><a href="docs/getting-started.html">Getting Started</a></li>
-              <li><a href="https://github.com/MCPAQL/spec/blob/main/docs/versions/v1.0.0-draft.md">Specification v1.0.0-draft</a></li>
-              <li><a href="https://github.com/MCPAQL/spec/blob/main/docs/crude-pattern.md">CRUDE Pattern</a></li>
-              <li><a href="https://github.com/MCPAQL/spec/blob/main/docs/introspection.md">Introspection</a></li>
+              <li><a href="spec/versions/v1.0.0-draft.html">Specification v1.0.0-draft</a></li>
+              <li><a href="spec/crude-pattern.html">CRUDE Pattern</a></li>
+              <li><a href="spec/introspection.html">Introspection</a></li>
             </ul>
           </article>
           <article class="card">
             <h3>2. Learn The Operational Rules</h3>
-            <p>Read the public summaries for routing, structured errors, safety controls, and conformance boundaries.</p>
+            <p>Read the public summaries for semantic routing, structured errors, safety controls, and conformance boundaries.</p>
             <ul>
               <li><a href="docs/protocol-core.html">Protocol Core</a></li>
               <li><a href="docs/error-model.html">Error Model</a></li>
@@ -137,6 +213,37 @@
               <li>Generator/output-policy and provenance requirements</li>
             </ul>
             <a href="docs/adapter-contracts.html">Open Adapter Contracts</a>
+          </article>
+        </div>
+      </section>
+
+      <section>
+        <h2 class="section-title">How MCP-AQL Differs From Familiar Patterns</h2>
+        <p class="section-subtitle">The protocol should answer the obvious comparison question directly instead of making readers infer it from the spec tree.</p>
+        <div class="grid cols-3">
+          <article class="card">
+            <h3>MCP</h3>
+            <p>
+              MCP-AQL is a protocol layer on top of MCP transport, not a replacement. The difference is semantic endpoints,
+              runtime discovery, and built-in safety classification instead of prose-only intent.
+            </p>
+            <a href="docs/getting-started.html">Read the guided explanation</a>
+          </article>
+          <article class="card">
+            <h3>GraphQL</h3>
+            <p>
+              Both use runtime discovery, but GraphQL requires a schema language and type system. MCP-AQL keeps the existing MCP transport
+              and adds semantic routing without introducing a new SDL.
+            </p>
+            <a href="spec/guides/protocol-comparison.html">Open the comparison guide</a>
+          </article>
+          <article class="card">
+            <h3>REST</h3>
+            <p>
+              REST uses HTTP verbs for semantics. MCP-AQL applies a similar idea to the MCP tool layer, where HTTP verbs do not exist,
+              so intent stays visible even when everything would otherwise look like an undifferentiated tool call.
+            </p>
+            <a href="spec/guides/protocol-comparison.html">See the detailed comparison</a>
           </article>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- lead the homepage with the MCP semantics gap and surface token-efficiency numbers early
- expand Getting Started with the MCP vs MCP-AQL framing, introspection explanation, walkthrough, and comparison section
- deepen Protocol Core, Error Model, and Security Model so the summary docs carry more real protocol substance

## Verification
- npm run generate:page-toc
- npm run generate:page-toc:check
- npm run validate:toc
- node --check public/js/search.js
- curl -s http://127.0.0.1:4101/ and key docs pages to confirm the updated sections render in preview

Closes #20
Closes #21
