### PR TITLE
release: merge develop into main

### DIFF
--- a/.github/workflows/spec-sync.yml
+++ b/.github/workflows/spec-sync.yml
@@ -1,0 +1,72 @@
+name: Spec Mirror Sync
+
+on:
+  schedule:
+    - cron: "15 14 * * 1-5"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: spec-mirror-sync
+  cancel-in-progress: false
+
+jobs:
+  sync-spec:
+    name: Sync website spec mirror from spec main
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout website
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Checkout spec main
+        uses: actions/checkout@v4
+        with:
+          repository: MCPAQL/spec
+          ref: main
+          path: .mirror/spec
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Setup pandoc
+        uses: r-lib/actions/setup-pandoc@v2
+
+      - name: Regenerate spec mirror
+        run: node scripts/generate-repo-docs.mjs --mirror spec --spec-dir .mirror/spec
+
+      - name: Validate derived TOCs
+        run: npm run validate:toc
+
+      - name: Remove temporary mirror checkout
+        run: rm -rf .mirror
+
+      - name: Create or update sync PR
+        uses: peter-evans/create-pull-request@v7
+        with:
+          add-paths: |
+            public/spec/**
+            public/data/search-index.json
+          base: develop
+          branch: automation/spec-sync
+          commit-message: "chore: sync website spec mirror from latest spec main"
+          title: "chore: sync website spec mirror from latest spec main"
+          body: |
+            ## Summary
+            - regenerate the website-hosted spec mirror from the latest `MCPAQL/spec` `main`
+            - refresh website search entries for the generated spec pages
+
+            ## Notes
+            - this PR was generated automatically by `.github/workflows/spec-sync.yml`
+            - adapter mirror content is intentionally left untouched by this workflow
+          labels: |
+            ci
+            enhancement
+          delete-branch: false

--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ Generate or refresh both repo mirrors:
 npm run generate:repo-docs
 ```
 
+Generate or refresh only the website-hosted spec mirror:
+
+```bash
+node scripts/generate-repo-docs.mjs --mirror spec --spec-dir ../spec
+```
+
 Generate or refresh only the derived TOCs for hand-authored long-form pages:
 
 ```bash
@@ -125,6 +131,12 @@ Pull requests that modify site content also run `.github/workflows/visidelta-pre
 - Builds rendered visual diffs with VisiDelta
 - Uploads an artifact for each run (`visidelta-<run_id>-<attempt>`)
 - Optionally publishes hosted previews when `VISIDELTA_PREVIEW_PAGES_TOKEN` is configured
+
+Scheduled and manual spec-mirror automation lives in `.github/workflows/spec-sync.yml`:
+
+- Checks out the latest `MCPAQL/spec` `main`
+- Regenerates only the website-hosted spec mirror
+- Opens or updates a PR against `develop` when generated `public/spec/**` output or `public/data/search-index.json` changes
 
 ## License
 

--- a/scripts/generate-repo-docs.mjs
+++ b/scripts/generate-repo-docs.mjs
@@ -16,13 +16,16 @@ const __dirname = path.dirname(__filename);
 const siteRoot = path.resolve(__dirname, "..");
 const publicRoot = path.join(siteRoot, "public");
 const searchBasePath = path.join(siteRoot, "source", "search-index.base.json");
+const generatedSearchIndexPath = path.join(publicRoot, "data", "search-index.json");
 
 const args = process.argv.slice(2);
 const isCheck = args.includes("--check");
 
 const mirrorConfigs = [createSpecConfig(), createAdapterConfig()];
+const selectedMirrorIds = parseMirrorSelection(args, mirrorConfigs);
+const selectedMirrorConfigs = mirrorConfigs.filter((config) => selectedMirrorIds.has(config.id));
 
-for (const config of mirrorConfigs) {
+for (const config of selectedMirrorConfigs) {
   if (!fs.existsSync(config.docsRoot)) {
     console.error(`${config.repoLabel} docs directory not found: ${config.docsRoot}`);
     process.exit(1);
@@ -31,7 +34,7 @@ for (const config of mirrorConfigs) {
 
 assertPandoc();
 
-const mirrorStates = mirrorConfigs.map(createMirrorState);
+const mirrorStates = selectedMirrorConfigs.map(createMirrorState);
 const docLookups = new Map(
   mirrorStates.map((state) => [
     state.config.repoSlug,
@@ -72,19 +75,29 @@ for (const state of mirrorStates) {
 }
 
 const baseSearchEntries = JSON.parse(fs.readFileSync(searchBasePath, "utf8"));
-const collectionEntries = mirrorStates.map((state) => state.config.collectionSearchEntry);
-const generatedSearchEntries = mirrorStates.flatMap((state) =>
-  state.docs.map((doc) => ({
-    title: `${state.config.searchTitlePrefix}: ${doc.title}`,
-    url: `/${doc.outputRel}`,
-    excerpt: doc.summary,
-    keywords: buildKeywords(doc, state.config)
-  }))
-);
+const existingSearchEntries = fs.existsSync(generatedSearchIndexPath)
+  ? JSON.parse(fs.readFileSync(generatedSearchIndexPath, "utf8"))
+  : [];
+const allMirrorSearchEntries = mirrorConfigs.flatMap((config) => {
+  if (!selectedMirrorIds.has(config.id)) {
+    return preserveExistingMirrorSearchEntries(existingSearchEntries, config);
+  }
+
+  const state = mirrorStates.find((candidate) => candidate.config.id === config.id);
+  return [
+    config.collectionSearchEntry,
+    ...state.docs.map((doc) => ({
+      title: `${config.searchTitlePrefix}: ${doc.title}`,
+      url: `/${doc.outputRel}`,
+      excerpt: doc.summary,
+      keywords: buildKeywords(doc, config)
+    }))
+  ];
+});
 
 changedFiles += writeFile(
-  path.join(publicRoot, "data", "search-index.json"),
-  `${JSON.stringify([...baseSearchEntries, ...collectionEntries, ...generatedSearchEntries], null, 2)}\n`
+  generatedSearchIndexPath,
+  `${JSON.stringify([...baseSearchEntries, ...allMirrorSearchEntries], null, 2)}\n`
 );
 
 if (isCheck && changedFiles > 0) {
@@ -97,6 +110,49 @@ const generatedSummary = mirrorStates
   .join(" and ");
 
 console.log(`${isCheck ? "Checked" : "Generated"} ${generatedSummary}.`);
+
+function parseMirrorSelection(rawArgs, configs) {
+  const selected = new Set();
+
+  for (let index = 0; index < rawArgs.length; index += 1) {
+    if (rawArgs[index] !== "--mirror") {
+      continue;
+    }
+
+    const rawValue = rawArgs[index + 1];
+    if (!rawValue) {
+      console.error("Expected a value after --mirror.");
+      process.exit(1);
+    }
+
+    for (const value of rawValue.split(",")) {
+      const normalized = value.trim().toLowerCase();
+      if (!normalized || normalized === "all") {
+        configs.forEach((config) => selected.add(config.id));
+        continue;
+      }
+
+      const match = configs.find((config) => config.id === normalized);
+      if (!match) {
+        console.error(`Unknown mirror id '${value}'. Expected one of: ${configs.map((config) => config.id).join(", ")}`);
+        process.exit(1);
+      }
+
+      selected.add(match.id);
+    }
+  }
+
+  if (!selected.size) {
+    configs.forEach((config) => selected.add(config.id));
+  }
+
+  return selected;
+}
+
+function preserveExistingMirrorSearchEntries(existingEntries, config) {
+  const prefix = `/${config.outputRootRel}/`;
+  return existingEntries.filter((entry) => typeof entry.url === "string" && entry.url.startsWith(prefix));
+}
 
 function createSpecConfig() {
   const repoRoot = resolveRepoRoot("--spec-dir", "../spec");


### PR DESCRIPTION
## Summary
- bring the latest website spec-mirror sync from `develop` into `main`
- bring the new spec-sync automation workflow into the release line
- keep `main` aligned with the current `develop` branch before the next site deployment cycle

## Included work
- website spec mirror refresh from the latest `MCPAQL/spec` main
- new `collection-querying` spec page and search/index updates
- automated spec-mirror sync workflow targeting `develop`
- scoped `--mirror spec` generator support and README documentation
