### PR TITLE
chore: sync website spec mirror from latest spec main

### DIFF
--- a/public/data/search-index.json
+++ b/public/data/search-index.json
@@ -274,18 +274,6 @@
     ]
   },
   {
-    "title": "Reference Adapter Docs",
-    "url": "/adapter-reference/index.html",
-    "excerpt": "Website-hosted mirror of the reference adapter repo docs covering runtime architecture, guides, ADRs, and examples.",
-    "keywords": [
-      "adapter docs",
-      "implementation",
-      "runtime",
-      "guides",
-      "reference adapter"
-    ]
-  },
-  {
     "title": "Spec: Dangerous Operation Classification Specification",
     "url": "/spec/adapter/danger-levels.html",
     "excerpt": "This document defines a standard classification system for dangerous operations in MCP-AQL adapters. Danger levels enable automatic lockdown of high-risk actions, consistent confirmation requirements, and trust-based per",
@@ -516,7 +504,7 @@
   {
     "title": "Spec: MCP-AQL Conformance Testing Specification",
     "url": "/spec/conformance-testing.html",
-    "excerpt": "Document Status: This document is an informative conformance framework specification aligned to the normative protocol requirements in docs/versions/v1.0.0-draft.md. Implementation Status: The full mcpaql-conformance run",
+    "excerpt": "Document Status: This document is an informative conformance framework specification aligned to the normative protocol requirements in docs/versions/v1.0.0-draft.md. Implementation Status: This repository now includes a ",
     "keywords": [
       "spec",
       "core",
@@ -573,6 +561,19 @@
     ]
   },
   {
+    "title": "Spec: MCP-AQL Aggregations",
+    "url": "/spec/features/aggregations.html",
+    "excerpt": "Document Status: This document is informative. For normative requirements, see MCP-AQL Specification v1.0.0.",
+    "keywords": [
+      "spec",
+      "features",
+      "docs",
+      "aggregations",
+      "mcp",
+      "aql"
+    ]
+  },
+  {
     "title": "Spec: MCP-AQL Collection Querying",
     "url": "/spec/features/collection-querying.html",
     "excerpt": "Document Status: This document is informative. For normative requirements, see MCP-AQL Specification v1.0.0.",
@@ -582,6 +583,20 @@
       "docs",
       "collection",
       "querying",
+      "mcp",
+      "aql"
+    ]
+  },
+  {
+    "title": "Spec: MCP-AQL Computed Fields",
+    "url": "/spec/features/computed-fields.html",
+    "excerpt": "Document Status: This document is informative. For normative requirements, see MCP-AQL Specification v1.0.0.",
+    "keywords": [
+      "spec",
+      "features",
+      "docs",
+      "computed",
+      "fields",
       "mcp",
       "aql"
     ]
@@ -614,6 +629,20 @@
     ]
   },
   {
+    "title": "Spec: MCP-AQL Relationship Queries",
+    "url": "/spec/features/relationship-queries.html",
+    "excerpt": "Document Status: This document is informative. For normative requirements, see MCP-AQL Specification v1.0.0.",
+    "keywords": [
+      "spec",
+      "features",
+      "docs",
+      "relationship",
+      "queries",
+      "mcp",
+      "aql"
+    ]
+  },
+  {
     "title": "Spec: Warnings Array Specification",
     "url": "/spec/features/warnings.html",
     "excerpt": "This document specifies the warnings array extension to MCP-AQL's discriminated response format. Warnings provide a mechanism to communicate non-fatal conditions to clients within successful responses, enabling proactive",
@@ -624,6 +653,20 @@
       "warnings",
       "array",
       "specification"
+    ]
+  },
+  {
+    "title": "Spec: Cross-Domain Implementation Guide",
+    "url": "/spec/guides/cross-domain-implementation.html",
+    "excerpt": "Document Status: This document is informative. For normative protocol requirements, see MCP-AQL Specification v1.0.0.",
+    "keywords": [
+      "spec",
+      "guides",
+      "docs",
+      "cross",
+      "domain",
+      "implementation",
+      "guide"
     ]
   },
   {
@@ -711,7 +754,7 @@
   {
     "title": "Spec: MCP-AQL Protocol Overview",
     "url": "/spec/overview.html",
-    "excerpt": "MCP-AQL (Model Context Protocol - Agent Query Language) is a protocol that consolidates discrete MCP tools into 5 CRUDE endpoints (Create, Read, Update, Delete, Execute), providing significant token reduction while maint",
+    "excerpt": "MCP-AQL (Model Context Protocol - Agent Query Language) is a protocol that consolidates discrete MCP tools into a small number of semantic endpoint families, providing significant token reduction while maintaining full f",
     "keywords": [
       "spec",
       "core",
@@ -880,7 +923,7 @@
   {
     "title": "Spec: MCP-AQL Specification",
     "url": "/spec/versions/v1.0.0-draft.html",
-    "excerpt": "MCP-AQL (Model Context Protocol - Advanced Agent API Adapter Query Language) is a protocol specification that consolidates multiple MCP tools into semantic CRUDE endpoints, providing significant token reduction while ena",
+    "excerpt": "MCP-AQL (Model Context Protocol - Advanced Agent API Adapter Query Language) is a protocol specification that consolidates multiple MCP tools into a small number of semantic endpoints, providing significant token reducti",
     "keywords": [
       "spec",
       "versions",
@@ -913,6 +956,18 @@
       "spec",
       "process",
       "changelog"
+    ]
+  },
+  {
+    "title": "Reference Adapter Docs",
+    "url": "/adapter-reference/index.html",
+    "excerpt": "Website-hosted mirror of the reference adapter repo docs covering runtime architecture, guides, ADRs, and examples.",
+    "keywords": [
+      "adapter docs",
+      "implementation",
+      "runtime",
+      "guides",
+      "reference adapter"
     ]
   },
   {

--- a/public/spec/README.html
+++ b/public/spec/README.html
@@ -50,10 +50,10 @@
   <ul><li><a href="security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Features</h3>
-  <ul><li><a href="features/collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="features/field-selection.html">Field Selection Specification</a></li><li><a href="features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="features/warnings.html">Warnings Array Specification</a></li></ul>
+  <ul><li><a href="features/aggregations.html">MCP-AQL Aggregations</a></li><li><a href="features/collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="features/computed-fields.html">MCP-AQL Computed Fields</a></li><li><a href="features/field-selection.html">Field Selection Specification</a></li><li><a href="features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="features/relationship-queries.html">MCP-AQL Relationship Queries</a></li><li><a href="features/warnings.html">Warnings Array Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Guides</h3>
-  <ul><li><a href="guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="guides/README.html">Developer Guides</a></li></ul>
+  <ul><li><a href="guides/cross-domain-implementation.html">Cross-Domain Implementation Guide</a></li><li><a href="guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
   <ul><li><a href="process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="process/versioning.html">Versioning Strategy</a></li><li><a href="repo/CHANGELOG.html">Changelog</a></li></ul>
@@ -120,46 +120,46 @@
 <h3 id="core-specification">Core Specification</h3>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Document</th>
 <th>Description</th>
 <th>Status</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><a href="versions/v1.0.0-draft.html">v1.0.0-draft</a></td>
 <td>Current specification version</td>
 <td>Draft</td>
 </tr>
-<tr>
+<tr class="even">
 <td><a href="crude-pattern.html">CRUDE Pattern</a></td>
-<td>Endpoint semantics and routing</td>
+<td>Standard semantic-endpoint profile and routing</td>
 <td>Draft</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><a href="endpoint-modes.html">Endpoint Modes</a></td>
-<td>CRUDE vs Single mode configuration</td>
+<td>Semantic endpoint mode and Single mode configuration</td>
 <td>Draft</td>
 </tr>
-<tr>
+<tr class="even">
 <td><a href="introspection.html">Introspection</a></td>
 <td>Runtime discovery system</td>
 <td>Draft</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><a href="operations.html">Operations</a></td>
 <td>Operation design guide</td>
 <td>Draft</td>
 </tr>
-<tr>
+<tr class="even">
 <td><a href="error-codes.html">Error Codes</a></td>
 <td>Structured error code system</td>
 <td>Draft (MVP)</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><a href="conformance-testing.html">Conformance Testing</a></td>
-<td>Test requirements and evaluation methodology</td>
+<td>Test requirements plus the fixture-driven runner model used in this repo</td>
 <td>Draft</td>
 </tr>
 </tbody>
@@ -167,24 +167,24 @@
 <h3 id="plugin--adapter-contracts">Plugin &amp; Adapter Contracts</h3>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Document</th>
 <th>Description</th>
 <th>Status</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><a href="plugin-contracts.html">Plugin Interface Contracts</a></td>
 <td>What each plugin type MUST provide</td>
 <td>Draft (MVP)</td>
 </tr>
-<tr>
+<tr class="even">
 <td><a href="adapter/element-type.html">Element Type Specification</a></td>
 <td>Declarative adapter schema format</td>
 <td>Draft (MVP)</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><a href="adapter/discovery-bundle.html">MCP Server Discovery Bundle</a></td>
 <td>Raw capture + normalized bundle contract for generator pipelines</td>
 <td>Draft</td>
@@ -194,26 +194,41 @@
 <h3 id="features">Features</h3>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Document</th>
 <th>Description</th>
 <th>Impl Status</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><a href="features/field-selection.html">Field Selection</a></td>
 <td>GraphQL-style response filtering</td>
 <td>Implemented</td>
 </tr>
-<tr>
+<tr class="even">
 <td><a href="features/collection-querying.html">Collection Querying</a></td>
 <td>Preferred query contract for list/search/query operations</td>
 <td>Draft</td>
 </tr>
-<tr>
+<tr class="odd">
+<td><a href="features/aggregations.html">Aggregations</a></td>
+<td>Server-side summaries for collection queries</td>
+<td>Draft</td>
+</tr>
+<tr class="even">
+<td><a href="features/computed-fields.html">Computed Fields</a></td>
+<td>Adapter-declared derived values and <code>_computed.</code> paths</td>
+<td>Draft</td>
+</tr>
+<tr class="odd">
 <td><a href="features/pagination.html">Pagination</a></td>
 <td>Cursor-based pagination semantics and response shape</td>
+<td>Draft</td>
+</tr>
+<tr class="even">
+<td><a href="features/relationship-queries.html">Relationship Queries</a></td>
+<td>Graph traversal and relationship query conventions</td>
 <td>Draft</td>
 </tr>
 </tbody>
@@ -221,14 +236,14 @@
 <h3 id="security">Security</h3>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Document</th>
 <th>Description</th>
 <th>Impl Status</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><a href="security/gatekeeper.html">Gatekeeper</a></td>
 <td>Multi-layer access control</td>
 <td>Implemented</td>
@@ -238,25 +253,25 @@
 <h3 id="process">Process</h3>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Document</th>
 <th>Description</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><a href="process/rfc-process.html">RFC Process</a></td>
 <td>How to propose specification changes</td>
 </tr>
-<tr>
+<tr class="even">
 <td><a href="process/breaking-changes.html">Breaking Changes</a></td>
 <td>Policy for handling breaking changes</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><a href="process/versioning.html">Versioning</a></td>
 <td>Version numbering and release process</td>
 </tr>
-<tr>
+<tr class="even">
 <td><a href="process/preliminary-public-launch-checklist.html">Preliminary Launch Checklist</a></td>
 <td>Coordinated draft-launch criteria</td>
 </tr>
@@ -265,15 +280,19 @@
 <h3 id="guides">Guides</h3>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Document</th>
 <th>Description</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><a href="guides/protocol-comparison.html">Protocol Comparison</a></td>
 <td>MCP-AQL vs other protocols</td>
+</tr>
+<tr class="even">
+<td><a href="guides/cross-domain-implementation.html">Cross-Domain Implementation</a></td>
+<td>Step-by-step guide for adapting MCP-AQL to domains beyond Dollhouse-style element management</td>
 </tr>
 </tbody>
 </table>
@@ -295,16 +314,14 @@
 </ul>
 <p><strong>Phase 2+ - Advanced:</strong></p>
 <ul>
-<li>Computed fields (#42)</li>
 <li>Streaming responses (#43)</li>
-<li>Relationship queries (#44)</li>
 <li>Schema versioning (#48)</li>
 </ul>
 <h2 id="reading-order">Reading Order</h2>
 <p>For newcomers to MCP-AQL:</p>
 <ol type="1">
 <li><strong><a href="versions/v1.0.0-draft.html">v1.0.0-draft</a></strong> - Start with the main specification</li>
-<li><strong><a href="crude-pattern.html">CRUDE Pattern</a></strong> - Understand the endpoint semantics</li>
+<li><strong><a href="crude-pattern.html">CRUDE Pattern</a></strong> - Understand the standard semantic-endpoint profile</li>
 <li><strong><a href="operations.html">Operations</a></strong> - Learn operation design patterns</li>
 <li><strong><a href="introspection.html">Introspection</a></strong> - Learn the discovery system</li>
 <li><strong><a href="conformance-testing.html">Conformance Testing</a></strong> - Understand conformance requirements</li>
@@ -313,15 +330,15 @@
 <ol type="1">
 <li><strong><a href="adapter/element-type.html">Element Type Specification</a></strong> - Declarative schema format</li>
 <li><strong><a href="plugin-contracts.html">Plugin Interface Contracts</a></strong> - Plugin system contracts</li>
-<li><strong><a href="../adapter-reference/architecture/overview.html">Architecture Overview</a></strong> - Understand adapter structure (in mcpaql-adapter repo)</li>
-<li><strong><a href="../adapter-reference/guides/development.html">Development Guide</a></strong> - Implementation walkthrough (in mcpaql-adapter repo)</li>
+<li><strong><a href="https://github.com/MCPAQL/mcpaql-adapter/blob/develop/docs/architecture/overview.md">Architecture Overview</a></strong> - Understand adapter structure (in mcpaql-adapter repo)</li>
+<li><strong><a href="https://github.com/MCPAQL/mcpaql-adapter/blob/develop/docs/guides/development.md">Development Guide</a></strong> - Implementation walkthrough (in mcpaql-adapter repo)</li>
 <li><strong><a href="security/gatekeeper.html">Gatekeeper</a></strong> - Security implementation</li>
 </ol>
 <h2 id="cross-repository-content">Cross-Repository Content</h2>
 <p>MCP-AQL follows a four-level protocol model:</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Level</th>
 <th>What</th>
 <th>Normative?</th>
@@ -329,25 +346,25 @@
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td>1. Wire format</td>
 <td>Request/response JSON, error codes, introspection</td>
 <td>MUST</td>
 <td><strong>this repo</strong></td>
 </tr>
-<tr>
+<tr class="even">
 <td>2. Schema semantics</td>
 <td>Operation declarations, params, auth, target</td>
 <td>MUST/SHOULD</td>
 <td><strong>this repo</strong></td>
 </tr>
-<tr>
+<tr class="odd">
 <td>3. Canonical format</td>
 <td>Markdown + YAML front matter interchange format</td>
 <td>SHOULD</td>
 <td><strong>this repo</strong></td>
 </tr>
-<tr>
+<tr class="even">
 <td>4. Implementation guidance</td>
 <td>Runtime architecture, plugin pipeline, dispatch</td>
 <td>Non-normative</td>

--- a/public/spec/adapter/danger-levels.html
+++ b/public/spec/adapter/danger-levels.html
@@ -50,10 +50,10 @@
   <ul><li><a href="../security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="../security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="../security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Features</h3>
-  <ul><li><a href="../features/collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
+  <ul><li><a href="../features/aggregations.html">MCP-AQL Aggregations</a></li><li><a href="../features/collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="../features/computed-fields.html">MCP-AQL Computed Fields</a></li><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/relationship-queries.html">MCP-AQL Relationship Queries</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Guides</h3>
-  <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
+  <ul><li><a href="../guides/cross-domain-implementation.html">Cross-Domain Implementation Guide</a></li><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
   <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li><li><a href="../repo/CHANGELOG.html">Changelog</a></li></ul>
@@ -155,7 +155,7 @@
 <h3 id="21-danger-level-values">2.1 Danger Level Values</h3>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Level</th>
 <th>Value</th>
 <th>Name</th>
@@ -163,31 +163,31 @@
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td>0</td>
 <td><code>safe</code></td>
 <td>Safe</td>
 <td>No restrictions</td>
 </tr>
-<tr>
+<tr class="even">
 <td>1</td>
 <td><code>reversible</code></td>
 <td>Reversible</td>
 <td>Standard confirmation</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>2</td>
 <td><code>destructive</code></td>
 <td>Destructive</td>
 <td>Enhanced confirmation</td>
 </tr>
-<tr>
+<tr class="even">
 <td>3</td>
 <td><code>dangerous</code></td>
 <td>Dangerous</td>
 <td>Explicit unlock required</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>4</td>
 <td><code>forbidden</code></td>
 <td>Forbidden</td>
@@ -333,34 +333,34 @@
 <p>When <code>danger.level</code> is not specified, defaults are inferred:</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>CRUDE Category</th>
 <th>Default Danger Level</th>
 <th>Rationale</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td>Read</td>
 <td><code>safe</code> (0)</td>
 <td>No state modification</td>
 </tr>
-<tr>
+<tr class="even">
 <td>Create</td>
 <td><code>reversible</code> (1)</td>
 <td>Adds data, reversible by delete</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>Update</td>
 <td><code>reversible</code> (1)</td>
 <td>Modifies data, often reversible</td>
 </tr>
-<tr>
+<tr class="even">
 <td>Delete</td>
 <td><code>destructive</code> (2)</td>
 <td>Removes data</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>Execute</td>
 <td><code>reversible</code> (1)</td>
 <td>Depends on operation</td>
@@ -399,7 +399,7 @@
 <p>The combination of adapter trust level and operation danger level determines behavior:</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Danger Level</th>
 <th>untested</th>
 <th>generated</th>
@@ -409,7 +409,7 @@
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td>safe (0)</td>
 <td>introspect_only</td>
 <td>allow</td>
@@ -417,7 +417,7 @@
 <td>allow</td>
 <td>allow</td>
 </tr>
-<tr>
+<tr class="even">
 <td>reversible (1)</td>
 <td>deny</td>
 <td>deny</td>
@@ -425,7 +425,7 @@
 <td>allow</td>
 <td>allow</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>destructive (2)</td>
 <td>deny</td>
 <td>deny</td>
@@ -433,7 +433,7 @@
 <td>allow</td>
 <td>allow</td>
 </tr>
-<tr>
+<tr class="even">
 <td>dangerous (3)</td>
 <td>deny</td>
 <td>deny</td>
@@ -441,7 +441,7 @@
 <td>confirm</td>
 <td>allow</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>forbidden (4)</td>
 <td>deny</td>
 <td>deny</td>
@@ -454,25 +454,25 @@
 <h3 id="42-behavior-definitions">4.2 Behavior Definitions</h3>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Behavior</th>
 <th>Description</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><code>allow</code></td>
 <td>Operation executes without additional gates</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>confirm</code></td>
 <td>Operation requires explicit user confirmation</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>deny</code></td>
 <td>Operation blocked with error response</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>introspect_only</code></td>
 <td>Only introspection operations permitted; all other operations (including safe ones) are blocked</td>
 </tr>
@@ -580,44 +580,44 @@
 <p>Operations matching these patterns SHOULD default to <code>dangerous</code>:</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Pattern</th>
 <th>Description</th>
 <th>Examples</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><code>force_*</code></td>
 <td>Force operations bypassing safety</td>
 <td><code>force_push</code>, <code>force_delete</code></td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>*_permanently</code></td>
 <td>Permanent/irreversible actions</td>
 <td><code>remove_permanently</code></td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>bulk_delete*</code></td>
 <td>Mass deletion operations</td>
 <td><code>bulk_delete_users</code></td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>override_*</code></td>
 <td>Safety override operations</td>
 <td><code>override_validation</code></td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>bypass_*</code></td>
 <td>Validation bypass</td>
 <td><code>bypass_approval</code></td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>*_without_backup</code></td>
 <td>Operations skipping backup</td>
 <td><code>delete_without_backup</code></td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>purge_*</code></td>
 <td>Purge/clean operations</td>
 <td><code>purge_logs</code>, <code>purge_cache</code></td>
@@ -628,44 +628,44 @@
 <p>Operations matching these patterns SHOULD default to <code>forbidden</code>:</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Pattern</th>
 <th>Description</th>
 <th>Examples</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><code>drop_*</code></td>
 <td>Drop database/table/collection</td>
 <td><code>drop_table</code>, <code>drop_database</code></td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>delete_all*</code></td>
 <td>Delete all records</td>
 <td><code>delete_all_users</code></td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>truncate_*</code></td>
 <td>Truncate operations</td>
 <td><code>truncate_table</code></td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>reset_*</code></td>
 <td>Reset to empty/factory state</td>
 <td><code>reset_database</code></td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>destroy_*</code></td>
 <td>Complete destruction</td>
 <td><code>destroy_environment</code></td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>wipe_*</code></td>
 <td>Wipe operations</td>
 <td><code>wipe_data</code></td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>*_production</code></td>
 <td>Production mutations</td>
 <td><code>deploy_production</code></td>
@@ -676,39 +676,39 @@
 <p>Operations matching these patterns are confirmed <code>safe</code>:</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Pattern</th>
 <th>Description</th>
 <th>Examples</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><code>get_*</code></td>
 <td>Retrieve single resource</td>
 <td><code>get_user</code>, <code>get_repo</code></td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>list_*</code></td>
 <td>List resources</td>
 <td><code>list_repos</code>, <code>list_users</code></td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>search_*</code></td>
 <td>Search operations</td>
 <td><code>search_issues</code></td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>count_*</code></td>
 <td>Count operations</td>
 <td><code>count_records</code></td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>check_*</code></td>
 <td>Validation checks</td>
 <td><code>check_status</code></td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>introspect*</code></td>
 <td>Introspection</td>
 <td><code>introspect</code></td>
@@ -763,7 +763,7 @@
 <p>The Autonomy Evaluator maps danger levels to safety tiers using a numeric risk score (0-100):</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Danger Level</th>
 <th>Risk Score Range</th>
 <th>Safety Tier</th>
@@ -771,31 +771,31 @@
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td>safe (0)</td>
 <td>0-15</td>
 <td><code>advisory</code></td>
 <td>No intervention</td>
 </tr>
-<tr>
+<tr class="even">
 <td>reversible (1)</td>
 <td>16-40</td>
 <td><code>advisory</code> or <code>confirm</code></td>
 <td>Depends on risk tolerance</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>destructive (2)</td>
 <td>41-60</td>
 <td><code>confirm</code></td>
 <td>Requires approval</td>
 </tr>
-<tr>
+<tr class="even">
 <td>dangerous (3)</td>
 <td>61-85</td>
 <td><code>verify</code></td>
 <td>Mandatory pause + approval</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>forbidden (4)</td>
 <td>86-100</td>
 <td><code>danger_zone</code></td>

--- a/public/spec/adapter/discovery-bundle.html
+++ b/public/spec/adapter/discovery-bundle.html
@@ -50,10 +50,10 @@
   <ul><li><a href="../security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="../security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="../security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Features</h3>
-  <ul><li><a href="../features/collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
+  <ul><li><a href="../features/aggregations.html">MCP-AQL Aggregations</a></li><li><a href="../features/collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="../features/computed-fields.html">MCP-AQL Computed Fields</a></li><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/relationship-queries.html">MCP-AQL Relationship Queries</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Guides</h3>
-  <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
+  <ul><li><a href="../guides/cross-domain-implementation.html">Cross-Domain Implementation Guide</a></li><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
   <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li><li><a href="../repo/CHANGELOG.html">Changelog</a></li></ul>

--- a/public/spec/adapter/element-type.html
+++ b/public/spec/adapter/element-type.html
@@ -50,10 +50,10 @@
   <ul><li><a href="../security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="../security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="../security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Features</h3>
-  <ul><li><a href="../features/collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
+  <ul><li><a href="../features/aggregations.html">MCP-AQL Aggregations</a></li><li><a href="../features/collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="../features/computed-fields.html">MCP-AQL Computed Fields</a></li><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/relationship-queries.html">MCP-AQL Relationship Queries</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Guides</h3>
-  <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
+  <ul><li><a href="../guides/cross-domain-implementation.html">Cross-Domain Implementation Guide</a></li><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
   <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li><li><a href="../repo/CHANGELOG.html">Changelog</a></li></ul>
@@ -425,39 +425,39 @@
 <p><strong>Supported types:</strong></p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Type</th>
 <th>Description</th>
 <th>Example</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><code>string</code></td>
 <td>Text value</td>
 <td><code>"hello"</code></td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>integer</code></td>
 <td>Whole number</td>
 <td><code>42</code></td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>number</code></td>
 <td>Decimal number</td>
 <td><code>3.14</code></td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>boolean</code></td>
 <td>True/false</td>
 <td><code>true</code></td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>array</code></td>
 <td>List of values</td>
 <td><code>[1, 2, 3]</code></td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>object</code></td>
 <td>Key-value map</td>
 <td><code>{"key": "value"}</code></td>
@@ -560,8 +560,8 @@
 <li><a href="trust-levels.html">Trust Levels Specification</a></li>
 <li><a href="danger-levels.html">Dangerous Operation Classification</a></li>
 <li><a href="rate-limiting.html">Rate Limiting Specification</a></li>
-<li><a href="../../adapter-reference/guides/development.html">Adapter Development Guide</a> (in mcpaql-adapter repo)</li>
-<li><a href="../../adapter-reference/architecture/runtime.html">Universal Adapter Runtime</a> (in mcpaql-adapter repo)</li>
+<li><a href="https://github.com/MCPAQL/mcpaql-adapter/blob/develop/docs/guides/development.md">Adapter Development Guide</a> (in mcpaql-adapter repo)</li>
+<li><a href="https://github.com/MCPAQL/mcpaql-adapter/blob/develop/docs/architecture/runtime.md">Universal Adapter Runtime</a> (in mcpaql-adapter repo)</li>
 <li>GitHub Issue: <a href="https://github.com/MCPAQL/spec/issues/61">#61</a></li>
 </ul>
 

--- a/public/spec/adapter/generator.html
+++ b/public/spec/adapter/generator.html
@@ -50,10 +50,10 @@
   <ul><li><a href="../security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="../security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="../security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Features</h3>
-  <ul><li><a href="../features/collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
+  <ul><li><a href="../features/aggregations.html">MCP-AQL Aggregations</a></li><li><a href="../features/collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="../features/computed-fields.html">MCP-AQL Computed Fields</a></li><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/relationship-queries.html">MCP-AQL Relationship Queries</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Guides</h3>
-  <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
+  <ul><li><a href="../guides/cross-domain-implementation.html">Cross-Domain Implementation Guide</a></li><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
   <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li><li><a href="../repo/CHANGELOG.html">Changelog</a></li></ul>
@@ -125,24 +125,24 @@
 <h3 id="12-generator-types">1.2 Generator Types</h3>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Type</th>
 <th>Description</th>
 <th>Use Case</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><strong>Schema-to-Code</strong></td>
 <td>Generates adapter source code from schema</td>
 <td>Development workflow</td>
 </tr>
-<tr>
+<tr class="even">
 <td><strong>Schema-to-Runtime</strong></td>
 <td>Generates runtime configuration</td>
 <td>Dynamic adapter loading</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><strong>Code-to-Schema</strong></td>
 <td>Extracts schema from existing adapter</td>
 <td>Migration, documentation</td>
@@ -267,34 +267,34 @@
 <p><strong>Validation error codes:</strong></p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Validation</th>
 <th>Error Code</th>
 <th>Example Message</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td>Missing required field</td>
 <td><code>SCHEMA_MISSING_FIELD</code></td>
 <td>"Required field 'adapter.name' is missing"</td>
 </tr>
-<tr>
+<tr class="even">
 <td>Type mismatch</td>
 <td><code>SCHEMA_INVALID_TYPE</code></td>
 <td>"Field 'params[0].required' expected boolean, got string"</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>Unresolved reference</td>
 <td><code>SCHEMA_UNRESOLVED_REF</code></td>
 <td>"Type reference 'Repository' not found in types"</td>
 </tr>
-<tr>
+<tr class="even">
 <td>Duplicate name</td>
 <td><code>SCHEMA_DUPLICATE_NAME</code></td>
 <td>"Operation 'get_user' defined multiple times in read endpoint"</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>Invalid naming</td>
 <td><code>SCHEMA_INVALID_NAME</code></td>
 <td>"Parameter name 'userName' must be snake_case (try 'user_name')"</td>
@@ -419,24 +419,24 @@
 <p><strong>Evolution strategy:</strong></p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Change Type</th>
 <th>Version Increment</th>
 <th>Example</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td>Breaking schema changes</td>
 <td>Major (<code>1.0</code> → <code>2.0</code>)</td>
 <td>Removing required fields, restructuring <code>endpoints</code></td>
 </tr>
-<tr>
+<tr class="even">
 <td>New optional features</td>
 <td>Minor (<code>1.0</code> → <code>1.1</code>)</td>
 <td>Adding <code>auth.config.scopes</code> field</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>Clarifications, fixes</td>
 <td>No change</td>
 <td>Documentation updates, validation improvements</td>
@@ -584,24 +584,24 @@
 <p>Generators MUST include the following licensing files:</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>File</th>
 <th>Content</th>
 <th>Notes</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><code>LICENSE</code></td>
 <td>AGPL-3.0 full text</td>
 <td>Standard AGPL-3.0 license</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>NOTICE.md</code></td>
 <td>Attribution notice</td>
 <td>Credits MCP-AQL project</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>COMMERCIAL-LICENSE.md</code></td>
 <td>Commercial options</td>
 <td>Contact information</td>
@@ -791,39 +791,39 @@
 <p>Generators SHOULD support multiple target languages:</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Language</th>
 <th>Status</th>
 <th>Template ID</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td>TypeScript</td>
 <td>Required</td>
 <td><code>typescript</code></td>
 </tr>
-<tr>
+<tr class="even">
 <td>JavaScript</td>
 <td>Required</td>
 <td><code>javascript</code></td>
 </tr>
-<tr>
+<tr class="odd">
 <td>Python</td>
 <td>Recommended</td>
 <td><code>python</code></td>
 </tr>
-<tr>
+<tr class="even">
 <td>Go</td>
 <td>Optional</td>
 <td><code>go</code></td>
 </tr>
-<tr>
+<tr class="odd">
 <td>Rust</td>
 <td>Optional</td>
 <td><code>rust</code></td>
 </tr>
-<tr>
+<tr class="even">
 <td>Java</td>
 <td>Optional</td>
 <td><code>java</code></td>
@@ -879,34 +879,34 @@
 <p>Generators MAY support template customization:</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Option</th>
 <th>Description</th>
 <th>Default</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><code>strict_mode</code></td>
 <td>Enable strict type checking</td>
 <td><code>true</code></td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>include_tests</code></td>
 <td>Generate test stubs</td>
 <td><code>true</code></td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>inline_docs</code></td>
 <td>Include JSDoc/docstrings</td>
 <td><code>true</code></td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>error_handling</code></td>
 <td>Error handling style</td>
 <td><code>structured</code></td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>http_client</code></td>
 <td>HTTP client library</td>
 <td>Language default</td>
@@ -921,19 +921,19 @@
 <h3 id="72-required-arguments">7.2 Required Arguments</h3>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Argument</th>
 <th>Description</th>
 <th>Example</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><code>--schema</code>, <code>-s</code></td>
 <td>Path to the input schema file (YAML or JSON)</td>
 <td><code>--schema adapter.yaml</code></td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>--target</code>, <code>-t</code></td>
 <td>Target language/platform</td>
 <td><code>--target typescript</code></td>
@@ -943,54 +943,54 @@
 <h3 id="73-optional-arguments">7.3 Optional Arguments</h3>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Argument</th>
 <th>Description</th>
 <th>Default</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><code>--output</code>, <code>-o</code></td>
 <td>Output directory for generated code</td>
 <td><code>./generated</code></td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>--config</code>, <code>-c</code></td>
 <td>Path to generator configuration file</td>
 <td>None</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>--output-format</code></td>
 <td>Output format (<code>human</code> or <code>json</code>)</td>
 <td><code>human</code></td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>--strict</code></td>
 <td>Enable strict validation mode (fail on warnings, enforce all optional constraints)</td>
 <td><code>false</code></td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>--dry-run</code></td>
 <td>Validate schema without generating output</td>
 <td><code>false</code></td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>--verbose</code>, <code>-v</code></td>
 <td>Enable verbose output</td>
 <td><code>false</code></td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>--quiet</code>, <code>-q</code></td>
 <td>Suppress non-error output</td>
 <td><code>false</code></td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>--version</code></td>
 <td>Print generator version and exit</td>
 <td>-</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>--help</code>, <code>-h</code></td>
 <td>Print help message and exit</td>
 <td>-</td>
@@ -1006,39 +1006,39 @@
 <p>Generators MUST use consistent exit codes:</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Code</th>
 <th>Meaning</th>
 <th>Description</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><code>0</code></td>
 <td>Success</td>
 <td>Generation completed successfully</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>1</code></td>
 <td>Internal error</td>
 <td>Unexpected error (assertion failures, uncaught exceptions)</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>2</code></td>
 <td>Schema validation error</td>
 <td>Input schema is invalid</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>3</code></td>
 <td>Configuration error</td>
 <td>Invalid generator configuration</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>4</code></td>
 <td>I/O error</td>
 <td>File read/write failure</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>5</code></td>
 <td>Template error</td>
 <td>Language template processing failed</td>
@@ -1120,8 +1120,12 @@
 </ol>
 <h3 id="83-conformance-testing">8.3 Conformance Testing</h3>
 <p>Generators SHOULD include conformance test generation:</p>
-<div class="sourceCode" id="cb21"><pre class="sourceCode bash"><code class="sourceCode bash"><span id="cb21-1"><a href="#cb21-1" aria-hidden="true" tabindex="-1"></a><span class="co"># Run conformance tests on generated adapter</span></span>
-<span id="cb21-2"><a href="#cb21-2" aria-hidden="true" tabindex="-1"></a><span class="ex">mcpaql-conformance</span> test ./generated-adapter</span></code></pre></div>
+<div class="sourceCode" id="cb21"><pre class="sourceCode bash"><code class="sourceCode bash"><span id="cb21-1"><a href="#cb21-1" aria-hidden="true" tabindex="-1"></a><span class="co"># Export fixture evidence alongside the adapter using the generator&#39;s own tooling</span></span>
+<span id="cb21-2"><a href="#cb21-2" aria-hidden="true" tabindex="-1"></a><span class="ex">node</span> ./generated-adapter/scripts/export-conformance-evidence.mjs <span class="op">&gt;</span> ./generated-adapter/conformance/reference.json</span>
+<span id="cb21-3"><a href="#cb21-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb21-4"><a href="#cb21-4" aria-hidden="true" tabindex="-1"></a><span class="co"># Run conformance tests on generated evidence</span></span>
+<span id="cb21-5"><a href="#cb21-5" aria-hidden="true" tabindex="-1"></a><span class="ex">node</span> scripts/run-conformance-tests.mjs test ./generated-adapter/conformance/reference.json <span class="at">--level</span> 1</span></code></pre></div>
+<p><code>export-conformance-evidence.mjs</code> is illustrative here: generators SHOULD provide an equivalent export step, but the exact script name and packaging are implementation-defined.</p>
 <p>See <a href="../conformance-testing.html">Conformance Testing Specification</a> for test requirements.</p>
 <hr />
 <h2 id="references">References</h2>

--- a/public/spec/adapter/rate-limiting.html
+++ b/public/spec/adapter/rate-limiting.html
@@ -50,10 +50,10 @@
   <ul><li><a href="../security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="../security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="../security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Features</h3>
-  <ul><li><a href="../features/collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
+  <ul><li><a href="../features/aggregations.html">MCP-AQL Aggregations</a></li><li><a href="../features/collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="../features/computed-fields.html">MCP-AQL Computed Fields</a></li><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/relationship-queries.html">MCP-AQL Relationship Queries</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Guides</h3>
-  <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
+  <ul><li><a href="../guides/cross-domain-implementation.html">Cross-Domain Implementation Guide</a></li><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
   <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li><li><a href="../repo/CHANGELOG.html">Changelog</a></li></ul>
@@ -323,24 +323,24 @@
 <h3 id="32-threshold-behaviors">3.2 Threshold Behaviors</h3>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Threshold</th>
 <th>Behavior</th>
 <th>User Experience</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><code>warn</code></td>
 <td>Log warning, continue</td>
 <td>Notification displayed</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>pause</code></td>
 <td>Require confirmation</td>
 <td>"Continue?" prompt</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>hard_stop</code></td>
 <td>Block all requests</td>
 <td>Error response</td>
@@ -474,29 +474,29 @@
 <h3 id="51-rate-limit-error-codes">5.1 Rate Limit Error Codes</h3>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Code</th>
 <th>Description</th>
 <th>Recovery</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><code>RATE_LIMIT_EXCEEDED</code></td>
 <td>Target API rate limit reached</td>
 <td>Wait for reset</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>RATE_LIMIT_QUOTA_PAUSE</code></td>
 <td>User quota pause threshold</td>
 <td>Confirm to continue</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>RATE_LIMIT_QUOTA_EXHAUSTED</code></td>
 <td>User quota hard stop</td>
 <td>Wait for reset</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>RATE_LIMIT_QUOTA_WARNING</code></td>
 <td>Approaching limit (in warnings)</td>
 <td>Consider slowing</td>
@@ -573,25 +573,25 @@
 <h3 id="63-status-values">6.3 Status Values</h3>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Status</th>
 <th>Meaning</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><code>ok</code></td>
 <td>Below warn threshold</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>warn</code></td>
 <td>Above warn, below pause</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>paused</code></td>
 <td>At pause threshold, confirmation required</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>exhausted</code></td>
 <td>At hard stop, requests blocked</td>
 </tr>

--- a/public/spec/adapter/trust-levels.html
+++ b/public/spec/adapter/trust-levels.html
@@ -50,10 +50,10 @@
   <ul><li><a href="../security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="../security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="../security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Features</h3>
-  <ul><li><a href="../features/collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
+  <ul><li><a href="../features/aggregations.html">MCP-AQL Aggregations</a></li><li><a href="../features/collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="../features/computed-fields.html">MCP-AQL Computed Fields</a></li><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/relationship-queries.html">MCP-AQL Relationship Queries</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Guides</h3>
-  <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
+  <ul><li><a href="../guides/cross-domain-implementation.html">Cross-Domain Implementation Guide</a></li><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
   <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li><li><a href="../repo/CHANGELOG.html">Changelog</a></li></ul>
@@ -148,34 +148,34 @@
 <h3 id="21-trust-level-values">2.1 Trust Level Values</h3>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Level</th>
 <th>Value</th>
 <th>Description</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td>Untested</td>
 <td><code>untested</code></td>
 <td>Newly created, no validation performed</td>
 </tr>
-<tr>
+<tr class="even">
 <td>Generated</td>
 <td><code>generated</code></td>
 <td>Programmatically generated, basic schema validation passed</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>Validated</td>
 <td><code>validated</code></td>
 <td>Passed programmatic test harness</td>
 </tr>
-<tr>
+<tr class="even">
 <td>Community Reviewed</td>
 <td><code>community_reviewed</code></td>
 <td>Validated plus community vetting process</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>Certified</td>
 <td><code>certified</code></td>
 <td>Official verification by vendor or trusted authority</td>
@@ -319,34 +319,34 @@
 <p><strong>Fields:</strong></p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Field</th>
 <th>Type</th>
 <th>Description</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><code>tests_passed</code></td>
 <td>integer</td>
 <td>Number of tests that passed</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>tests_total</code></td>
 <td>integer</td>
 <td>Total number of tests executed</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>endpoints_verified</code></td>
 <td>integer</td>
 <td>Number of API endpoints tested</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>coverage_percent</code></td>
 <td>number</td>
 <td>Percentage of operations covered by tests</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>last_api_response</code></td>
 <td>string</td>
 <td>Timestamp of last successful API response</td>
@@ -369,34 +369,34 @@
 <p><strong>Promotion record fields:</strong></p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Field</th>
 <th>Type</th>
 <th>Description</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><code>from</code></td>
 <td>string</td>
 <td>Previous trust level</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>to</code></td>
 <td>string</td>
 <td>New trust level</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>at</code></td>
 <td>string</td>
 <td>ISO 8601 timestamp</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>by</code></td>
 <td>string</td>
 <td>Tool or person identifier</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>reason</code></td>
 <td>string</td>
 <td>Optional explanation</td>
@@ -417,39 +417,39 @@
 <p><strong>Certification fields:</strong></p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Field</th>
 <th>Type</th>
 <th>Description</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><code>authority</code></td>
 <td>string</td>
 <td>Certifying organization name</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>signature</code></td>
 <td>string</td>
 <td>Cryptographic signature (base64)</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>certificate_id</code></td>
 <td>string</td>
 <td>Unique certificate identifier</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>issued_at</code></td>
 <td>string</td>
 <td>When certification was granted</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>expires_at</code></td>
 <td>string</td>
 <td>When certification expires</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>scope</code></td>
 <td>array</td>
 <td>What the certification covers</td>
@@ -465,29 +465,29 @@
 <h3 id="42-promotion-triggers">4.2 Promotion Triggers</h3>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Transition</th>
 <th>Trigger</th>
 <th>Requirements</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td>untested → generated</td>
 <td>Schema validation</td>
 <td>YAML parses, required fields present, valid structure</td>
 </tr>
-<tr>
+<tr class="even">
 <td>generated → validated</td>
 <td>Test harness pass</td>
 <td>All read ops succeed, representative create/update tested</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>validated → community_reviewed</td>
 <td>Community review</td>
 <td>N reviewers approve, no security flags</td>
 </tr>
-<tr>
+<tr class="even">
 <td>community_reviewed → certified</td>
 <td>Vendor attestation</td>
 <td>Signed certificate from recognized authority</td>
@@ -518,25 +518,25 @@
 <p>Adapters SHOULD be periodically re-validated to maintain trust level:</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Trust Level</th>
 <th>Recommended Re-validation</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td>generated</td>
 <td>On each use (schema check)</td>
 </tr>
-<tr>
+<tr class="even">
 <td>validated</td>
 <td>Weekly or on API version change</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>community_reviewed</td>
 <td>Monthly</td>
 </tr>
-<tr>
+<tr class="even">
 <td>certified</td>
 <td>Per certification terms</td>
 </tr>
@@ -548,33 +548,33 @@
 <p>Systems SHOULD enforce minimum trust levels for operations based on risk:</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Operation Category</th>
 <th>Minimum Trust Level</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td>Introspection</td>
 <td><code>untested</code></td>
 </tr>
-<tr>
+<tr class="even">
 <td>Read operations</td>
 <td><code>generated</code></td>
 </tr>
-<tr>
+<tr class="odd">
 <td>Safe create operations</td>
 <td><code>validated</code></td>
 </tr>
-<tr>
+<tr class="even">
 <td>Update operations</td>
 <td><code>validated</code></td>
 </tr>
-<tr>
+<tr class="odd">
 <td>Delete operations</td>
 <td><code>community_reviewed</code></td>
 </tr>
-<tr>
+<tr class="even">
 <td>Dangerous operations</td>
 <td><code>certified</code></td>
 </tr>

--- a/public/spec/adr/ADR-001-crude-pattern.html
+++ b/public/spec/adr/ADR-001-crude-pattern.html
@@ -50,10 +50,10 @@
   <ul><li><a href="../security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="../security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="../security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Features</h3>
-  <ul><li><a href="../features/collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
+  <ul><li><a href="../features/aggregations.html">MCP-AQL Aggregations</a></li><li><a href="../features/collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="../features/computed-fields.html">MCP-AQL Computed Fields</a></li><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/relationship-queries.html">MCP-AQL Relationship Queries</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Guides</h3>
-  <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
+  <ul><li><a href="../guides/cross-domain-implementation.html">Cross-Domain Implementation Guide</a></li><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
   <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li><li><a href="../repo/CHANGELOG.html">Changelog</a></li></ul>
@@ -114,29 +114,29 @@
 <p>Traditional CRUD (Create, Read, Update, Delete) operations are well-suited for managing resource definitions and state. However, MCP-AQL needs to support runtime execution operations that have fundamentally different characteristics:</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Characteristic</th>
 <th>CRUD Operations</th>
 <th>Execution Operations</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td>Idempotency</td>
 <td>Generally idempotent</td>
 <td>Non-idempotent</td>
 </tr>
-<tr>
+<tr class="even">
 <td>Target</td>
 <td>Element definitions</td>
 <td>Runtime state</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>Lifecycle</td>
 <td>Discrete operations</td>
 <td>Stateful lifecycle</td>
 </tr>
-<tr>
+<tr class="even">
 <td>Side effects</td>
 <td>Predictable</td>
 <td>Unbounded</td>

--- a/public/spec/adr/ADR-002-graphql-style-input.html
+++ b/public/spec/adr/ADR-002-graphql-style-input.html
@@ -50,10 +50,10 @@
   <ul><li><a href="../security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="../security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="../security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Features</h3>
-  <ul><li><a href="../features/collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
+  <ul><li><a href="../features/aggregations.html">MCP-AQL Aggregations</a></li><li><a href="../features/collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="../features/computed-fields.html">MCP-AQL Computed Fields</a></li><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/relationship-queries.html">MCP-AQL Relationship Queries</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Guides</h3>
-  <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
+  <ul><li><a href="../guides/cross-domain-implementation.html">Cross-Domain Implementation Guide</a></li><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
   <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li><li><a href="../repo/CHANGELOG.html">Changelog</a></li></ul>

--- a/public/spec/adr/ADR-003-snake-case-parameters.html
+++ b/public/spec/adr/ADR-003-snake-case-parameters.html
@@ -50,10 +50,10 @@
   <ul><li><a href="../security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="../security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="../security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Features</h3>
-  <ul><li><a href="../features/collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
+  <ul><li><a href="../features/aggregations.html">MCP-AQL Aggregations</a></li><li><a href="../features/collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="../features/computed-fields.html">MCP-AQL Computed Fields</a></li><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/relationship-queries.html">MCP-AQL Relationship Queries</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Guides</h3>
-  <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
+  <ul><li><a href="../guides/cross-domain-implementation.html">Cross-Domain Implementation Guide</a></li><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
   <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li><li><a href="../repo/CHANGELOG.html">Changelog</a></li></ul>

--- a/public/spec/adr/ADR-004-schema-driven-operations.html
+++ b/public/spec/adr/ADR-004-schema-driven-operations.html
@@ -50,10 +50,10 @@
   <ul><li><a href="../security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="../security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="../security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Features</h3>
-  <ul><li><a href="../features/collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
+  <ul><li><a href="../features/aggregations.html">MCP-AQL Aggregations</a></li><li><a href="../features/collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="../features/computed-fields.html">MCP-AQL Computed Fields</a></li><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/relationship-queries.html">MCP-AQL Relationship Queries</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Guides</h3>
-  <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
+  <ul><li><a href="../guides/cross-domain-implementation.html">Cross-Domain Implementation Guide</a></li><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
   <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li><li><a href="../repo/CHANGELOG.html">Changelog</a></li></ul>

--- a/public/spec/adr/ADR-005-introspection-system.html
+++ b/public/spec/adr/ADR-005-introspection-system.html
@@ -50,10 +50,10 @@
   <ul><li><a href="../security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="../security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="../security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Features</h3>
-  <ul><li><a href="../features/collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
+  <ul><li><a href="../features/aggregations.html">MCP-AQL Aggregations</a></li><li><a href="../features/collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="../features/computed-fields.html">MCP-AQL Computed Fields</a></li><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/relationship-queries.html">MCP-AQL Relationship Queries</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Guides</h3>
-  <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
+  <ul><li><a href="../guides/cross-domain-implementation.html">Cross-Domain Implementation Guide</a></li><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
   <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li><li><a href="../repo/CHANGELOG.html">Changelog</a></li></ul>

--- a/public/spec/adr/ADR-006-discriminated-responses.html
+++ b/public/spec/adr/ADR-006-discriminated-responses.html
@@ -50,10 +50,10 @@
   <ul><li><a href="../security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="../security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="../security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Features</h3>
-  <ul><li><a href="../features/collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
+  <ul><li><a href="../features/aggregations.html">MCP-AQL Aggregations</a></li><li><a href="../features/collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="../features/computed-fields.html">MCP-AQL Computed Fields</a></li><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/relationship-queries.html">MCP-AQL Relationship Queries</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Guides</h3>
-  <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
+  <ul><li><a href="../guides/cross-domain-implementation.html">Cross-Domain Implementation Guide</a></li><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
   <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li><li><a href="../repo/CHANGELOG.html">Changelog</a></li></ul>

--- a/public/spec/adr/README.html
+++ b/public/spec/adr/README.html
@@ -50,10 +50,10 @@
   <ul><li><a href="../security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="../security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="../security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Features</h3>
-  <ul><li><a href="../features/collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
+  <ul><li><a href="../features/aggregations.html">MCP-AQL Aggregations</a></li><li><a href="../features/collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="../features/computed-fields.html">MCP-AQL Computed Fields</a></li><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/relationship-queries.html">MCP-AQL Relationship Queries</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Guides</h3>
-  <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
+  <ul><li><a href="../guides/cross-domain-implementation.html">Cross-Domain Implementation Guide</a></li><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
   <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li><li><a href="../repo/CHANGELOG.html">Changelog</a></li></ul>

--- a/public/spec/adr/index.html
+++ b/public/spec/adr/index.html
@@ -50,10 +50,10 @@
   <ul><li><a href="../security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="../security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="../security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Features</h3>
-  <ul><li><a href="../features/collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
+  <ul><li><a href="../features/aggregations.html">MCP-AQL Aggregations</a></li><li><a href="../features/collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="../features/computed-fields.html">MCP-AQL Computed Fields</a></li><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/relationship-queries.html">MCP-AQL Relationship Queries</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Guides</h3>
-  <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
+  <ul><li><a href="../guides/cross-domain-implementation.html">Cross-Domain Implementation Guide</a></li><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
   <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li><li><a href="../repo/CHANGELOG.html">Changelog</a></li></ul>
@@ -113,7 +113,7 @@
 <h2 id="adr-index">ADR Index</h2>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>ADR</th>
 <th>Title</th>
 <th>Status</th>
@@ -121,37 +121,37 @@
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><a href="ADR-001-crude-pattern.html">ADR-001</a></td>
 <td>CRUDE Pattern</td>
 <td>Accepted</td>
 <td>Extends CRUD with Execute endpoint for runtime operations</td>
 </tr>
-<tr>
+<tr class="even">
 <td><a href="ADR-002-graphql-style-input.html">ADR-002</a></td>
 <td>GraphQL-Style Input Objects</td>
 <td>Accepted</td>
 <td>Nested <code>input</code> objects for update operations</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><a href="ADR-003-snake-case-parameters.html">ADR-003</a></td>
 <td>snake_case Parameters</td>
 <td>Accepted</td>
 <td>Standardizes on snake_case for LLM compatibility</td>
 </tr>
-<tr>
+<tr class="even">
 <td><a href="ADR-004-schema-driven-operations.html">ADR-004</a></td>
 <td>Schema-Driven Operations</td>
 <td>Accepted</td>
 <td>Declarative operation definitions as single source of truth</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><a href="ADR-005-introspection-system.html">ADR-005</a></td>
 <td>Introspection System</td>
 <td>Accepted</td>
 <td>GraphQL-style runtime discovery via <code>introspect</code> operation</td>
 </tr>
-<tr>
+<tr class="even">
 <td><a href="ADR-006-discriminated-responses.html">ADR-006</a></td>
 <td>Discriminated Responses</td>
 <td>Accepted</td>

--- a/public/spec/architecture/README.html
+++ b/public/spec/architecture/README.html
@@ -50,10 +50,10 @@
   <ul><li><a href="../security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="../security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="../security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Features</h3>
-  <ul><li><a href="../features/collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
+  <ul><li><a href="../features/aggregations.html">MCP-AQL Aggregations</a></li><li><a href="../features/collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="../features/computed-fields.html">MCP-AQL Computed Fields</a></li><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/relationship-queries.html">MCP-AQL Relationship Queries</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Guides</h3>
-  <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
+  <ul><li><a href="../guides/cross-domain-implementation.html">Cross-Domain Implementation Guide</a></li><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
   <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li><li><a href="../repo/CHANGELOG.html">Changelog</a></li></ul>
@@ -100,27 +100,27 @@
 <h2 id="moved-documents">Moved Documents</h2>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Former Location</th>
 <th>New Location</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><code>overview.md</code></td>
-<td><a href="../../adapter-reference/architecture/overview.html">mcpaql-adapter/docs/architecture/overview.md</a></td>
+<td><a href="https://github.com/MCPAQL/mcpaql-adapter/blob/develop/docs/architecture/overview.md">mcpaql-adapter/docs/architecture/overview.md</a></td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>adapter-runtime.md</code></td>
-<td><a href="../../adapter-reference/architecture/runtime.html">mcpaql-adapter/docs/architecture/runtime.md</a></td>
+<td><a href="https://github.com/MCPAQL/mcpaql-adapter/blob/develop/docs/architecture/runtime.md">mcpaql-adapter/docs/architecture/runtime.md</a></td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>plugin-interface.md</code></td>
-<td>Split: normative contracts in <a href="../plugin-contracts.html">plugin-contracts.md</a>, implementation in <a href="../../adapter-reference/architecture/plugin-system.html">mcpaql-adapter/docs/architecture/plugin-system.md</a></td>
+<td>Split: normative contracts in <a href="../plugin-contracts.html">plugin-contracts.md</a>, implementation in <a href="https://github.com/MCPAQL/mcpaql-adapter/blob/develop/docs/architecture/plugin-system.md">mcpaql-adapter/docs/architecture/plugin-system.md</a></td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>schema-driven-dispatch.md</code></td>
-<td><a href="../../adapter-reference/architecture/dispatch.html">mcpaql-adapter/docs/architecture/dispatch.md</a></td>
+<td><a href="https://github.com/MCPAQL/mcpaql-adapter/blob/develop/docs/architecture/dispatch.md">mcpaql-adapter/docs/architecture/dispatch.md</a></td>
 </tr>
 </tbody>
 </table>

--- a/public/spec/conformance-testing.html
+++ b/public/spec/conformance-testing.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="description" content="Document Status: This document is an informative conformance framework specification aligned to the normative protocol requirements in docs/versions/v1.0.0-draft.md. Implementation Status: The full mcpaql-conformance run">
+  <meta name="description" content="Document Status: This document is an informative conformance framework specification aligned to the normative protocol requirements in docs/versions/v1.0.0-draft.md. Implementation Status: This repository now includes a ">
   <title>MCP-AQL Spec | MCP-AQL Conformance Testing Specification</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -50,10 +50,10 @@
   <ul><li><a href="security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Features</h3>
-  <ul><li><a href="features/collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="features/field-selection.html">Field Selection Specification</a></li><li><a href="features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="features/warnings.html">Warnings Array Specification</a></li></ul>
+  <ul><li><a href="features/aggregations.html">MCP-AQL Aggregations</a></li><li><a href="features/collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="features/computed-fields.html">MCP-AQL Computed Fields</a></li><li><a href="features/field-selection.html">Field Selection Specification</a></li><li><a href="features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="features/relationship-queries.html">MCP-AQL Relationship Queries</a></li><li><a href="features/warnings.html">Warnings Array Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Guides</h3>
-  <ul><li><a href="guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="guides/README.html">Developer Guides</a></li></ul>
+  <ul><li><a href="guides/cross-domain-implementation.html">Cross-Domain Implementation Guide</a></li><li><a href="guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
   <ul><li><a href="process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="process/versioning.html">Versioning Strategy</a></li><li><a href="repo/CHANGELOG.html">Changelog</a></li></ul>
@@ -84,7 +84,7 @@
           <div class="hero-inner">
             <span class="status-pill">REPO-SYNCED SPEC DOC</span>
             <h1>MCP-AQL Conformance Testing Specification</h1>
-            <p class="lede">Document Status: This document is an informative conformance framework specification aligned to the normative protocol requirements in docs/versions/v1.0.0-draft.md. Implementation Status: The full mcpaql-conformance run</p>
+            <p class="lede">Document Status: This document is an informative conformance framework specification aligned to the normative protocol requirements in docs/versions/v1.0.0-draft.md. Implementation Status: This repository now includes a </p>
             <div class="spec-meta"><span class="state-chip live">Support document</span><span class="state-chip pending">Draft</span><span class="state-chip">1.0.0-draft</span><span class="state-chip">2026-04-15</span></div>
             <p class="spec-source">Source: <a href="https://github.com/MCPAQL/spec/blob/main/docs/conformance-testing.md">spec/docs/conformance-testing.md</a></p>
             <div class="hero-actions">
@@ -112,7 +112,7 @@
             <p><strong>Version:</strong> 1.0.0-draft <strong>Status:</strong> Draft <strong>Last Updated:</strong> 2026-04-15</p>
 <blockquote>
 <p><strong>Document Status:</strong> This document is an <strong>informative conformance framework specification</strong> aligned to the normative protocol requirements in <code>docs/versions/v1.0.0-draft.md</code>.</p>
-<p><strong>Implementation Status:</strong> The full <code>mcpaql-conformance</code> runner defined here is not yet published in this repository. Current implemented checks are schema/example validation in <code>scripts/validate-schema-examples.mjs</code>.</p>
+<p><strong>Implementation Status:</strong> This repository now includes a fixture-driven prototype runner in <code>scripts/run-conformance-tests.mjs</code> plus reference evidence bundles under <code>tests/conformance/</code>. A future packaged <code>mcpaql-conformance</code> tool may add live adapter execution on top of this baseline.</p>
 </blockquote>
 <h2 id="abstract">Abstract</h2>
 <p>This document specifies the conformance testing requirements for MCP-AQL implementations. It defines conformance levels, test categories, pass/fail criteria, and evaluation methodologies including LLM-based semantic evaluation.</p>
@@ -125,30 +125,31 @@
 <li>How to evaluate test results</li>
 <li>How to report conformance levels</li>
 </ul>
+<p>The repository implementation currently validates <strong>evidence bundles</strong> instead of probing live adapters over the network. Each bundle captures introspection responses, accepted parameter sets, representative success and failure results, and optional semantic-discoverability examples. This keeps the spec repo reviewable and deterministic while a future external runner grows into direct adapter execution.</p>
 <h3 id="12-terminology">1.2 Terminology</h3>
 <p>The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in <a href="https://www.rfc-editor.org/rfc/rfc2119">RFC 2119</a>.</p>
 <h3 id="13-test-result-classifications">1.3 Test Result Classifications</h3>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Result</th>
 <th>Meaning</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><strong>PASS</strong></td>
 <td>Test criteria fully satisfied</td>
 </tr>
-<tr>
+<tr class="even">
 <td><strong>FAIL</strong></td>
 <td>Test criteria not met, conformance blocked</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><strong>WARN</strong></td>
 <td>Test criteria partially met, conformance not blocked</td>
 </tr>
-<tr>
+<tr class="even">
 <td><strong>SKIP</strong></td>
 <td>Test not applicable to this implementation</td>
 </tr>
@@ -161,33 +162,33 @@
 <p><strong>Requirements:</strong></p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Requirement</th>
 <th>Description</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td>Introspect (operations)</td>
 <td><code>introspect</code> operation with <code>query: "operations"</code> implemented</td>
 </tr>
-<tr>
+<tr class="even">
 <td>Introspect (types)</td>
 <td><code>introspect</code> operation with <code>query: "types"</code> implemented</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>Endpoint routing</td>
-<td>Operations routed to correct CRUDE endpoint</td>
+<td>Operations routed to the correct documented semantic endpoint family in semantic endpoint mode</td>
 </tr>
-<tr>
+<tr class="even">
 <td>Response format</td>
 <td>Discriminated union responses (<code>{ success, data }</code> or <code>{ success, error }</code>)</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>Error handling</td>
 <td>Structured error responses with code and message</td>
 </tr>
-<tr>
+<tr class="even">
 <td>Parameter naming</td>
 <td>snake_case parameter naming convention</td>
 </tr>
@@ -205,29 +206,29 @@
 <p><strong>Requirements:</strong></p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Requirement</th>
 <th>Description</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td>Level 1</td>
 <td>All Level 1 requirements</td>
 </tr>
-<tr>
+<tr class="even">
 <td>Endpoint modes</td>
-<td>Both CRUDE mode and Single-endpoint mode supported</td>
+<td><code>crude</code> semantic endpoint mode and <code>single</code> mode supported</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>Field selection</td>
 <td><code>fields</code> parameter on READ operations, with preset-name support documented where implemented</td>
 </tr>
-<tr>
+<tr class="even">
 <td>Batch operations</td>
 <td>Multi-operation batching with individual results</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>Cross-cutting params</td>
 <td>Consistent documentation for collection-query controls such as <code>query</code>, <code>filter</code>, pagination, field selection, and sorting</td>
 </tr>
@@ -236,6 +237,7 @@
 <p><strong>Test Categories Required:</strong></p>
 <ul>
 <li>All Level 1 test categories</li>
+<li>Level 2 Features (SHOULD PASS)</li>
 <li>Constraint Documentation (SHOULD PASS)</li>
 <li>Semantic Evaluation (SHOULD PASS)</li>
 </ul>
@@ -361,53 +363,58 @@ MCP-AQL Level 2 Conformant</code></pre>
 <p>The following test categories MUST pass for Level 1 conformance:</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Category</th>
 <th>Tests</th>
 <th>Rationale</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td>Introspection Fidelity</td>
-<td>2</td>
+<td>4</td>
 <td>LLMs must trust introspection</td>
 </tr>
-<tr>
+<tr class="even">
 <td>Parameter Handling</td>
-<td>3</td>
+<td>4</td>
 <td>Consistent behavior across operations</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>Error Quality</td>
-<td>2</td>
+<td>3</td>
 <td>Usable error messages</td>
 </tr>
-<tr>
+<tr class="even">
 <td>Round-Trip Integrity</td>
 <td>2</td>
 <td>Data consistency guarantee</td>
 </tr>
 </tbody>
 </table>
-<p><strong>Total MUST PASS tests:</strong> 9</p>
+<p><strong>Total MUST PASS tests:</strong> 13</p>
 <h3 id="42-should-pass-requirements">4.2 SHOULD PASS Requirements</h3>
 <p>The following test categories SHOULD pass for Level 2 conformance:</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Category</th>
 <th>Tests</th>
 <th>Rationale</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td>Constraint Documentation</td>
 <td>2</td>
 <td>Discoverable constraints</td>
 </tr>
-<tr>
+<tr class="even">
+<td>Level 2 Features</td>
+<td>3</td>
+<td>Endpoint modes, field selection, and batch operations</td>
+</tr>
+<tr class="odd">
 <td>Semantic Evaluation</td>
 <td>Per implementation</td>
 <td>LLM discoverability</td>
@@ -460,29 +467,29 @@ MCP-AQL Level 2 Conformant</code></pre>
 <h3 id="53-test-categories-requiring-semantic-evaluation">5.3 Test Categories Requiring Semantic Evaluation</h3>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Category</th>
 <th>Example Prompt</th>
 <th>Why Semantic Matters</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td>Introspection Discovery</td>
 <td>"List available operations"</td>
 <td>LLM may describe operations differently</td>
 </tr>
-<tr>
+<tr class="even">
 <td>Field Selection Discovery</td>
 <td>"Does search support field selection?"</td>
 <td>Affirmative answer may use varied phrasing</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>Error Understanding</td>
 <td>"Handle this error gracefully"</td>
 <td>Recovery strategies may vary</td>
 </tr>
-<tr>
+<tr class="even">
 <td>Operation Selection</td>
 <td>"Create an element"</td>
 <td>Correct tool choice matters more than exact call format</td>
@@ -492,14 +499,12 @@ MCP-AQL Level 2 Conformant</code></pre>
 <h3 id="54-evaluation-workflow">5.4 Evaluation Workflow</h3>
 <pre class="mermaid"><code>graph TD
     A[Run Test] --&gt; B{Tier 1 Pass?}
-    B --&gt;|Yes| C{Tier 2 Required?}
+    B --&gt;|Yes| C{Tier 2 Pass?}
     B --&gt;|No| D{Tier 2 Pass?}
-    C --&gt;|No| E[PASS]
-    C --&gt;|Yes| F{Tier 2 Pass?}
+    C --&gt;|Yes| E[PASS]
+    C --&gt;|No| F[FAIL]
     D --&gt;|Yes| G[WARN: Update patterns]
-    D --&gt;|No| H[FAIL]
-    F --&gt;|Yes| E
-    F --&gt;|No| H</code></pre>
+    D --&gt;|No| F</code></pre>
 <hr />
 <h2 id="6-reporting">6. Reporting</h2>
 <h3 id="61-conformance-report-format">6.1 Conformance Report Format</h3>
@@ -508,7 +513,7 @@ MCP-AQL Level 2 Conformant</code></pre>
 <span id="cb16-2"><a href="#cb16-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;implementation&quot;</span><span class="fu">:</span> <span class="st">&quot;example-adapter&quot;</span><span class="fu">,</span></span>
 <span id="cb16-3"><a href="#cb16-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;version&quot;</span><span class="fu">:</span> <span class="st">&quot;1.0.0&quot;</span><span class="fu">,</span></span>
 <span id="cb16-4"><a href="#cb16-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;specVersion&quot;</span><span class="fu">:</span> <span class="st">&quot;1.0.0-draft&quot;</span><span class="fu">,</span></span>
-<span id="cb16-5"><a href="#cb16-5" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;testDate&quot;</span><span class="fu">:</span> <span class="st">&quot;2026-01-29T00:00:00Z&quot;</span><span class="fu">,</span></span>
+<span id="cb16-5"><a href="#cb16-5" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;requestedLevel&quot;</span><span class="fu">:</span> <span class="dv">1</span><span class="fu">,</span></span>
 <span id="cb16-6"><a href="#cb16-6" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;conformanceLevel&quot;</span><span class="fu">:</span> <span class="dv">1</span><span class="fu">,</span></span>
 <span id="cb16-7"><a href="#cb16-7" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;summary&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
 <span id="cb16-8"><a href="#cb16-8" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;total&quot;</span><span class="fu">:</span> <span class="dv">11</span><span class="fu">,</span></span>
@@ -520,7 +525,7 @@ MCP-AQL Level 2 Conformant</code></pre>
 <span id="cb16-14"><a href="#cb16-14" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;categories&quot;</span><span class="fu">:</span> <span class="ot">[</span></span>
 <span id="cb16-15"><a href="#cb16-15" aria-hidden="true" tabindex="-1"></a>    <span class="fu">{</span></span>
 <span id="cb16-16"><a href="#cb16-16" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;Introspection Fidelity&quot;</span><span class="fu">,</span></span>
-<span id="cb16-17"><a href="#cb16-17" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;required&quot;</span><span class="fu">:</span> <span class="st">&quot;MUST&quot;</span><span class="fu">,</span></span>
+<span id="cb16-17"><a href="#cb16-17" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;required&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
 <span id="cb16-18"><a href="#cb16-18" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;result&quot;</span><span class="fu">:</span> <span class="st">&quot;PASS&quot;</span><span class="fu">,</span></span>
 <span id="cb16-19"><a href="#cb16-19" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;tests&quot;</span><span class="fu">:</span> <span class="ot">[</span></span>
 <span id="cb16-20"><a href="#cb16-20" aria-hidden="true" tabindex="-1"></a>        <span class="fu">{</span> <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;Parameter Accuracy&quot;</span><span class="fu">,</span> <span class="dt">&quot;result&quot;</span><span class="fu">:</span> <span class="st">&quot;PASS&quot;</span> <span class="fu">}</span><span class="ot">,</span></span>
@@ -540,30 +545,37 @@ MCP-AQL Level 2 Conformant</code></pre>
 <h3 id="71-cli-invocation">7.1 CLI Invocation</h3>
 <p>Conformance test runners SHOULD provide a command-line interface:</p>
 <div class="sourceCode" id="cb18"><pre class="sourceCode bash"><code class="sourceCode bash"><span id="cb18-1"><a href="#cb18-1" aria-hidden="true" tabindex="-1"></a><span class="ex">mcpaql-conformance</span> <span class="op">&lt;</span>command<span class="op">&gt;</span> <span class="pp">[</span><span class="ss">options</span><span class="pp">]</span></span></code></pre></div>
+<p>The current repository prototype is invoked as:</p>
+<div class="sourceCode" id="cb19"><pre class="sourceCode bash"><code class="sourceCode bash"><span id="cb19-1"><a href="#cb19-1" aria-hidden="true" tabindex="-1"></a><span class="ex">node</span> scripts/run-conformance-tests.mjs <span class="op">&lt;</span>command<span class="op">&gt;</span> <span class="pp">[</span><span class="ss">options</span><span class="pp">]</span></span></code></pre></div>
 <h3 id="72-commands">7.2 Commands</h3>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Command</th>
 <th>Description</th>
 <th>Example</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><code>test</code></td>
-<td>Run conformance tests against an adapter</td>
-<td><code>mcpaql-conformance test ./adapter</code></td>
+<td>Run conformance tests against a fixture evidence bundle</td>
+<td><code>node scripts/run-conformance-tests.mjs test tests/conformance/evidence/reference-level2.json --level 2</code></td>
 </tr>
-<tr>
+<tr class="even">
+<td><code>verify-fixtures</code></td>
+<td>Verify all repository reference fixtures against their expected exit codes</td>
+<td><code>node scripts/run-conformance-tests.mjs verify-fixtures</code></td>
+</tr>
+<tr class="odd">
 <td><code>report</code></td>
-<td>Generate formatted report from test results file</td>
-<td><code>mcpaql-conformance report ./results.json</code></td>
+<td>Generate formatted output from a JSON results file</td>
+<td><code>node scripts/run-conformance-tests.mjs report ./results.json --format markdown</code></td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>version</code></td>
 <td>Print tool version</td>
-<td><code>mcpaql-conformance version</code></td>
+<td><code>node scripts/run-conformance-tests.mjs version</code></td>
 </tr>
 </tbody>
 </table>
@@ -571,110 +583,105 @@ MCP-AQL Level 2 Conformant</code></pre>
 <h3 id="73-test-command-options">7.3 Test Command Options</h3>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Option</th>
 <th>Description</th>
 <th>Default</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><code>--level</code>, <code>-l</code></td>
 <td>Conformance level to test (1 or 2)</td>
 <td><code>1</code></td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>--output</code>, <code>-o</code></td>
 <td>Output file for results</td>
 <td>stdout</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>--format</code>, <code>-f</code></td>
 <td>Output format (<code>json</code>, <code>text</code>, <code>markdown</code>)</td>
 <td><code>text</code></td>
 </tr>
-<tr>
-<td><code>--verbose</code>, <code>-v</code></td>
-<td>Enable verbose output</td>
-<td><code>false</code></td>
-</tr>
-<tr>
+<tr class="even">
 <td><code>--tier</code></td>
 <td>Evaluation tier (<code>1</code>, <code>2</code>, <code>both</code>)</td>
 <td><code>both</code></td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>--category</code>, <code>-c</code></td>
 <td>Run specific test category only</td>
 <td>All</td>
 </tr>
-<tr>
-<td><code>--timeout</code></td>
-<td>Test timeout in seconds</td>
-<td><code>30</code></td>
-</tr>
 </tbody>
 </table>
+<p><code>--tier 2</code> and <code>--tier both</code> currently produce the same semantic-evaluation behavior. The runner reserves the distinction for future live-adapter or split-tier expansion.</p>
 <h3 id="74-exit-codes">7.4 Exit Codes</h3>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Code</th>
 <th>Meaning</th>
 <th>Description</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><code>0</code></td>
 <td>All tests passed</td>
 <td>Conformance achieved at requested level</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>1</code></td>
 <td>Tests failed</td>
 <td>One or more MUST PASS tests failed</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>2</code></td>
 <td>Tests warned</td>
 <td>All MUST PASS passed, but SHOULD PASS tests warned</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>3</code></td>
 <td>Configuration error</td>
-<td>Invalid adapter path or configuration</td>
-</tr>
-<tr>
-<td><code>4</code></td>
-<td>Timeout</td>
-<td>Tests exceeded timeout limit</td>
-</tr>
-<tr>
-<td><code>5</code></td>
-<td>Internal error</td>
-<td>Unexpected error in test runner</td>
+<td>Invalid fixture/report path, malformed JSON, unknown command, or invalid report input</td>
 </tr>
 </tbody>
 </table>
 <h3 id="75-example-usage">7.5 Example Usage</h3>
 <p><strong>Run Level 1 conformance tests:</strong></p>
-<div class="sourceCode" id="cb19"><pre class="sourceCode bash"><code class="sourceCode bash"><span id="cb19-1"><a href="#cb19-1" aria-hidden="true" tabindex="-1"></a><span class="ex">mcpaql-conformance</span> test ./generated-adapter <span class="at">--level</span> 1</span></code></pre></div>
+<div class="sourceCode" id="cb20"><pre class="sourceCode bash"><code class="sourceCode bash"><span id="cb20-1"><a href="#cb20-1" aria-hidden="true" tabindex="-1"></a><span class="ex">node</span> scripts/run-conformance-tests.mjs test <span class="dt">\</span></span>
+<span id="cb20-2"><a href="#cb20-2" aria-hidden="true" tabindex="-1"></a>  tests/conformance/evidence/reference-level1.json <span class="dt">\</span></span>
+<span id="cb20-3"><a href="#cb20-3" aria-hidden="true" tabindex="-1"></a>  <span class="at">--level</span> 1</span></code></pre></div>
 <p><strong>Run Level 2 tests with JSON output:</strong></p>
-<div class="sourceCode" id="cb20"><pre class="sourceCode bash"><code class="sourceCode bash"><span id="cb20-1"><a href="#cb20-1" aria-hidden="true" tabindex="-1"></a><span class="ex">mcpaql-conformance</span> test ./adapter <span class="at">--level</span> 2 <span class="at">--format</span> json <span class="at">--output</span> results.json</span></code></pre></div>
+<div class="sourceCode" id="cb21"><pre class="sourceCode bash"><code class="sourceCode bash"><span id="cb21-1"><a href="#cb21-1" aria-hidden="true" tabindex="-1"></a><span class="ex">node</span> scripts/run-conformance-tests.mjs test <span class="dt">\</span></span>
+<span id="cb21-2"><a href="#cb21-2" aria-hidden="true" tabindex="-1"></a>  tests/conformance/evidence/reference-level2.json <span class="dt">\</span></span>
+<span id="cb21-3"><a href="#cb21-3" aria-hidden="true" tabindex="-1"></a>  <span class="at">--level</span> 2 <span class="dt">\</span></span>
+<span id="cb21-4"><a href="#cb21-4" aria-hidden="true" tabindex="-1"></a>  <span class="at">--format</span> json <span class="dt">\</span></span>
+<span id="cb21-5"><a href="#cb21-5" aria-hidden="true" tabindex="-1"></a>  <span class="at">--output</span> results.json</span></code></pre></div>
 <p><strong>Run specific test category:</strong></p>
-<div class="sourceCode" id="cb21"><pre class="sourceCode bash"><code class="sourceCode bash"><span id="cb21-1"><a href="#cb21-1" aria-hidden="true" tabindex="-1"></a><span class="ex">mcpaql-conformance</span> test ./adapter <span class="at">--category</span> <span class="st">&quot;Introspection Fidelity&quot;</span></span></code></pre></div>
-<p><strong>Verbose output with Tier 2 semantic evaluation:</strong></p>
-<div class="sourceCode" id="cb22"><pre class="sourceCode bash"><code class="sourceCode bash"><span id="cb22-1"><a href="#cb22-1" aria-hidden="true" tabindex="-1"></a><span class="ex">mcpaql-conformance</span> test ./adapter <span class="at">--level</span> 2 <span class="at">--tier</span> both <span class="at">--verbose</span></span></code></pre></div>
+<div class="sourceCode" id="cb22"><pre class="sourceCode bash"><code class="sourceCode bash"><span id="cb22-1"><a href="#cb22-1" aria-hidden="true" tabindex="-1"></a><span class="ex">node</span> scripts/run-conformance-tests.mjs test <span class="dt">\</span></span>
+<span id="cb22-2"><a href="#cb22-2" aria-hidden="true" tabindex="-1"></a>  tests/conformance/evidence/reference-level2.json <span class="dt">\</span></span>
+<span id="cb22-3"><a href="#cb22-3" aria-hidden="true" tabindex="-1"></a>  <span class="at">--level</span> 2 <span class="dt">\</span></span>
+<span id="cb22-4"><a href="#cb22-4" aria-hidden="true" tabindex="-1"></a>  <span class="at">--category</span> <span class="st">&quot;Introspection Fidelity&quot;</span></span></code></pre></div>
+<p><strong>Tier 2 semantic evaluation:</strong></p>
+<div class="sourceCode" id="cb23"><pre class="sourceCode bash"><code class="sourceCode bash"><span id="cb23-1"><a href="#cb23-1" aria-hidden="true" tabindex="-1"></a><span class="ex">node</span> scripts/run-conformance-tests.mjs test <span class="dt">\</span></span>
+<span id="cb23-2"><a href="#cb23-2" aria-hidden="true" tabindex="-1"></a>  tests/conformance/evidence/reference-level2.json <span class="dt">\</span></span>
+<span id="cb23-3"><a href="#cb23-3" aria-hidden="true" tabindex="-1"></a>  <span class="at">--level</span> 2 <span class="dt">\</span></span>
+<span id="cb23-4"><a href="#cb23-4" aria-hidden="true" tabindex="-1"></a>  <span class="at">--tier</span> both</span></code></pre></div>
 <p><strong>Generate markdown report from results:</strong></p>
-<div class="sourceCode" id="cb23"><pre class="sourceCode bash"><code class="sourceCode bash"><span id="cb23-1"><a href="#cb23-1" aria-hidden="true" tabindex="-1"></a><span class="ex">mcpaql-conformance</span> report ./results.json <span class="at">--format</span> markdown <span class="op">&gt;</span> CONFORMANCE.md</span></code></pre></div>
+<div class="sourceCode" id="cb24"><pre class="sourceCode bash"><code class="sourceCode bash"><span id="cb24-1"><a href="#cb24-1" aria-hidden="true" tabindex="-1"></a><span class="ex">node</span> scripts/run-conformance-tests.mjs report ./results.json <span class="at">--format</span> markdown <span class="op">&gt;</span> CONFORMANCE.md</span></code></pre></div>
+<p><strong>Verify the repository reference fixtures:</strong></p>
+<div class="sourceCode" id="cb25"><pre class="sourceCode bash"><code class="sourceCode bash"><span id="cb25-1"><a href="#cb25-1" aria-hidden="true" tabindex="-1"></a><span class="ex">npm</span> run test:conformance</span></code></pre></div>
 <h3 id="76-integration-with-generator">7.6 Integration with Generator</h3>
 <p>The adapter generator (see <a href="adapter/generator.html">Adapter Generator Specification</a>) SHOULD invoke conformance tests as part of the generation workflow:</p>
-<div class="sourceCode" id="cb24"><pre class="sourceCode bash"><code class="sourceCode bash"><span id="cb24-1"><a href="#cb24-1" aria-hidden="true" tabindex="-1"></a><span class="co"># Generate adapter and run conformance tests</span></span>
-<span id="cb24-2"><a href="#cb24-2" aria-hidden="true" tabindex="-1"></a><span class="ex">mcpaql-generate</span> <span class="at">--schema</span> adapter.yaml <span class="at">--target</span> typescript <span class="at">--output</span> ./adapter</span>
-<span id="cb24-3"><a href="#cb24-3" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb24-4"><a href="#cb24-4" aria-hidden="true" tabindex="-1"></a><span class="co"># Test generated adapter</span></span>
-<span id="cb24-5"><a href="#cb24-5" aria-hidden="true" tabindex="-1"></a><span class="ex">mcpaql-conformance</span> test ./adapter <span class="at">--level</span> 1</span></code></pre></div>
+<div class="sourceCode" id="cb26"><pre class="sourceCode bash"><code class="sourceCode bash"><span id="cb26-1"><a href="#cb26-1" aria-hidden="true" tabindex="-1"></a><span class="co"># Generate adapter and run conformance tests</span></span>
+<span id="cb26-2"><a href="#cb26-2" aria-hidden="true" tabindex="-1"></a><span class="ex">mcpaql-generate</span> <span class="at">--schema</span> adapter.yaml <span class="at">--target</span> typescript <span class="at">--output</span> ./adapter</span>
+<span id="cb26-3"><a href="#cb26-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb26-4"><a href="#cb26-4" aria-hidden="true" tabindex="-1"></a><span class="co"># Test generated fixture evidence</span></span>
+<span id="cb26-5"><a href="#cb26-5" aria-hidden="true" tabindex="-1"></a><span class="ex">node</span> scripts/run-conformance-tests.mjs test ./adapter/conformance/reference.json <span class="at">--level</span> 1</span></code></pre></div>
 <hr />
 <h2 id="references">References</h2>
 <ul>
@@ -682,7 +689,6 @@ MCP-AQL Level 2 Conformant</code></pre>
 <li><a href="introspection.html">Introspection Specification</a></li>
 <li><a href="operations.html">Operations Specification</a></li>
 <li><a href="https://github.com/MCPAQL/spec/issues/10">GitHub Issue #10</a> - Conformance test suite</li>
-<li><a href="https://github.com/MCPAQL/spec/issues/55">GitHub Issue #55</a> - Conformance test requirements</li>
 <li><a href="https://github.com/MCPAQL/spec/issues/56">GitHub Issue #56</a> - LLM semantic evaluation</li>
 </ul>
 

--- a/public/spec/crude-pattern.html
+++ b/public/spec/crude-pattern.html
@@ -50,10 +50,10 @@
   <ul><li><a href="security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Features</h3>
-  <ul><li><a href="features/collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="features/field-selection.html">Field Selection Specification</a></li><li><a href="features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="features/warnings.html">Warnings Array Specification</a></li></ul>
+  <ul><li><a href="features/aggregations.html">MCP-AQL Aggregations</a></li><li><a href="features/collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="features/computed-fields.html">MCP-AQL Computed Fields</a></li><li><a href="features/field-selection.html">Field Selection Specification</a></li><li><a href="features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="features/relationship-queries.html">MCP-AQL Relationship Queries</a></li><li><a href="features/warnings.html">Warnings Array Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Guides</h3>
-  <ul><li><a href="guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="guides/README.html">Developer Guides</a></li></ul>
+  <ul><li><a href="guides/cross-domain-implementation.html">Cross-Domain Implementation Guide</a></li><li><a href="guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
   <ul><li><a href="process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="process/versioning.html">Versioning Strategy</a></li><li><a href="repo/CHANGELOG.html">Changelog</a></li></ul>
@@ -114,10 +114,10 @@
 <p><strong>Document Status:</strong> This document is <strong>informative</strong>. For normative requirements, see <a href="versions/v1.0.0-draft.html">MCP-AQL Specification v1.0.0</a>.</p>
 </blockquote>
 <h2 id="abstract">Abstract</h2>
-<p>This document specifies the CRUDE (Create, Read, Update, Delete, Execute) endpoint pattern, which extends traditional CRUD semantics with an Execute endpoint for runtime lifecycle operations.</p>
+<p>This document specifies the CRUDE (Create, Read, Update, Delete, Execute) endpoint pattern, which extends traditional CRUD semantics with an Execute endpoint for runtime lifecycle operations. CRUDE is the standard semantic-endpoint profile in MCP-AQL, not the only allowed endpoint-family design.</p>
 <h2 id="1-introduction">1. Introduction</h2>
 <h3 id="11-purpose">1.1 Purpose</h3>
-<p>The CRUDE pattern provides semantic grouping of operations by their effect on system state. This grouping enables:</p>
+<p>The CRUDE pattern provides a standard semantic grouping of operations by their effect on system state. This grouping enables:</p>
 <ul>
 <li>Permission-based access control at the endpoint level</li>
 <li>Clear separation of read-only, additive, modifying, and destructive operations</li>
@@ -136,8 +136,9 @@
 <ul>
 <li>Defines its own operations</li>
 <li>Classifies each operation into the appropriate CRUDE endpoint</li>
-<li>Documents its operation-to-endpoint mapping via introspection</li>
+<li>Documents its operation-to-endpoint mapping via introspection when exposing the CRUDE profile</li>
 </ul>
+<p>Adapters MAY instead expose alternate semantic endpoint families when that better matches the target API. See <a href="endpoint-modes.html">Endpoint Modes</a> and the normative specification for the generalized semantic-endpoint model.</p>
 <hr />
 <h2 id="2-endpoint-definitions">2. Endpoint Definitions</h2>
 <h3 id="21-create-endpoint">2.1 CREATE Endpoint</h3>
@@ -238,8 +239,8 @@ EXECUTE     false        true</code></pre>
 </ul>
 <hr />
 <h2 id="4-endpoint-modes">4. Endpoint Modes</h2>
-<h3 id="41-crude-mode">4.1 CRUDE Mode</h3>
-<p>Exposes five separate MCP tools, one per endpoint:</p>
+<h3 id="41-crude-profile-within-semantic-endpoint-mode">4.1 CRUDE Profile Within Semantic Endpoint Mode</h3>
+<p>Within semantic endpoint mode, the standard CRUDE profile exposes five separate MCP tools, one per endpoint:</p>
 <pre><code>mcp_aql_create   - CREATE operations
 mcp_aql_read     - READ operations
 mcp_aql_update   - UPDATE operations
@@ -365,34 +366,34 @@ mcp_aql_execute  - EXECUTE operations</code></pre>
 <p>Each endpoint has canonical verbs that adapters SHOULD use for standard operations:</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Endpoint</th>
 <th>Canonical Verb</th>
 <th>Example Operation</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td>CREATE</td>
 <td><code>create</code></td>
 <td><code>create_user</code></td>
 </tr>
-<tr>
+<tr class="even">
 <td>READ</td>
 <td><code>get</code> (single), <code>list</code> (multiple)</td>
 <td><code>get_document</code>, <code>list_users</code></td>
 </tr>
-<tr>
+<tr class="odd">
 <td>UPDATE</td>
 <td><code>update</code></td>
 <td><code>update_profile</code></td>
 </tr>
-<tr>
+<tr class="even">
 <td>DELETE</td>
 <td><code>delete</code></td>
 <td><code>delete_account</code></td>
 </tr>
-<tr>
+<tr class="odd">
 <td>EXECUTE</td>
 <td><code>execute</code> (initiate), <code>cancel</code> (terminate)</td>
 <td><code>execute_workflow</code>, <code>cancel_task</code></td>
@@ -405,16 +406,16 @@ mcp_aql_execute  - EXECUTE operations</code></pre>
 <hr />
 <h2 id="7-conformance-requirements">7. Conformance Requirements</h2>
 <h3 id="71-must-requirements">7.1 MUST Requirements</h3>
-<p>Conforming implementations MUST:</p>
+<p>Implementations exposing the CRUDE profile MUST:</p>
 <ol type="1">
-<li>Implement all five CRUDE endpoints OR the single unified endpoint</li>
+<li>Implement all five CRUDE endpoints, or offer a single unified endpoint that preserves the same CRUDE semantic classification internally</li>
 <li>Route operations to their correct endpoints according to classification</li>
-<li>Return errors for operations sent to incorrect endpoints (CRUDE mode)</li>
+<li>Return errors for operations sent to incorrect endpoints in CRUDE mode</li>
 <li>Apply permission flags accurately for each endpoint</li>
-<li>Implement the <code>introspect</code> operation (READ endpoint)</li>
+<li>Implement the <code>introspect</code> operation as a READ-category operation</li>
 </ol>
 <h3 id="72-should-requirements">7.2 SHOULD Requirements</h3>
-<p>Conforming implementations SHOULD:</p>
+<p>Implementations exposing the CRUDE profile SHOULD:</p>
 <ol type="1">
 <li>Support both CRUDE and Single endpoint modes</li>
 <li>Provide configuration for mode selection</li>

--- a/public/spec/endpoint-modes.html
+++ b/public/spec/endpoint-modes.html
@@ -50,10 +50,10 @@
   <ul><li><a href="security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Features</h3>
-  <ul><li><a href="features/collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="features/field-selection.html">Field Selection Specification</a></li><li><a href="features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="features/warnings.html">Warnings Array Specification</a></li></ul>
+  <ul><li><a href="features/aggregations.html">MCP-AQL Aggregations</a></li><li><a href="features/collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="features/computed-fields.html">MCP-AQL Computed Fields</a></li><li><a href="features/field-selection.html">Field Selection Specification</a></li><li><a href="features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="features/relationship-queries.html">MCP-AQL Relationship Queries</a></li><li><a href="features/warnings.html">Warnings Array Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Guides</h3>
-  <ul><li><a href="guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="guides/README.html">Developer Guides</a></li></ul>
+  <ul><li><a href="guides/cross-domain-implementation.html">Cross-Domain Implementation Guide</a></li><li><a href="guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
   <ul><li><a href="process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="process/versioning.html">Versioning Strategy</a></li><li><a href="repo/CHANGELOG.html">Changelog</a></li></ul>
@@ -101,7 +101,7 @@
               <p class="page-toc-intro">Use the outline to move through longer pages without losing your place.</p>
             </div>
             <ol class="page-toc-list" data-page-toc-list>
-              <li class="page-toc-item level-2"><a href="#abstract" data-toc-target="abstract">Abstract</a></li><li class="page-toc-item level-2"><a href="#1-introduction" data-toc-target="1-introduction">1. Introduction</a></li><li class="page-toc-item level-2"><a href="#2-mode-comparison" data-toc-target="2-mode-comparison">2. Mode Comparison</a></li><li class="page-toc-item level-2"><a href="#3-configuration" data-toc-target="3-configuration">3. Configuration</a></li><li class="page-toc-item level-2"><a href="#4-crude-mode" data-toc-target="4-crude-mode">4. CRUDE Mode</a></li><li class="page-toc-item level-2"><a href="#5-single-mode" data-toc-target="5-single-mode">5. Single Mode</a></li><li class="page-toc-item level-2"><a href="#6-security-considerations" data-toc-target="6-security-considerations">6. Security Considerations</a></li><li class="page-toc-item level-2"><a href="#7-tool-registration" data-toc-target="7-tool-registration">7. Tool Registration</a></li><li class="page-toc-item level-2"><a href="#8-conformance-requirements" data-toc-target="8-conformance-requirements">8. Conformance Requirements</a></li><li class="page-toc-item level-2"><a href="#references" data-toc-target="references">References</a></li>
+              <li class="page-toc-item level-2"><a href="#abstract" data-toc-target="abstract">Abstract</a></li><li class="page-toc-item level-2"><a href="#1-introduction" data-toc-target="1-introduction">1. Introduction</a></li><li class="page-toc-item level-2"><a href="#2-mode-comparison" data-toc-target="2-mode-comparison">2. Mode Comparison</a></li><li class="page-toc-item level-2"><a href="#3-configuration" data-toc-target="3-configuration">3. Configuration</a></li><li class="page-toc-item level-2"><a href="#4-semantic-endpoint-mode" data-toc-target="4-semantic-endpoint-mode">4. Semantic Endpoint Mode</a></li><li class="page-toc-item level-2"><a href="#5-single-mode" data-toc-target="5-single-mode">5. Single Mode</a></li><li class="page-toc-item level-2"><a href="#6-security-considerations" data-toc-target="6-security-considerations">6. Security Considerations</a></li><li class="page-toc-item level-2"><a href="#7-tool-registration" data-toc-target="7-tool-registration">7. Tool Registration</a></li><li class="page-toc-item level-2"><a href="#8-conformance-requirements" data-toc-target="8-conformance-requirements">8. Conformance Requirements</a></li><li class="page-toc-item level-2"><a href="#references" data-toc-target="references">References</a></li>
             </ol>
           </div>
         </section>
@@ -114,7 +114,7 @@
 <p><strong>Document Status:</strong> This document is <strong>informative</strong>. For normative requirements, see <a href="versions/v1.0.0-draft.html">MCP-AQL Specification v1.0.0</a>.</p>
 </blockquote>
 <h2 id="abstract">Abstract</h2>
-<p>MCP-AQL supports two operational modes for exposing endpoints to clients: CRUDE mode (5 semantic endpoints) and Single mode (1 unified endpoint). This document specifies configuration, routing behavior, security implications, and trade-offs for each mode.</p>
+<p>MCP-AQL supports two operational modes for exposing endpoints to clients: Semantic Endpoint mode and Single mode. The standard CRUDE profile is one semantic-endpoint profile within Semantic Endpoint mode. This document specifies configuration, routing behavior, security implications, and trade-offs for each mode.</p>
 <hr />
 <h2 id="1-introduction">1. Introduction</h2>
 <h3 id="11-purpose">1.1 Purpose</h3>
@@ -136,27 +136,39 @@
 <h3 id="13-terminology">1.3 Terminology</h3>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Term</th>
 <th>Definition</th>
 </tr>
 </thead>
 <tbody>
-<tr>
-<td><strong>CRUDE Mode</strong></td>
-<td>Five separate MCP tools, one per semantic endpoint</td>
+<tr class="odd">
+<td><strong>Semantic Endpoint Mode</strong></td>
+<td>Multiple exposed MCP tools whose names and purposes are semantically legible to clients</td>
 </tr>
-<tr>
+<tr class="even">
+<td><strong>Semantic Endpoint Profile</strong></td>
+<td>A specific semantic set exposed in Semantic Endpoint mode (for example CRUDE)</td>
+</tr>
+<tr class="odd">
+<td><strong>CRUDE Profile</strong></td>
+<td>The standard five-endpoint semantic profile: Create, Read, Update, Delete, Execute</td>
+</tr>
+<tr class="even">
 <td><strong>Single Mode</strong></td>
 <td>One unified MCP tool that routes internally</td>
 </tr>
-<tr>
-<td><strong>Endpoint</strong></td>
-<td>An MCP tool registered with the client</td>
+<tr class="odd">
+<td><strong>Endpoint Family</strong></td>
+<td>A named MCP tool or logical grouping that contains one or more operations</td>
 </tr>
-<tr>
+<tr class="even">
+<td><strong>Semantic Category</strong></td>
+<td>One of the standardized effect categories: CREATE, READ, UPDATE, DELETE, EXECUTE</td>
+</tr>
+<tr class="odd">
 <td><strong>Operation</strong></td>
-<td>A named action within an endpoint</td>
+<td>A named action exposed by the adapter</td>
 </tr>
 </tbody>
 </table>
@@ -165,98 +177,130 @@
 <h3 id="21-summary">2.1 Summary</h3>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Aspect</th>
-<th>CRUDE Mode (5 Endpoints)</th>
-<th>Single Mode (1 Endpoint)</th>
+<th>Semantic Endpoint Mode</th>
+<th>Single Mode</th>
 </tr>
 </thead>
 <tbody>
-<tr>
-<td><strong>Endpoints</strong></td>
-<td>5 semantic endpoints</td>
-<td>1 unified endpoint</td>
+<tr class="odd">
+<td><strong>Exposed tools</strong></td>
+<td>Multiple semantic endpoint tools</td>
+<td>1 unified tool</td>
 </tr>
-<tr>
-<td><strong>Typical Token Cost</strong></td>
-<td>~4,300 tokens</td>
-<td>~1,100 tokens</td>
+<tr class="even">
+<td><strong>Semantic categories</strong></td>
+<td>Still standardized per operation</td>
+<td>Routed internally</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><strong>Routing</strong></td>
-<td>Client chooses endpoint</td>
+<td>Client chooses endpoint family</td>
 <td>Server routes internally</td>
 </tr>
-<tr>
-<td><strong>Permission Control</strong></td>
+<tr class="even">
+<td><strong>Permission control</strong></td>
 <td>Endpoint-level granularity</td>
 <td>Operation-level only</td>
 </tr>
-<tr>
-<td><strong>Client Complexity</strong></td>
-<td>Client MUST select correct endpoint</td>
-<td>Simple single entry point</td>
+<tr class="odd">
+<td><strong>Token cost</strong></td>
+<td>Low to medium</td>
+<td>Lowest</td>
 </tr>
-<tr>
-<td><strong>Error Messages</strong></td>
-<td>Semantic endpoint mismatch errors</td>
-<td>Generic routing errors</td>
+<tr class="even">
+<td><strong>Best fit</strong></td>
+<td>When endpoint semantics should remain visible to the client</td>
+<td>Minimal tool surface</td>
 </tr>
 </tbody>
 </table>
-<h3 id="22-visual-comparison">2.2 Visual Comparison</h3>
-<pre><code>CRUDE Mode                          Single Mode
-============                        ===========
-
-Client                              Client
-  |                                   |
-  +---&gt; mcp_aql_create                +---&gt; mcp_aql
-  |                                         |
-  +---&gt; mcp_aql_read                        v
-  |                                   [Internal Router]
-  +---&gt; mcp_aql_update                      |
-  |                                   +-----+-----+-----+-----+
-  +---&gt; mcp_aql_delete                |     |     |     |     |
-  |                                   C     R     U     D     E
-  +---&gt; mcp_aql_execute</code></pre>
+<h3 id="22-typical-shapes">2.2 Typical Shapes</h3>
+<p>Semantic endpoint mode can expose different semantic profiles. The key requirement is that the endpoint names and descriptions communicate intent clearly enough that a client or LLM can infer where an operation belongs.</p>
+<p><strong>Standard CRUDE profile</strong></p>
+<pre class="text"><code>mcp_aql_create
+mcp_aql_read
+mcp_aql_update
+mcp_aql_delete
+mcp_aql_execute</code></pre>
+<p><strong>Extended CRUDE-style profile</strong></p>
+<pre class="text"><code>mcp_aql_create
+mcp_aql_read
+mcp_aql_update
+mcp_aql_delete
+mcp_aql_execute
+mcp_aql_authorize</code></pre>
+<p><strong>Alternative semantic profile</strong></p>
+<pre class="text"><code>mcp_aql_discover
+mcp_aql_query
+mcp_aql_manage
+mcp_aql_operate</code></pre>
+<p><strong>Single mode</strong></p>
+<pre class="text"><code>mcp_aql</code></pre>
+<p>Profiles like <code>discover</code>, <code>query</code>, <code>manage</code>, and <code>operate</code> remain semantic because they tell the client what kind of intent belongs there. Profiles built purely from domain buckets without clear action semantics are much weaker for discoverability.</p>
 <h3 id="23-token-efficiency">2.3 Token Efficiency</h3>
-<p>Endpoint consolidation provides significant token reduction compared to discrete tools:</p>
+<p>Endpoint consolidation provides significant token reduction compared to fully discrete tools:</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Configuration</th>
 <th>Typical Token Cost</th>
 <th>Reduction</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td>Discrete tools (e.g., 40+ tools)</td>
 <td>~30,000 tokens</td>
 <td>baseline</td>
 </tr>
-<tr>
-<td>CRUDE mode (5 endpoints)</td>
-<td>~4,300 tokens</td>
-<td>~85%</td>
+<tr class="even">
+<td>Semantic endpoint mode (4-8 tools typical)</td>
+<td>~4,300-6,500 tokens</td>
+<td>~78-85%</td>
 </tr>
-<tr>
-<td>Single mode (1 endpoint)</td>
+<tr class="odd">
+<td>Single mode (1 tool)</td>
 <td>~1,100 tokens</td>
 <td>~96%</td>
 </tr>
 </tbody>
 </table>
-<p>Note: Actual token costs vary based on operation count and description length.</p>
+<p>Note: Actual token costs vary based on operation count, endpoint descriptions, and whether schemas enumerate operations inline.</p>
 <hr />
 <h2 id="3-configuration">3. Configuration</h2>
 <h3 id="31-mode-selection">3.1 Mode Selection</h3>
 <p>Implementations SHOULD provide runtime configuration for endpoint mode selection.</p>
 <p><strong>Recommended Environment Variable:</strong></p>
-<pre><code>MCP_AQL_ENDPOINT_MODE=crude|single|all</code></pre>
-<p><strong>Values:</strong> | Value | Behavior | |-------|----------| | <code>crude</code> | Register 5 semantic endpoints | | <code>single</code> | Register 1 unified endpoint | | <code>all</code> | Register all 6 endpoints |</p>
+<pre class="text"><code>MCP_AQL_ENDPOINT_MODE=semantic|single|all</code></pre>
+<p><strong>Optional Semantic Profile Selection:</strong></p>
+<pre class="text"><code>MCP_AQL_ENDPOINT_PROFILE=crude|&lt;adapter_profile_name&gt;</code></pre>
+<p><strong>Values:</strong></p>
+<table>
+<thead>
+<tr class="header">
+<th>Value</th>
+<th>Behavior</th>
+</tr>
+</thead>
+<tbody>
+<tr class="odd">
+<td><code>semantic</code></td>
+<td>Register the active semantic-endpoint profile</td>
+</tr>
+<tr class="even">
+<td><code>single</code></td>
+<td>Register 1 unified endpoint</td>
+</tr>
+<tr class="odd">
+<td><code>all</code></td>
+<td>Register the active semantic-endpoint profile plus the unified endpoint</td>
+</tr>
+</tbody>
+</table>
 <h3 id="32-default-mode">3.2 Default Mode</h3>
-<p>If no configuration is provided, implementations SHOULD default to CRUDE mode, which provides the best balance of token efficiency and permission granularity.</p>
+<p>If no configuration is provided, implementations SHOULD default to the standard CRUDE profile, which provides a strong balance of token efficiency, discoverability, and permission granularity.</p>
 <h3 id="33-runtime-configuration">3.3 Runtime Configuration</h3>
 <p>Implementations MAY support additional configuration methods:</p>
 <ul>
@@ -264,115 +308,176 @@ Client                              Client
 <li>Programmatic API</li>
 <li>Environment-specific defaults</li>
 </ul>
+<p>If an implementation supports multiple semantic endpoint profiles, it SHOULD document which profile is active and expose that via introspection.</p>
 <hr />
-<h2 id="4-crude-mode">4. CRUDE Mode</h2>
-<h3 id="41-endpoint-registration">4.1 Endpoint Registration</h3>
-<p>In CRUDE mode, five MCP tools are registered:</p>
+<h2 id="4-semantic-endpoint-mode">4. Semantic Endpoint Mode</h2>
+<h3 id="41-standard-crude-profile">4.1 Standard CRUDE Profile</h3>
+<p>In the standard CRUDE profile, five MCP tools are registered:</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Tool Name</th>
 <th>Semantic Category</th>
 <th>Operations</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><code>mcp_aql_create</code></td>
-<td>Additive, non-destructive</td>
+<td>CREATE</td>
 <td>Create, add, register</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>mcp_aql_read</code></td>
-<td>Safe, read-only</td>
+<td>READ</td>
 <td>List, get, search, introspect</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>mcp_aql_update</code></td>
-<td>Modifying</td>
+<td>UPDATE</td>
 <td>Edit, modify, update</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>mcp_aql_delete</code></td>
-<td>Destructive</td>
+<td>DELETE</td>
 <td>Delete, remove, clear</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>mcp_aql_execute</code></td>
-<td>Runtime lifecycle</td>
+<td>EXECUTE</td>
 <td>Run, start, stop, cancel</td>
 </tr>
 </tbody>
 </table>
 <h3 id="42-client-responsibility">4.2 Client Responsibility</h3>
-<p>In CRUDE mode, clients MUST select the correct endpoint for each operation. If a client sends an operation to the wrong endpoint, the adapter MUST reject the request.</p>
+<p>In the CRUDE profile, clients MUST select the correct endpoint family for each operation. If a client sends an operation to the wrong tool, the adapter MUST reject the request.</p>
 <p><strong>Example: Correct Usage</strong></p>
-<div class="sourceCode" id="cb3"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb3-1"><a href="#cb3-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Via mcp_aql_read endpoint</span></span>
-<span id="cb3-2"><a href="#cb3-2" aria-hidden="true" tabindex="-1"></a>{</span>
-<span id="cb3-3"><a href="#cb3-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;list_items&quot;</span><span class="op">,</span></span>
-<span id="cb3-4"><a href="#cb3-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> { <span class="dt">limit</span><span class="op">:</span> <span class="dv">10</span> }</span>
-<span id="cb3-5"><a href="#cb3-5" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<div class="sourceCode" id="cb7"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb7-1"><a href="#cb7-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Via mcp_aql_read endpoint</span></span>
+<span id="cb7-2"><a href="#cb7-2" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb7-3"><a href="#cb7-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;list_items&quot;</span><span class="op">,</span></span>
+<span id="cb7-4"><a href="#cb7-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> { <span class="dt">limit</span><span class="op">:</span> <span class="dv">10</span> }</span>
+<span id="cb7-5"><a href="#cb7-5" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
 <p><strong>Example: Incorrect Usage</strong></p>
-<div class="sourceCode" id="cb4"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb4-1"><a href="#cb4-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Via mcp_aql_create endpoint (WRONG - list_items is a READ operation)</span></span>
-<span id="cb4-2"><a href="#cb4-2" aria-hidden="true" tabindex="-1"></a>{</span>
-<span id="cb4-3"><a href="#cb4-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;list_items&quot;</span><span class="op">,</span></span>
-<span id="cb4-4"><a href="#cb4-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> { <span class="dt">limit</span><span class="op">:</span> <span class="dv">10</span> }</span>
-<span id="cb4-5"><a href="#cb4-5" aria-hidden="true" tabindex="-1"></a>}</span>
-<span id="cb4-6"><a href="#cb4-6" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb4-7"><a href="#cb4-7" aria-hidden="true" tabindex="-1"></a><span class="co">// Response:</span></span>
-<span id="cb4-8"><a href="#cb4-8" aria-hidden="true" tabindex="-1"></a>{</span>
-<span id="cb4-9"><a href="#cb4-9" aria-hidden="true" tabindex="-1"></a>  <span class="dt">success</span><span class="op">:</span> <span class="kw">false</span><span class="op">,</span></span>
-<span id="cb4-10"><a href="#cb4-10" aria-hidden="true" tabindex="-1"></a>  <span class="dt">error</span><span class="op">:</span> <span class="st">&quot;Operation &#39;list_items&#39; must be called via mcp_aql_read, not mcp_aql_create&quot;</span></span>
-<span id="cb4-11"><a href="#cb4-11" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
-<h3 id="43-route-enforcement">4.3 Route Enforcement</h3>
-<p>Adapters MUST validate that operations are sent to their assigned endpoint.</p>
+<div class="sourceCode" id="cb8"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb8-1"><a href="#cb8-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Via mcp_aql_create endpoint (WRONG - list_items is a READ operation)</span></span>
+<span id="cb8-2"><a href="#cb8-2" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb8-3"><a href="#cb8-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;list_items&quot;</span><span class="op">,</span></span>
+<span id="cb8-4"><a href="#cb8-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> { <span class="dt">limit</span><span class="op">:</span> <span class="dv">10</span> }</span>
+<span id="cb8-5"><a href="#cb8-5" aria-hidden="true" tabindex="-1"></a>}</span>
+<span id="cb8-6"><a href="#cb8-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb8-7"><a href="#cb8-7" aria-hidden="true" tabindex="-1"></a><span class="co">// Response:</span></span>
+<span id="cb8-8"><a href="#cb8-8" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb8-9"><a href="#cb8-9" aria-hidden="true" tabindex="-1"></a>  <span class="dt">success</span><span class="op">:</span> <span class="kw">false</span><span class="op">,</span></span>
+<span id="cb8-10"><a href="#cb8-10" aria-hidden="true" tabindex="-1"></a>  <span class="dt">error</span><span class="op">:</span> <span class="st">&quot;Operation &#39;list_items&#39; must be called via mcp_aql_read, not mcp_aql_create&quot;</span></span>
+<span id="cb8-11"><a href="#cb8-11" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<h3 id="43-why-use-crude">4.3 Why Use CRUDE</h3>
+<p>The CRUDE profile is the recommended general-purpose grouping because it:</p>
+<ul>
+<li>Preserves standardized safety boundaries</li>
+<li>Produces predictable tool names across adapters</li>
+<li>Works well when the target system does not already imply a better domain partition</li>
+</ul>
+<h3 id="44-alternative-semantic-endpoint-profiles">4.4 Alternative Semantic Endpoint Profiles</h3>
+<p>Implementations MAY define alternate semantic endpoint profiles when a different semantic split communicates intent more clearly to the client than CRUDE does.</p>
+<p>Semantic endpoint families MAY mix multiple semantic categories, but each operation MUST still have exactly one standardized semantic category documented via introspection.</p>
+<h3 id="45-client-responsibility">4.5 Client Responsibility</h3>
+<p>In semantic endpoint mode, clients MUST choose the correct exposed endpoint family for each operation. Adapters MUST reject operations sent to the wrong semantic endpoint family.</p>
+<p><strong>Example: Correct Usage</strong></p>
+<div class="sourceCode" id="cb9"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb9-1"><a href="#cb9-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Via mcp_aql_query endpoint</span></span>
+<span id="cb9-2"><a href="#cb9-2" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb9-3"><a href="#cb9-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;search_documents&quot;</span><span class="op">,</span></span>
+<span id="cb9-4"><a href="#cb9-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> { <span class="dt">query</span><span class="op">:</span> <span class="st">&quot;pricing&quot;</span><span class="op">,</span> <span class="dt">limit</span><span class="op">:</span> <span class="dv">10</span> }</span>
+<span id="cb9-5"><a href="#cb9-5" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<p><strong>Example: Incorrect Usage</strong></p>
+<div class="sourceCode" id="cb10"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb10-1"><a href="#cb10-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Via mcp_aql_operate endpoint (WRONG - search_documents belongs to the query family)</span></span>
+<span id="cb10-2"><a href="#cb10-2" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb10-3"><a href="#cb10-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;search_documents&quot;</span><span class="op">,</span></span>
+<span id="cb10-4"><a href="#cb10-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> { <span class="dt">query</span><span class="op">:</span> <span class="st">&quot;pricing&quot;</span><span class="op">,</span> <span class="dt">limit</span><span class="op">:</span> <span class="dv">10</span> }</span>
+<span id="cb10-5"><a href="#cb10-5" aria-hidden="true" tabindex="-1"></a>}</span>
+<span id="cb10-6"><a href="#cb10-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb10-7"><a href="#cb10-7" aria-hidden="true" tabindex="-1"></a><span class="co">// Response:</span></span>
+<span id="cb10-8"><a href="#cb10-8" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb10-9"><a href="#cb10-9" aria-hidden="true" tabindex="-1"></a>  <span class="dt">success</span><span class="op">:</span> <span class="kw">false</span><span class="op">,</span></span>
+<span id="cb10-10"><a href="#cb10-10" aria-hidden="true" tabindex="-1"></a>  <span class="dt">error</span><span class="op">:</span> <span class="st">&quot;Operation &#39;search_documents&#39; must be called via mcp_aql_query, not mcp_aql_operate&quot;</span></span>
+<span id="cb10-11"><a href="#cb10-11" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<h3 id="46-route-enforcement">4.6 Route Enforcement</h3>
+<p>Adapters in semantic endpoint mode MUST validate that operations are sent to their assigned endpoint family.</p>
 <p><strong>Validation Logic:</strong></p>
 <ol type="1">
 <li>Extract operation name from request</li>
-<li>Look up the correct endpoint for that operation</li>
-<li>Compare with the endpoint that received the request</li>
-<li>If mismatch, return an error specifying the correct endpoint</li>
+<li>Look up the documented endpoint family for that operation</li>
+<li>Compare with the endpoint family that received the request</li>
+<li>If mismatch, return an error specifying the correct endpoint family</li>
 </ol>
-<h3 id="44-endpoint-descriptions">4.4 Endpoint Descriptions</h3>
-<p>Each endpoint SHOULD include a description listing:</p>
+<h3 id="47-endpoint-descriptions">4.7 Endpoint Descriptions</h3>
+<p>Each semantic endpoint family SHOULD include a description listing:</p>
 <ul>
-<li>The semantic category</li>
+<li>The family purpose</li>
+<li>The semantic categories commonly found in that family</li>
 <li>Available operations (or a sample with introspection guidance)</li>
 <li>Quick-start examples</li>
 </ul>
+<p>Endpoint family names SHOULD be action-oriented or otherwise intent-revealing. Names like <code>query</code>, <code>manage</code>, <code>operate</code>, <code>observe</code>, or <code>control</code> are usually better semantic signals than opaque domain buckets.</p>
 <p><strong>Example Description Format:</strong></p>
-<pre><code>Additive, non-destructive operations.
+<pre class="text"><code>Query-oriented operations for retrieval, filtering, aggregation, and field selection.
 
-Supported operations: create_item, add_entry, register_callback
+Primary semantic categories: READ
 
-These operations add new data without removing or overwriting existing content.
+Supported operations: list_datasets, get_dataset, search_datasets
 
 Quick start example:
-{ operation: &quot;create_item&quot;, params: { name: &quot;example&quot; } }
+{ operation: &quot;search_datasets&quot;, params: { query: &quot;pricing&quot;, limit: 10 } }
 
-Use introspection to discover all available operations:
-{ operation: &quot;introspect&quot;, params: { query: &quot;operations&quot; } }</code></pre>
+Discover required parameters:
+{ operation: &quot;introspect&quot;, params: { query: &quot;operations&quot;, name: &quot;search_datasets&quot; } }</code></pre>
+<h3 id="48-example-alternative-semantic-endpoint-profiles">4.8 Example Alternative Semantic Endpoint Profiles</h3>
+<p>The following examples are illustrative only. They show valid semantic endpoint profiles besides the standard CRUDE profile.</p>
+<p><strong>Extended CRUDE-style profile</strong></p>
+<pre class="text"><code>mcp_aql_create     - Additive operations
+mcp_aql_read       - Safe, read-only operations
+mcp_aql_update     - Modifying operations
+mcp_aql_delete     - Destructive operations
+mcp_aql_execute    - Runtime lifecycle operations
+mcp_aql_authorize  - Permission grants, approvals, policy assignment</code></pre>
+<p>This remains a semantic-endpoint profile because each endpoint communicates a specific kind of intent to the client.</p>
+<p><strong>Database-oriented semantic endpoints</strong></p>
+<pre class="text"><code>mcp_aql_inspect     - Schema discovery, capability checks, metadata inspection
+mcp_aql_query       - Retrieval, filtering, joins, aggregations, exports
+mcp_aql_mutate      - Inserts, updates, deletes, bulk edits
+mcp_aql_administer  - Migrations, maintenance tasks, index rebuilds, long-running jobs</code></pre>
+<p>This is a valid semantic-endpoint profile when the target system is best understood through inspection, query, mutation, and administration semantics.</p>
+<p><strong>Hardware / device semantic endpoints</strong></p>
+<pre class="text"><code>mcp_aql_discover   - Device discovery, capabilities, configuration metadata
+mcp_aql_observe    - Sensor reads, health checks, status polling, event history
+mcp_aql_control    - Actuation, calibration, restart, firmware operations
+mcp_aql_maintain   - Diagnostics, firmware staging, lifecycle maintenance tasks</code></pre>
+<p>This is a valid semantic-endpoint profile when the clearest semantic split is between discovering devices, observing live state, issuing control actions, and performing maintenance.</p>
+<p><strong>Content / knowledge semantic endpoints</strong></p>
+<pre class="text"><code>mcp_aql_curate    - Collection curation, taxonomy changes, metadata maintenance
+mcp_aql_search    - Search, retrieval, ranking, summaries
+mcp_aql_publish   - Imports, indexing jobs, publishing, review actions</code></pre>
+<p>This is a valid semantic-endpoint profile when the target API separates curation, retrieval, and publishing or processing semantics.</p>
+<p>In all of these cases, the adapter still documents each operation's standardized semantic category through introspection, even when the semantic endpoints do not map one-to-one to CRUDE tools.</p>
 <hr />
 <h2 id="5-single-mode">5. Single Mode</h2>
 <h3 id="51-endpoint-registration">5.1 Endpoint Registration</h3>
 <p>In Single mode, one MCP tool is registered:</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Tool Name</th>
 <th>Purpose</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><code>mcp_aql</code></td>
-<td>All operations through unified entry point</td>
+<td>All operations through a unified entry point</td>
 </tr>
 </tbody>
 </table>
 <h3 id="52-server-side-routing">5.2 Server-Side Routing</h3>
-<p>The adapter routes operations internally based on their classification:</p>
-<pre><code>Client Request
+<p>The adapter routes operations internally based on each operation's semantic category and handler mapping.</p>
+<pre class="text"><code>Client Request
      |
      v
 mcp_aql endpoint
@@ -380,7 +485,7 @@ mcp_aql endpoint
      v
 [Operation Router]
      |
-     +---&gt; Determines correct CRUDE category
+     +---&gt; Resolves endpoint family + semantic category
      |
      v
 [Appropriate Handler]
@@ -391,157 +496,161 @@ Response</code></pre>
 <p>In Single mode:</p>
 <ol type="1">
 <li>All operations are accepted through <code>mcp_aql</code></li>
-<li>The adapter determines the correct handler based on operation classification</li>
-<li>The same semantic rules apply as CRUDE mode</li>
+<li>The adapter determines the correct handler based on operation metadata</li>
+<li>The same semantic category rules apply as in semantic endpoint mode</li>
 <li>Permission enforcement occurs server-side</li>
 </ol>
-<h3 id="54-unknown-operations">5.4 Unknown Operations</h3>
-<p>If an operation is not recognized:</p>
-<div class="sourceCode" id="cb7"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb7-1"><a href="#cb7-1" aria-hidden="true" tabindex="-1"></a>{</span>
-<span id="cb7-2"><a href="#cb7-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">success</span><span class="op">:</span> <span class="kw">false</span><span class="op">,</span></span>
-<span id="cb7-3"><a href="#cb7-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">error</span><span class="op">:</span> <span class="st">&quot;Unknown operation: &#39;invalid_op&#39;. Use introspect to discover available operations.&quot;</span></span>
-<span id="cb7-4"><a href="#cb7-4" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
-<h3 id="55-endpoint-description">5.5 Endpoint Description</h3>
+<h3 id="54-unified-endpoint-description">5.4 Unified Endpoint Description</h3>
 <p>The unified endpoint SHOULD provide:</p>
 <ul>
-<li>Overview of available operation categories</li>
+<li>Overview of available endpoint families or semantic categories</li>
 <li>Guidance to use introspection for discovery</li>
 <li>Quick-start examples</li>
 </ul>
 <p><strong>Example Description:</strong></p>
-<pre><code>Unified MCP-AQL endpoint for all operations.
+<pre class="text"><code>Unified MCP-AQL endpoint for all operations.
 
-Operations are automatically routed based on their semantic category (Create, Read, Update, Delete, Execute).
+Operations are automatically routed based on their documented semantic category and endpoint-family mapping.
 
 Use introspection to discover available operations:
 { operation: &quot;introspect&quot;, params: { query: &quot;operations&quot; } }</code></pre>
+<h3 id="55-unknown-operations">5.5 Unknown Operations</h3>
+<p>If a client submits an operation name that the adapter does not recognize, the adapter SHOULD return a structured error rather than attempting best-effort routing:</p>
+<div class="sourceCode" id="cb18"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb18-1"><a href="#cb18-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb18-2"><a href="#cb18-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb18-3"><a href="#cb18-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;error&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb18-4"><a href="#cb18-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;code&quot;</span><span class="fu">:</span> <span class="st">&quot;VALIDATION_UNKNOWN_OPERATION&quot;</span><span class="fu">,</span></span>
+<span id="cb18-5"><a href="#cb18-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;Unknown operation &#39;archive_table&#39;. Use introspect to discover supported operations.&quot;</span></span>
+<span id="cb18-6"><a href="#cb18-6" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb18-7"><a href="#cb18-7" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
 <hr />
 <h2 id="6-security-considerations">6. Security Considerations</h2>
-<h3 id="61-crude-mode-security">6.1 CRUDE Mode Security</h3>
-<p><strong>Advantages:</strong></p>
+<h3 id="61-semantic-endpoint-mode-security">6.1 Semantic Endpoint Mode Security</h3>
+<p>Semantic endpoint mode, including the CRUDE profile, provides:</p>
 <ul>
-<li>Endpoint-level permission blocking (e.g., disable <code>mcp_aql_delete</code> entirely)</li>
-<li>Semantic errors help clients self-correct</li>
-<li>Platform-level permission hints via MCP annotations</li>
-<li>Clear audit separation by operation category</li>
+<li>Endpoint-level permission blocking</li>
+<li>More specific mismatch errors</li>
+<li>MCP annotation hints that may vary by exposed family</li>
+<li>Clearer audit separation by exposed family</li>
 </ul>
 <p><strong>Characteristics:</strong></p>
 <ul>
-<li>Client is responsible for endpoint selection</li>
+<li>Client is responsible for endpoint-family selection</li>
 <li>Adapter enforces route validation</li>
-<li>Dangerous operations isolated to DELETE/EXECUTE endpoints</li>
+<li>Risk can be isolated into smaller families</li>
 </ul>
 <h3 id="62-single-mode-security">6.2 Single Mode Security</h3>
-<p><strong>Advantages:</strong></p>
+<p>Single mode provides:</p>
 <ul>
 <li>Smaller attack surface (one endpoint)</li>
-<li>Server-side routing prevents endpoint bypass</li>
-<li>Simpler client implementation reduces error risk</li>
+<li>Server-side routing that prevents endpoint bypass</li>
+<li>Simpler client integration</li>
 </ul>
 <p><strong>Characteristics:</strong></p>
 <ul>
-<li>Cannot block operations by endpoint</li>
-<li>All routing decisions made server-side</li>
-<li>Audit logging requires operation-level granularity</li>
+<li>Cannot block operations by semantic endpoint family alone</li>
+<li>All routing decisions are server-side</li>
+<li>Audit logging relies more heavily on operation-level metadata</li>
 </ul>
 <h3 id="63-security-trade-offs">6.3 Security Trade-offs</h3>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Security Aspect</th>
-<th>CRUDE Mode</th>
+<th>Semantic Endpoint Mode</th>
 <th>Single Mode</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td>Endpoint-level blocking</td>
 <td>Yes</td>
 <td>No</td>
 </tr>
-<tr>
+<tr class="even">
 <td>Client error prevention</td>
-<td>Better (semantic errors)</td>
-<td>Worse (generic errors)</td>
+<td>Better</td>
+<td>Worse</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>Attack surface</td>
-<td>Larger (5 endpoints)</td>
-<td>Smaller (1 endpoint)</td>
+<td>Larger</td>
+<td>Smaller</td>
 </tr>
-<tr>
+<tr class="even">
 <td>Audit granularity</td>
-<td>Endpoint + Operation</td>
+<td>Endpoint family + operation</td>
 <td>Operation only</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>Bypass resistance</td>
-<td>Client-dependent</td>
-<td>Server-enforced</td>
+<td>Adapter-enforced</td>
+<td>Adapter-enforced</td>
 </tr>
 </tbody>
 </table>
 <h3 id="64-common-security-enforcement">6.4 Common Security Enforcement</h3>
-<p>Both modes MUST:</p>
+<p>All modes MUST:</p>
 <ul>
 <li>Validate operation parameters</li>
 <li>Enforce the same permission model</li>
 <li>Apply safety tier classifications</li>
-<li>Support confirmation for destructive operations (if implemented)</li>
+<li>Support confirmation for destructive operations when implemented</li>
 </ul>
 <hr />
 <h2 id="7-tool-registration">7. Tool Registration</h2>
 <h3 id="71-mcp-tool-annotations">7.1 MCP Tool Annotations</h3>
-<p>Adapters SHOULD include MCP tool annotations to hint at operation safety:</p>
-<p><strong>CRUDE Mode Annotations:</strong></p>
-<div class="sourceCode" id="cb9"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb9-1"><a href="#cb9-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
-<span id="cb9-2"><a href="#cb9-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;mcp_aql_read&quot;</span><span class="fu">,</span></span>
-<span id="cb9-3"><a href="#cb9-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;annotations&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb9-4"><a href="#cb9-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;readOnlyHint&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
-<span id="cb9-5"><a href="#cb9-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;destructiveHint&quot;</span><span class="fu">:</span> <span class="kw">false</span></span>
-<span id="cb9-6"><a href="#cb9-6" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
-<span id="cb9-7"><a href="#cb9-7" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span>
-<span id="cb9-8"><a href="#cb9-8" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb9-9"><a href="#cb9-9" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
-<span id="cb9-10"><a href="#cb9-10" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;mcp_aql_delete&quot;</span><span class="fu">,</span></span>
-<span id="cb9-11"><a href="#cb9-11" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;annotations&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb9-12"><a href="#cb9-12" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;readOnlyHint&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
-<span id="cb9-13"><a href="#cb9-13" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;destructiveHint&quot;</span><span class="fu">:</span> <span class="kw">true</span></span>
-<span id="cb9-14"><a href="#cb9-14" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
-<span id="cb9-15"><a href="#cb9-15" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
-<p><strong>Single Mode Annotations:</strong></p>
-<div class="sourceCode" id="cb10"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb10-1"><a href="#cb10-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
-<span id="cb10-2"><a href="#cb10-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;mcp_aql&quot;</span><span class="fu">,</span></span>
-<span id="cb10-3"><a href="#cb10-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;annotations&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb10-4"><a href="#cb10-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;readOnlyHint&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
-<span id="cb10-5"><a href="#cb10-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;destructiveHint&quot;</span><span class="fu">:</span> <span class="kw">true</span></span>
-<span id="cb10-6"><a href="#cb10-6" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
-<span id="cb10-7"><a href="#cb10-7" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<p>Adapters SHOULD include MCP tool annotations to hint at operation safety.</p>
+<p><strong>CRUDE Profile Example:</strong></p>
+<div class="sourceCode" id="cb19"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb19-1"><a href="#cb19-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb19-2"><a href="#cb19-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;mcp_aql_read&quot;</span><span class="fu">,</span></span>
+<span id="cb19-3"><a href="#cb19-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;annotations&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb19-4"><a href="#cb19-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;readOnlyHint&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb19-5"><a href="#cb19-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;destructiveHint&quot;</span><span class="fu">:</span> <span class="kw">false</span></span>
+<span id="cb19-6"><a href="#cb19-6" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb19-7"><a href="#cb19-7" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<p><strong>Alternative Semantic Endpoint Example:</strong></p>
+<div class="sourceCode" id="cb20"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb20-1"><a href="#cb20-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb20-2"><a href="#cb20-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;mcp_aql_control&quot;</span><span class="fu">,</span></span>
+<span id="cb20-3"><a href="#cb20-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;annotations&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb20-4"><a href="#cb20-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;readOnlyHint&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb20-5"><a href="#cb20-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;destructiveHint&quot;</span><span class="fu">:</span> <span class="kw">true</span></span>
+<span id="cb20-6"><a href="#cb20-6" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb20-7"><a href="#cb20-7" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<p>Semantic endpoint families SHOULD set annotations conservatively based on the riskiest operation that family exposes.</p>
+<p><strong>Single Mode Example:</strong></p>
+<div class="sourceCode" id="cb21"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb21-1"><a href="#cb21-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb21-2"><a href="#cb21-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;mcp_aql&quot;</span><span class="fu">,</span></span>
+<span id="cb21-3"><a href="#cb21-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;annotations&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb21-4"><a href="#cb21-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;readOnlyHint&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb21-5"><a href="#cb21-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;destructiveHint&quot;</span><span class="fu">:</span> <span class="kw">true</span></span>
+<span id="cb21-6"><a href="#cb21-6" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb21-7"><a href="#cb21-7" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
 <p>Note: Single mode uses <code>destructiveHint: true</code> because it can route to destructive operations.</p>
 <h3 id="72-input-schema">7.2 Input Schema</h3>
-<p>Both modes use the same input schema:</p>
-<div class="sourceCode" id="cb11"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb11-1"><a href="#cb11-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
-<span id="cb11-2"><a href="#cb11-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;object&quot;</span><span class="fu">,</span></span>
-<span id="cb11-3"><a href="#cb11-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;properties&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb11-4"><a href="#cb11-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb11-5"><a href="#cb11-5" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;string&quot;</span><span class="fu">,</span></span>
-<span id="cb11-6"><a href="#cb11-6" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Operation name to execute&quot;</span></span>
-<span id="cb11-7"><a href="#cb11-7" aria-hidden="true" tabindex="-1"></a>    <span class="fu">},</span></span>
-<span id="cb11-8"><a href="#cb11-8" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb11-9"><a href="#cb11-9" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;object&quot;</span><span class="fu">,</span></span>
-<span id="cb11-10"><a href="#cb11-10" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Operation parameters&quot;</span></span>
-<span id="cb11-11"><a href="#cb11-11" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
-<span id="cb11-12"><a href="#cb11-12" aria-hidden="true" tabindex="-1"></a>  <span class="fu">},</span></span>
-<span id="cb11-13"><a href="#cb11-13" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;required&quot;</span><span class="fu">:</span> <span class="ot">[</span><span class="st">&quot;operation&quot;</span><span class="ot">]</span></span>
-<span id="cb11-14"><a href="#cb11-14" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
-<p>Adapters MAY extend this schema with additional common properties (e.g., <code>resource_type</code>, <code>fields</code>).</p>
+<p>All modes use the same base input schema:</p>
+<div class="sourceCode" id="cb22"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb22-1"><a href="#cb22-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb22-2"><a href="#cb22-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;object&quot;</span><span class="fu">,</span></span>
+<span id="cb22-3"><a href="#cb22-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;properties&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb22-4"><a href="#cb22-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb22-5"><a href="#cb22-5" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;string&quot;</span><span class="fu">,</span></span>
+<span id="cb22-6"><a href="#cb22-6" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Operation name to execute&quot;</span></span>
+<span id="cb22-7"><a href="#cb22-7" aria-hidden="true" tabindex="-1"></a>    <span class="fu">},</span></span>
+<span id="cb22-8"><a href="#cb22-8" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb22-9"><a href="#cb22-9" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;object&quot;</span><span class="fu">,</span></span>
+<span id="cb22-10"><a href="#cb22-10" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Operation parameters&quot;</span></span>
+<span id="cb22-11"><a href="#cb22-11" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb22-12"><a href="#cb22-12" aria-hidden="true" tabindex="-1"></a>  <span class="fu">},</span></span>
+<span id="cb22-13"><a href="#cb22-13" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;required&quot;</span><span class="fu">:</span> <span class="ot">[</span><span class="st">&quot;operation&quot;</span><span class="ot">]</span></span>
+<span id="cb22-14"><a href="#cb22-14" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<p>Adapters MAY extend this schema with additional common properties such as <code>resource_type</code>, <code>fields</code>, or <code>_meta</code>.</p>
 <hr />
 <h2 id="8-conformance-requirements">8. Conformance Requirements</h2>
 <h3 id="81-must-requirements">8.1 MUST Requirements</h3>
 <p>Conforming implementations MUST:</p>
 <ol type="1">
-<li>Support at least one endpoint mode (CRUDE or Single)</li>
-<li>Enforce operation routing validation in CRUDE mode</li>
+<li>Support at least one endpoint mode (<code>semantic</code> or <code>single</code>)</li>
+<li>Enforce operation routing validation in semantic endpoint mode</li>
 <li>Return proper error responses for unknown operations</li>
 <li>Route operations to correct handlers in Single mode</li>
 <li>Apply consistent permission enforcement regardless of mode</li>
@@ -549,16 +658,16 @@ Use introspection to discover available operations:
 <h3 id="82-should-requirements">8.2 SHOULD Requirements</h3>
 <p>Conforming implementations SHOULD:</p>
 <ol type="1">
-<li>Support both CRUDE and Single endpoint modes</li>
+<li>Support both a semantic endpoint mode and Single mode</li>
 <li>Provide runtime configuration for mode selection</li>
 <li>Include MCP tool annotations for permission hints</li>
 <li>Provide helpful error messages that guide clients to correct usage</li>
-<li>Document available operations via introspection</li>
+<li>Document operation-to-endpoint-family mapping via introspection</li>
 </ol>
 <h3 id="83-may-requirements">8.3 MAY Requirements</h3>
 <p>Conforming implementations MAY:</p>
 <ol type="1">
-<li>Support "all" mode exposing all 6 endpoints simultaneously</li>
+<li>Support <code>all</code> mode exposing both semantic-endpoint and single surfaces simultaneously</li>
 <li>Implement per-endpoint access control</li>
 <li>Provide mode-specific audit logging</li>
 <li>Support dynamic mode switching without restart</li>

--- a/public/spec/error-codes.html
+++ b/public/spec/error-codes.html
@@ -50,10 +50,10 @@
   <ul><li><a href="security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Features</h3>
-  <ul><li><a href="features/collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="features/field-selection.html">Field Selection Specification</a></li><li><a href="features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="features/warnings.html">Warnings Array Specification</a></li></ul>
+  <ul><li><a href="features/aggregations.html">MCP-AQL Aggregations</a></li><li><a href="features/collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="features/computed-fields.html">MCP-AQL Computed Fields</a></li><li><a href="features/field-selection.html">Field Selection Specification</a></li><li><a href="features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="features/relationship-queries.html">MCP-AQL Relationship Queries</a></li><li><a href="features/warnings.html">Warnings Array Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Guides</h3>
-  <ul><li><a href="guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="guides/README.html">Developer Guides</a></li></ul>
+  <ul><li><a href="guides/cross-domain-implementation.html">Cross-Domain Implementation Guide</a></li><li><a href="guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
   <ul><li><a href="process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="process/versioning.html">Versioning Strategy</a></li><li><a href="repo/CHANGELOG.html">Changelog</a></li></ul>
@@ -225,49 +225,49 @@
 <h3 id="32-category-prefixes">3.2 Category Prefixes</h3>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Category</th>
 <th>Description</th>
 <th>HTTP Range</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><code>VALIDATION_</code></td>
 <td>Input validation errors</td>
 <td>400, 422</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>NOT_FOUND_</code></td>
 <td>Resource not found</td>
 <td>404</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>PERMISSION_</code></td>
 <td>Authentication/authorization</td>
 <td>401, 403</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>CONFLICT_</code></td>
 <td>Resource conflicts</td>
 <td>409</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>RATE_LIMIT_</code></td>
 <td>Rate limiting</td>
 <td>429</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>TOKEN_</code></td>
 <td>Confirmation token errors</td>
 <td>400, 403</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>SCHEMA_</code></td>
 <td>Schema validation errors (generators)</td>
 <td>N/A</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>INTERNAL_</code></td>
 <td>Server errors</td>
 <td>500+</td>
@@ -283,54 +283,54 @@
 <p>The MVP includes 8 essential error codes:</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Code</th>
 <th>Category</th>
 <th>Description</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><code>VALIDATION_MISSING_PARAM</code></td>
 <td>Validation</td>
 <td>Required parameter not provided</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>VALIDATION_INVALID_TYPE</code></td>
 <td>Validation</td>
 <td>Parameter has wrong type</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>VALIDATION_UNKNOWN_PARAM</code></td>
 <td>Validation</td>
 <td>Request contains parameter not defined in operation schema</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>VALIDATION_INVALID_ENCODING</code></td>
 <td>Validation</td>
 <td>Request contains invalid character encoding</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>VALIDATION_PAYLOAD_TOO_LARGE</code></td>
 <td>Validation</td>
 <td>Request or response exceeds size limits</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>NOT_FOUND_OPERATION</code></td>
 <td>Not Found</td>
 <td>Requested operation does not exist</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>NOT_FOUND_RESOURCE</code></td>
 <td>Not Found</td>
 <td>Target resource not found (HTTP 404)</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>PERMISSION_DENIED</code></td>
 <td>Permission</td>
 <td>Access denied (HTTP 401/403)</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>INTERNAL_ERROR</code></td>
 <td>Internal</td>
 <td>Server error or unexpected failure</td>
@@ -605,64 +605,64 @@
 <h3 id="51-phase-1-error-code-registry">5.1 Phase 1 Error Code Registry</h3>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Code</th>
 <th>Category</th>
 <th>Description</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><code>PERMISSION_TRUST_LEVEL_INSUFFICIENT</code></td>
 <td>Permission</td>
 <td>Adapter trust level too low for operation</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>PERMISSION_DANGER_LEVEL_DENIED</code></td>
 <td>Permission</td>
 <td>Operation danger level exceeds trust allowance</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>CONFIRMATION_REQUIRED</code></td>
 <td>Permission</td>
 <td>Dangerous operation requires user confirmation</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>RATE_LIMIT_EXCEEDED</code></td>
 <td>Rate Limit</td>
 <td>Target API rate limit reached</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>RATE_LIMIT_QUOTA_PAUSE</code></td>
 <td>Rate Limit</td>
 <td>User quota pause threshold reached</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>RATE_LIMIT_QUOTA_EXHAUSTED</code></td>
 <td>Rate Limit</td>
 <td>User quota hard stop reached</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>RATE_LIMIT_QUOTA_WARNING</code></td>
 <td>Rate Limit</td>
 <td>Approaching quota limit (warning)</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>TOKEN_INVALID</code></td>
 <td>Token</td>
 <td>Confirmation token not found or malformed</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>TOKEN_EXPIRED</code></td>
 <td>Token</td>
 <td>Confirmation token has expired</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>TOKEN_ALREADY_USED</code></td>
 <td>Token</td>
 <td>Confirmation token has already been redeemed</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>TOKEN_SCOPE_MISMATCH</code></td>
 <td>Token</td>
 <td>Token issued for different operation or parameters</td>
@@ -1011,64 +1011,64 @@
 <p>The runtime maps HTTP status codes to MCP-AQL error codes:</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>HTTP Status</th>
 <th>Error Code</th>
 <th>Description</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td>400</td>
 <td><code>VALIDATION_INVALID_TYPE</code></td>
 <td>Bad request (default for validation errors)</td>
 </tr>
-<tr>
+<tr class="even">
 <td>400</td>
 <td><code>VALIDATION_MISSING_PARAM</code></td>
 <td>Bad request (missing required parameter)</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>400</td>
 <td><code>VALIDATION_UNKNOWN_PARAM</code></td>
 <td>Bad request (unknown parameter)</td>
 </tr>
-<tr>
+<tr class="even">
 <td>401</td>
 <td><code>PERMISSION_DENIED</code></td>
 <td>Authentication required</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>403</td>
 <td><code>PERMISSION_DENIED</code></td>
 <td>Forbidden</td>
 </tr>
-<tr>
+<tr class="even">
 <td>404</td>
 <td><code>NOT_FOUND_RESOURCE</code></td>
 <td>Not found</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>422</td>
 <td><code>VALIDATION_INVALID_TYPE</code></td>
 <td>Unprocessable entity</td>
 </tr>
-<tr>
+<tr class="even">
 <td>500</td>
 <td><code>INTERNAL_ERROR</code></td>
 <td>Internal server error</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>502</td>
 <td><code>INTERNAL_ERROR</code></td>
 <td>Bad gateway</td>
 </tr>
-<tr>
+<tr class="even">
 <td>503</td>
 <td><code>INTERNAL_ERROR</code></td>
 <td>Service unavailable</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>504</td>
 <td><code>INTERNAL_ERROR</code></td>
 <td>Gateway timeout</td>
@@ -1199,7 +1199,7 @@
 <li><a href="adapter/danger-levels.html">Dangerous Operation Classification</a></li>
 <li><a href="adapter/trust-levels.html">Trust Levels Specification</a></li>
 <li><a href="adapter/rate-limiting.html">Rate Limiting Specification</a></li>
-<li><a href="../adapter-reference/architecture/runtime.html">Universal Adapter Runtime</a> (in mcpaql-adapter repo)</li>
+<li><a href="https://github.com/MCPAQL/mcpaql-adapter/blob/develop/docs/architecture/runtime.md">Universal Adapter Runtime</a> (in mcpaql-adapter repo)</li>
 <li><a href="https://github.com/DollhouseMCP/mcp-server-v2-refactor/issues/298">DollhouseMCP Implementation</a></li>
 <li>GitHub Issue: <a href="https://github.com/MCPAQL/spec/issues/35">#35</a></li>
 </ul>

--- a/public/spec/features/aggregations.html
+++ b/public/spec/features/aggregations.html
@@ -1,0 +1,267 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Document Status: This document is informative. For normative requirements, see MCP-AQL Specification v1.0.0.">
+  <title>MCP-AQL Spec | MCP-AQL Aggregations</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../../css/style.css">
+</head>
+<body>
+  <header>
+    <div class="container">
+      <nav>
+        <a class="logo" href="../../index.html"><span class="logo-mark"></span>MCP-AQL</a>
+        <ul class="nav-links">
+          <li><a href="../../index.html">Home</a></li>
+          <li><a href="../../docs/index.html">Docs</a></li>
+          <li><a href="../../launch-checklist.html">Launch Checklist</a></li>
+          <li><a href="../../apis/index.html">Adapter Patterns</a></li>
+        </ul>
+        <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
+          <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
+          <input id="site-search-input" data-search-input type="search" placeholder="Search MCP-AQL docs, spec pages, and adapter patterns...">
+          <span class="search-count" data-search-count></span>
+          <ul class="search-results" data-search-results hidden></ul>
+        </form>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <div class="container docs-shell">
+      <aside class="docs-side">
+        <h2>Repo-Synced Spec</h2>
+        <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
+        <div class="docs-side-group">
+  <h3>Core</h3>
+  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li><li><a href="../repo/README.html">MCP-AQL Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Versions</h3>
+  <ul><li><a href="../versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Adapter</h3>
+  <ul><li><a href="../adapter/danger-levels.html">Dangerous Operation Classification Specification</a></li><li><a href="../adapter/discovery-bundle.html">MCP Server Discovery Bundle</a></li><li><a href="../adapter/element-type.html">Adapter Element Type Specification</a></li><li><a href="../adapter/generator.html">Adapter Generator Specification</a></li><li><a href="../adapter/rate-limiting.html">Rate Limiting and Quota Management Specification</a></li><li><a href="../adapter/trust-levels.html">Trust Levels Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Security</h3>
+  <ul><li><a href="../security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="../security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="../security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Features</h3>
+  <ul><li><a class="current" aria-current="page" href="aggregations.html">MCP-AQL Aggregations</a></li><li><a href="collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="computed-fields.html">MCP-AQL Computed Fields</a></li><li><a href="field-selection.html">Field Selection Specification</a></li><li><a href="pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="relationship-queries.html">MCP-AQL Relationship Queries</a></li><li><a href="warnings.html">Warnings Array Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Guides</h3>
+  <ul><li><a href="../guides/cross-domain-implementation.html">Cross-Domain Implementation Guide</a></li><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Process</h3>
+  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li><li><a href="../repo/CHANGELOG.html">Changelog</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Architecture</h3>
+  <ul><li><a href="../architecture/README.html">Architecture Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Research</h3>
+  <ul><li><a href="../research/mcp-vs-mcpaql-vs-a2a.html">Protocol Landscape: MCP vs MCP-AQL vs A2A</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Reference</h3>
+  <ul><li><a href="../reference/README.html">Reference Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>ADRs</h3>
+  <ul><li><a href="../adr/ADR-001-crude-pattern.html">ADR-001: CRUDE Pattern (Extending CRUD with Execute)</a></li><li><a href="../adr/ADR-002-graphql-style-input.html">ADR-002: GraphQL-Style Input Objects for Updates</a></li><li><a href="../adr/ADR-003-snake-case-parameters.html">ADR-003: snake_case Parameter Convention</a></li><li><a href="../adr/ADR-004-schema-driven-operations.html">ADR-004: Schema-Driven Operation Definitions</a></li><li><a href="../adr/ADR-005-introspection-system.html">ADR-005: GraphQL-Style Introspection System</a></li><li><a href="../adr/ADR-006-discriminated-responses.html">ADR-006: Discriminated Response Format</a></li><li><a href="../adr/index.html">Architecture Decision Records</a></li><li><a href="../adr/README.html">Architecture Decision Records</a></li></ul>
+</div>
+      </aside>
+
+      <article class="docs-main">
+        <nav class="breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../../index.html">Home</a></li>
+            <li><a href="../index.html">Full Spec</a></li>
+            <li><span class="current">MCP-AQL Aggregations</span></li>
+          </ol>
+        </nav>
+        <section class="hero docs-hero">
+          <div class="hero-inner">
+            <span class="status-pill">REPO-SYNCED SPEC DOC</span>
+            <h1>MCP-AQL Aggregations</h1>
+            <p class="lede">Document Status: This document is informative. For normative requirements, see MCP-AQL Specification v1.0.0.</p>
+            <div class="spec-meta"><span class="state-chip live">Support document</span><span class="state-chip pending">Draft</span><span class="state-chip">1.0.0-draft</span><span class="state-chip">2026-04-15</span></div>
+            <p class="spec-source">Source: <a href="https://github.com/MCPAQL/spec/blob/main/docs/features/aggregations.md">spec/docs/features/aggregations.md</a></p>
+            <div class="hero-actions">
+              <a class="btn btn-primary" href="https://github.com/MCPAQL/spec/blob/main/docs/features/aggregations.md">Open Source Markdown</a><a class="btn btn-secondary" href="../index.html">Browse Full Spec Reference</a>
+            </div>
+          </div>
+        </section>
+
+        <section class="page-toc-shell" data-page-toc>
+          <div class="card page-toc-card">
+            <div class="page-toc-head">
+              <p class="page-toc-kicker">On this page</p>
+              <h2>Jump to a section</h2>
+              <p class="page-toc-intro">Use the outline to move through longer pages without losing your place.</p>
+            </div>
+            <ol class="page-toc-list" data-page-toc-list>
+              <li class="page-toc-item level-2"><a href="#abstract" data-toc-target="abstract">Abstract</a></li><li class="page-toc-item level-2"><a href="#1-preferred-request-shape" data-toc-target="1-preferred-request-shape">1. Preferred Request Shape</a></li><li class="page-toc-item level-2"><a href="#2-supported-operations" data-toc-target="2-supported-operations">2. Supported Operations</a></li><li class="page-toc-item level-2"><a href="#3-response-shape" data-toc-target="3-response-shape">3. Response Shape</a></li><li class="page-toc-item level-2"><a href="#4-composition-rules" data-toc-target="4-composition-rules">4. Composition Rules</a></li><li class="page-toc-item level-2"><a href="#5-introspection-guidance" data-toc-target="5-introspection-guidance">5. Introspection Guidance</a></li><li class="page-toc-item level-2"><a href="#6-relationship-to-other-docs" data-toc-target="6-relationship-to-other-docs">6. Relationship to Other Docs</a></li>
+            </ol>
+          </div>
+        </section>
+
+
+        <section>
+          <div class="card spec-prose">
+            <p><strong>Version:</strong> 1.0.0-draft <strong>Status:</strong> Draft <strong>Last Updated:</strong> 2026-04-15</p>
+<blockquote>
+<p><strong>Document Status:</strong> This document is <strong>informative</strong>. For normative requirements, see <a href="../versions/v1.0.0-draft.html">MCP-AQL Specification v1.0.0</a>.</p>
+</blockquote>
+<h2 id="abstract">Abstract</h2>
+<p>This document defines the preferred MCP-AQL shape for server-side aggregation on collection-returning READ operations. Aggregations let adapters return counts, groupings, and numeric summaries without forcing clients or LLMs to fetch every record and compute the answer themselves.</p>
+<h2 id="1-preferred-request-shape">1. Preferred Request Shape</h2>
+<p>Aggregation is expressed through an <code>aggregate</code> object in <code>params</code>:</p>
+<div class="sourceCode" id="cb1"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb1-2"><a href="#cb1-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;search_widgets&quot;</span><span class="op">,</span></span>
+<span id="cb1-3"><a href="#cb1-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> {</span>
+<span id="cb1-4"><a href="#cb1-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">filter</span><span class="op">:</span> {</span>
+<span id="cb1-5"><a href="#cb1-5" aria-hidden="true" tabindex="-1"></a>      <span class="dt">status</span><span class="op">:</span> <span class="st">&quot;active&quot;</span></span>
+<span id="cb1-6"><a href="#cb1-6" aria-hidden="true" tabindex="-1"></a>    }<span class="op">,</span></span>
+<span id="cb1-7"><a href="#cb1-7" aria-hidden="true" tabindex="-1"></a>    <span class="dt">aggregate</span><span class="op">:</span> {</span>
+<span id="cb1-8"><a href="#cb1-8" aria-hidden="true" tabindex="-1"></a>      <span class="dt">total</span><span class="op">:</span> {</span>
+<span id="cb1-9"><a href="#cb1-9" aria-hidden="true" tabindex="-1"></a>        <span class="dt">count</span><span class="op">:</span> <span class="kw">true</span></span>
+<span id="cb1-10"><a href="#cb1-10" aria-hidden="true" tabindex="-1"></a>      }<span class="op">,</span></span>
+<span id="cb1-11"><a href="#cb1-11" aria-hidden="true" tabindex="-1"></a>      <span class="dt">by_status</span><span class="op">:</span> {</span>
+<span id="cb1-12"><a href="#cb1-12" aria-hidden="true" tabindex="-1"></a>        <span class="dt">group_by</span><span class="op">:</span> <span class="st">&quot;status&quot;</span><span class="op">,</span></span>
+<span id="cb1-13"><a href="#cb1-13" aria-hidden="true" tabindex="-1"></a>        <span class="dt">count</span><span class="op">:</span> <span class="kw">true</span></span>
+<span id="cb1-14"><a href="#cb1-14" aria-hidden="true" tabindex="-1"></a>      }<span class="op">,</span></span>
+<span id="cb1-15"><a href="#cb1-15" aria-hidden="true" tabindex="-1"></a>      <span class="dt">average_size</span><span class="op">:</span> {</span>
+<span id="cb1-16"><a href="#cb1-16" aria-hidden="true" tabindex="-1"></a>        <span class="dt">avg</span><span class="op">:</span> <span class="st">&quot;size_bytes&quot;</span></span>
+<span id="cb1-17"><a href="#cb1-17" aria-hidden="true" tabindex="-1"></a>      }</span>
+<span id="cb1-18"><a href="#cb1-18" aria-hidden="true" tabindex="-1"></a>    }</span>
+<span id="cb1-19"><a href="#cb1-19" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb1-20"><a href="#cb1-20" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<p>Each key under <code>aggregate</code> is a caller-chosen result label. The value describes the computation to perform.</p>
+<h2 id="2-supported-operations">2. Supported Operations</h2>
+<p>The preferred aggregation vocabulary is:</p>
+<table>
+<thead>
+<tr class="header">
+<th>Key</th>
+<th>Meaning</th>
+</tr>
+</thead>
+<tbody>
+<tr class="odd">
+<td><code>count</code></td>
+<td>Count matching records</td>
+</tr>
+<tr class="even">
+<td><code>group_by</code></td>
+<td>Group records by a field</td>
+</tr>
+<tr class="odd">
+<td><code>sum</code></td>
+<td>Sum a numeric field</td>
+</tr>
+<tr class="even">
+<td><code>avg</code></td>
+<td>Average a numeric field</td>
+</tr>
+<tr class="odd">
+<td><code>min</code></td>
+<td>Minimum value for a field</td>
+</tr>
+<tr class="even">
+<td><code>max</code></td>
+<td>Maximum value for a field</td>
+</tr>
+</tbody>
+</table>
+<p>Adapters MAY support a subset, but SHOULD expose the supported functions and fields through introspection.</p>
+<p>Within a single named expression, <code>group_by</code> MAY be combined with one or more summary functions such as <code>count</code>, <code>sum</code>, <code>avg</code>, <code>min</code>, or <code>max</code>. Adapters SHOULD document any unsupported combinations. A bare <code>group_by</code> without at least one summary function is NOT RECOMMENDED because it leaves the result shape underspecified.</p>
+<h2 id="3-response-shape">3. Response Shape</h2>
+<p>When <code>aggregate</code> is present, the preferred summary-first response shape is:</p>
+<div class="sourceCode" id="cb2"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb2-2"><a href="#cb2-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb2-3"><a href="#cb2-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;data&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb2-4"><a href="#cb2-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;aggregations&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb2-5"><a href="#cb2-5" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;total&quot;</span><span class="fu">:</span> <span class="dv">25</span><span class="fu">,</span></span>
+<span id="cb2-6"><a href="#cb2-6" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;by_status&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb2-7"><a href="#cb2-7" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;active&quot;</span><span class="fu">:</span> <span class="dv">18</span><span class="fu">,</span></span>
+<span id="cb2-8"><a href="#cb2-8" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;paused&quot;</span><span class="fu">:</span> <span class="dv">7</span></span>
+<span id="cb2-9"><a href="#cb2-9" aria-hidden="true" tabindex="-1"></a>      <span class="fu">},</span></span>
+<span id="cb2-10"><a href="#cb2-10" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;average_size&quot;</span><span class="fu">:</span> <span class="fl">913.4</span></span>
+<span id="cb2-11"><a href="#cb2-11" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb2-12"><a href="#cb2-12" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb2-13"><a href="#cb2-13" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<p>Adapters SHOULD omit raw <code>items</code> by default when an aggregation request is summary-oriented. If an adapter supports returning both summaries and rows in one call, it SHOULD use an explicit <code>include_items: true</code> flag.</p>
+<div class="sourceCode" id="cb3"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb3-1"><a href="#cb3-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb3-2"><a href="#cb3-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb3-3"><a href="#cb3-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;data&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb3-4"><a href="#cb3-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;aggregations&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb3-5"><a href="#cb3-5" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;total&quot;</span><span class="fu">:</span> <span class="dv">25</span><span class="fu">,</span></span>
+<span id="cb3-6"><a href="#cb3-6" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;by_status&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb3-7"><a href="#cb3-7" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;active&quot;</span><span class="fu">:</span> <span class="dv">18</span><span class="fu">,</span></span>
+<span id="cb3-8"><a href="#cb3-8" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;paused&quot;</span><span class="fu">:</span> <span class="dv">7</span></span>
+<span id="cb3-9"><a href="#cb3-9" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span></span>
+<span id="cb3-10"><a href="#cb3-10" aria-hidden="true" tabindex="-1"></a>    <span class="fu">},</span></span>
+<span id="cb3-11"><a href="#cb3-11" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;items&quot;</span><span class="fu">:</span> <span class="ot">[</span></span>
+<span id="cb3-12"><a href="#cb3-12" aria-hidden="true" tabindex="-1"></a>      <span class="fu">{</span></span>
+<span id="cb3-13"><a href="#cb3-13" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;widget_id&quot;</span><span class="fu">:</span> <span class="st">&quot;w_001&quot;</span><span class="fu">,</span></span>
+<span id="cb3-14"><a href="#cb3-14" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;status&quot;</span><span class="fu">:</span> <span class="st">&quot;active&quot;</span></span>
+<span id="cb3-15"><a href="#cb3-15" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span></span>
+<span id="cb3-16"><a href="#cb3-16" aria-hidden="true" tabindex="-1"></a>    <span class="ot">]</span></span>
+<span id="cb3-17"><a href="#cb3-17" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb3-18"><a href="#cb3-18" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<h2 id="4-composition-rules">4. Composition Rules</h2>
+<ul>
+<li>Aggregations are applied after <code>query</code> and <code>filter</code>.</li>
+<li><code>sort</code> applies to the pre-aggregation record set. In summary-only mode, adapters MAY ignore it when ordering has no effect on the aggregate result.</li>
+<li><code>fields</code> does not rename or project aggregate result keys. Clients SHOULD use the names defined inside <code>aggregate</code> to control which summary values appear in the response.</li>
+<li>Aggregations SHOULD respect the same access-control and visibility rules as ordinary reads.</li>
+<li>Adapters SHOULD reject unsupported aggregation functions or fields with a structured validation error.</li>
+<li>Multiple named aggregations MAY appear in the same request.</li>
+</ul>
+<h2 id="5-introspection-guidance">5. Introspection Guidance</h2>
+<p>Adapters SHOULD advertise aggregation support through operation detail metadata:</p>
+<div class="sourceCode" id="cb4"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb4-1"><a href="#cb4-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb4-2"><a href="#cb4-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;aggregation_support&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb4-3"><a href="#cb4-3" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;supported&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb4-4"><a href="#cb4-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;default_mode&quot;</span><span class="fu">:</span> <span class="st">&quot;summary_only&quot;</span><span class="fu">,</span></span>
+<span id="cb4-5"><a href="#cb4-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;functions&quot;</span><span class="fu">:</span> <span class="ot">[</span><span class="st">&quot;count&quot;</span><span class="ot">,</span> <span class="st">&quot;group_by&quot;</span><span class="ot">,</span> <span class="st">&quot;sum&quot;</span><span class="ot">,</span> <span class="st">&quot;avg&quot;</span><span class="ot">,</span> <span class="st">&quot;min&quot;</span><span class="ot">,</span> <span class="st">&quot;max&quot;</span><span class="ot">]</span><span class="fu">,</span></span>
+<span id="cb4-6"><a href="#cb4-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;groupable_fields&quot;</span><span class="fu">:</span> <span class="ot">[</span><span class="st">&quot;status&quot;</span><span class="ot">,</span> <span class="st">&quot;category&quot;</span><span class="ot">]</span><span class="fu">,</span></span>
+<span id="cb4-7"><a href="#cb4-7" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;numeric_fields&quot;</span><span class="fu">:</span> <span class="ot">[</span><span class="st">&quot;size_bytes&quot;</span><span class="ot">,</span> <span class="st">&quot;usage_count&quot;</span><span class="ot">]</span></span>
+<span id="cb4-8"><a href="#cb4-8" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb4-9"><a href="#cb4-9" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<p>This keeps aggregation discoverable without requiring the client to guess which fields or functions are valid.</p>
+<h2 id="6-relationship-to-other-docs">6. Relationship to Other Docs</h2>
+<ul>
+<li><a href="collection-querying.html">Collection Querying</a> describes how <code>aggregate</code> composes with <code>query</code>, <code>filter</code>, <code>sort</code>, <code>fields</code>, and pagination.</li>
+<li><a href="../operations.html">Operations</a> defines the shared request and response conventions used by aggregation-capable READ operations.</li>
+</ul>
+
+          </div>
+        </section>
+        <nav class="page-nav" aria-label="Page navigation">
+  <a class="page-nav-link prev" href="../security/gatekeeper.html">
+    <span class="page-nav-eyebrow">Previous page</span>
+    <strong class="page-nav-label">Security Model: Gatekeeper Specification</strong>
+  </a>
+  <a class="page-nav-link next" href="collection-querying.html">
+    <span class="page-nav-eyebrow">Next page</span>
+    <strong class="page-nav-label">MCP-AQL Collection Querying</strong>
+  </a>
+</nav>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div class="container">
+      <p>&copy; 2026 DollhouseMCP Inc. d/b/a Dollhouse Research. MCP-AQL public draft documentation portal.</p>
+      <div class="footer-links">
+        <a href="../../docs/index.html">Docs Library</a><a href="../index.html">Repo-Synced Spec</a><a href="https://github.com/MCPAQL">MCPAQL Organization</a><a href="https://dollhouseresearch.com">Dollhouse Research</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../../js/search.js"></script>
+</body>
+</html>

--- a/public/spec/features/collection-querying.html
+++ b/public/spec/features/collection-querying.html
@@ -50,10 +50,10 @@
   <ul><li><a href="../security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="../security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="../security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Features</h3>
-  <ul><li><a class="current" aria-current="page" href="collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="field-selection.html">Field Selection Specification</a></li><li><a href="pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="warnings.html">Warnings Array Specification</a></li></ul>
+  <ul><li><a href="aggregations.html">MCP-AQL Aggregations</a></li><li><a class="current" aria-current="page" href="collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="computed-fields.html">MCP-AQL Computed Fields</a></li><li><a href="field-selection.html">Field Selection Specification</a></li><li><a href="pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="relationship-queries.html">MCP-AQL Relationship Queries</a></li><li><a href="warnings.html">Warnings Array Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Guides</h3>
-  <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
+  <ul><li><a href="../guides/cross-domain-implementation.html">Cross-Domain Implementation Guide</a></li><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
   <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li><li><a href="../repo/CHANGELOG.html">Changelog</a></li></ul>
@@ -101,7 +101,7 @@
               <p class="page-toc-intro">Use the outline to move through longer pages without losing your place.</p>
             </div>
             <ol class="page-toc-list" data-page-toc-list>
-              <li class="page-toc-item level-2"><a href="#abstract" data-toc-target="abstract">Abstract</a></li><li class="page-toc-item level-2"><a href="#1-operation-families" data-toc-target="1-operation-families">1. Operation Families</a></li><li class="page-toc-item level-2"><a href="#2-preferred-request-shape" data-toc-target="2-preferred-request-shape">2. Preferred Request Shape</a></li><li class="page-toc-item level-3"><a href="#21-text-query" data-toc-target="21-text-query">2.1 Text Query</a></li><li class="page-toc-item level-3"><a href="#22-structured-filters" data-toc-target="22-structured-filters">2.2 Structured Filters</a></li><li class="page-toc-item level-3"><a href="#23-sorting" data-toc-target="23-sorting">2.3 Sorting</a></li><li class="page-toc-item level-3"><a href="#24-field-selection" data-toc-target="24-field-selection">2.4 Field Selection</a></li><li class="page-toc-item level-3"><a href="#25-pagination" data-toc-target="25-pagination">2.5 Pagination</a></li><li class="page-toc-item level-2"><a href="#3-capability-matrix" data-toc-target="3-capability-matrix">3. Capability Matrix</a></li><li class="page-toc-item level-2"><a href="#4-search-semantics" data-toc-target="4-search-semantics">4. Search Semantics</a></li><li class="page-toc-item level-3"><a href="#41-multi-word-queries" data-toc-target="41-multi-word-queries">4.1 Multi-Word Queries</a></li><li class="page-toc-item level-3"><a href="#42-structured-query-grammars" data-toc-target="42-structured-query-grammars">4.2 Structured Query Grammars</a></li><li class="page-toc-item level-2"><a href="#5-validation-guidance" data-toc-target="5-validation-guidance">5. Validation Guidance</a></li><li class="page-toc-item level-2"><a href="#6-introspection-guidance" data-toc-target="6-introspection-guidance">6. Introspection Guidance</a></li><li class="page-toc-item level-2"><a href="#7-relationship-to-other-feature-docs" data-toc-target="7-relationship-to-other-feature-docs">7. Relationship to Other Feature Docs</a></li>
+              <li class="page-toc-item level-2"><a href="#abstract" data-toc-target="abstract">Abstract</a></li><li class="page-toc-item level-2"><a href="#1-operation-families" data-toc-target="1-operation-families">1. Operation Families</a></li><li class="page-toc-item level-2"><a href="#2-preferred-request-shape" data-toc-target="2-preferred-request-shape">2. Preferred Request Shape</a></li><li class="page-toc-item level-3"><a href="#21-text-query" data-toc-target="21-text-query">2.1 Text Query</a></li><li class="page-toc-item level-3"><a href="#22-structured-filters" data-toc-target="22-structured-filters">2.2 Structured Filters</a></li><li class="page-toc-item level-3"><a href="#23-sorting" data-toc-target="23-sorting">2.3 Sorting</a></li><li class="page-toc-item level-3"><a href="#24-field-selection" data-toc-target="24-field-selection">2.4 Field Selection</a></li><li class="page-toc-item level-3"><a href="#25-aggregations" data-toc-target="25-aggregations">2.5 Aggregations</a></li><li class="page-toc-item level-3"><a href="#26-pagination" data-toc-target="26-pagination">2.6 Pagination</a></li><li class="page-toc-item level-2"><a href="#3-capability-matrix" data-toc-target="3-capability-matrix">3. Capability Matrix</a></li><li class="page-toc-item level-2"><a href="#4-search-semantics" data-toc-target="4-search-semantics">4. Search Semantics</a></li><li class="page-toc-item level-3"><a href="#41-multi-word-queries" data-toc-target="41-multi-word-queries">4.1 Multi-Word Queries</a></li><li class="page-toc-item level-3"><a href="#42-structured-query-grammars" data-toc-target="42-structured-query-grammars">4.2 Structured Query Grammars</a></li><li class="page-toc-item level-2"><a href="#5-validation-guidance" data-toc-target="5-validation-guidance">5. Validation Guidance</a></li><li class="page-toc-item level-2"><a href="#6-introspection-guidance" data-toc-target="6-introspection-guidance">6. Introspection Guidance</a></li><li class="page-toc-item level-2"><a href="#7-relationship-to-other-feature-docs" data-toc-target="7-relationship-to-other-feature-docs">7. Relationship to Other Feature Docs</a></li>
             </ol>
           </div>
         </section>
@@ -114,31 +114,31 @@
 <p><strong>Document Status:</strong> This document is <strong>informative</strong>. For normative requirements, see <a href="../versions/v1.0.0-draft.html">MCP-AQL Specification v1.0.0</a>.</p>
 </blockquote>
 <h2 id="abstract">Abstract</h2>
-<p>This document defines the preferred request contract for collection-returning READ operations in MCP-AQL. It aligns <code>list_*</code>, <code>search_*</code>, and <code>query_*</code> operations around a consistent shape for free-text search, structured filtering, sorting, field selection, and pagination.</p>
+<p>This document defines the preferred request contract for collection-returning READ operations in MCP-AQL. It aligns <code>list_*</code>, <code>search_*</code>, and <code>query_*</code> operations around a consistent shape for free-text search, structured filtering, sorting, field selection, aggregation, and pagination.</p>
 <p>The goal is not to force every adapter into the same backend implementation. The goal is to give clients, adapter authors, and future spec work a stable query-language surface to build on.</p>
 <hr />
 <h2 id="1-operation-families">1. Operation Families</h2>
 <p>MCP-AQL commonly exposes three collection-oriented READ patterns:</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Pattern</th>
 <th>Purpose</th>
 <th>Typical Example</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><code>list_*</code></td>
 <td>Enumerate a collection without requiring text search</td>
 <td><code>list_elements</code></td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>search_*</code></td>
 <td>Free-text retrieval over a collection</td>
 <td><code>search_elements</code></td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>query_*</code></td>
 <td>Structured or adapter-defined query grammar</td>
 <td><code>query_elements</code></td>
@@ -201,40 +201,55 @@
 <li>A preset string such as <code>minimal</code>, <code>standard</code>, or <code>full</code></li>
 <li>An array of explicit field paths</li>
 </ul></li>
+<li>Computed fields SHOULD use the <code>_computed.</code> prefix when they are projected through <code>fields</code>, for example <code>_computed.age_days</code>.</li>
 <li>Separate <code>preset</code> parameters SHOULD be treated as compatibility aliases only.</li>
 </ul>
-<h3 id="25-pagination">2.5 Pagination</h3>
-<p>Cursor pagination is the preferred collection-pagination shape:</p>
+<h3 id="25-aggregations">2.5 Aggregations</h3>
+<ul>
+<li><code>aggregate</code> is the preferred summary-computation control for collection operations.</li>
+<li>The preferred shape is a map of named aggregation expressions:</li>
+</ul>
 <div class="sourceCode" id="cb3"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb3-1"><a href="#cb3-1" aria-hidden="true" tabindex="-1"></a>{</span>
-<span id="cb3-2"><a href="#cb3-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">first</span><span class="op">:</span> <span class="dv">25</span><span class="op">,</span></span>
-<span id="cb3-3"><a href="#cb3-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">after</span><span class="op">:</span> <span class="st">&quot;cursor_abc123&quot;</span></span>
-<span id="cb3-4"><a href="#cb3-4" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<span id="cb3-2"><a href="#cb3-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">aggregate</span><span class="op">:</span> {</span>
+<span id="cb3-3"><a href="#cb3-3" aria-hidden="true" tabindex="-1"></a>    <span class="dt">total</span><span class="op">:</span> { <span class="dt">count</span><span class="op">:</span> <span class="kw">true</span> }<span class="op">,</span></span>
+<span id="cb3-4"><a href="#cb3-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">by_status</span><span class="op">:</span> { <span class="dt">group_by</span><span class="op">:</span> <span class="st">&quot;status&quot;</span><span class="op">,</span> <span class="dt">count</span><span class="op">:</span> <span class="kw">true</span> }</span>
+<span id="cb3-5"><a href="#cb3-5" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb3-6"><a href="#cb3-6" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<ul>
+<li>When <code>aggregate</code> is present, adapters SHOULD return summary data by default unless <code>include_items: true</code> is explicitly requested.</li>
+</ul>
+<h3 id="26-pagination">2.6 Pagination</h3>
+<p>Cursor pagination is the preferred collection-pagination shape:</p>
+<div class="sourceCode" id="cb4"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb4-1"><a href="#cb4-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb4-2"><a href="#cb4-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">first</span><span class="op">:</span> <span class="dv">25</span><span class="op">,</span></span>
+<span id="cb4-3"><a href="#cb4-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">after</span><span class="op">:</span> <span class="st">&quot;cursor_abc123&quot;</span></span>
+<span id="cb4-4"><a href="#cb4-4" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
 <p>Preferred cursor parameters:</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Parameter</th>
 <th>Type</th>
 <th>Meaning</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><code>first</code></td>
 <td>number</td>
 <td>Number of items from the start</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>after</code></td>
 <td>string</td>
 <td>Cursor to continue after</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>last</code></td>
 <td>number</td>
 <td>Number of items from the end</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>before</code></td>
 <td>string</td>
 <td>Cursor to continue before</td>
@@ -253,37 +268,41 @@
 <p>The following matrix describes the preferred forward direction for collection-returning READ operations:</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Operation Family</th>
 <th><code>query</code></th>
 <th><code>filter</code></th>
 <th><code>sort</code></th>
+<th><code>aggregate</code></th>
 <th>Pagination</th>
 <th><code>fields</code></th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><code>list_*</code></td>
 <td>Not required</td>
 <td>SHOULD support</td>
 <td>SHOULD support</td>
+<td>MAY support</td>
 <td>SHOULD support</td>
 <td>SHOULD support</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>search_*</code></td>
 <td>SHOULD support as the canonical text parameter</td>
 <td>SHOULD support</td>
 <td>SHOULD support</td>
+<td>SHOULD support for summary-style searches</td>
 <td>SHOULD support</td>
 <td>SHOULD support</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>query_*</code></td>
 <td>MUST document grammar</td>
 <td>SHOULD document composition rules</td>
 <td>SHOULD support when meaningful</td>
+<td>SHOULD document support when meaningful</td>
 <td>SHOULD support</td>
 <td>SHOULD support</td>
 </tr>
@@ -331,6 +350,8 @@
 <ul>
 <li>Supported collection-query parameters in <code>OperationDetails.parameters</code></li>
 <li>Whether the operation supports field selection</li>
+<li>Whether the operation supports aggregation and which functions are available</li>
+<li>Which computed fields are available, if any</li>
 <li>Which pagination style is supported</li>
 <li>Which filter keys and sort fields are accepted</li>
 <li>Examples combining multiple controls in one request</li>
@@ -340,6 +361,8 @@
 <h2 id="7-relationship-to-other-feature-docs">7. Relationship to Other Feature Docs</h2>
 <ul>
 <li><a href="field-selection.html">Field Selection</a> defines how <code>fields</code> works</li>
+<li><a href="aggregations.html">Aggregations</a> defines the preferred <code>aggregate</code> request and response shape</li>
+<li><a href="computed-fields.html">Computed Fields</a> defines the <code>_computed.</code> projection and metadata pattern</li>
 <li><a href="pagination.html">Pagination</a> defines cursor pagination response semantics</li>
 <li><a href="../operations.html">Operations</a> defines general parameter conventions and operation schema guidance</li>
 </ul>
@@ -348,13 +371,13 @@
           </div>
         </section>
         <nav class="page-nav" aria-label="Page navigation">
-  <a class="page-nav-link prev" href="../security/gatekeeper.html">
+  <a class="page-nav-link prev" href="aggregations.html">
     <span class="page-nav-eyebrow">Previous page</span>
-    <strong class="page-nav-label">Security Model: Gatekeeper Specification</strong>
+    <strong class="page-nav-label">MCP-AQL Aggregations</strong>
   </a>
-  <a class="page-nav-link next" href="field-selection.html">
+  <a class="page-nav-link next" href="computed-fields.html">
     <span class="page-nav-eyebrow">Next page</span>
-    <strong class="page-nav-label">Field Selection Specification</strong>
+    <strong class="page-nav-label">MCP-AQL Computed Fields</strong>
   </a>
 </nav>
       </article>

--- a/public/spec/features/computed-fields.html
+++ b/public/spec/features/computed-fields.html
@@ -1,0 +1,237 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Document Status: This document is informative. For normative requirements, see MCP-AQL Specification v1.0.0.">
+  <title>MCP-AQL Spec | MCP-AQL Computed Fields</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../../css/style.css">
+</head>
+<body>
+  <header>
+    <div class="container">
+      <nav>
+        <a class="logo" href="../../index.html"><span class="logo-mark"></span>MCP-AQL</a>
+        <ul class="nav-links">
+          <li><a href="../../index.html">Home</a></li>
+          <li><a href="../../docs/index.html">Docs</a></li>
+          <li><a href="../../launch-checklist.html">Launch Checklist</a></li>
+          <li><a href="../../apis/index.html">Adapter Patterns</a></li>
+        </ul>
+        <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
+          <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
+          <input id="site-search-input" data-search-input type="search" placeholder="Search MCP-AQL docs, spec pages, and adapter patterns...">
+          <span class="search-count" data-search-count></span>
+          <ul class="search-results" data-search-results hidden></ul>
+        </form>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <div class="container docs-shell">
+      <aside class="docs-side">
+        <h2>Repo-Synced Spec</h2>
+        <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
+        <div class="docs-side-group">
+  <h3>Core</h3>
+  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li><li><a href="../repo/README.html">MCP-AQL Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Versions</h3>
+  <ul><li><a href="../versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Adapter</h3>
+  <ul><li><a href="../adapter/danger-levels.html">Dangerous Operation Classification Specification</a></li><li><a href="../adapter/discovery-bundle.html">MCP Server Discovery Bundle</a></li><li><a href="../adapter/element-type.html">Adapter Element Type Specification</a></li><li><a href="../adapter/generator.html">Adapter Generator Specification</a></li><li><a href="../adapter/rate-limiting.html">Rate Limiting and Quota Management Specification</a></li><li><a href="../adapter/trust-levels.html">Trust Levels Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Security</h3>
+  <ul><li><a href="../security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="../security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="../security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Features</h3>
+  <ul><li><a href="aggregations.html">MCP-AQL Aggregations</a></li><li><a href="collection-querying.html">MCP-AQL Collection Querying</a></li><li><a class="current" aria-current="page" href="computed-fields.html">MCP-AQL Computed Fields</a></li><li><a href="field-selection.html">Field Selection Specification</a></li><li><a href="pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="relationship-queries.html">MCP-AQL Relationship Queries</a></li><li><a href="warnings.html">Warnings Array Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Guides</h3>
+  <ul><li><a href="../guides/cross-domain-implementation.html">Cross-Domain Implementation Guide</a></li><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Process</h3>
+  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li><li><a href="../repo/CHANGELOG.html">Changelog</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Architecture</h3>
+  <ul><li><a href="../architecture/README.html">Architecture Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Research</h3>
+  <ul><li><a href="../research/mcp-vs-mcpaql-vs-a2a.html">Protocol Landscape: MCP vs MCP-AQL vs A2A</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Reference</h3>
+  <ul><li><a href="../reference/README.html">Reference Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>ADRs</h3>
+  <ul><li><a href="../adr/ADR-001-crude-pattern.html">ADR-001: CRUDE Pattern (Extending CRUD with Execute)</a></li><li><a href="../adr/ADR-002-graphql-style-input.html">ADR-002: GraphQL-Style Input Objects for Updates</a></li><li><a href="../adr/ADR-003-snake-case-parameters.html">ADR-003: snake_case Parameter Convention</a></li><li><a href="../adr/ADR-004-schema-driven-operations.html">ADR-004: Schema-Driven Operation Definitions</a></li><li><a href="../adr/ADR-005-introspection-system.html">ADR-005: GraphQL-Style Introspection System</a></li><li><a href="../adr/ADR-006-discriminated-responses.html">ADR-006: Discriminated Response Format</a></li><li><a href="../adr/index.html">Architecture Decision Records</a></li><li><a href="../adr/README.html">Architecture Decision Records</a></li></ul>
+</div>
+      </aside>
+
+      <article class="docs-main">
+        <nav class="breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../../index.html">Home</a></li>
+            <li><a href="../index.html">Full Spec</a></li>
+            <li><span class="current">MCP-AQL Computed Fields</span></li>
+          </ol>
+        </nav>
+        <section class="hero docs-hero">
+          <div class="hero-inner">
+            <span class="status-pill">REPO-SYNCED SPEC DOC</span>
+            <h1>MCP-AQL Computed Fields</h1>
+            <p class="lede">Document Status: This document is informative. For normative requirements, see MCP-AQL Specification v1.0.0.</p>
+            <div class="spec-meta"><span class="state-chip live">Support document</span><span class="state-chip pending">Draft</span><span class="state-chip">1.0.0-draft</span><span class="state-chip">2026-04-15</span></div>
+            <p class="spec-source">Source: <a href="https://github.com/MCPAQL/spec/blob/main/docs/features/computed-fields.md">spec/docs/features/computed-fields.md</a></p>
+            <div class="hero-actions">
+              <a class="btn btn-primary" href="https://github.com/MCPAQL/spec/blob/main/docs/features/computed-fields.md">Open Source Markdown</a><a class="btn btn-secondary" href="../index.html">Browse Full Spec Reference</a>
+            </div>
+          </div>
+        </section>
+
+        <section class="page-toc-shell" data-page-toc>
+          <div class="card page-toc-card">
+            <div class="page-toc-head">
+              <p class="page-toc-kicker">On this page</p>
+              <h2>Jump to a section</h2>
+              <p class="page-toc-intro">Use the outline to move through longer pages without losing your place.</p>
+            </div>
+            <ol class="page-toc-list" data-page-toc-list>
+              <li class="page-toc-item level-2"><a href="#abstract" data-toc-target="abstract">Abstract</a></li><li class="page-toc-item level-2"><a href="#1-requesting-computed-fields" data-toc-target="1-requesting-computed-fields">1. Requesting Computed Fields</a></li><li class="page-toc-item level-2"><a href="#2-response-shape" data-toc-target="2-response-shape">2. Response Shape</a></li><li class="page-toc-item level-2"><a href="#3-filter-and-sort-composition" data-toc-target="3-filter-and-sort-composition">3. Filter and Sort Composition</a></li><li class="page-toc-item level-2"><a href="#4-introspection-guidance" data-toc-target="4-introspection-guidance">4. Introspection Guidance</a></li><li class="page-toc-item level-2"><a href="#5-common-patterns" data-toc-target="5-common-patterns">5. Common Patterns</a></li><li class="page-toc-item level-2"><a href="#6-relationship-to-other-docs" data-toc-target="6-relationship-to-other-docs">6. Relationship to Other Docs</a></li>
+            </ol>
+          </div>
+        </section>
+
+
+        <section>
+          <div class="card spec-prose">
+            <p><strong>Version:</strong> 1.0.0-draft <strong>Status:</strong> Draft <strong>Last Updated:</strong> 2026-04-15</p>
+<blockquote>
+<p><strong>Document Status:</strong> This document is <strong>informative</strong>. For normative requirements, see <a href="../versions/v1.0.0-draft.html">MCP-AQL Specification v1.0.0</a>.</p>
+</blockquote>
+<h2 id="abstract">Abstract</h2>
+<p>This document defines the preferred MCP-AQL shape for adapter-declared computed fields. Computed fields let adapters expose derived values such as ages, counts, or status booleans without forcing clients or LLMs to reconstruct them from raw records.</p>
+<h2 id="1-requesting-computed-fields">1. Requesting Computed Fields</h2>
+<p>Computed fields use the <code>_computed.</code> prefix inside <code>fields</code>:</p>
+<div class="sourceCode" id="cb1"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb1-2"><a href="#cb1-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;get_widget&quot;</span><span class="op">,</span></span>
+<span id="cb1-3"><a href="#cb1-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> {</span>
+<span id="cb1-4"><a href="#cb1-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">widget_id</span><span class="op">:</span> <span class="st">&quot;widget_123&quot;</span><span class="op">,</span></span>
+<span id="cb1-5"><a href="#cb1-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">fields</span><span class="op">:</span> [<span class="st">&quot;widget_name&quot;</span><span class="op">,</span> <span class="st">&quot;_computed.age_days&quot;</span><span class="op">,</span> <span class="st">&quot;_computed.child_count&quot;</span>]</span>
+<span id="cb1-6"><a href="#cb1-6" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb1-7"><a href="#cb1-7" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<p>The <code>_computed.</code> prefix keeps derived values visibly distinct from persisted fields while still composing with normal field selection.</p>
+<h2 id="2-response-shape">2. Response Shape</h2>
+<p>Computed values are returned under the <code>_computed</code> object:</p>
+<div class="sourceCode" id="cb2"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb2-2"><a href="#cb2-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb2-3"><a href="#cb2-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;data&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb2-4"><a href="#cb2-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;widget_name&quot;</span><span class="fu">:</span> <span class="st">&quot;Atlas Widget&quot;</span><span class="fu">,</span></span>
+<span id="cb2-5"><a href="#cb2-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;_computed&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb2-6"><a href="#cb2-6" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;age_days&quot;</span><span class="fu">:</span> <span class="dv">47</span><span class="fu">,</span></span>
+<span id="cb2-7"><a href="#cb2-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;child_count&quot;</span><span class="fu">:</span> <span class="dv">12</span></span>
+<span id="cb2-8"><a href="#cb2-8" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb2-9"><a href="#cb2-9" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb2-10"><a href="#cb2-10" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<h2 id="3-filter-and-sort-composition">3. Filter and Sort Composition</h2>
+<p>Adapters MAY allow computed fields in other query-language controls when they can evaluate them efficiently:</p>
+<div class="sourceCode" id="cb3"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb3-1"><a href="#cb3-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb3-2"><a href="#cb3-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;search_widgets&quot;</span><span class="op">,</span></span>
+<span id="cb3-3"><a href="#cb3-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> {</span>
+<span id="cb3-4"><a href="#cb3-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">filter</span><span class="op">:</span> {</span>
+<span id="cb3-5"><a href="#cb3-5" aria-hidden="true" tabindex="-1"></a>      <span class="st">&quot;_computed.is_stale&quot;</span><span class="op">:</span> <span class="kw">true</span></span>
+<span id="cb3-6"><a href="#cb3-6" aria-hidden="true" tabindex="-1"></a>    }<span class="op">,</span></span>
+<span id="cb3-7"><a href="#cb3-7" aria-hidden="true" tabindex="-1"></a>    <span class="dt">sort</span><span class="op">:</span> {</span>
+<span id="cb3-8"><a href="#cb3-8" aria-hidden="true" tabindex="-1"></a>      <span class="dt">field</span><span class="op">:</span> <span class="st">&quot;_computed.age_days&quot;</span><span class="op">,</span></span>
+<span id="cb3-9"><a href="#cb3-9" aria-hidden="true" tabindex="-1"></a>      <span class="dt">order</span><span class="op">:</span> <span class="st">&quot;desc&quot;</span></span>
+<span id="cb3-10"><a href="#cb3-10" aria-hidden="true" tabindex="-1"></a>    }<span class="op">,</span></span>
+<span id="cb3-11"><a href="#cb3-11" aria-hidden="true" tabindex="-1"></a>    <span class="dt">fields</span><span class="op">:</span> [<span class="st">&quot;widget_name&quot;</span><span class="op">,</span> <span class="st">&quot;_computed.age_days&quot;</span>]</span>
+<span id="cb3-12"><a href="#cb3-12" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb3-13"><a href="#cb3-13" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<p>If an adapter does not support computed-field filtering or sorting, it SHOULD reject those requests clearly instead of silently ignoring them. See <a href="../error-codes.html">Error Codes</a> for the preferred structured error patterns.</p>
+<h2 id="4-introspection-guidance">4. Introspection Guidance</h2>
+<p>Adapters SHOULD advertise computed fields in operation detail metadata:</p>
+<div class="sourceCode" id="cb4"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb4-1"><a href="#cb4-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb4-2"><a href="#cb4-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;computed_fields&quot;</span><span class="fu">:</span> <span class="ot">[</span></span>
+<span id="cb4-3"><a href="#cb4-3" aria-hidden="true" tabindex="-1"></a>    <span class="fu">{</span></span>
+<span id="cb4-4"><a href="#cb4-4" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;age_days&quot;</span><span class="fu">,</span></span>
+<span id="cb4-5"><a href="#cb4-5" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;number&quot;</span><span class="fu">,</span></span>
+<span id="cb4-6"><a href="#cb4-6" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Days since creation&quot;</span><span class="fu">,</span></span>
+<span id="cb4-7"><a href="#cb4-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;filterable&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb4-8"><a href="#cb4-8" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;sortable&quot;</span><span class="fu">:</span> <span class="kw">true</span></span>
+<span id="cb4-9"><a href="#cb4-9" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb4-10"><a href="#cb4-10" aria-hidden="true" tabindex="-1"></a>    <span class="fu">{</span></span>
+<span id="cb4-11"><a href="#cb4-11" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;child_count&quot;</span><span class="fu">,</span></span>
+<span id="cb4-12"><a href="#cb4-12" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;number&quot;</span><span class="fu">,</span></span>
+<span id="cb4-13"><a href="#cb4-13" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Number of child widgets&quot;</span><span class="fu">,</span></span>
+<span id="cb4-14"><a href="#cb4-14" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;filterable&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb4-15"><a href="#cb4-15" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;sortable&quot;</span><span class="fu">:</span> <span class="kw">true</span></span>
+<span id="cb4-16"><a href="#cb4-16" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb4-17"><a href="#cb4-17" aria-hidden="true" tabindex="-1"></a>  <span class="ot">]</span></span>
+<span id="cb4-18"><a href="#cb4-18" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<p>This gives clients a machine-readable list of the derived values they can ask for, plus whether those values participate in filtering and sorting.</p>
+<h2 id="5-common-patterns">5. Common Patterns</h2>
+<table>
+<thead>
+<tr class="header">
+<th>Pattern</th>
+<th>Examples</th>
+</tr>
+</thead>
+<tbody>
+<tr class="odd">
+<td>Time-derived</td>
+<td><code>age_days</code>, <code>time_until_due</code></td>
+</tr>
+<tr class="even">
+<td>Counts</td>
+<td><code>child_count</code>, <code>reference_count</code></td>
+</tr>
+<tr class="odd">
+<td>Status-derived</td>
+<td><code>is_stale</code>, <code>needs_attention</code></td>
+</tr>
+<tr class="even">
+<td>Size-derived</td>
+<td><code>estimated_tokens</code>, <code>size_human</code></td>
+</tr>
+</tbody>
+</table>
+<h2 id="6-relationship-to-other-docs">6. Relationship to Other Docs</h2>
+<ul>
+<li><a href="field-selection.html">Field Selection</a> defines the <code>_computed.</code> field path convention.</li>
+<li><a href="collection-querying.html">Collection Querying</a> describes how computed fields interact with filters, sort clauses, and aggregation.</li>
+</ul>
+
+          </div>
+        </section>
+        <nav class="page-nav" aria-label="Page navigation">
+  <a class="page-nav-link prev" href="collection-querying.html">
+    <span class="page-nav-eyebrow">Previous page</span>
+    <strong class="page-nav-label">MCP-AQL Collection Querying</strong>
+  </a>
+  <a class="page-nav-link next" href="field-selection.html">
+    <span class="page-nav-eyebrow">Next page</span>
+    <strong class="page-nav-label">Field Selection Specification</strong>
+  </a>
+</nav>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div class="container">
+      <p>&copy; 2026 DollhouseMCP Inc. d/b/a Dollhouse Research. MCP-AQL public draft documentation portal.</p>
+      <div class="footer-links">
+        <a href="../../docs/index.html">Docs Library</a><a href="../index.html">Repo-Synced Spec</a><a href="https://github.com/MCPAQL">MCPAQL Organization</a><a href="https://dollhouseresearch.com">Dollhouse Research</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../../js/search.js"></script>
+</body>
+</html>

--- a/public/spec/features/field-selection.html
+++ b/public/spec/features/field-selection.html
@@ -50,10 +50,10 @@
   <ul><li><a href="../security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="../security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="../security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Features</h3>
-  <ul><li><a href="collection-querying.html">MCP-AQL Collection Querying</a></li><li><a class="current" aria-current="page" href="field-selection.html">Field Selection Specification</a></li><li><a href="pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="warnings.html">Warnings Array Specification</a></li></ul>
+  <ul><li><a href="aggregations.html">MCP-AQL Aggregations</a></li><li><a href="collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="computed-fields.html">MCP-AQL Computed Fields</a></li><li><a class="current" aria-current="page" href="field-selection.html">Field Selection Specification</a></li><li><a href="pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="relationship-queries.html">MCP-AQL Relationship Queries</a></li><li><a href="warnings.html">Warnings Array Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Guides</h3>
-  <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
+  <ul><li><a href="../guides/cross-domain-implementation.html">Cross-Domain Implementation Guide</a></li><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
   <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li><li><a href="../repo/CHANGELOG.html">Changelog</a></li></ul>
@@ -101,7 +101,7 @@
               <p class="page-toc-intro">Use the outline to move through longer pages without losing your place.</p>
             </div>
             <ol class="page-toc-list" data-page-toc-list>
-              <li class="page-toc-item level-2"><a href="#abstract" data-toc-target="abstract">Abstract</a></li><li class="page-toc-item level-2"><a href="#1-introduction" data-toc-target="1-introduction">1. Introduction</a></li><li class="page-toc-item level-3"><a href="#11-purpose" data-toc-target="11-purpose">1.1 Purpose</a></li><li class="page-toc-item level-3"><a href="#12-status" data-toc-target="12-status">1.2 Status</a></li><li class="page-toc-item level-3"><a href="#13-token-impact" data-toc-target="13-token-impact">1.3 Token Impact</a></li><li class="page-toc-item level-2"><a href="#2-request-format" data-toc-target="2-request-format">2. Request Format</a></li><li class="page-toc-item level-3"><a href="#21-fields-parameter" data-toc-target="21-fields-parameter">2.1 Fields Parameter</a></li><li class="page-toc-item level-3"><a href="#22-preset-compatibility-alias" data-toc-target="22-preset-compatibility-alias">2.2 Preset Compatibility Alias</a></li><li class="page-toc-item level-3"><a href="#23-combined-usage" data-toc-target="23-combined-usage">2.3 Combined Usage</a></li><li class="page-toc-item level-3"><a href="#24-nested-fields" data-toc-target="24-nested-fields">2.4 Nested Fields</a></li><li class="page-toc-item level-2"><a href="#3-presets" data-toc-target="3-presets">3. Presets</a></li><li class="page-toc-item level-3"><a href="#31-standard-presets" data-toc-target="31-standard-presets">3.1 Standard Presets</a></li><li class="page-toc-item level-3"><a href="#32-default-behavior" data-toc-target="32-default-behavior">3.2 Default Behavior</a></li><li class="page-toc-item level-3"><a href="#33-custom-presets" data-toc-target="33-custom-presets">3.3 Custom Presets</a></li><li class="page-toc-item level-2"><a href="#4-response-format" data-toc-target="4-response-format">4. Response Format</a></li><li class="page-toc-item level-3"><a href="#41-filtered-response" data-toc-target="41-filtered-response">4.1 Filtered Response</a></li><li class="page-toc-item level-3"><a href="#42-collection-response" data-toc-target="42-collection-response">4.2 Collection Response</a></li><li class="page-toc-item level-3"><a href="#43-missing-fields" data-toc-target="43-missing-fields">4.3 Missing Fields</a></li><li class="page-toc-item level-2"><a href="#5-implementation-requirements" data-toc-target="5-implementation-requirements">5. Implementation Requirements</a></li><li class="page-toc-item level-3"><a href="#51-must-requirements" data-toc-target="51-must-requirements">5.1 MUST Requirements</a></li><li class="page-toc-item level-3"><a href="#52-should-requirements" data-toc-target="52-should-requirements">5.2 SHOULD Requirements</a></li><li class="page-toc-item level-3"><a href="#53-introspection" data-toc-target="53-introspection">5.3 Introspection</a></li><li class="page-toc-item level-2"><a href="#references" data-toc-target="references">References</a></li>
+              <li class="page-toc-item level-2"><a href="#abstract" data-toc-target="abstract">Abstract</a></li><li class="page-toc-item level-2"><a href="#1-introduction" data-toc-target="1-introduction">1. Introduction</a></li><li class="page-toc-item level-2"><a href="#2-request-format" data-toc-target="2-request-format">2. Request Format</a></li><li class="page-toc-item level-2"><a href="#3-presets" data-toc-target="3-presets">3. Presets</a></li><li class="page-toc-item level-2"><a href="#4-response-format" data-toc-target="4-response-format">4. Response Format</a></li><li class="page-toc-item level-2"><a href="#5-implementation-requirements" data-toc-target="5-implementation-requirements">5. Implementation Requirements</a></li><li class="page-toc-item level-2"><a href="#references" data-toc-target="references">References</a></li>
             </ol>
           </div>
         </section>
@@ -127,7 +127,7 @@
 <h3 id="13-token-impact">1.3 Token Impact</h3>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Scenario</th>
 <th>Without Selection</th>
 <th>With Selection</th>
@@ -135,19 +135,19 @@
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td>List 10 items (full)</td>
 <td>~2,500 tokens</td>
 <td>~800 tokens</td>
 <td>~68%</td>
 </tr>
-<tr>
+<tr class="even">
 <td>Get single item (full)</td>
 <td>~350 tokens</td>
 <td>~120 tokens</td>
 <td>~65%</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>Search results (20 items)</td>
 <td>~4,000 tokens</td>
 <td>~1,200 tokens</td>
@@ -196,6 +196,15 @@
 <span id="cb5-4"><a href="#cb5-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">fields</span><span class="op">:</span> [<span class="st">&quot;id&quot;</span><span class="op">,</span> <span class="st">&quot;name&quot;</span><span class="op">,</span> <span class="st">&quot;settings.theme&quot;</span><span class="op">,</span> <span class="st">&quot;settings.language&quot;</span>]</span>
 <span id="cb5-5"><a href="#cb5-5" aria-hidden="true" tabindex="-1"></a>  }</span>
 <span id="cb5-6"><a href="#cb5-6" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<h3 id="25-computed-fields">2.5 Computed Fields</h3>
+<p>When adapters expose derived values, the preferred field path convention is the <code>_computed.</code> prefix:</p>
+<div class="sourceCode" id="cb6"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb6-1"><a href="#cb6-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb6-2"><a href="#cb6-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;get_user&quot;</span><span class="op">,</span></span>
+<span id="cb6-3"><a href="#cb6-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> {</span>
+<span id="cb6-4"><a href="#cb6-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">fields</span><span class="op">:</span> [<span class="st">&quot;id&quot;</span><span class="op">,</span> <span class="st">&quot;name&quot;</span><span class="op">,</span> <span class="st">&quot;_computed.age_days&quot;</span>]</span>
+<span id="cb6-5"><a href="#cb6-5" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb6-6"><a href="#cb6-6" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<p>This convention keeps derived values explicit while still composing with normal field selection.</p>
 <hr />
 <h2 id="3-presets">3. Presets</h2>
 <h3 id="31-standard-presets">3.1 Standard Presets</h3>
@@ -218,50 +227,50 @@
 </ul>
 <h3 id="33-custom-presets">3.3 Custom Presets</h3>
 <p>Adapters MAY define additional presets specific to their domain:</p>
-<div class="sourceCode" id="cb6"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb6-1"><a href="#cb6-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Example custom presets for a user adapter</span></span>
-<span id="cb6-2"><a href="#cb6-2" aria-hidden="true" tabindex="-1"></a><span class="st">&quot;contact&quot;</span><span class="op">:</span> [<span class="st">&quot;id&quot;</span><span class="op">,</span> <span class="st">&quot;name&quot;</span><span class="op">,</span> <span class="st">&quot;email&quot;</span><span class="op">,</span> <span class="st">&quot;phone&quot;</span>]</span>
-<span id="cb6-3"><a href="#cb6-3" aria-hidden="true" tabindex="-1"></a><span class="st">&quot;profile&quot;</span><span class="op">:</span> [<span class="st">&quot;id&quot;</span><span class="op">,</span> <span class="st">&quot;name&quot;</span><span class="op">,</span> <span class="st">&quot;bio&quot;</span><span class="op">,</span> <span class="st">&quot;avatar_url&quot;</span>]</span></code></pre></div>
+<div class="sourceCode" id="cb7"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb7-1"><a href="#cb7-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Example custom presets for a user adapter</span></span>
+<span id="cb7-2"><a href="#cb7-2" aria-hidden="true" tabindex="-1"></a><span class="st">&quot;contact&quot;</span><span class="op">:</span> [<span class="st">&quot;id&quot;</span><span class="op">,</span> <span class="st">&quot;name&quot;</span><span class="op">,</span> <span class="st">&quot;email&quot;</span><span class="op">,</span> <span class="st">&quot;phone&quot;</span>]</span>
+<span id="cb7-3"><a href="#cb7-3" aria-hidden="true" tabindex="-1"></a><span class="st">&quot;profile&quot;</span><span class="op">:</span> [<span class="st">&quot;id&quot;</span><span class="op">,</span> <span class="st">&quot;name&quot;</span><span class="op">,</span> <span class="st">&quot;bio&quot;</span><span class="op">,</span> <span class="st">&quot;avatar_url&quot;</span>]</span></code></pre></div>
 <p>Custom presets SHOULD be discoverable via introspection.</p>
 <hr />
 <h2 id="4-response-format">4. Response Format</h2>
 <h3 id="41-filtered-response">4.1 Filtered Response</h3>
 <p>Only requested fields appear in response:</p>
 <p><strong>Request:</strong></p>
-<div class="sourceCode" id="cb7"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb7-1"><a href="#cb7-1" aria-hidden="true" tabindex="-1"></a>{</span>
-<span id="cb7-2"><a href="#cb7-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;get_user&quot;</span><span class="op">,</span></span>
-<span id="cb7-3"><a href="#cb7-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> {</span>
-<span id="cb7-4"><a href="#cb7-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">user_id</span><span class="op">:</span> <span class="st">&quot;123&quot;</span><span class="op">,</span></span>
-<span id="cb7-5"><a href="#cb7-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">fields</span><span class="op">:</span> [<span class="st">&quot;id&quot;</span><span class="op">,</span> <span class="st">&quot;name&quot;</span>]</span>
-<span id="cb7-6"><a href="#cb7-6" aria-hidden="true" tabindex="-1"></a>  }</span>
-<span id="cb7-7"><a href="#cb7-7" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
-<p><strong>Response:</strong></p>
 <div class="sourceCode" id="cb8"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb8-1"><a href="#cb8-1" aria-hidden="true" tabindex="-1"></a>{</span>
-<span id="cb8-2"><a href="#cb8-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">success</span><span class="op">:</span> <span class="kw">true</span><span class="op">,</span></span>
-<span id="cb8-3"><a href="#cb8-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">data</span><span class="op">:</span> {</span>
-<span id="cb8-4"><a href="#cb8-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">id</span><span class="op">:</span> <span class="st">&quot;123&quot;</span><span class="op">,</span></span>
-<span id="cb8-5"><a href="#cb8-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;Alice&quot;</span></span>
+<span id="cb8-2"><a href="#cb8-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;get_user&quot;</span><span class="op">,</span></span>
+<span id="cb8-3"><a href="#cb8-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> {</span>
+<span id="cb8-4"><a href="#cb8-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">user_id</span><span class="op">:</span> <span class="st">&quot;123&quot;</span><span class="op">,</span></span>
+<span id="cb8-5"><a href="#cb8-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">fields</span><span class="op">:</span> [<span class="st">&quot;id&quot;</span><span class="op">,</span> <span class="st">&quot;name&quot;</span>]</span>
 <span id="cb8-6"><a href="#cb8-6" aria-hidden="true" tabindex="-1"></a>  }</span>
 <span id="cb8-7"><a href="#cb8-7" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<p><strong>Response:</strong></p>
+<div class="sourceCode" id="cb9"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb9-1"><a href="#cb9-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb9-2"><a href="#cb9-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">success</span><span class="op">:</span> <span class="kw">true</span><span class="op">,</span></span>
+<span id="cb9-3"><a href="#cb9-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">data</span><span class="op">:</span> {</span>
+<span id="cb9-4"><a href="#cb9-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">id</span><span class="op">:</span> <span class="st">&quot;123&quot;</span><span class="op">,</span></span>
+<span id="cb9-5"><a href="#cb9-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;Alice&quot;</span></span>
+<span id="cb9-6"><a href="#cb9-6" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb9-7"><a href="#cb9-7" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
 <h3 id="42-collection-response">4.2 Collection Response</h3>
 <p>For collections, selection applies to each item:</p>
 <p><strong>Request:</strong></p>
-<div class="sourceCode" id="cb9"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb9-1"><a href="#cb9-1" aria-hidden="true" tabindex="-1"></a>{</span>
-<span id="cb9-2"><a href="#cb9-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;list_users&quot;</span><span class="op">,</span></span>
-<span id="cb9-3"><a href="#cb9-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> {</span>
-<span id="cb9-4"><a href="#cb9-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">fields</span><span class="op">:</span> <span class="st">&quot;minimal&quot;</span></span>
-<span id="cb9-5"><a href="#cb9-5" aria-hidden="true" tabindex="-1"></a>  }</span>
-<span id="cb9-6"><a href="#cb9-6" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
-<p><strong>Response:</strong></p>
 <div class="sourceCode" id="cb10"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb10-1"><a href="#cb10-1" aria-hidden="true" tabindex="-1"></a>{</span>
-<span id="cb10-2"><a href="#cb10-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">success</span><span class="op">:</span> <span class="kw">true</span><span class="op">,</span></span>
-<span id="cb10-3"><a href="#cb10-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">data</span><span class="op">:</span> {</span>
-<span id="cb10-4"><a href="#cb10-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">items</span><span class="op">:</span> [</span>
-<span id="cb10-5"><a href="#cb10-5" aria-hidden="true" tabindex="-1"></a>      { <span class="dt">id</span><span class="op">:</span> <span class="st">&quot;1&quot;</span><span class="op">,</span> <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;Alice&quot;</span> }<span class="op">,</span></span>
-<span id="cb10-6"><a href="#cb10-6" aria-hidden="true" tabindex="-1"></a>      { <span class="dt">id</span><span class="op">:</span> <span class="st">&quot;2&quot;</span><span class="op">,</span> <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;Bob&quot;</span> }</span>
-<span id="cb10-7"><a href="#cb10-7" aria-hidden="true" tabindex="-1"></a>    ]<span class="op">,</span></span>
-<span id="cb10-8"><a href="#cb10-8" aria-hidden="true" tabindex="-1"></a>    <span class="dt">pagination</span><span class="op">:</span> { <span class="op">...</span> }  <span class="co">// Pagination not affected by selection</span></span>
-<span id="cb10-9"><a href="#cb10-9" aria-hidden="true" tabindex="-1"></a>  }</span>
-<span id="cb10-10"><a href="#cb10-10" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<span id="cb10-2"><a href="#cb10-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;list_users&quot;</span><span class="op">,</span></span>
+<span id="cb10-3"><a href="#cb10-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> {</span>
+<span id="cb10-4"><a href="#cb10-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">fields</span><span class="op">:</span> <span class="st">&quot;minimal&quot;</span></span>
+<span id="cb10-5"><a href="#cb10-5" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb10-6"><a href="#cb10-6" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<p><strong>Response:</strong></p>
+<div class="sourceCode" id="cb11"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb11-1"><a href="#cb11-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb11-2"><a href="#cb11-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">success</span><span class="op">:</span> <span class="kw">true</span><span class="op">,</span></span>
+<span id="cb11-3"><a href="#cb11-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">data</span><span class="op">:</span> {</span>
+<span id="cb11-4"><a href="#cb11-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">items</span><span class="op">:</span> [</span>
+<span id="cb11-5"><a href="#cb11-5" aria-hidden="true" tabindex="-1"></a>      { <span class="dt">id</span><span class="op">:</span> <span class="st">&quot;1&quot;</span><span class="op">,</span> <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;Alice&quot;</span> }<span class="op">,</span></span>
+<span id="cb11-6"><a href="#cb11-6" aria-hidden="true" tabindex="-1"></a>      { <span class="dt">id</span><span class="op">:</span> <span class="st">&quot;2&quot;</span><span class="op">,</span> <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;Bob&quot;</span> }</span>
+<span id="cb11-7"><a href="#cb11-7" aria-hidden="true" tabindex="-1"></a>    ]<span class="op">,</span></span>
+<span id="cb11-8"><a href="#cb11-8" aria-hidden="true" tabindex="-1"></a>    <span class="dt">pagination</span><span class="op">:</span> { <span class="op">...</span> }  <span class="co">// Pagination not affected by selection</span></span>
+<span id="cb11-9"><a href="#cb11-9" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb11-10"><a href="#cb11-10" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
 <h3 id="43-missing-fields">4.3 Missing Fields</h3>
 <p>If a requested field doesn't exist on an item:</p>
 <ul>
@@ -269,6 +278,18 @@
 <li><strong>No error</strong> - Silently skip</li>
 <li><strong>Consistent behavior</strong> - Same across all items</li>
 </ul>
+<h3 id="44-computed-field-responses">4.4 Computed Field Responses</h3>
+<p>Requested computed fields SHOULD appear under the <code>_computed</code> object:</p>
+<div class="sourceCode" id="cb12"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb12-1"><a href="#cb12-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb12-2"><a href="#cb12-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb12-3"><a href="#cb12-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;data&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb12-4"><a href="#cb12-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;id&quot;</span><span class="fu">:</span> <span class="st">&quot;123&quot;</span><span class="fu">,</span></span>
+<span id="cb12-5"><a href="#cb12-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;Alice&quot;</span><span class="fu">,</span></span>
+<span id="cb12-6"><a href="#cb12-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;_computed&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb12-7"><a href="#cb12-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;age_days&quot;</span><span class="fu">:</span> <span class="dv">47</span></span>
+<span id="cb12-8"><a href="#cb12-8" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb12-9"><a href="#cb12-9" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb12-10"><a href="#cb12-10" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
 <hr />
 <h2 id="5-implementation-requirements">5. Implementation Requirements</h2>
 <h3 id="51-must-requirements">5.1 MUST Requirements</h3>
@@ -287,32 +308,34 @@
 <li>Support field selection on search results</li>
 <li>Validate field names against known fields</li>
 <li>Accept <code>preset</code> as a compatibility alias only when needed for older clients</li>
+<li>Document any <code>_computed.</code> field paths that can be requested</li>
 </ol>
 <blockquote>
 <p><strong>Collection Querying Note:</strong> Field selection is one part of the broader collection-query contract. See <a href="collection-querying.html">Collection Querying</a> for guidance on composing <code>fields</code> with <code>query</code>, <code>filter</code>, <code>sort</code>, and pagination.</p>
 </blockquote>
 <h3 id="53-introspection">5.3 Introspection</h3>
 <p>Field selection options SHOULD be discoverable:</p>
-<div class="sourceCode" id="cb11"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb11-1"><a href="#cb11-1" aria-hidden="true" tabindex="-1"></a>{</span>
-<span id="cb11-2"><a href="#cb11-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;introspect&quot;</span><span class="op">,</span></span>
-<span id="cb11-3"><a href="#cb11-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> { <span class="dt">query</span><span class="op">:</span> <span class="st">&quot;types&quot;</span><span class="op">,</span> <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;FieldSelection&quot;</span> }</span>
-<span id="cb11-4"><a href="#cb11-4" aria-hidden="true" tabindex="-1"></a>}</span>
-<span id="cb11-5"><a href="#cb11-5" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb11-6"><a href="#cb11-6" aria-hidden="true" tabindex="-1"></a><span class="co">// Response:</span></span>
-<span id="cb11-7"><a href="#cb11-7" aria-hidden="true" tabindex="-1"></a>{</span>
-<span id="cb11-8"><a href="#cb11-8" aria-hidden="true" tabindex="-1"></a>  <span class="dt">success</span><span class="op">:</span> <span class="kw">true</span><span class="op">,</span></span>
-<span id="cb11-9"><a href="#cb11-9" aria-hidden="true" tabindex="-1"></a>  <span class="dt">data</span><span class="op">:</span> {</span>
-<span id="cb11-10"><a href="#cb11-10" aria-hidden="true" tabindex="-1"></a>    <span class="dt">type</span><span class="op">:</span> {</span>
-<span id="cb11-11"><a href="#cb11-11" aria-hidden="true" tabindex="-1"></a>      <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;FieldSelection&quot;</span><span class="op">,</span></span>
-<span id="cb11-12"><a href="#cb11-12" aria-hidden="true" tabindex="-1"></a>      <span class="dt">kind</span><span class="op">:</span> <span class="st">&quot;object&quot;</span><span class="op">,</span></span>
-<span id="cb11-13"><a href="#cb11-13" aria-hidden="true" tabindex="-1"></a>      <span class="dt">description</span><span class="op">:</span> <span class="st">&quot;Field selection configuration&quot;</span><span class="op">,</span></span>
-<span id="cb11-14"><a href="#cb11-14" aria-hidden="true" tabindex="-1"></a>      <span class="dt">fields</span><span class="op">:</span> [</span>
-<span id="cb11-15"><a href="#cb11-15" aria-hidden="true" tabindex="-1"></a>        { <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;presets&quot;</span><span class="op">,</span> <span class="dt">type</span><span class="op">:</span> <span class="st">&quot;array&quot;</span><span class="op">,</span> <span class="dt">description</span><span class="op">:</span> <span class="st">&quot;Available presets&quot;</span> }<span class="op">,</span></span>
-<span id="cb11-16"><a href="#cb11-16" aria-hidden="true" tabindex="-1"></a>        { <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;fields&quot;</span><span class="op">,</span> <span class="dt">type</span><span class="op">:</span> <span class="st">&quot;object&quot;</span><span class="op">,</span> <span class="dt">description</span><span class="op">:</span> <span class="st">&quot;Available fields by type&quot;</span> }</span>
-<span id="cb11-17"><a href="#cb11-17" aria-hidden="true" tabindex="-1"></a>      ]</span>
-<span id="cb11-18"><a href="#cb11-18" aria-hidden="true" tabindex="-1"></a>    }</span>
-<span id="cb11-19"><a href="#cb11-19" aria-hidden="true" tabindex="-1"></a>  }</span>
-<span id="cb11-20"><a href="#cb11-20" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<div class="sourceCode" id="cb13"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb13-1"><a href="#cb13-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb13-2"><a href="#cb13-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;introspect&quot;</span><span class="op">,</span></span>
+<span id="cb13-3"><a href="#cb13-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> { <span class="dt">query</span><span class="op">:</span> <span class="st">&quot;types&quot;</span><span class="op">,</span> <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;FieldSelection&quot;</span> }</span>
+<span id="cb13-4"><a href="#cb13-4" aria-hidden="true" tabindex="-1"></a>}</span>
+<span id="cb13-5"><a href="#cb13-5" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb13-6"><a href="#cb13-6" aria-hidden="true" tabindex="-1"></a><span class="co">// Response:</span></span>
+<span id="cb13-7"><a href="#cb13-7" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb13-8"><a href="#cb13-8" aria-hidden="true" tabindex="-1"></a>  <span class="dt">success</span><span class="op">:</span> <span class="kw">true</span><span class="op">,</span></span>
+<span id="cb13-9"><a href="#cb13-9" aria-hidden="true" tabindex="-1"></a>  <span class="dt">data</span><span class="op">:</span> {</span>
+<span id="cb13-10"><a href="#cb13-10" aria-hidden="true" tabindex="-1"></a>    <span class="dt">type</span><span class="op">:</span> {</span>
+<span id="cb13-11"><a href="#cb13-11" aria-hidden="true" tabindex="-1"></a>      <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;FieldSelection&quot;</span><span class="op">,</span></span>
+<span id="cb13-12"><a href="#cb13-12" aria-hidden="true" tabindex="-1"></a>      <span class="dt">kind</span><span class="op">:</span> <span class="st">&quot;object&quot;</span><span class="op">,</span></span>
+<span id="cb13-13"><a href="#cb13-13" aria-hidden="true" tabindex="-1"></a>      <span class="dt">description</span><span class="op">:</span> <span class="st">&quot;Field selection configuration&quot;</span><span class="op">,</span></span>
+<span id="cb13-14"><a href="#cb13-14" aria-hidden="true" tabindex="-1"></a>      <span class="dt">fields</span><span class="op">:</span> [</span>
+<span id="cb13-15"><a href="#cb13-15" aria-hidden="true" tabindex="-1"></a>        { <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;presets&quot;</span><span class="op">,</span> <span class="dt">type</span><span class="op">:</span> <span class="st">&quot;array&quot;</span><span class="op">,</span> <span class="dt">description</span><span class="op">:</span> <span class="st">&quot;Available presets&quot;</span> }<span class="op">,</span></span>
+<span id="cb13-16"><a href="#cb13-16" aria-hidden="true" tabindex="-1"></a>        { <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;fields&quot;</span><span class="op">,</span> <span class="dt">type</span><span class="op">:</span> <span class="st">&quot;object&quot;</span><span class="op">,</span> <span class="dt">description</span><span class="op">:</span> <span class="st">&quot;Available fields by type&quot;</span> }<span class="op">,</span></span>
+<span id="cb13-17"><a href="#cb13-17" aria-hidden="true" tabindex="-1"></a>        { <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;computed_fields&quot;</span><span class="op">,</span> <span class="dt">type</span><span class="op">:</span> <span class="st">&quot;array&quot;</span><span class="op">,</span> <span class="dt">description</span><span class="op">:</span> <span class="st">&quot;Available derived field definitions&quot;</span> }</span>
+<span id="cb13-18"><a href="#cb13-18" aria-hidden="true" tabindex="-1"></a>      ]</span>
+<span id="cb13-19"><a href="#cb13-19" aria-hidden="true" tabindex="-1"></a>    }</span>
+<span id="cb13-20"><a href="#cb13-20" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb13-21"><a href="#cb13-21" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
 <hr />
 <h2 id="references">References</h2>
 <ul>
@@ -324,9 +347,9 @@
           </div>
         </section>
         <nav class="page-nav" aria-label="Page navigation">
-  <a class="page-nav-link prev" href="collection-querying.html">
+  <a class="page-nav-link prev" href="computed-fields.html">
     <span class="page-nav-eyebrow">Previous page</span>
-    <strong class="page-nav-label">MCP-AQL Collection Querying</strong>
+    <strong class="page-nav-label">MCP-AQL Computed Fields</strong>
   </a>
   <a class="page-nav-link next" href="pagination.html">
     <span class="page-nav-eyebrow">Next page</span>

--- a/public/spec/features/pagination.html
+++ b/public/spec/features/pagination.html
@@ -50,10 +50,10 @@
   <ul><li><a href="../security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="../security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="../security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Features</h3>
-  <ul><li><a href="collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="field-selection.html">Field Selection Specification</a></li><li><a class="current" aria-current="page" href="pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="warnings.html">Warnings Array Specification</a></li></ul>
+  <ul><li><a href="aggregations.html">MCP-AQL Aggregations</a></li><li><a href="collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="computed-fields.html">MCP-AQL Computed Fields</a></li><li><a href="field-selection.html">Field Selection Specification</a></li><li><a class="current" aria-current="page" href="pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="relationship-queries.html">MCP-AQL Relationship Queries</a></li><li><a href="warnings.html">Warnings Array Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Guides</h3>
-  <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
+  <ul><li><a href="../guides/cross-domain-implementation.html">Cross-Domain Implementation Guide</a></li><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
   <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li><li><a href="../repo/CHANGELOG.html">Changelog</a></li></ul>
@@ -175,29 +175,29 @@
 <h3 id="22-parameter-combinations">2.2 Parameter Combinations</h3>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Parameters</th>
 <th>Behavior</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><code>first</code></td>
 <td>First N items from start</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>first</code> + <code>after</code></td>
 <td>First N items after cursor</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>last</code></td>
 <td>Last N items from end</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>last</code> + <code>before</code></td>
 <td>Last N items before cursor</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>None</td>
 <td>Default page size from start</td>
 </tr>
@@ -295,34 +295,34 @@
 <h3 id="32-pageinfo-requirements">3.2 PageInfo Requirements</h3>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Field</th>
 <th>Required</th>
 <th>Notes</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><code>hasNextPage</code></td>
 <td>Yes</td>
 <td>Always include, even if false</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>hasPreviousPage</code></td>
 <td>Yes</td>
 <td>Always include, even if false</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>startCursor</code></td>
 <td>Conditional</td>
 <td>Required when results are returned (<code>items.length &gt; 0</code> or <code>edges.length &gt; 0</code>)</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>endCursor</code></td>
 <td>Conditional</td>
 <td>Required when results are returned (<code>items.length &gt; 0</code> or <code>edges.length &gt; 0</code>)</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>totalCount</code></td>
 <td>No</td>
 <td>Include when available without performance impact</td>
@@ -439,25 +439,25 @@
 <h3 id="44-choosing-response-format">4.4 Choosing Response Format</h3>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Use Case</th>
 <th>Recommended Format</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td>Simple listing</td>
 <td><code>items</code> array</td>
 </tr>
-<tr>
+<tr class="even">
 <td>Modify during iteration</td>
 <td><code>edges</code> with cursors</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>LLM context (minimize tokens)</td>
 <td><code>items</code> array</td>
 </tr>
-<tr>
+<tr class="even">
 <td>Resume from specific item</td>
 <td><code>edges</code> with cursors</td>
 </tr>
@@ -507,34 +507,34 @@
 <p>The following operation types SHOULD support pagination:</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Operation</th>
 <th>Required</th>
 <th>Notes</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><code>list_elements</code></td>
 <td>Yes</td>
 <td>Core element listing</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>search_elements</code></td>
 <td>Yes</td>
 <td>Search results</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>query_elements</code></td>
 <td>Yes</td>
 <td>Complex queries</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>list_*</code></td>
 <td>Yes</td>
 <td>Any list operation</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>search_*</code></td>
 <td>Yes</td>
 <td>Any search operation</td>
@@ -545,21 +545,21 @@
 <p>When pagination parameters are omitted:</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Aspect</th>
 <th>Default</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td>Page size</td>
 <td>Implementation-defined (RECOMMENDED: 20)</td>
 </tr>
-<tr>
+<tr class="even">
 <td>Direction</td>
 <td>Forward (from start)</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>Cursor</td>
 <td>None (first page)</td>
 </tr>
@@ -711,9 +711,9 @@
     <span class="page-nav-eyebrow">Previous page</span>
     <strong class="page-nav-label">Field Selection Specification</strong>
   </a>
-  <a class="page-nav-link next" href="warnings.html">
+  <a class="page-nav-link next" href="relationship-queries.html">
     <span class="page-nav-eyebrow">Next page</span>
-    <strong class="page-nav-label">Warnings Array Specification</strong>
+    <strong class="page-nav-label">MCP-AQL Relationship Queries</strong>
   </a>
 </nav>
       </article>

--- a/public/spec/features/relationship-queries.html
+++ b/public/spec/features/relationship-queries.html
@@ -1,0 +1,294 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Document Status: This document is informative. For normative requirements, see MCP-AQL Specification v1.0.0.">
+  <title>MCP-AQL Spec | MCP-AQL Relationship Queries</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../../css/style.css">
+</head>
+<body>
+  <header>
+    <div class="container">
+      <nav>
+        <a class="logo" href="../../index.html"><span class="logo-mark"></span>MCP-AQL</a>
+        <ul class="nav-links">
+          <li><a href="../../index.html">Home</a></li>
+          <li><a href="../../docs/index.html">Docs</a></li>
+          <li><a href="../../launch-checklist.html">Launch Checklist</a></li>
+          <li><a href="../../apis/index.html">Adapter Patterns</a></li>
+        </ul>
+        <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
+          <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
+          <input id="site-search-input" data-search-input type="search" placeholder="Search MCP-AQL docs, spec pages, and adapter patterns...">
+          <span class="search-count" data-search-count></span>
+          <ul class="search-results" data-search-results hidden></ul>
+        </form>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <div class="container docs-shell">
+      <aside class="docs-side">
+        <h2>Repo-Synced Spec</h2>
+        <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
+        <div class="docs-side-group">
+  <h3>Core</h3>
+  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li><li><a href="../repo/README.html">MCP-AQL Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Versions</h3>
+  <ul><li><a href="../versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Adapter</h3>
+  <ul><li><a href="../adapter/danger-levels.html">Dangerous Operation Classification Specification</a></li><li><a href="../adapter/discovery-bundle.html">MCP Server Discovery Bundle</a></li><li><a href="../adapter/element-type.html">Adapter Element Type Specification</a></li><li><a href="../adapter/generator.html">Adapter Generator Specification</a></li><li><a href="../adapter/rate-limiting.html">Rate Limiting and Quota Management Specification</a></li><li><a href="../adapter/trust-levels.html">Trust Levels Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Security</h3>
+  <ul><li><a href="../security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="../security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="../security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Features</h3>
+  <ul><li><a href="aggregations.html">MCP-AQL Aggregations</a></li><li><a href="collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="computed-fields.html">MCP-AQL Computed Fields</a></li><li><a href="field-selection.html">Field Selection Specification</a></li><li><a href="pagination.html">Cursor-Based Pagination Specification</a></li><li><a class="current" aria-current="page" href="relationship-queries.html">MCP-AQL Relationship Queries</a></li><li><a href="warnings.html">Warnings Array Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Guides</h3>
+  <ul><li><a href="../guides/cross-domain-implementation.html">Cross-Domain Implementation Guide</a></li><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Process</h3>
+  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li><li><a href="../repo/CHANGELOG.html">Changelog</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Architecture</h3>
+  <ul><li><a href="../architecture/README.html">Architecture Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Research</h3>
+  <ul><li><a href="../research/mcp-vs-mcpaql-vs-a2a.html">Protocol Landscape: MCP vs MCP-AQL vs A2A</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Reference</h3>
+  <ul><li><a href="../reference/README.html">Reference Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>ADRs</h3>
+  <ul><li><a href="../adr/ADR-001-crude-pattern.html">ADR-001: CRUDE Pattern (Extending CRUD with Execute)</a></li><li><a href="../adr/ADR-002-graphql-style-input.html">ADR-002: GraphQL-Style Input Objects for Updates</a></li><li><a href="../adr/ADR-003-snake-case-parameters.html">ADR-003: snake_case Parameter Convention</a></li><li><a href="../adr/ADR-004-schema-driven-operations.html">ADR-004: Schema-Driven Operation Definitions</a></li><li><a href="../adr/ADR-005-introspection-system.html">ADR-005: GraphQL-Style Introspection System</a></li><li><a href="../adr/ADR-006-discriminated-responses.html">ADR-006: Discriminated Response Format</a></li><li><a href="../adr/index.html">Architecture Decision Records</a></li><li><a href="../adr/README.html">Architecture Decision Records</a></li></ul>
+</div>
+      </aside>
+
+      <article class="docs-main">
+        <nav class="breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../../index.html">Home</a></li>
+            <li><a href="../index.html">Full Spec</a></li>
+            <li><span class="current">MCP-AQL Relationship Queries</span></li>
+          </ol>
+        </nav>
+        <section class="hero docs-hero">
+          <div class="hero-inner">
+            <span class="status-pill">REPO-SYNCED SPEC DOC</span>
+            <h1>MCP-AQL Relationship Queries</h1>
+            <p class="lede">Document Status: This document is informative. For normative requirements, see MCP-AQL Specification v1.0.0.</p>
+            <div class="spec-meta"><span class="state-chip live">Support document</span><span class="state-chip pending">Draft</span><span class="state-chip">1.0.0-draft</span><span class="state-chip">2026-04-15</span></div>
+            <p class="spec-source">Source: <a href="https://github.com/MCPAQL/spec/blob/main/docs/features/relationship-queries.md">spec/docs/features/relationship-queries.md</a></p>
+            <div class="hero-actions">
+              <a class="btn btn-primary" href="https://github.com/MCPAQL/spec/blob/main/docs/features/relationship-queries.md">Open Source Markdown</a><a class="btn btn-secondary" href="../index.html">Browse Full Spec Reference</a>
+            </div>
+          </div>
+        </section>
+
+        <section class="page-toc-shell" data-page-toc>
+          <div class="card page-toc-card">
+            <div class="page-toc-head">
+              <p class="page-toc-kicker">On this page</p>
+              <h2>Jump to a section</h2>
+              <p class="page-toc-intro">Use the outline to move through longer pages without losing your place.</p>
+            </div>
+            <ol class="page-toc-list" data-page-toc-list>
+              <li class="page-toc-item level-2"><a href="#abstract" data-toc-target="abstract">Abstract</a></li><li class="page-toc-item level-2"><a href="#1-preferred-operation-shape" data-toc-target="1-preferred-operation-shape">1. Preferred Operation Shape</a></li><li class="page-toc-item level-2"><a href="#2-core-parameters" data-toc-target="2-core-parameters">2. Core Parameters</a></li><li class="page-toc-item level-2"><a href="#3-response-shape" data-toc-target="3-response-shape">3. Response Shape</a></li><li class="page-toc-item level-2"><a href="#4-standard-relationship-vocabulary" data-toc-target="4-standard-relationship-vocabulary">4. Standard Relationship Vocabulary</a></li><li class="page-toc-item level-2"><a href="#5-depth-and-cycle-handling" data-toc-target="5-depth-and-cycle-handling">5. Depth and Cycle Handling</a></li><li class="page-toc-item level-2"><a href="#6-introspection-guidance" data-toc-target="6-introspection-guidance">6. Introspection Guidance</a></li><li class="page-toc-item level-2"><a href="#7-relationship-to-other-docs" data-toc-target="7-relationship-to-other-docs">7. Relationship to Other Docs</a></li>
+            </ol>
+          </div>
+        </section>
+
+
+        <section>
+          <div class="card spec-prose">
+            <p><strong>Version:</strong> 1.0.0-draft <strong>Status:</strong> Draft <strong>Last Updated:</strong> 2026-04-15</p>
+<blockquote>
+<p><strong>Document Status:</strong> This document is <strong>informative</strong>. For normative requirements, see <a href="../versions/v1.0.0-draft.html">MCP-AQL Specification v1.0.0</a>.</p>
+</blockquote>
+<h2 id="abstract">Abstract</h2>
+<p>This document defines the preferred MCP-AQL shape for relationship traversal and graph-oriented READ operations. Relationship queries give clients a standard way to move through adapter-defined connections without manually fetching each node one hop at a time.</p>
+<h2 id="1-preferred-operation-shape">1. Preferred Operation Shape</h2>
+<p>The preferred operation name is <code>query_relationships</code>:</p>
+<div class="sourceCode" id="cb1"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb1-2"><a href="#cb1-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;query_relationships&quot;</span><span class="op">,</span></span>
+<span id="cb1-3"><a href="#cb1-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> {</span>
+<span id="cb1-4"><a href="#cb1-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">root</span><span class="op">:</span> {</span>
+<span id="cb1-5"><a href="#cb1-5" aria-hidden="true" tabindex="-1"></a>      <span class="dt">element_type</span><span class="op">:</span> <span class="st">&quot;agent&quot;</span><span class="op">,</span></span>
+<span id="cb1-6"><a href="#cb1-6" aria-hidden="true" tabindex="-1"></a>      <span class="dt">element_name</span><span class="op">:</span> <span class="st">&quot;code_reviewer&quot;</span></span>
+<span id="cb1-7"><a href="#cb1-7" aria-hidden="true" tabindex="-1"></a>    }<span class="op">,</span></span>
+<span id="cb1-8"><a href="#cb1-8" aria-hidden="true" tabindex="-1"></a>    <span class="dt">direction</span><span class="op">:</span> <span class="st">&quot;outgoing&quot;</span><span class="op">,</span></span>
+<span id="cb1-9"><a href="#cb1-9" aria-hidden="true" tabindex="-1"></a>    <span class="dt">relationship</span><span class="op">:</span> <span class="st">&quot;uses&quot;</span><span class="op">,</span></span>
+<span id="cb1-10"><a href="#cb1-10" aria-hidden="true" tabindex="-1"></a>    <span class="dt">depth</span><span class="op">:</span> <span class="dv">2</span><span class="op">,</span></span>
+<span id="cb1-11"><a href="#cb1-11" aria-hidden="true" tabindex="-1"></a>    <span class="dt">include</span><span class="op">:</span> [<span class="st">&quot;root&quot;</span><span class="op">,</span> <span class="st">&quot;relationships&quot;</span><span class="op">,</span> <span class="st">&quot;graph.nodes&quot;</span><span class="op">,</span> <span class="st">&quot;graph.edges&quot;</span>]</span>
+<span id="cb1-12"><a href="#cb1-12" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb1-13"><a href="#cb1-13" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<h2 id="2-core-parameters">2. Core Parameters</h2>
+<table>
+<thead>
+<tr class="header">
+<th>Parameter</th>
+<th>Required</th>
+<th>Meaning</th>
+</tr>
+</thead>
+<tbody>
+<tr class="odd">
+<td><code>root</code></td>
+<td>Yes</td>
+<td>Starting resource for the traversal</td>
+</tr>
+<tr class="even">
+<td><code>direction</code></td>
+<td>Yes</td>
+<td><code>incoming</code>, <code>outgoing</code>, or <code>both</code></td>
+</tr>
+<tr class="odd">
+<td><code>relationship</code></td>
+<td>No</td>
+<td>Relationship type to match</td>
+</tr>
+<tr class="even">
+<td><code>depth</code></td>
+<td>No</td>
+<td>Maximum traversal depth</td>
+</tr>
+<tr class="odd">
+<td><code>include</code></td>
+<td>No</td>
+<td>Optional response-section selector for <code>root</code>, <code>relationships</code>, <code>graph.nodes</code>, and <code>graph.edges</code>; all sections returned if omitted</td>
+</tr>
+<tr class="even">
+<td><code>first</code> / <code>after</code></td>
+<td>No</td>
+<td>Optional pagination controls when traversals are large</td>
+</tr>
+</tbody>
+</table>
+<p>Adapters MAY add domain-specific root identifiers or filter controls, but SHOULD keep the traversal vocabulary stable.</p>
+<p>When pagination is supported for large traversals, the request shape remains the same:</p>
+<div class="sourceCode" id="cb2"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb2-2"><a href="#cb2-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;query_relationships&quot;</span><span class="op">,</span></span>
+<span id="cb2-3"><a href="#cb2-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> {</span>
+<span id="cb2-4"><a href="#cb2-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">root</span><span class="op">:</span> {</span>
+<span id="cb2-5"><a href="#cb2-5" aria-hidden="true" tabindex="-1"></a>      <span class="dt">element_type</span><span class="op">:</span> <span class="st">&quot;agent&quot;</span><span class="op">,</span></span>
+<span id="cb2-6"><a href="#cb2-6" aria-hidden="true" tabindex="-1"></a>      <span class="dt">element_name</span><span class="op">:</span> <span class="st">&quot;code_reviewer&quot;</span></span>
+<span id="cb2-7"><a href="#cb2-7" aria-hidden="true" tabindex="-1"></a>    }<span class="op">,</span></span>
+<span id="cb2-8"><a href="#cb2-8" aria-hidden="true" tabindex="-1"></a>    <span class="dt">direction</span><span class="op">:</span> <span class="st">&quot;outgoing&quot;</span><span class="op">,</span></span>
+<span id="cb2-9"><a href="#cb2-9" aria-hidden="true" tabindex="-1"></a>    <span class="dt">relationship</span><span class="op">:</span> <span class="st">&quot;uses&quot;</span><span class="op">,</span></span>
+<span id="cb2-10"><a href="#cb2-10" aria-hidden="true" tabindex="-1"></a>    <span class="dt">depth</span><span class="op">:</span> <span class="dv">2</span><span class="op">,</span></span>
+<span id="cb2-11"><a href="#cb2-11" aria-hidden="true" tabindex="-1"></a>    <span class="dt">first</span><span class="op">:</span> <span class="dv">25</span><span class="op">,</span></span>
+<span id="cb2-12"><a href="#cb2-12" aria-hidden="true" tabindex="-1"></a>    <span class="dt">after</span><span class="op">:</span> <span class="st">&quot;cursor_rel_001&quot;</span></span>
+<span id="cb2-13"><a href="#cb2-13" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb2-14"><a href="#cb2-14" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<h2 id="3-response-shape">3. Response Shape</h2>
+<div class="sourceCode" id="cb3"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb3-1"><a href="#cb3-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb3-2"><a href="#cb3-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb3-3"><a href="#cb3-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;data&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb3-4"><a href="#cb3-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;root&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb3-5"><a href="#cb3-5" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;element_type&quot;</span><span class="fu">:</span> <span class="st">&quot;agent&quot;</span><span class="fu">,</span></span>
+<span id="cb3-6"><a href="#cb3-6" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;element_name&quot;</span><span class="fu">:</span> <span class="st">&quot;code_reviewer&quot;</span></span>
+<span id="cb3-7"><a href="#cb3-7" aria-hidden="true" tabindex="-1"></a>    <span class="fu">},</span></span>
+<span id="cb3-8"><a href="#cb3-8" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;relationships&quot;</span><span class="fu">:</span> <span class="ot">[</span></span>
+<span id="cb3-9"><a href="#cb3-9" aria-hidden="true" tabindex="-1"></a>      <span class="fu">{</span></span>
+<span id="cb3-10"><a href="#cb3-10" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;uses&quot;</span><span class="fu">,</span></span>
+<span id="cb3-11"><a href="#cb3-11" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;direction&quot;</span><span class="fu">:</span> <span class="st">&quot;outgoing&quot;</span><span class="fu">,</span></span>
+<span id="cb3-12"><a href="#cb3-12" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;target&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb3-13"><a href="#cb3-13" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;element_type&quot;</span><span class="fu">:</span> <span class="st">&quot;skill&quot;</span><span class="fu">,</span></span>
+<span id="cb3-14"><a href="#cb3-14" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;element_name&quot;</span><span class="fu">:</span> <span class="st">&quot;typescript_analysis&quot;</span></span>
+<span id="cb3-15"><a href="#cb3-15" aria-hidden="true" tabindex="-1"></a>        <span class="fu">},</span></span>
+<span id="cb3-16"><a href="#cb3-16" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;depth&quot;</span><span class="fu">:</span> <span class="dv">1</span></span>
+<span id="cb3-17"><a href="#cb3-17" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span></span>
+<span id="cb3-18"><a href="#cb3-18" aria-hidden="true" tabindex="-1"></a>    <span class="ot">]</span><span class="fu">,</span></span>
+<span id="cb3-19"><a href="#cb3-19" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;graph&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb3-20"><a href="#cb3-20" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;nodes&quot;</span><span class="fu">:</span> <span class="ot">[</span></span>
+<span id="cb3-21"><a href="#cb3-21" aria-hidden="true" tabindex="-1"></a>        <span class="fu">{</span></span>
+<span id="cb3-22"><a href="#cb3-22" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;id&quot;</span><span class="fu">:</span> <span class="st">&quot;agent:code_reviewer&quot;</span><span class="fu">,</span></span>
+<span id="cb3-23"><a href="#cb3-23" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;element_type&quot;</span><span class="fu">:</span> <span class="st">&quot;agent&quot;</span><span class="fu">,</span></span>
+<span id="cb3-24"><a href="#cb3-24" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;element_name&quot;</span><span class="fu">:</span> <span class="st">&quot;code_reviewer&quot;</span></span>
+<span id="cb3-25"><a href="#cb3-25" aria-hidden="true" tabindex="-1"></a>        <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb3-26"><a href="#cb3-26" aria-hidden="true" tabindex="-1"></a>        <span class="fu">{</span></span>
+<span id="cb3-27"><a href="#cb3-27" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;id&quot;</span><span class="fu">:</span> <span class="st">&quot;skill:typescript_analysis&quot;</span><span class="fu">,</span></span>
+<span id="cb3-28"><a href="#cb3-28" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;element_type&quot;</span><span class="fu">:</span> <span class="st">&quot;skill&quot;</span><span class="fu">,</span></span>
+<span id="cb3-29"><a href="#cb3-29" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;element_name&quot;</span><span class="fu">:</span> <span class="st">&quot;typescript_analysis&quot;</span></span>
+<span id="cb3-30"><a href="#cb3-30" aria-hidden="true" tabindex="-1"></a>        <span class="fu">}</span></span>
+<span id="cb3-31"><a href="#cb3-31" aria-hidden="true" tabindex="-1"></a>      <span class="ot">]</span><span class="fu">,</span></span>
+<span id="cb3-32"><a href="#cb3-32" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;edges&quot;</span><span class="fu">:</span> <span class="ot">[</span></span>
+<span id="cb3-33"><a href="#cb3-33" aria-hidden="true" tabindex="-1"></a>        <span class="fu">{</span></span>
+<span id="cb3-34"><a href="#cb3-34" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;source&quot;</span><span class="fu">:</span> <span class="st">&quot;agent:code_reviewer&quot;</span><span class="fu">,</span></span>
+<span id="cb3-35"><a href="#cb3-35" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;target&quot;</span><span class="fu">:</span> <span class="st">&quot;skill:typescript_analysis&quot;</span><span class="fu">,</span></span>
+<span id="cb3-36"><a href="#cb3-36" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;uses&quot;</span></span>
+<span id="cb3-37"><a href="#cb3-37" aria-hidden="true" tabindex="-1"></a>        <span class="fu">}</span></span>
+<span id="cb3-38"><a href="#cb3-38" aria-hidden="true" tabindex="-1"></a>      <span class="ot">]</span></span>
+<span id="cb3-39"><a href="#cb3-39" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb3-40"><a href="#cb3-40" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb3-41"><a href="#cb3-41" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<p>If <code>include</code> is omitted, adapters SHOULD return <code>root</code>, <code>relationships</code>, and <code>graph</code> together. If <code>include</code> is present, adapters SHOULD limit the response to the requested sections.</p>
+<p><code>relationships</code> is the preferred flat traversal list for simple consumers that want to iterate edges in order. <code>graph.nodes</code> and <code>graph.edges</code> are the preferred graph-native shape for visualization, graph algorithms, and other clients that need explicit node/edge separation. The <code>relationships</code> list and <code>graph.edges</code> MAY describe the same connections in different shapes.</p>
+<h2 id="4-standard-relationship-vocabulary">4. Standard Relationship Vocabulary</h2>
+<p>The preferred portable relationship types are:</p>
+<ul>
+<li><code>uses</code></li>
+<li><code>extends</code></li>
+<li><code>references</code></li>
+<li><code>triggers</code></li>
+<li><code>composes</code></li>
+</ul>
+<p>Adapters MAY define additional relationship types. When they do, they SHOULD document them in introspection and keep custom semantics explicit.</p>
+<h2 id="5-depth-and-cycle-handling">5. Depth and Cycle Handling</h2>
+<ul>
+<li>Adapters SHOULD document a maximum supported traversal depth.</li>
+<li>Adapters SHOULD avoid infinite traversal by deduplicating visited nodes.</li>
+<li>When cycles are present, adapters SHOULD still emit the edge but MUST prevent unbounded expansion.</li>
+</ul>
+<h2 id="6-introspection-guidance">6. Introspection Guidance</h2>
+<p>Adapters SHOULD advertise relationship-query support through operation detail metadata:</p>
+<div class="sourceCode" id="cb4"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb4-1"><a href="#cb4-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb4-2"><a href="#cb4-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;relationship_capabilities&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb4-3"><a href="#cb4-3" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;supported&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb4-4"><a href="#cb4-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;directions&quot;</span><span class="fu">:</span> <span class="ot">[</span><span class="st">&quot;incoming&quot;</span><span class="ot">,</span> <span class="st">&quot;outgoing&quot;</span><span class="ot">,</span> <span class="st">&quot;both&quot;</span><span class="ot">]</span><span class="fu">,</span></span>
+<span id="cb4-5"><a href="#cb4-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;relationship_types&quot;</span><span class="fu">:</span> <span class="ot">[</span><span class="st">&quot;uses&quot;</span><span class="ot">,</span> <span class="st">&quot;extends&quot;</span><span class="ot">,</span> <span class="st">&quot;references&quot;</span><span class="ot">,</span> <span class="st">&quot;triggers&quot;</span><span class="ot">,</span> <span class="st">&quot;composes&quot;</span><span class="ot">]</span><span class="fu">,</span></span>
+<span id="cb4-6"><a href="#cb4-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;max_depth&quot;</span><span class="fu">:</span> <span class="dv">3</span></span>
+<span id="cb4-7"><a href="#cb4-7" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb4-8"><a href="#cb4-8" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<h2 id="7-relationship-to-other-docs">7. Relationship to Other Docs</h2>
+<ul>
+<li><a href="collection-querying.html">Collection Querying</a> defines how record-level <code>fields</code> and pagination compose with collection-style responses.</li>
+<li><a href="../operations.html">Operations</a> documents the common request and response conventions used by <code>query_relationships</code>.</li>
+</ul>
+
+          </div>
+        </section>
+        <nav class="page-nav" aria-label="Page navigation">
+  <a class="page-nav-link prev" href="pagination.html">
+    <span class="page-nav-eyebrow">Previous page</span>
+    <strong class="page-nav-label">Cursor-Based Pagination Specification</strong>
+  </a>
+  <a class="page-nav-link next" href="warnings.html">
+    <span class="page-nav-eyebrow">Next page</span>
+    <strong class="page-nav-label">Warnings Array Specification</strong>
+  </a>
+</nav>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div class="container">
+      <p>&copy; 2026 DollhouseMCP Inc. d/b/a Dollhouse Research. MCP-AQL public draft documentation portal.</p>
+      <div class="footer-links">
+        <a href="../../docs/index.html">Docs Library</a><a href="../index.html">Repo-Synced Spec</a><a href="https://github.com/MCPAQL">MCPAQL Organization</a><a href="https://dollhouseresearch.com">Dollhouse Research</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../../js/search.js"></script>
+</body>
+</html>

--- a/public/spec/features/warnings.html
+++ b/public/spec/features/warnings.html
@@ -50,10 +50,10 @@
   <ul><li><a href="../security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="../security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="../security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Features</h3>
-  <ul><li><a href="collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="field-selection.html">Field Selection Specification</a></li><li><a href="pagination.html">Cursor-Based Pagination Specification</a></li><li><a class="current" aria-current="page" href="warnings.html">Warnings Array Specification</a></li></ul>
+  <ul><li><a href="aggregations.html">MCP-AQL Aggregations</a></li><li><a href="collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="computed-fields.html">MCP-AQL Computed Fields</a></li><li><a href="field-selection.html">Field Selection Specification</a></li><li><a href="pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="relationship-queries.html">MCP-AQL Relationship Queries</a></li><li><a class="current" aria-current="page" href="warnings.html">Warnings Array Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Guides</h3>
-  <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
+  <ul><li><a href="../guides/cross-domain-implementation.html">Cross-Domain Implementation Guide</a></li><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
   <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li><li><a href="../repo/CHANGELOG.html">Changelog</a></li></ul>
@@ -139,34 +139,34 @@
 <h3 id="13-relationship-to-errors">1.3 Relationship to Errors</h3>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Aspect</th>
 <th>Error</th>
 <th>Warning</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td>Response success</td>
 <td><code>false</code></td>
 <td><code>true</code></td>
 </tr>
-<tr>
+<tr class="even">
 <td>Operation completed</td>
 <td>No</td>
 <td>Yes</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>Client action</td>
 <td>Required</td>
 <td>Optional</td>
 </tr>
-<tr>
+<tr class="even">
 <td>Blocks execution</td>
 <td>Yes</td>
 <td>No</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>Schema structure</td>
 <td><code>error</code> object</td>
 <td><code>warnings</code> array</td>
@@ -288,24 +288,24 @@
 <p>The optional <code>severity</code> field helps clients prioritize warnings when multiple are present:</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Level</th>
 <th>Description</th>
 <th>Example Use Cases</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><code>high</code></td>
 <td>Requires immediate attention; may affect operations soon</td>
 <td>Quota nearly exhausted, imminent deprecation removal</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>medium</code></td>
 <td>Should be addressed but not urgent</td>
 <td>Approaching limits, scheduled deprecation</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>low</code></td>
 <td>Informational; can be safely deferred or filtered</td>
 <td>Performance hints, soft deprecation notices</td>
@@ -316,24 +316,24 @@
 <p>For sorting, filtering, and programmatic comparison, implementations SHOULD use this numeric mapping:</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Severity</th>
 <th>Numeric Value</th>
 <th>Sort Order</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><code>high</code></td>
 <td>0</td>
 <td>First (most urgent)</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>medium</code></td>
 <td>1</td>
 <td>Second</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>low</code></td>
 <td>2</td>
 <td>Third (least urgent)</td>
@@ -387,29 +387,29 @@
 <h3 id="34-warning-categories">3.4 Warning Categories</h3>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Category</th>
 <th>Description</th>
 <th>Example</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><code>RATE_LIMIT_</code></td>
 <td>Approaching rate/quota limits</td>
 <td><code>RATE_LIMIT_QUOTA_WARNING</code></td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>DEPRECATION_</code></td>
 <td>Deprecated feature usage</td>
 <td><code>DEPRECATION_WARNING</code></td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>VALIDATION_</code></td>
 <td>Data quality issues</td>
 <td><code>VALIDATION_TRUNCATED_WARNING</code></td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>PERFORMANCE_</code></td>
 <td>Performance concerns</td>
 <td><code>PERFORMANCE_SLOW_QUERY_WARNING</code></td>
@@ -425,19 +425,19 @@
 <p><strong>Severity recommendations:</strong></p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Condition</th>
 <th>Severity</th>
 <th>Rationale</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td>&gt;90% of quota consumed</td>
 <td><code>high</code></td>
 <td>Imminent limit, requires immediate attention</td>
 </tr>
-<tr>
+<tr class="even">
 <td>At warn_threshold (default 80%)</td>
 <td><code>medium</code></td>
 <td>Standard warning, action advisable</td>
@@ -475,24 +475,24 @@
 <p><strong>Severity recommendations:</strong></p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Condition</th>
 <th>Severity</th>
 <th>Rationale</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td>Within 30 days of removal_date</td>
 <td><code>high</code></td>
 <td>Urgent migration required</td>
 </tr>
-<tr>
+<tr class="even">
 <td>More than 30 days from removal_date</td>
 <td><code>medium</code></td>
 <td>Migration advisable</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>No removal_date set (soft deprecation)</td>
 <td><code>low</code></td>
 <td>Informational, no urgency</td>
@@ -530,19 +530,19 @@
 <p><strong>Severity recommendations:</strong></p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Condition</th>
 <th>Severity</th>
 <th>Rationale</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td>Significant data loss (&gt;50% truncated)</td>
 <td><code>medium</code></td>
 <td>User may miss important data</td>
 </tr>
-<tr>
+<tr class="even">
 <td>Minor truncation (≤50% truncated)</td>
 <td><code>low</code></td>
 <td>Informational, pagination available</td>
@@ -578,24 +578,24 @@
 <p><strong>Severity recommendations:</strong></p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Condition</th>
 <th>Severity</th>
 <th>Rationale</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td>&gt;10x threshold exceeded</td>
 <td><code>high</code></td>
 <td>Severe degradation, may indicate systemic issue</td>
 </tr>
-<tr>
+<tr class="even">
 <td>2-10x threshold exceeded</td>
 <td><code>medium</code></td>
 <td>Notable slowdown, optimization recommended</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>Just above threshold (&lt;2x)</td>
 <td><code>low</code></td>
 <td>Minor performance concern</td>
@@ -672,25 +672,25 @@
 <p>When displaying warnings to users:</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Warning Category</th>
 <th>Display Recommendation</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><code>RATE_LIMIT_</code></td>
 <td>Prominent, real-time indicator</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>DEPRECATION_</code></td>
 <td>One-time notification per session</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>VALIDATION_</code></td>
 <td>Inline with affected data</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>PERFORMANCE_</code></td>
 <td>Status bar or background notification</td>
 </tr>
@@ -776,25 +776,25 @@
 <h4 id="deduplication-recommendations">Deduplication Recommendations</h4>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Context</th>
 <th>Recommendation</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td>Single request</td>
 <td>Server SHOULD deduplicate identical warnings</td>
 </tr>
-<tr>
+<tr class="even">
 <td>Batch operations</td>
 <td>Server SHOULD collapse per-item warnings into summary</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>Client session</td>
 <td>Client MAY deduplicate across requests</td>
 </tr>
-<tr>
+<tr class="even">
 <td>Long-running clients</td>
 <td>Client SHOULD use time-based expiration</td>
 </tr>
@@ -812,13 +812,13 @@
           </div>
         </section>
         <nav class="page-nav" aria-label="Page navigation">
-  <a class="page-nav-link prev" href="pagination.html">
+  <a class="page-nav-link prev" href="relationship-queries.html">
     <span class="page-nav-eyebrow">Previous page</span>
-    <strong class="page-nav-label">Cursor-Based Pagination Specification</strong>
+    <strong class="page-nav-label">MCP-AQL Relationship Queries</strong>
   </a>
-  <a class="page-nav-link next" href="../guides/protocol-comparison.html">
+  <a class="page-nav-link next" href="../guides/cross-domain-implementation.html">
     <span class="page-nav-eyebrow">Next page</span>
-    <strong class="page-nav-label">Protocol Comparison Guide</strong>
+    <strong class="page-nav-label">Cross-Domain Implementation Guide</strong>
   </a>
 </nav>
       </article>

--- a/public/spec/guides/README.html
+++ b/public/spec/guides/README.html
@@ -50,10 +50,10 @@
   <ul><li><a href="../security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="../security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="../security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Features</h3>
-  <ul><li><a href="../features/collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
+  <ul><li><a href="../features/aggregations.html">MCP-AQL Aggregations</a></li><li><a href="../features/collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="../features/computed-fields.html">MCP-AQL Computed Fields</a></li><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/relationship-queries.html">MCP-AQL Relationship Queries</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Guides</h3>
-  <ul><li><a href="protocol-comparison.html">Protocol Comparison Guide</a></li><li><a class="current" aria-current="page" href="README.html">Developer Guides</a></li></ul>
+  <ul><li><a href="cross-domain-implementation.html">Cross-Domain Implementation Guide</a></li><li><a href="protocol-comparison.html">Protocol Comparison Guide</a></li><li><a class="current" aria-current="page" href="README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
   <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li><li><a href="../repo/CHANGELOG.html">Changelog</a></li></ul>
@@ -97,6 +97,10 @@
         <section>
           <div class="card spec-prose">
             <p>Step-by-step guides for implementing and using MCP-AQL adapters.</p>
+<ul>
+<li><a href="protocol-comparison.html">Protocol Comparison</a> - Understand MCP-AQL through familiar protocols</li>
+<li><a href="cross-domain-implementation.html">Cross-Domain Implementation</a> - Map your own domain into MCP-AQL operations, introspection, and query controls</li>
+</ul>
 
           </div>
         </section>

--- a/public/spec/guides/cross-domain-implementation.html
+++ b/public/spec/guides/cross-domain-implementation.html
@@ -1,0 +1,498 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Document Status: This document is informative. For normative protocol requirements, see MCP-AQL Specification v1.0.0.">
+  <title>MCP-AQL Spec | Cross-Domain Implementation Guide</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../../css/style.css">
+</head>
+<body>
+  <header>
+    <div class="container">
+      <nav>
+        <a class="logo" href="../../index.html"><span class="logo-mark"></span>MCP-AQL</a>
+        <ul class="nav-links">
+          <li><a href="../../index.html">Home</a></li>
+          <li><a href="../../docs/index.html">Docs</a></li>
+          <li><a href="../../launch-checklist.html">Launch Checklist</a></li>
+          <li><a href="../../apis/index.html">Adapter Patterns</a></li>
+        </ul>
+        <form class="site-search" data-search-form data-index-url="../../data/search-index.json" role="search">
+          <label class="sr-only" for="site-search-input">Search MCP-AQL docs</label>
+          <input id="site-search-input" data-search-input type="search" placeholder="Search MCP-AQL docs, spec pages, and adapter patterns...">
+          <span class="search-count" data-search-count></span>
+          <ul class="search-results" data-search-results hidden></ul>
+        </form>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <div class="container docs-shell">
+      <aside class="docs-side">
+        <h2>Repo-Synced Spec</h2>
+        <p class="docs-side-note">Generated from <code>MCPAQL/spec</code> so the website carries the deeper protocol material too.</p>
+        <div class="docs-side-group">
+  <h3>Core</h3>
+  <ul><li><a href="../conformance-testing.html">MCP-AQL Conformance Testing Specification</a></li><li><a href="../crude-pattern.html">MCP-AQL CRUDE Pattern Specification</a></li><li><a href="../endpoint-modes.html">MCP-AQL Endpoint Modes Specification</a></li><li><a href="../error-codes.html">Structured Error Codes Specification</a></li><li><a href="../introspection.html">MCP-AQL Introspection Specification</a></li><li><a href="../licensing-options.html">MCP-AQL Licensing Options (Working Notes)</a></li><li><a href="../mcp-integration.html">MCP Integration Specification</a></li><li><a href="../operations.html">MCP-AQL Operations Specification</a></li><li><a href="../overview.html">MCP-AQL Protocol Overview</a></li><li><a href="../plugin-contracts.html">Plugin Interface Contracts</a></li><li><a href="../README.html">MCP-AQL Specification Documentation</a></li><li><a href="../repo/README.html">MCP-AQL Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Versions</h3>
+  <ul><li><a href="../versions/v1.0.0-draft.html">MCP-AQL Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Adapter</h3>
+  <ul><li><a href="../adapter/danger-levels.html">Dangerous Operation Classification Specification</a></li><li><a href="../adapter/discovery-bundle.html">MCP Server Discovery Bundle</a></li><li><a href="../adapter/element-type.html">Adapter Element Type Specification</a></li><li><a href="../adapter/generator.html">Adapter Generator Specification</a></li><li><a href="../adapter/rate-limiting.html">Rate Limiting and Quota Management Specification</a></li><li><a href="../adapter/trust-levels.html">Trust Levels Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Security</h3>
+  <ul><li><a href="../security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="../security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="../security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Features</h3>
+  <ul><li><a href="../features/aggregations.html">MCP-AQL Aggregations</a></li><li><a href="../features/collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="../features/computed-fields.html">MCP-AQL Computed Fields</a></li><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/relationship-queries.html">MCP-AQL Relationship Queries</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Guides</h3>
+  <ul><li><a class="current" aria-current="page" href="cross-domain-implementation.html">Cross-Domain Implementation Guide</a></li><li><a href="protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="README.html">Developer Guides</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Process</h3>
+  <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li><li><a href="../repo/CHANGELOG.html">Changelog</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Architecture</h3>
+  <ul><li><a href="../architecture/README.html">Architecture Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Research</h3>
+  <ul><li><a href="../research/mcp-vs-mcpaql-vs-a2a.html">Protocol Landscape: MCP vs MCP-AQL vs A2A</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>Reference</h3>
+  <ul><li><a href="../reference/README.html">Reference Documentation</a></li></ul>
+</div><div class="docs-side-group">
+  <h3>ADRs</h3>
+  <ul><li><a href="../adr/ADR-001-crude-pattern.html">ADR-001: CRUDE Pattern (Extending CRUD with Execute)</a></li><li><a href="../adr/ADR-002-graphql-style-input.html">ADR-002: GraphQL-Style Input Objects for Updates</a></li><li><a href="../adr/ADR-003-snake-case-parameters.html">ADR-003: snake_case Parameter Convention</a></li><li><a href="../adr/ADR-004-schema-driven-operations.html">ADR-004: Schema-Driven Operation Definitions</a></li><li><a href="../adr/ADR-005-introspection-system.html">ADR-005: GraphQL-Style Introspection System</a></li><li><a href="../adr/ADR-006-discriminated-responses.html">ADR-006: Discriminated Response Format</a></li><li><a href="../adr/index.html">Architecture Decision Records</a></li><li><a href="../adr/README.html">Architecture Decision Records</a></li></ul>
+</div>
+      </aside>
+
+      <article class="docs-main">
+        <nav class="breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../../index.html">Home</a></li>
+            <li><a href="../index.html">Full Spec</a></li>
+            <li><span class="current">Cross-Domain Implementation Guide</span></li>
+          </ol>
+        </nav>
+        <section class="hero docs-hero">
+          <div class="hero-inner">
+            <span class="status-pill">REPO-SYNCED SPEC DOC</span>
+            <h1>Cross-Domain Implementation Guide</h1>
+            <p class="lede">Document Status: This document is informative. For normative protocol requirements, see MCP-AQL Specification v1.0.0.</p>
+            <div class="spec-meta"><span class="state-chip live">Support document</span><span class="state-chip pending">Draft</span><span class="state-chip">1.0.0-draft</span><span class="state-chip">2026-04-15</span></div>
+            <p class="spec-source">Source: <a href="https://github.com/MCPAQL/spec/blob/main/docs/guides/cross-domain-implementation.md">spec/docs/guides/cross-domain-implementation.md</a></p>
+            <div class="hero-actions">
+              <a class="btn btn-primary" href="https://github.com/MCPAQL/spec/blob/main/docs/guides/cross-domain-implementation.md">Open Source Markdown</a><a class="btn btn-secondary" href="../index.html">Browse Full Spec Reference</a>
+            </div>
+          </div>
+        </section>
+
+        <section class="page-toc-shell" data-page-toc>
+          <div class="card page-toc-card">
+            <div class="page-toc-head">
+              <p class="page-toc-kicker">On this page</p>
+              <h2>Jump to a section</h2>
+              <p class="page-toc-intro">Use the outline to move through longer pages without losing your place.</p>
+            </div>
+            <ol class="page-toc-list" data-page-toc-list>
+              <li class="page-toc-item level-2"><a href="#abstract" data-toc-target="abstract">Abstract</a></li><li class="page-toc-item level-2"><a href="#1-start-with-domain-mapping" data-toc-target="1-start-with-domain-mapping">1. Start with Domain Mapping</a></li><li class="page-toc-item level-2"><a href="#2-choose-stable-resource-identifiers" data-toc-target="2-choose-stable-resource-identifiers">2. Choose Stable Resource Identifiers</a></li><li class="page-toc-item level-2"><a href="#3-design-operations-around-crude" data-toc-target="3-design-operations-around-crude">3. Design Operations Around CRUDE</a></li><li class="page-toc-item level-2"><a href="#4-build-introspection-first" data-toc-target="4-build-introspection-first">4. Build Introspection First</a></li><li class="page-toc-item level-2"><a href="#5-use-predictable-response-shapes" data-toc-target="5-use-predictable-response-shapes">5. Use Predictable Response Shapes</a></li><li class="page-toc-item level-2"><a href="#6-domain-examples" data-toc-target="6-domain-examples">6. Domain Examples</a></li><li class="page-toc-item level-3"><a href="#61-database-management" data-toc-target="61-database-management">6.1 Database Management</a></li><li class="page-toc-item level-3"><a href="#62-file-system-management" data-toc-target="62-file-system-management">6.2 File System Management</a></li><li class="page-toc-item level-3"><a href="#63-api-gateway-administration" data-toc-target="63-api-gateway-administration">6.3 API Gateway Administration</a></li><li class="page-toc-item level-3"><a href="#64-iot-device-control" data-toc-target="64-iot-device-control">6.4 IoT Device Control</a></li><li class="page-toc-item level-2"><a href="#7-conformance-checklist" data-toc-target="7-conformance-checklist">7. Conformance Checklist</a></li><li class="page-toc-item level-2"><a href="#8-implementation-templates" data-toc-target="8-implementation-templates">8. Implementation Templates</a></li><li class="page-toc-item level-3"><a href="#81-operation-template" data-toc-target="81-operation-template">8.1 Operation Template</a></li><li class="page-toc-item level-3"><a href="#82-introspection-detail-template" data-toc-target="82-introspection-detail-template">8.2 Introspection Detail Template</a></li><li class="page-toc-item level-3"><a href="#83-collection-query-template" data-toc-target="83-collection-query-template">8.3 Collection Query Template</a></li><li class="page-toc-item level-2"><a href="#9-common-pitfalls" data-toc-target="9-common-pitfalls">9. Common Pitfalls</a></li><li class="page-toc-item level-2"><a href="#references" data-toc-target="references">References</a></li>
+            </ol>
+          </div>
+        </section>
+
+
+        <section>
+          <div class="card spec-prose">
+            <p><strong>Version:</strong> 1.0.0-draft <strong>Status:</strong> Draft <strong>Last Updated:</strong> 2026-04-15</p>
+<blockquote>
+<p><strong>Document Status:</strong> This document is <strong>informative</strong>. For normative protocol requirements, see <a href="../versions/v1.0.0-draft.html">MCP-AQL Specification v1.0.0</a>.</p>
+</blockquote>
+<h2 id="abstract">Abstract</h2>
+<p>This guide shows how to adapt MCP-AQL to domains beyond AI element management. It focuses on the practical translation step: taking an existing API or system, mapping its resources and operations into MCP-AQL, and preserving the discoverability and token-efficiency benefits that make the protocol useful for AI clients.</p>
+<h2 id="1-start-with-domain-mapping">1. Start with Domain Mapping</h2>
+<p>Before you name any operations, identify three core pieces:</p>
+<table>
+<thead>
+<tr class="header">
+<th>Question</th>
+<th>What you are mapping</th>
+<th>Example</th>
+</tr>
+</thead>
+<tbody>
+<tr class="odd">
+<td>What are the primary resources?</td>
+<td>MCP-AQL resource or type names</td>
+<td><code>database</code>, <code>table</code>, <code>file</code>, <code>route</code>, <code>device</code></td>
+</tr>
+<tr class="even">
+<td>How are they identified?</td>
+<td>Stable lookup parameters</td>
+<td><code>database_name</code>, <code>table_name</code>, <code>file_path</code>, <code>route_id</code>, <code>device_id</code></td>
+</tr>
+<tr class="odd">
+<td>Which actions matter most?</td>
+<td>MCP-AQL operations</td>
+<td><code>list_tables</code>, <code>get_file</code>, <code>update_route</code>, <code>execute_firmware_upgrade</code></td>
+</tr>
+</tbody>
+</table>
+<p>The best first pass is usually:</p>
+<ol type="1">
+<li>list the nouns in your domain</li>
+<li>list the real tasks users perform</li>
+<li>group those tasks into CRUDE semantics</li>
+</ol>
+<h2 id="2-choose-stable-resource-identifiers">2. Choose Stable Resource Identifiers</h2>
+<p>MCP-AQL works best when identifiers are:</p>
+<ul>
+<li>stable across sessions</li>
+<li>explicit in parameter names</li>
+<li>specific enough to avoid ambiguity</li>
+</ul>
+<p>Good examples:</p>
+<ul>
+<li><code>database_name</code></li>
+<li><code>table_name</code></li>
+<li><code>file_path</code></li>
+<li><code>route_id</code></li>
+<li><code>device_id</code></li>
+</ul>
+<p>Avoid vague identifiers like <code>name</code> or <code>id</code> when the operation could target more than one resource type.</p>
+<h2 id="3-design-operations-around-crude">3. Design Operations Around CRUDE</h2>
+<p>CRUDE (Create, Read, Update, Delete, Execute) maps each operation to its effect on system state. See the <a href="../crude-pattern.html">CRUDE Pattern</a> for full classification rules.</p>
+<p>Map each real action to the endpoint that best reflects its effect:</p>
+<table>
+<thead>
+<tr class="header">
+<th>Endpoint</th>
+<th>Use for</th>
+<th>Example</th>
+</tr>
+</thead>
+<tbody>
+<tr class="odd">
+<td><code>CREATE</code></td>
+<td>Additive changes</td>
+<td><code>create_route</code>, <code>create_table_snapshot</code></td>
+</tr>
+<tr class="even">
+<td><code>READ</code></td>
+<td>Safe lookups and queries</td>
+<td><code>list_tables</code>, <code>search_files</code>, <code>query_relationships</code></td>
+</tr>
+<tr class="odd">
+<td><code>UPDATE</code></td>
+<td>Mutations to existing state</td>
+<td><code>update_device_config</code>, <code>update_route</code></td>
+</tr>
+<tr class="even">
+<td><code>DELETE</code></td>
+<td>Removals</td>
+<td><code>delete_route</code>, <code>delete_file_alias</code></td>
+</tr>
+<tr class="odd">
+<td><code>EXECUTE</code></td>
+<td>Runtime or non-idempotent actions</td>
+<td><code>execute_backup</code>, <code>execute_firmware_upgrade</code></td>
+</tr>
+</tbody>
+</table>
+<p>If an action starts a process or can be retried/cancelled later, it usually belongs in <code>EXECUTE</code>, not <code>UPDATE</code>.</p>
+<h2 id="4-build-introspection-first">4. Build Introspection First</h2>
+<blockquote>
+<p><strong>Note:</strong> The <code>introspect</code> operation (READ endpoint) is the only operation MCP-AQL requires all adapters to implement. Everything else is adapter-defined.</p>
+</blockquote>
+<p>An adapter is much easier for AI clients to use when the <code>introspect</code> experience is accurate before the business logic is complete.</p>
+<p>For each operation, make sure introspection can answer:</p>
+<ul>
+<li>what the operation is called</li>
+<li>which endpoint it belongs to</li>
+<li>which parameters are accepted</li>
+<li>which parameters are required</li>
+<li>what type comes back</li>
+<li>which optional query features it supports</li>
+</ul>
+<p>For collection-oriented READ operations, document query-language controls such as:</p>
+<ul>
+<li><code>query</code></li>
+<li><code>filter</code></li>
+<li><code>sort</code></li>
+<li><code>fields</code></li>
+<li><code>aggregate</code></li>
+<li>pagination parameters</li>
+</ul>
+<h2 id="5-use-predictable-response-shapes">5. Use Predictable Response Shapes</h2>
+<p>Every operation should still return MCP-AQL’s discriminated response pattern:</p>
+<div class="sourceCode" id="cb1"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb1-2"><a href="#cb1-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb1-3"><a href="#cb1-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;data&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb1-4"><a href="#cb1-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;items&quot;</span><span class="fu">:</span> <span class="ot">[]</span></span>
+<span id="cb1-5"><a href="#cb1-5" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb1-6"><a href="#cb1-6" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<p>Single-resource lookups keep the same envelope but return one object:</p>
+<div class="sourceCode" id="cb2"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb2-2"><a href="#cb2-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb2-3"><a href="#cb2-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;data&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb2-4"><a href="#cb2-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;device&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb2-5"><a href="#cb2-5" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;device_id&quot;</span><span class="fu">:</span> <span class="st">&quot;dev_001&quot;</span><span class="fu">,</span></span>
+<span id="cb2-6"><a href="#cb2-6" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;status&quot;</span><span class="fu">:</span> <span class="st">&quot;online&quot;</span></span>
+<span id="cb2-7"><a href="#cb2-7" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb2-8"><a href="#cb2-8" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb2-9"><a href="#cb2-9" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<div class="sourceCode" id="cb3"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb3-1"><a href="#cb3-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb3-2"><a href="#cb3-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb3-3"><a href="#cb3-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;error&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb3-4"><a href="#cb3-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;code&quot;</span><span class="fu">:</span> <span class="st">&quot;VALIDATION_MISSING_PARAM&quot;</span><span class="fu">,</span></span>
+<span id="cb3-5"><a href="#cb3-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;Missing required parameter &#39;table_name&#39;.&quot;</span></span>
+<span id="cb3-6"><a href="#cb3-6" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb3-7"><a href="#cb3-7" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<p>That consistency matters more than the domain itself. It lets a client move from one adapter to another without re-learning the envelope. See <a href="../error-codes.html">Error Codes</a> for the standard validation and execution error catalog.</p>
+<h2 id="6-domain-examples">6. Domain Examples</h2>
+<h3 id="61-database-management">6.1 Database Management</h3>
+<p><strong>Resources</strong></p>
+<ul>
+<li><code>database</code></li>
+<li><code>table</code></li>
+<li><code>query_job</code></li>
+</ul>
+<p><strong>Representative operations</strong></p>
+<ul>
+<li><code>list_databases</code></li>
+<li><code>list_tables</code></li>
+<li><code>get_table_schema</code></li>
+<li><code>query_rows</code></li>
+<li><code>execute_query_job</code></li>
+</ul>
+<p><strong>Identifier pattern</strong></p>
+<ul>
+<li><code>database_name</code></li>
+<li><code>table_name</code></li>
+<li><code>query_job_id</code></li>
+</ul>
+<p><strong>Useful query controls</strong></p>
+<ul>
+<li><code>fields</code> for projections</li>
+<li><code>filter</code> for row predicates</li>
+<li><code>aggregate</code> for counts and grouped summaries</li>
+</ul>
+<h3 id="62-file-system-management">6.2 File System Management</h3>
+<p><strong>Resources</strong></p>
+<ul>
+<li><code>file</code></li>
+<li><code>directory</code></li>
+<li><code>permission_entry</code></li>
+</ul>
+<p><strong>Representative operations</strong></p>
+<ul>
+<li><code>list_directory</code></li>
+<li><code>get_file</code></li>
+<li><code>search_files</code></li>
+<li><code>update_file_metadata</code></li>
+<li><code>delete_file</code></li>
+</ul>
+<p><strong>Identifier pattern</strong></p>
+<ul>
+<li><code>file_path</code></li>
+<li><code>directory_path</code></li>
+</ul>
+<p><strong>Useful query controls</strong></p>
+<ul>
+<li><code>query</code> for name/content search</li>
+<li><code>fields</code> for light listings</li>
+<li>computed fields such as <code>_computed.size_human</code> (see <a href="../features/field-selection.html">Field Selection</a> for computed field semantics)</li>
+</ul>
+<h3 id="63-api-gateway-administration">6.3 API Gateway Administration</h3>
+<p><strong>Resources</strong></p>
+<ul>
+<li><code>route</code></li>
+<li><code>service</code></li>
+<li><code>consumer</code></li>
+<li><code>plugin</code></li>
+</ul>
+<p><strong>Representative operations</strong></p>
+<ul>
+<li><code>list_routes</code></li>
+<li><code>get_route</code></li>
+<li><code>create_route</code></li>
+<li><code>update_route</code></li>
+<li><code>delete_route</code></li>
+<li><code>query_relationships</code></li>
+</ul>
+<p><strong>Identifier pattern</strong></p>
+<ul>
+<li><code>route_id</code></li>
+<li><code>service_id</code></li>
+<li><code>consumer_id</code></li>
+</ul>
+<p><strong>Useful query controls</strong></p>
+<ul>
+<li>relationship queries for route-to-service and plugin-to-route traversal</li>
+<li><code>aggregate</code> for route counts by status or environment</li>
+</ul>
+<h3 id="64-iot-device-control">6.4 IoT Device Control</h3>
+<p><strong>Resources</strong></p>
+<ul>
+<li><code>device</code></li>
+<li><code>group</code></li>
+<li><code>firmware_job</code></li>
+<li><code>telemetry_event</code></li>
+</ul>
+<p><strong>Representative operations</strong></p>
+<ul>
+<li><code>list_devices</code></li>
+<li><code>get_device</code></li>
+<li><code>update_device_config</code></li>
+<li><code>execute_firmware_upgrade</code></li>
+<li><code>list_telemetry_events</code></li>
+</ul>
+<p><strong>Identifier pattern</strong></p>
+<ul>
+<li><code>device_id</code></li>
+<li><code>group_id</code></li>
+<li><code>firmware_job_id</code></li>
+</ul>
+<p><strong>Useful query controls</strong></p>
+<ul>
+<li><code>filter</code> on status, site, or firmware version</li>
+<li>computed fields like <code>_computed.is_stale</code></li>
+</ul>
+<p>Long-running jobs such as <code>execute_firmware_upgrade</code> SHOULD expose lifecycle state through introspection so clients can discover supported statuses and follow-up actions.</p>
+<h2 id="7-conformance-checklist">7. Conformance Checklist</h2>
+<p>Use this as a pre-release checklist for a new domain adapter:</p>
+<ul>
+<li>Every operation has a stable snake_case name.</li>
+<li>Every operation is placed on the correct CRUDE endpoint.</li>
+<li><code>introspect</code> documents every accepted parameter.</li>
+<li>Required parameters fail with structured validation errors.</li>
+<li>Collection READ operations document their supported query controls.</li>
+<li>READ responses use <code>fields</code> and pagination consistently where supported. See <a href="../features/collection-querying.html">Collection Querying</a> and <a href="../features/pagination.html">Pagination</a>.</li>
+<li>Errors avoid leaking implementation details.</li>
+<li>At least one round-trip create/read or update/read example is tested.</li>
+<li>Any domain-specific constraints are documented in introspection.</li>
+</ul>
+<h2 id="8-implementation-templates">8. Implementation Templates</h2>
+<h3 id="81-operation-template">8.1 Operation Template</h3>
+<div class="sourceCode" id="cb4"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb4-1"><a href="#cb4-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb4-2"><a href="#cb4-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;list_tables&quot;</span><span class="fu">,</span></span>
+<span id="cb4-3"><a href="#cb4-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;List tables within a database&quot;</span><span class="fu">,</span></span>
+<span id="cb4-4"><a href="#cb4-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;endpoint&quot;</span><span class="fu">:</span> <span class="st">&quot;READ&quot;</span><span class="fu">,</span></span>
+<span id="cb4-5"><a href="#cb4-5" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb4-6"><a href="#cb4-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;database_name&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb4-7"><a href="#cb4-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;string&quot;</span><span class="fu">,</span></span>
+<span id="cb4-8"><a href="#cb4-8" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;required&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb4-9"><a href="#cb4-9" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Database to inspect&quot;</span></span>
+<span id="cb4-10"><a href="#cb4-10" aria-hidden="true" tabindex="-1"></a>    <span class="fu">},</span></span>
+<span id="cb4-11"><a href="#cb4-11" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;query&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb4-12"><a href="#cb4-12" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;string&quot;</span><span class="fu">,</span></span>
+<span id="cb4-13"><a href="#cb4-13" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;required&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb4-14"><a href="#cb4-14" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Optional free-text table search&quot;</span></span>
+<span id="cb4-15"><a href="#cb4-15" aria-hidden="true" tabindex="-1"></a>    <span class="fu">},</span></span>
+<span id="cb4-16"><a href="#cb4-16" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;fields&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb4-17"><a href="#cb4-17" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;array&quot;</span><span class="fu">,</span></span>
+<span id="cb4-18"><a href="#cb4-18" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;required&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb4-19"><a href="#cb4-19" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Optional field projection&quot;</span></span>
+<span id="cb4-20"><a href="#cb4-20" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb4-21"><a href="#cb4-21" aria-hidden="true" tabindex="-1"></a>  <span class="fu">},</span></span>
+<span id="cb4-22"><a href="#cb4-22" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;returns&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb4-23"><a href="#cb4-23" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;TableList&quot;</span><span class="fu">,</span></span>
+<span id="cb4-24"><a href="#cb4-24" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;kind&quot;</span><span class="fu">:</span> <span class="st">&quot;object&quot;</span></span>
+<span id="cb4-25"><a href="#cb4-25" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb4-26"><a href="#cb4-26" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<h3 id="82-introspection-detail-template">8.2 Introspection Detail Template</h3>
+<div class="sourceCode" id="cb5"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb5-1"><a href="#cb5-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb5-2"><a href="#cb5-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;list_tables&quot;</span><span class="fu">,</span></span>
+<span id="cb5-3"><a href="#cb5-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;semantic_category&quot;</span><span class="fu">:</span> <span class="st">&quot;READ&quot;</span><span class="fu">,</span></span>
+<span id="cb5-4"><a href="#cb5-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;endpoint&quot;</span><span class="fu">:</span> <span class="st">&quot;read&quot;</span><span class="fu">,</span></span>
+<span id="cb5-5"><a href="#cb5-5" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;mcpTool&quot;</span><span class="fu">:</span> <span class="st">&quot;mcp_aql_read&quot;</span><span class="fu">,</span></span>
+<span id="cb5-6"><a href="#cb5-6" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;List tables within a database.&quot;</span><span class="fu">,</span></span>
+<span id="cb5-7"><a href="#cb5-7" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;permissions&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb5-8"><a href="#cb5-8" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;readOnly&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb5-9"><a href="#cb5-9" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;destructive&quot;</span><span class="fu">:</span> <span class="kw">false</span></span>
+<span id="cb5-10"><a href="#cb5-10" aria-hidden="true" tabindex="-1"></a>  <span class="fu">},</span></span>
+<span id="cb5-11"><a href="#cb5-11" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;parameters&quot;</span><span class="fu">:</span> <span class="ot">[</span></span>
+<span id="cb5-12"><a href="#cb5-12" aria-hidden="true" tabindex="-1"></a>    <span class="fu">{</span></span>
+<span id="cb5-13"><a href="#cb5-13" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;database_name&quot;</span><span class="fu">,</span></span>
+<span id="cb5-14"><a href="#cb5-14" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;string&quot;</span><span class="fu">,</span></span>
+<span id="cb5-15"><a href="#cb5-15" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;required&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb5-16"><a href="#cb5-16" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Database to inspect.&quot;</span></span>
+<span id="cb5-17"><a href="#cb5-17" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb5-18"><a href="#cb5-18" aria-hidden="true" tabindex="-1"></a>    <span class="fu">{</span></span>
+<span id="cb5-19"><a href="#cb5-19" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;fields&quot;</span><span class="fu">,</span></span>
+<span id="cb5-20"><a href="#cb5-20" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;array&quot;</span><span class="fu">,</span></span>
+<span id="cb5-21"><a href="#cb5-21" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;required&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb5-22"><a href="#cb5-22" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Optional field projection.&quot;</span></span>
+<span id="cb5-23"><a href="#cb5-23" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb5-24"><a href="#cb5-24" aria-hidden="true" tabindex="-1"></a>  <span class="ot">]</span><span class="fu">,</span></span>
+<span id="cb5-25"><a href="#cb5-25" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;returns&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb5-26"><a href="#cb5-26" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;TableList&quot;</span><span class="fu">,</span></span>
+<span id="cb5-27"><a href="#cb5-27" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;kind&quot;</span><span class="fu">:</span> <span class="st">&quot;object&quot;</span></span>
+<span id="cb5-28"><a href="#cb5-28" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb5-29"><a href="#cb5-29" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<h3 id="83-collection-query-template">8.3 Collection Query Template</h3>
+<div class="sourceCode" id="cb6"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb6-1"><a href="#cb6-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb6-2"><a href="#cb6-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;search_routes&quot;</span><span class="fu">,</span></span>
+<span id="cb6-3"><a href="#cb6-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb6-4"><a href="#cb6-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;query&quot;</span><span class="fu">:</span> <span class="st">&quot;payments&quot;</span><span class="fu">,</span></span>
+<span id="cb6-5"><a href="#cb6-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;filter&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb6-6"><a href="#cb6-6" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;status&quot;</span><span class="fu">:</span> <span class="st">&quot;active&quot;</span></span>
+<span id="cb6-7"><a href="#cb6-7" aria-hidden="true" tabindex="-1"></a>    <span class="fu">},</span></span>
+<span id="cb6-8"><a href="#cb6-8" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;sort&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb6-9"><a href="#cb6-9" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;field&quot;</span><span class="fu">:</span> <span class="st">&quot;updated_at&quot;</span><span class="fu">,</span></span>
+<span id="cb6-10"><a href="#cb6-10" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;order&quot;</span><span class="fu">:</span> <span class="st">&quot;desc&quot;</span></span>
+<span id="cb6-11"><a href="#cb6-11" aria-hidden="true" tabindex="-1"></a>    <span class="fu">},</span></span>
+<span id="cb6-12"><a href="#cb6-12" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;fields&quot;</span><span class="fu">:</span> <span class="ot">[</span><span class="st">&quot;route_id&quot;</span><span class="ot">,</span> <span class="st">&quot;path&quot;</span><span class="ot">,</span> <span class="st">&quot;_computed.health_score&quot;</span><span class="ot">]</span><span class="fu">,</span></span>
+<span id="cb6-13"><a href="#cb6-13" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;first&quot;</span><span class="fu">:</span> <span class="dv">25</span></span>
+<span id="cb6-14"><a href="#cb6-14" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb6-15"><a href="#cb6-15" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<h2 id="9-common-pitfalls">9. Common Pitfalls</h2>
+<ul>
+<li>Mirroring backend naming exactly instead of exposing a stable MCP-AQL surface.</li>
+<li>Using overly generic identifiers like <code>id</code> when <code>route_id</code> or <code>device_id</code> is clearer.</li>
+<li>Treating long-running actions as <code>UPDATE</code> when they should be <code>EXECUTE</code>.</li>
+<li>Forgetting to document compatibility pagination shapes (such as <code>limit</code> / <code>offset</code>) or alias parameters that an adapter accepts alongside the preferred MCP-AQL names.</li>
+<li>Adding query features in implementation without exposing them in introspection.</li>
+</ul>
+<h2 id="references">References</h2>
+<ul>
+<li><a href="../versions/v1.0.0-draft.html">MCP-AQL Specification</a></li>
+<li><a href="../operations.html">Operations Guide</a></li>
+<li><a href="../introspection.html">Introspection Specification</a></li>
+<li><a href="../features/collection-querying.html">Collection Querying</a></li>
+<li><a href="../conformance-testing.html">Conformance Testing</a></li>
+</ul>
+
+          </div>
+        </section>
+        <nav class="page-nav" aria-label="Page navigation">
+  <a class="page-nav-link prev" href="../features/warnings.html">
+    <span class="page-nav-eyebrow">Previous page</span>
+    <strong class="page-nav-label">Warnings Array Specification</strong>
+  </a>
+  <a class="page-nav-link next" href="protocol-comparison.html">
+    <span class="page-nav-eyebrow">Next page</span>
+    <strong class="page-nav-label">Protocol Comparison Guide</strong>
+  </a>
+</nav>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div class="container">
+      <p>&copy; 2026 DollhouseMCP Inc. d/b/a Dollhouse Research. MCP-AQL public draft documentation portal.</p>
+      <div class="footer-links">
+        <a href="../../docs/index.html">Docs Library</a><a href="../index.html">Repo-Synced Spec</a><a href="https://github.com/MCPAQL">MCPAQL Organization</a><a href="https://dollhouseresearch.com">Dollhouse Research</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../../js/search.js"></script>
+</body>
+</html>

--- a/public/spec/guides/protocol-comparison.html
+++ b/public/spec/guides/protocol-comparison.html
@@ -50,10 +50,10 @@
   <ul><li><a href="../security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="../security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="../security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Features</h3>
-  <ul><li><a href="../features/collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
+  <ul><li><a href="../features/aggregations.html">MCP-AQL Aggregations</a></li><li><a href="../features/collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="../features/computed-fields.html">MCP-AQL Computed Fields</a></li><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/relationship-queries.html">MCP-AQL Relationship Queries</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Guides</h3>
-  <ul><li><a class="current" aria-current="page" href="protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="README.html">Developer Guides</a></li></ul>
+  <ul><li><a href="cross-domain-implementation.html">Cross-Domain Implementation Guide</a></li><li><a class="current" aria-current="page" href="protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
   <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li><li><a href="../repo/CHANGELOG.html">Changelog</a></li></ul>
@@ -124,7 +124,7 @@
 <p>MCP-AQL supports multiple endpoint modes with different token trade-offs:</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Mode</th>
 <th>Endpoints</th>
 <th>Token Cost</th>
@@ -133,21 +133,21 @@
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><strong>Discrete</strong></td>
 <td>Many individual tools</td>
 <td>~30,000</td>
 <td>Baseline</td>
 <td>Traditional MCP</td>
 </tr>
-<tr>
+<tr class="even">
 <td><strong>CRUDE</strong></td>
 <td>5 semantic endpoints</td>
 <td>~4,300</td>
 <td>~85%</td>
 <td>Host-level permission control</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><strong>Single</strong></td>
 <td>1 unified endpoint</td>
 <td>~1,100</td>
@@ -161,29 +161,29 @@
 <p>Developers often approach new protocols through the lens of what they already know. This guide provides mental models for understanding MCP-AQL by drawing parallels to:</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Protocol</th>
 <th>Similarity to MCP-AQL</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><strong>GraphQL</strong></td>
 <td>Introspection, typed operations, nested input objects</td>
 </tr>
-<tr>
+<tr class="even">
 <td><strong>MongoDB</strong></td>
 <td>Document-based operations, flexible queries</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><strong>REST</strong></td>
 <td>Resource-oriented endpoints, HTTP-like semantics</td>
 </tr>
-<tr>
+<tr class="even">
 <td><strong>SQL</strong></td>
 <td>Structured queries, CRUD operations</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><strong>Classic MCP</strong></td>
 <td>Tool-based interface (what MCP-AQL can replace)</td>
 </tr>
@@ -202,7 +202,7 @@
 <h2 id="quick-reference-table">Quick Reference Table</h2>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Concept</th>
 <th>GraphQL</th>
 <th>MongoDB</th>
@@ -212,7 +212,7 @@
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><strong>Define Operation</strong></td>
 <td><code>mutation createUser</code></td>
 <td><code>db.users.insertOne()</code></td>
@@ -220,7 +220,7 @@
 <td><code>INSERT INTO users</code></td>
 <td><code>{ operation: "..." }</code></td>
 </tr>
-<tr>
+<tr class="even">
 <td><strong>Specify Parameters</strong></td>
 <td><code>variables: { ... }</code></td>
 <td><code>{ filter: { ... } }</code></td>
@@ -228,7 +228,7 @@
 <td><code>WHERE clause</code></td>
 <td><code>params: { ... }</code></td>
 </tr>
-<tr>
+<tr class="odd">
 <td><strong>Target Type</strong></td>
 <td>Type in schema</td>
 <td>Collection name</td>
@@ -236,7 +236,7 @@
 <td>Table name</td>
 <td>Implementation-defined</td>
 </tr>
-<tr>
+<tr class="even">
 <td><strong>Read One</strong></td>
 <td><code>query { user(id) }</code></td>
 <td><code>findOne({ _id })</code></td>
@@ -244,7 +244,7 @@
 <td><code>SELECT ... WHERE id=</code></td>
 <td>Read operation</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><strong>Read Many</strong></td>
 <td><code>query { users }</code></td>
 <td><code>find({})</code></td>
@@ -252,7 +252,7 @@
 <td><code>SELECT * FROM</code></td>
 <td>List operation</td>
 </tr>
-<tr>
+<tr class="even">
 <td><strong>Create</strong></td>
 <td><code>mutation { createUser }</code></td>
 <td><code>insertOne()</code></td>
@@ -260,7 +260,7 @@
 <td><code>INSERT INTO</code></td>
 <td>Create operation</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><strong>Update</strong></td>
 <td><code>mutation { updateUser }</code></td>
 <td><code>updateOne()</code></td>
@@ -268,7 +268,7 @@
 <td><code>UPDATE ... SET</code></td>
 <td>Update operation</td>
 </tr>
-<tr>
+<tr class="even">
 <td><strong>Delete</strong></td>
 <td><code>mutation { deleteUser }</code></td>
 <td><code>deleteOne()</code></td>
@@ -276,7 +276,7 @@
 <td><code>DELETE FROM</code></td>
 <td>Delete operation</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><strong>Search</strong></td>
 <td><code>query { search(q) }</code></td>
 <td><code>find({ $text })</code></td>
@@ -284,7 +284,7 @@
 <td><code>LIKE '%term%'</code></td>
 <td>Search operation</td>
 </tr>
-<tr>
+<tr class="even">
 <td><strong>Discover Schema</strong></td>
 <td><code>__schema</code> introspection</td>
 <td><code>db.getCollectionInfos()</code></td>
@@ -292,7 +292,7 @@
 <td><code>DESCRIBE table</code></td>
 <td><code>introspect</code></td>
 </tr>
-<tr>
+<tr class="odd">
 <td><strong>Field Selection</strong></td>
 <td>Field list in query</td>
 <td>Projection <code>{ field: 1 }</code></td>
@@ -300,7 +300,7 @@
 <td><code>SELECT a, b</code></td>
 <td><code>fields</code> param or preset</td>
 </tr>
-<tr>
+<tr class="even">
 <td><strong>Response Format</strong></td>
 <td><code>{ data, errors }</code></td>
 <td>Document / cursor</td>
@@ -308,7 +308,7 @@
 <td>Result set</td>
 <td><code>{ success, data/error }</code></td>
 </tr>
-<tr>
+<tr class="odd">
 <td><strong>Error Handling</strong></td>
 <td><code>errors</code> array</td>
 <td>Exception</td>
@@ -325,34 +325,34 @@
 <p>GraphQL separates read operations (queries) from write operations (mutations). MCP-AQL takes this further with the <strong>CRUDE pattern</strong> (5 semantic categories):</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>GraphQL</th>
 <th>MCP-AQL Endpoint</th>
 <th>Purpose</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><code>query</code></td>
 <td><code>mcp_aql_read</code></td>
 <td>Read-only operations</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>mutation</code> (create)</td>
 <td><code>mcp_aql_create</code></td>
 <td>Additive operations</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>mutation</code> (update)</td>
 <td><code>mcp_aql_update</code></td>
 <td>Modifying operations</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>mutation</code> (delete)</td>
 <td><code>mcp_aql_delete</code></td>
 <td>Destructive operations</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>subscription</code></td>
 <td><code>mcp_aql_execute</code></td>
 <td>Runtime/stateful operations</td>
@@ -380,21 +380,21 @@
 <p>In GraphQL, you query specific types (<code>User</code>, <code>Post</code>). In MCP-AQL, implementations define their own resource type parameter:</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>GraphQL</th>
 <th>MCP-AQL Pattern</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><code>type User</code></td>
 <td><code>resource_type: "user"</code></td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>type Post</code></td>
 <td><code>resource_type: "post"</code></td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>type Comment</code></td>
 <td><code>resource_type: "comment"</code></td>
 </tr>
@@ -459,24 +459,24 @@
 <span id="cb8-7"><a href="#cb8-7" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Preset</th>
 <th>Description</th>
 <th>Typical Token Savings</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><code>minimal</code></td>
 <td>Only identifier and description</td>
 <td>~86%</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>standard</code></td>
 <td>Common fields for most use cases</td>
 <td>~73%</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>full</code></td>
 <td>All fields (default)</td>
 <td>0%</td>
@@ -486,34 +486,34 @@
 <h3 id="key-differences-from-graphql">Key Differences from GraphQL</h3>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Aspect</th>
 <th>GraphQL</th>
 <th>MCP-AQL</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><strong>Field Selection</strong></td>
 <td>Client selects specific fields</td>
 <td><code>fields</code> param or presets</td>
 </tr>
-<tr>
+<tr class="even">
 <td><strong>Subscriptions</strong></td>
 <td>Real-time WebSocket streams</td>
 <td>EXECUTE for stateful lifecycle</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><strong>Schema Definition</strong></td>
 <td>SDL files</td>
 <td>Declarative operation schemas</td>
 </tr>
-<tr>
+<tr class="even">
 <td><strong>Fragments/Aliases</strong></td>
 <td>Supported</td>
 <td>Not applicable</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><strong>Batching</strong></td>
 <td>DataLoader pattern</td>
 <td>Built-in batch operations</td>
@@ -527,25 +527,25 @@
 <p>MongoDB organizes documents into collections. MCP-AQL implementations define resource type parameters:</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>MongoDB</th>
 <th>MCP-AQL Pattern</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><code>db.users</code></td>
 <td><code>resource_type: "user"</code></td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>db.posts</code></td>
 <td><code>resource_type: "post"</code></td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>db.comments</code></td>
 <td><code>resource_type: "comment"</code></td>
 </tr>
-<tr>
+<tr class="even">
 <td>Collection name in method</td>
 <td>Passed as parameter</td>
 </tr>
@@ -554,33 +554,33 @@
 <h3 id="crud-method-mapping">CRUD Method Mapping</h3>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>MongoDB</th>
 <th>MCP-AQL</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><code>insertOne()</code></td>
 <td><code>create_resource</code></td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>find()</code></td>
 <td><code>list_resources</code></td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>findOne()</code></td>
 <td><code>get_resource</code></td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>updateOne()</code></td>
 <td><code>update_resource</code></td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>deleteOne()</code></td>
 <td><code>delete_resource</code></td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>aggregate()</code></td>
 <td><code>search</code> or <code>query_resources</code></td>
 </tr>
@@ -642,34 +642,34 @@
 <h3 id="key-differences-from-mongodb">Key Differences from MongoDB</h3>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Aspect</th>
 <th>MongoDB</th>
 <th>MCP-AQL</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><strong>Query Operators</strong></td>
 <td>Rich ($gt, $in, $regex)</td>
 <td>Simplified search/filter</td>
 </tr>
-<tr>
+<tr class="even">
 <td><strong>Aggregation</strong></td>
 <td>Complex pipelines</td>
 <td>Normalized via <code>search</code> operation</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><strong>Indexes</strong></td>
 <td>User-defined</td>
 <td>Managed by server</td>
 </tr>
-<tr>
+<tr class="even">
 <td><strong>Transactions</strong></td>
 <td>Multi-document ACID</td>
 <td>Per-operation atomicity</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><strong>Cursors</strong></td>
 <td>Iterable result sets</td>
 <td>Paginated responses</td>
@@ -683,34 +683,34 @@
 <p>REST uses HTTP methods for semantics. MCP-AQL uses 5 semantic endpoints:</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>HTTP Method</th>
 <th>MCP-AQL Endpoint</th>
 <th>Description</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><code>POST</code> (create)</td>
 <td><code>mcp_aql_create</code></td>
 <td>Create new resources</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>GET</code></td>
 <td><code>mcp_aql_read</code></td>
 <td>Read resources</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>PUT</code> / <code>PATCH</code></td>
 <td><code>mcp_aql_update</code></td>
 <td>Modify resources</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>DELETE</code></td>
 <td><code>mcp_aql_delete</code></td>
 <td>Remove resources</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>N/A</td>
 <td><code>mcp_aql_execute</code></td>
 <td>Runtime operations</td>
@@ -721,29 +721,29 @@
 <p>REST encodes resources in URLs. MCP-AQL uses <code>operation</code> plus implementation-defined parameters:</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>REST Pattern</th>
 <th>MCP-AQL Pattern</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><code>GET /resources</code></td>
 <td><code>{ operation: "list_resources" }</code></td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>GET /resources/:id</code></td>
 <td><code>{ operation: "get_resource", params: { id } }</code></td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>POST /resources</code></td>
 <td><code>{ operation: "create_resource", params: { ... } }</code></td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>PUT /resources/:id</code></td>
 <td><code>{ operation: "update_resource", params: { id, input } }</code></td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>DELETE /resources/:id</code></td>
 <td><code>{ operation: "delete_resource", params: { id } }</code></td>
 </tr>
@@ -791,25 +791,25 @@ Content-Type: application/json
 <h3 id="error-handling">Error Handling</h3>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>REST</th>
 <th>MCP-AQL</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td>HTTP 200 OK</td>
 <td><code>{ success: true, data: ... }</code></td>
 </tr>
-<tr>
+<tr class="even">
 <td>HTTP 400 Bad Request</td>
 <td><code>{ success: false, error: "Invalid parameter..." }</code></td>
 </tr>
-<tr>
+<tr class="odd">
 <td>HTTP 404 Not Found</td>
 <td><code>{ success: false, error: "Resource not found..." }</code></td>
 </tr>
-<tr>
+<tr class="even">
 <td>HTTP 500 Internal Error</td>
 <td><code>{ success: false, error: "..." }</code></td>
 </tr>
@@ -847,34 +847,34 @@ Content-Type: application/json
 <h3 id="key-differences-from-rest">Key Differences from REST</h3>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Aspect</th>
 <th>REST</th>
 <th>MCP-AQL</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><strong>Transport</strong></td>
 <td>HTTP</td>
 <td>MCP (stdio/SSE)</td>
 </tr>
-<tr>
+<tr class="even">
 <td><strong>Versioning</strong></td>
 <td>URL path (<code>/v1/...</code>)</td>
 <td>Schema version in response</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><strong>HATEOAS</strong></td>
 <td>Links in responses</td>
 <td>Introspection for discovery</td>
 </tr>
-<tr>
+<tr class="even">
 <td><strong>Caching</strong></td>
 <td>HTTP headers</td>
 <td>Server-managed</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><strong>Authentication</strong></td>
 <td>Headers (Bearer, API key)</td>
 <td>MCP session-based</td>
@@ -888,21 +888,21 @@ Content-Type: application/json
 <p>SQL organizes data into tables. MCP-AQL implementations define resource type parameters:</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>SQL</th>
 <th>MCP-AQL Pattern</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><code>users</code> table</td>
 <td><code>resource_type: "user"</code></td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>posts</code> table</td>
 <td><code>resource_type: "post"</code></td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>SELECT * FROM users</code></td>
 <td><code>list_resources</code> with <code>resource_type</code></td>
 </tr>
@@ -911,33 +911,33 @@ Content-Type: application/json
 <h3 id="sql-statement-mapping">SQL Statement Mapping</h3>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>SQL</th>
 <th>MCP-AQL Pattern</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><code>INSERT INTO</code></td>
 <td>Create operation</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>SELECT * FROM</code></td>
 <td>List operation</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>SELECT ... WHERE id =</code></td>
 <td>Get operation</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>UPDATE ... SET</code></td>
 <td>Update operation</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>DELETE FROM</code></td>
 <td>Delete operation</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>SELECT ... WHERE ... LIKE</code></td>
 <td>Search operation</td>
 </tr>
@@ -997,17 +997,17 @@ Content-Type: application/json
 <h3 id="schema-discovery">Schema Discovery</h3>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>SQL</th>
 <th>MCP-AQL</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><code>DESCRIBE users</code></td>
 <td><code>introspect</code> with <code>query: "types"</code></td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>SHOW TABLES</code></td>
 <td><code>introspect</code> with <code>query: "operations"</code></td>
 </tr>
@@ -1016,34 +1016,34 @@ Content-Type: application/json
 <h3 id="key-differences-from-sql">Key Differences from SQL</h3>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Aspect</th>
 <th>SQL</th>
 <th>MCP-AQL</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><strong>Query Language</strong></td>
 <td>Declarative SQL</td>
 <td>Structured JSON</td>
 </tr>
-<tr>
+<tr class="even">
 <td><strong>Joins</strong></td>
 <td>Complex multi-table joins</td>
 <td>Resource relationships via handlers</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><strong>Transactions</strong></td>
 <td>BEGIN/COMMIT/ROLLBACK</td>
 <td>Per-operation atomicity</td>
 </tr>
-<tr>
+<tr class="even">
 <td><strong>Indexes</strong></td>
 <td>User-defined CREATE INDEX</td>
 <td>Managed by server</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><strong>Stored Procedures</strong></td>
 <td>User-defined functions</td>
 <td>Agent execution</td>
@@ -1104,44 +1104,44 @@ mcp_aql_execute - EXECUTE operations (execute workflows, update state)</code></p
 <h3 id="tool-to-operation-mapping">Tool to Operation Mapping</h3>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Classic Tool Pattern</th>
 <th>MCP-AQL Operation Pattern</th>
 <th>Endpoint</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><code>create_&lt;type&gt;</code></td>
 <td><code>create_resource</code> + <code>resource_type</code></td>
 <td>CREATE</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>list_&lt;type&gt;s</code></td>
 <td><code>list_resources</code> + <code>resource_type</code></td>
 <td>READ</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>get_&lt;type&gt;</code></td>
 <td><code>get_resource</code> + <code>resource_type</code></td>
 <td>READ</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>edit_&lt;type&gt;</code></td>
 <td><code>update_resource</code> + <code>resource_type</code></td>
 <td>UPDATE</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>delete_&lt;type&gt;</code></td>
 <td><code>delete_resource</code> + <code>resource_type</code></td>
 <td>DELETE</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>search_&lt;type&gt;s</code></td>
 <td><code>search</code></td>
 <td>READ</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>execute_&lt;workflow&gt;</code></td>
 <td><code>execute_workflow</code></td>
 <td>EXECUTE</td>
@@ -1153,7 +1153,7 @@ mcp_aql_execute - EXECUTE operations (execute workflows, update state)</code></p
 <p><strong>After:</strong> Explicit CRUDE endpoint permissions:</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Endpoint</th>
 <th>readOnly</th>
 <th>destructive</th>
@@ -1161,31 +1161,31 @@ mcp_aql_execute - EXECUTE operations (execute workflows, update state)</code></p
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td>CREATE</td>
 <td>false</td>
 <td>false</td>
 <td>Additive, non-destructive</td>
 </tr>
-<tr>
+<tr class="even">
 <td>READ</td>
 <td>true</td>
 <td>false</td>
 <td>Safe, read-only</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>UPDATE</td>
 <td>false</td>
 <td>true</td>
 <td>Modifying</td>
 </tr>
-<tr>
+<tr class="even">
 <td>DELETE</td>
 <td>false</td>
 <td>true</td>
 <td>Destructive</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>EXECUTE</td>
 <td>false</td>
 <td>true</td>
@@ -1209,7 +1209,7 @@ mcp_aql_execute - EXECUTE operations (execute workflows, update state)</code></p
 <p>This table maps concepts across all compared protocols.</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Concept</th>
 <th>GraphQL</th>
 <th>MongoDB</th>
@@ -1219,7 +1219,7 @@ mcp_aql_execute - EXECUTE operations (execute workflows, update state)</code></p
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><strong>Namespace</strong></td>
 <td>Schema</td>
 <td>Database</td>
@@ -1227,7 +1227,7 @@ mcp_aql_execute - EXECUTE operations (execute workflows, update state)</code></p
 <td>Schema</td>
 <td>Implementation-defined</td>
 </tr>
-<tr>
+<tr class="even">
 <td><strong>Type/Entity</strong></td>
 <td>Type</td>
 <td>Collection</td>
@@ -1235,7 +1235,7 @@ mcp_aql_execute - EXECUTE operations (execute workflows, update state)</code></p
 <td>Table</td>
 <td>Resource type param</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><strong>Instance</strong></td>
 <td>Object</td>
 <td>Document</td>
@@ -1243,7 +1243,7 @@ mcp_aql_execute - EXECUTE operations (execute workflows, update state)</code></p
 <td>Row</td>
 <td>Resource</td>
 </tr>
-<tr>
+<tr class="even">
 <td><strong>Identifier</strong></td>
 <td>ID field</td>
 <td><code>_id</code></td>
@@ -1251,7 +1251,7 @@ mcp_aql_execute - EXECUTE operations (execute workflows, update state)</code></p
 <td>Primary key</td>
 <td>Resource ID</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><strong>Create</strong></td>
 <td>Mutation</td>
 <td><code>insertOne</code></td>
@@ -1259,7 +1259,7 @@ mcp_aql_execute - EXECUTE operations (execute workflows, update state)</code></p
 <td>INSERT</td>
 <td><code>create_*</code> operation</td>
 </tr>
-<tr>
+<tr class="even">
 <td><strong>Read One</strong></td>
 <td>Query</td>
 <td><code>findOne</code></td>
@@ -1267,7 +1267,7 @@ mcp_aql_execute - EXECUTE operations (execute workflows, update state)</code></p
 <td>SELECT ... WHERE</td>
 <td><code>get_*</code> operation</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><strong>Read Many</strong></td>
 <td>Query</td>
 <td><code>find</code></td>
@@ -1275,7 +1275,7 @@ mcp_aql_execute - EXECUTE operations (execute workflows, update state)</code></p
 <td>SELECT *</td>
 <td><code>list_*</code> operation</td>
 </tr>
-<tr>
+<tr class="even">
 <td><strong>Update</strong></td>
 <td>Mutation</td>
 <td><code>updateOne</code></td>
@@ -1283,7 +1283,7 @@ mcp_aql_execute - EXECUTE operations (execute workflows, update state)</code></p
 <td>UPDATE</td>
 <td><code>update_*</code> operation</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><strong>Delete</strong></td>
 <td>Mutation</td>
 <td><code>deleteOne</code></td>
@@ -1291,7 +1291,7 @@ mcp_aql_execute - EXECUTE operations (execute workflows, update state)</code></p
 <td>DELETE</td>
 <td><code>delete_*</code> operation</td>
 </tr>
-<tr>
+<tr class="even">
 <td><strong>Search</strong></td>
 <td>Query</td>
 <td><code>find</code>+text</td>
@@ -1299,7 +1299,7 @@ mcp_aql_execute - EXECUTE operations (execute workflows, update state)</code></p
 <td>LIKE/FTS</td>
 <td><code>search</code> operation</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><strong>Schema Discovery</strong></td>
 <td><code>__schema</code></td>
 <td><code>getCollectionInfos</code></td>
@@ -1307,7 +1307,7 @@ mcp_aql_execute - EXECUTE operations (execute workflows, update state)</code></p
 <td>DESCRIBE</td>
 <td><code>introspect</code></td>
 </tr>
-<tr>
+<tr class="even">
 <td><strong>Parameters</strong></td>
 <td>Variables</td>
 <td>Filter/options</td>
@@ -1315,7 +1315,7 @@ mcp_aql_execute - EXECUTE operations (execute workflows, update state)</code></p
 <td>WHERE/VALUES</td>
 <td><code>params</code> object</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><strong>Response</strong></td>
 <td><code>{ data, errors }</code></td>
 <td>Document</td>
@@ -1323,7 +1323,7 @@ mcp_aql_execute - EXECUTE operations (execute workflows, update state)</code></p
 <td>Result set</td>
 <td><code>{ success, data/error }</code></td>
 </tr>
-<tr>
+<tr class="even">
 <td><strong>Error</strong></td>
 <td><code>errors</code> array</td>
 <td>Exception</td>
@@ -1331,7 +1331,7 @@ mcp_aql_execute - EXECUTE operations (execute workflows, update state)</code></p
 <td>SQLSTATE</td>
 <td><code>{ success: false, error }</code></td>
 </tr>
-<tr>
+<tr class="odd">
 <td><strong>Batch</strong></td>
 <td>N/A (single)</td>
 <td><code>insertMany</code></td>
@@ -1339,7 +1339,7 @@ mcp_aql_execute - EXECUTE operations (execute workflows, update state)</code></p
 <td>Transaction</td>
 <td><code>operations</code> array</td>
 </tr>
-<tr>
+<tr class="even">
 <td><strong>Pagination</strong></td>
 <td><code>first/after</code></td>
 <td><code>skip/limit</code></td>
@@ -1551,24 +1551,24 @@ GET /api/swagger.json HTTP/1.1</code></pre>
 <h3 id="token-efficiency-summary">Token Efficiency Summary</h3>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Feature</th>
 <th>Token Savings</th>
 <th>Description</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><strong>CRUDE Consolidation</strong></td>
 <td>~85-96%</td>
 <td>Semantic endpoints instead of discrete tools</td>
 </tr>
-<tr>
+<tr class="even">
 <td><strong>On-Demand Introspection</strong></td>
 <td>~95%</td>
 <td>Query schemas as needed vs. upfront parsing</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><strong>Field Selection</strong></td>
 <td>~70-90%</td>
 <td>Return only requested fields in responses</td>
@@ -1587,9 +1587,9 @@ GET /api/swagger.json HTTP/1.1</code></pre>
           </div>
         </section>
         <nav class="page-nav" aria-label="Page navigation">
-  <a class="page-nav-link prev" href="../features/warnings.html">
+  <a class="page-nav-link prev" href="cross-domain-implementation.html">
     <span class="page-nav-eyebrow">Previous page</span>
-    <strong class="page-nav-label">Warnings Array Specification</strong>
+    <strong class="page-nav-label">Cross-Domain Implementation Guide</strong>
   </a>
   <a class="page-nav-link next" href="README.html">
     <span class="page-nav-eyebrow">Next page</span>

--- a/public/spec/index.html
+++ b/public/spec/index.html
@@ -65,7 +65,7 @@
   <div class="grid cols-3 spec-index-grid">
     <article class="card">
   <h3><a class="card-title-link" href="conformance-testing.html">MCP-AQL Conformance Testing Specification</a></h3>
-  <p>Document Status: This document is an informative conformance framework specification aligned to the normative protocol requirements in docs/versions/v1.0.0-draft.md. Implementation Status: The full mcpaql-conformance run</p>
+  <p>Document Status: This document is an informative conformance framework specification aligned to the normative protocol requirements in docs/versions/v1.0.0-draft.md. Implementation Status: This repository now includes a </p>
   <div class="spec-meta">
     <span class="state-chip live">Support document</span>
     <span class="state-chip pending">Draft</span>
@@ -129,7 +129,7 @@
 </article>
 <article class="card">
   <h3><a class="card-title-link" href="overview.html">MCP-AQL Protocol Overview</a></h3>
-  <p>MCP-AQL (Model Context Protocol - Agent Query Language) is a protocol that consolidates discrete MCP tools into 5 CRUDE endpoints (Create, Read, Update, Delete, Execute), providing significant token reduction while maint</p>
+  <p>MCP-AQL (Model Context Protocol - Agent Query Language) is a protocol that consolidates discrete MCP tools into a small number of semantic endpoint families, providing significant token reduction while maintaining full f</p>
   <div class="spec-meta">
     <span class="state-chip live">Support document</span>
     
@@ -166,7 +166,7 @@
   <div class="grid cols-3 spec-index-grid">
     <article class="card">
   <h3><a class="card-title-link" href="versions/v1.0.0-draft.html">MCP-AQL Specification</a></h3>
-  <p>MCP-AQL (Model Context Protocol - Advanced Agent API Adapter Query Language) is a protocol specification that consolidates multiple MCP tools into semantic CRUDE endpoints, providing significant token reduction while ena</p>
+  <p>MCP-AQL (Model Context Protocol - Advanced Agent API Adapter Query Language) is a protocol specification that consolidates multiple MCP tools into a small number of semantic endpoints, providing significant token reducti</p>
   <div class="spec-meta">
     <span class="state-chip live">Support document</span>
     <span class="state-chip pending">Draft</span>
@@ -260,7 +260,23 @@
   <h2 class="section-title">Features</h2>
   <div class="grid cols-3 spec-index-grid">
     <article class="card">
+  <h3><a class="card-title-link" href="features/aggregations.html">MCP-AQL Aggregations</a></h3>
+  <p>Document Status: This document is informative. For normative requirements, see MCP-AQL Specification v1.0.0.</p>
+  <div class="spec-meta">
+    <span class="state-chip live">Support document</span>
+    <span class="state-chip pending">Draft</span>
+  </div>
+</article>
+<article class="card">
   <h3><a class="card-title-link" href="features/collection-querying.html">MCP-AQL Collection Querying</a></h3>
+  <p>Document Status: This document is informative. For normative requirements, see MCP-AQL Specification v1.0.0.</p>
+  <div class="spec-meta">
+    <span class="state-chip live">Support document</span>
+    <span class="state-chip pending">Draft</span>
+  </div>
+</article>
+<article class="card">
+  <h3><a class="card-title-link" href="features/computed-fields.html">MCP-AQL Computed Fields</a></h3>
   <p>Document Status: This document is informative. For normative requirements, see MCP-AQL Specification v1.0.0.</p>
   <div class="spec-meta">
     <span class="state-chip live">Support document</span>
@@ -284,6 +300,14 @@
   </div>
 </article>
 <article class="card">
+  <h3><a class="card-title-link" href="features/relationship-queries.html">MCP-AQL Relationship Queries</a></h3>
+  <p>Document Status: This document is informative. For normative requirements, see MCP-AQL Specification v1.0.0.</p>
+  <div class="spec-meta">
+    <span class="state-chip live">Support document</span>
+    <span class="state-chip pending">Draft</span>
+  </div>
+</article>
+<article class="card">
   <h3><a class="card-title-link" href="features/warnings.html">Warnings Array Specification</a></h3>
   <p>This document specifies the warnings array extension to MCP-AQL's discriminated response format. Warnings provide a mechanism to communicate non-fatal conditions to clients within successful responses, enabling proactive</p>
   <div class="spec-meta">
@@ -297,6 +321,14 @@
   <h2 class="section-title">Guides</h2>
   <div class="grid cols-3 spec-index-grid">
     <article class="card">
+  <h3><a class="card-title-link" href="guides/cross-domain-implementation.html">Cross-Domain Implementation Guide</a></h3>
+  <p>Document Status: This document is informative. For normative protocol requirements, see MCP-AQL Specification v1.0.0.</p>
+  <div class="spec-meta">
+    <span class="state-chip live">Support document</span>
+    <span class="state-chip pending">Draft</span>
+  </div>
+</article>
+<article class="card">
   <h3><a class="card-title-link" href="guides/protocol-comparison.html">Protocol Comparison Guide</a></h3>
   <p>This document helps developers familiar with GraphQL, MongoDB, REST, SQL, or classic MCP understand MCP-AQL by mapping familiar concepts to their MCP-AQL equivalents.</p>
   <div class="spec-meta">

--- a/public/spec/introspection.html
+++ b/public/spec/introspection.html
@@ -50,10 +50,10 @@
   <ul><li><a href="security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Features</h3>
-  <ul><li><a href="features/collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="features/field-selection.html">Field Selection Specification</a></li><li><a href="features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="features/warnings.html">Warnings Array Specification</a></li></ul>
+  <ul><li><a href="features/aggregations.html">MCP-AQL Aggregations</a></li><li><a href="features/collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="features/computed-fields.html">MCP-AQL Computed Fields</a></li><li><a href="features/field-selection.html">Field Selection Specification</a></li><li><a href="features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="features/relationship-queries.html">MCP-AQL Relationship Queries</a></li><li><a href="features/warnings.html">Warnings Array Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Guides</h3>
-  <ul><li><a href="guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="guides/README.html">Developer Guides</a></li></ul>
+  <ul><li><a href="guides/cross-domain-implementation.html">Cross-Domain Implementation Guide</a></li><li><a href="guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
   <ul><li><a href="process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="process/versioning.html">Versioning Strategy</a></li><li><a href="repo/CHANGELOG.html">Changelog</a></li></ul>
@@ -150,7 +150,7 @@
 <hr />
 <h2 id="2-introspection-query-types">2. Introspection Query Types</h2>
 <h3 id="21-the-introspect-operation">2.1 The <code>introspect</code> Operation</h3>
-<p>All introspection is performed through the <code>introspect</code> operation on the READ endpoint. This is the only operation that MCP-AQL REQUIRES all adapters to implement.</p>
+<p>All introspection is performed through the <code>introspect</code> operation as a READ-category operation. In semantic endpoint mode, adapters expose it on a documented READ-oriented endpoint family; in Single mode, it is available through the unified endpoint. This is the only operation that MCP-AQL REQUIRES all adapters to implement.</p>
 <p><strong>Request Format:</strong></p>
 <div class="sourceCode" id="cb2"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a>{</span>
 <span id="cb2-2"><a href="#cb2-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;introspect&quot;</span><span class="op">,</span></span>
@@ -162,19 +162,19 @@
 <h3 id="22-query-types">2.2 Query Types</h3>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Query</th>
 <th>Description</th>
 <th>Optional <code>name</code> Parameter</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><code>operations</code></td>
 <td>List all available operations</td>
 <td>Get details for a specific operation</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>types</code></td>
 <td>List all available types</td>
 <td>Get details for a specific type</td>
@@ -231,32 +231,60 @@
 <h3 id="32-operationinfo-list-item">3.2 OperationInfo (List Item)</h3>
 <p>Summary information for an operation in list responses:</p>
 <div class="sourceCode" id="cb5"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb5-1"><a href="#cb5-1" aria-hidden="true" tabindex="-1"></a><span class="kw">interface</span> OperationInfo {</span>
-<span id="cb5-2"><a href="#cb5-2" aria-hidden="true" tabindex="-1"></a>  name<span class="op">:</span> <span class="dt">string</span><span class="op">;</span>        <span class="co">// Operation identifier (e.g., &quot;create_entity&quot;)</span></span>
-<span id="cb5-3"><a href="#cb5-3" aria-hidden="true" tabindex="-1"></a>  endpoint<span class="op">:</span> <span class="dt">string</span><span class="op">;</span>    <span class="co">// CRUDE endpoint (e.g., &quot;CREATE&quot;)</span></span>
-<span id="cb5-4"><a href="#cb5-4" aria-hidden="true" tabindex="-1"></a>  description<span class="op">:</span> <span class="dt">string</span><span class="op">;</span> <span class="co">// Brief description</span></span>
-<span id="cb5-5"><a href="#cb5-5" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<span id="cb5-2"><a href="#cb5-2" aria-hidden="true" tabindex="-1"></a>  name<span class="op">:</span> <span class="dt">string</span><span class="op">;</span>               <span class="co">// Operation identifier (e.g., &quot;create_entity&quot;)</span></span>
+<span id="cb5-3"><a href="#cb5-3" aria-hidden="true" tabindex="-1"></a>  semantic_category<span class="op">:</span> <span class="dt">string</span><span class="op">;</span>  <span class="co">// Standard category (e.g., &quot;CREATE&quot;)</span></span>
+<span id="cb5-4"><a href="#cb5-4" aria-hidden="true" tabindex="-1"></a>  endpoint<span class="op">:</span> <span class="dt">string</span><span class="op">;</span>           <span class="co">// Exposed endpoint family (e.g., &quot;query&quot;, &quot;create&quot;)</span></span>
+<span id="cb5-5"><a href="#cb5-5" aria-hidden="true" tabindex="-1"></a>  description<span class="op">:</span> <span class="dt">string</span><span class="op">;</span>        <span class="co">// Brief description</span></span>
+<span id="cb5-6"><a href="#cb5-6" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
 <h3 id="33-operationdetails-detail-response">3.3 OperationDetails (Detail Response)</h3>
 <p>Complete information for a specific operation:</p>
 <div class="sourceCode" id="cb6"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb6-1"><a href="#cb6-1" aria-hidden="true" tabindex="-1"></a><span class="kw">interface</span> OperationDetails {</span>
 <span id="cb6-2"><a href="#cb6-2" aria-hidden="true" tabindex="-1"></a>  name<span class="op">:</span> <span class="dt">string</span><span class="op">;</span>                    <span class="co">// Operation identifier</span></span>
-<span id="cb6-3"><a href="#cb6-3" aria-hidden="true" tabindex="-1"></a>  endpoint<span class="op">:</span> <span class="dt">string</span><span class="op">;</span>                <span class="co">// CRUDE endpoint</span></span>
-<span id="cb6-4"><a href="#cb6-4" aria-hidden="true" tabindex="-1"></a>  mcpTool<span class="op">:</span> <span class="dt">string</span><span class="op">;</span>                 <span class="co">// MCP tool name (e.g., &quot;mcp_aql_create&quot;)</span></span>
-<span id="cb6-5"><a href="#cb6-5" aria-hidden="true" tabindex="-1"></a>  description<span class="op">:</span> <span class="dt">string</span><span class="op">;</span>             <span class="co">// Detailed description</span></span>
-<span id="cb6-6"><a href="#cb6-6" aria-hidden="true" tabindex="-1"></a>  permissions<span class="op">:</span> EndpointPermissions<span class="op">;</span></span>
-<span id="cb6-7"><a href="#cb6-7" aria-hidden="true" tabindex="-1"></a>  parameters<span class="op">:</span> ParameterInfo[]<span class="op">;</span>     <span class="co">// Parameter definitions (see note below)</span></span>
-<span id="cb6-8"><a href="#cb6-8" aria-hidden="true" tabindex="-1"></a>  returns<span class="op">:</span> TypeInfo<span class="op">;</span>               <span class="co">// Return type information</span></span>
-<span id="cb6-9"><a href="#cb6-9" aria-hidden="true" tabindex="-1"></a>  examples<span class="op">:</span> OperationExample[]<span class="op">;</span>    <span class="co">// Example invocations</span></span>
-<span id="cb6-10"><a href="#cb6-10" aria-hidden="true" tabindex="-1"></a>}</span>
-<span id="cb6-11"><a href="#cb6-11" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb6-12"><a href="#cb6-12" aria-hidden="true" tabindex="-1"></a><span class="kw">interface</span> EndpointPermissions {</span>
-<span id="cb6-13"><a href="#cb6-13" aria-hidden="true" tabindex="-1"></a>  readOnly<span class="op">:</span> <span class="dt">boolean</span><span class="op">;</span>    <span class="co">// Whether operation modifies state</span></span>
-<span id="cb6-14"><a href="#cb6-14" aria-hidden="true" tabindex="-1"></a>  destructive<span class="op">:</span> <span class="dt">boolean</span><span class="op">;</span> <span class="co">// Whether operation removes state</span></span>
-<span id="cb6-15"><a href="#cb6-15" aria-hidden="true" tabindex="-1"></a>}</span>
-<span id="cb6-16"><a href="#cb6-16" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb6-17"><a href="#cb6-17" aria-hidden="true" tabindex="-1"></a><span class="kw">interface</span> OperationExample {</span>
-<span id="cb6-18"><a href="#cb6-18" aria-hidden="true" tabindex="-1"></a>  description<span class="op">?:</span> <span class="dt">string</span><span class="op">;</span> <span class="co">// Human-readable description of the example</span></span>
-<span id="cb6-19"><a href="#cb6-19" aria-hidden="true" tabindex="-1"></a>  request<span class="op">:</span> <span class="dt">object</span><span class="op">;</span>      <span class="co">// Example request object</span></span>
-<span id="cb6-20"><a href="#cb6-20" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<span id="cb6-3"><a href="#cb6-3" aria-hidden="true" tabindex="-1"></a>  semantic_category<span class="op">:</span> <span class="dt">string</span><span class="op">;</span>       <span class="co">// Standard category</span></span>
+<span id="cb6-4"><a href="#cb6-4" aria-hidden="true" tabindex="-1"></a>  endpoint<span class="op">:</span> <span class="dt">string</span><span class="op">;</span>                <span class="co">// Exposed endpoint family</span></span>
+<span id="cb6-5"><a href="#cb6-5" aria-hidden="true" tabindex="-1"></a>  mcpTool<span class="op">:</span> <span class="dt">string</span><span class="op">;</span>                 <span class="co">// Actual MCP tool name (e.g., &quot;mcp_aql_query&quot;)</span></span>
+<span id="cb6-6"><a href="#cb6-6" aria-hidden="true" tabindex="-1"></a>  description<span class="op">:</span> <span class="dt">string</span><span class="op">;</span>             <span class="co">// Detailed description</span></span>
+<span id="cb6-7"><a href="#cb6-7" aria-hidden="true" tabindex="-1"></a>  permissions<span class="op">:</span> EndpointPermissions<span class="op">;</span></span>
+<span id="cb6-8"><a href="#cb6-8" aria-hidden="true" tabindex="-1"></a>  parameters<span class="op">:</span> ParameterInfo[]<span class="op">;</span>     <span class="co">// Parameter definitions (see note below)</span></span>
+<span id="cb6-9"><a href="#cb6-9" aria-hidden="true" tabindex="-1"></a>  returns<span class="op">:</span> TypeInfo<span class="op">;</span>               <span class="co">// Return type information</span></span>
+<span id="cb6-10"><a href="#cb6-10" aria-hidden="true" tabindex="-1"></a>  examples<span class="op">:</span> OperationExample[]<span class="op">;</span>    <span class="co">// Example invocations</span></span>
+<span id="cb6-11"><a href="#cb6-11" aria-hidden="true" tabindex="-1"></a>  computed_fields<span class="op">?:</span> ComputedFieldInfo[]<span class="op">;</span></span>
+<span id="cb6-12"><a href="#cb6-12" aria-hidden="true" tabindex="-1"></a>  aggregation_support<span class="op">?:</span> AggregationSupport<span class="op">;</span></span>
+<span id="cb6-13"><a href="#cb6-13" aria-hidden="true" tabindex="-1"></a>  relationship_capabilities<span class="op">?:</span> RelationshipCapabilities<span class="op">;</span></span>
+<span id="cb6-14"><a href="#cb6-14" aria-hidden="true" tabindex="-1"></a>}</span>
+<span id="cb6-15"><a href="#cb6-15" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb6-16"><a href="#cb6-16" aria-hidden="true" tabindex="-1"></a><span class="kw">interface</span> EndpointPermissions {</span>
+<span id="cb6-17"><a href="#cb6-17" aria-hidden="true" tabindex="-1"></a>  readOnly<span class="op">:</span> <span class="dt">boolean</span><span class="op">;</span>    <span class="co">// Whether operation modifies state</span></span>
+<span id="cb6-18"><a href="#cb6-18" aria-hidden="true" tabindex="-1"></a>  destructive<span class="op">:</span> <span class="dt">boolean</span><span class="op">;</span> <span class="co">// Whether operation removes state</span></span>
+<span id="cb6-19"><a href="#cb6-19" aria-hidden="true" tabindex="-1"></a>}</span>
+<span id="cb6-20"><a href="#cb6-20" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb6-21"><a href="#cb6-21" aria-hidden="true" tabindex="-1"></a><span class="kw">interface</span> OperationExample {</span>
+<span id="cb6-22"><a href="#cb6-22" aria-hidden="true" tabindex="-1"></a>  description<span class="op">?:</span> <span class="dt">string</span><span class="op">;</span> <span class="co">// Human-readable description of the example</span></span>
+<span id="cb6-23"><a href="#cb6-23" aria-hidden="true" tabindex="-1"></a>  request<span class="op">:</span> <span class="dt">object</span><span class="op">;</span>      <span class="co">// Example request object</span></span>
+<span id="cb6-24"><a href="#cb6-24" aria-hidden="true" tabindex="-1"></a>}</span>
+<span id="cb6-25"><a href="#cb6-25" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb6-26"><a href="#cb6-26" aria-hidden="true" tabindex="-1"></a><span class="kw">interface</span> ComputedFieldInfo {</span>
+<span id="cb6-27"><a href="#cb6-27" aria-hidden="true" tabindex="-1"></a>  name<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb6-28"><a href="#cb6-28" aria-hidden="true" tabindex="-1"></a>  type<span class="op">:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb6-29"><a href="#cb6-29" aria-hidden="true" tabindex="-1"></a>  description<span class="op">?:</span> <span class="dt">string</span><span class="op">;</span></span>
+<span id="cb6-30"><a href="#cb6-30" aria-hidden="true" tabindex="-1"></a>  filterable<span class="op">?:</span> <span class="dt">boolean</span><span class="op">;</span></span>
+<span id="cb6-31"><a href="#cb6-31" aria-hidden="true" tabindex="-1"></a>  sortable<span class="op">?:</span> <span class="dt">boolean</span><span class="op">;</span></span>
+<span id="cb6-32"><a href="#cb6-32" aria-hidden="true" tabindex="-1"></a>}</span>
+<span id="cb6-33"><a href="#cb6-33" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb6-34"><a href="#cb6-34" aria-hidden="true" tabindex="-1"></a><span class="kw">interface</span> AggregationSupport {</span>
+<span id="cb6-35"><a href="#cb6-35" aria-hidden="true" tabindex="-1"></a>  supported<span class="op">:</span> <span class="dt">boolean</span><span class="op">;</span></span>
+<span id="cb6-36"><a href="#cb6-36" aria-hidden="true" tabindex="-1"></a>  default_mode<span class="op">?:</span> <span class="st">&quot;summary_only&quot;</span> <span class="op">|</span> <span class="st">&quot;include_items&quot;</span><span class="op">;</span></span>
+<span id="cb6-37"><a href="#cb6-37" aria-hidden="true" tabindex="-1"></a>  functions<span class="op">?:</span> <span class="dt">string</span>[]<span class="op">;</span></span>
+<span id="cb6-38"><a href="#cb6-38" aria-hidden="true" tabindex="-1"></a>  groupable_fields<span class="op">?:</span> <span class="dt">string</span>[]<span class="op">;</span></span>
+<span id="cb6-39"><a href="#cb6-39" aria-hidden="true" tabindex="-1"></a>  numeric_fields<span class="op">?:</span> <span class="dt">string</span>[]<span class="op">;</span></span>
+<span id="cb6-40"><a href="#cb6-40" aria-hidden="true" tabindex="-1"></a>}</span>
+<span id="cb6-41"><a href="#cb6-41" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb6-42"><a href="#cb6-42" aria-hidden="true" tabindex="-1"></a><span class="kw">interface</span> RelationshipCapabilities {</span>
+<span id="cb6-43"><a href="#cb6-43" aria-hidden="true" tabindex="-1"></a>  supported<span class="op">:</span> <span class="dt">boolean</span><span class="op">;</span></span>
+<span id="cb6-44"><a href="#cb6-44" aria-hidden="true" tabindex="-1"></a>  directions<span class="op">?:</span> <span class="bu">Array</span><span class="op">&lt;</span><span class="st">&quot;incoming&quot;</span> <span class="op">|</span> <span class="st">&quot;outgoing&quot;</span> <span class="op">|</span> <span class="st">&quot;both&quot;</span><span class="op">&gt;;</span></span>
+<span id="cb6-45"><a href="#cb6-45" aria-hidden="true" tabindex="-1"></a>  relationship_types<span class="op">?:</span> <span class="dt">string</span>[]<span class="op">;</span></span>
+<span id="cb6-46"><a href="#cb6-46" aria-hidden="true" tabindex="-1"></a>  max_depth<span class="op">?:</span> <span class="dt">number</span><span class="op">;</span></span>
+<span id="cb6-47"><a href="#cb6-47" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
 <blockquote>
 <p><strong>Terminology Note:</strong> The <code>parameters</code> array here describes the definitions of accepted parameters. At request time, callers provide parameter values via the <code>params</code> object (see <a href="versions/v1.0.0-draft.html#41-standard-request-structure">Section 4.1 of the normative spec</a>). The keys of <code>params</code> correspond to the <code>name</code> field of each <code>ParameterInfo</code> entry.</p>
 </blockquote>
@@ -289,44 +317,44 @@
 <p>Constraint fields are <strong>the highest-value properties in the introspection system</strong> - they prevent LLM hallucination by telling agents exactly what values are valid.</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Field</th>
 <th>Type</th>
 <th>Purpose</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><code>enum</code></td>
 <td>array</td>
 <td>Lists all valid values; LLM can select from these</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>minimum</code>/<code>maximum</code></td>
 <td>number</td>
 <td>Numeric bounds; LLM can generate values in range</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>minLength</code>/<code>maxLength</code></td>
 <td>integer</td>
 <td>String length limits</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>pattern</code></td>
 <td>string</td>
 <td>Regex pattern for validation</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>format</code></td>
 <td>string</td>
 <td>Semantic format hint (date-time, email, uri, uuid)</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>items</code></td>
 <td>object</td>
 <td>Element schema for array parameters</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>sensitive</code></td>
 <td>boolean</td>
 <td>Flag for passwords/API keys; clients SHOULD mask input</td>
@@ -386,7 +414,7 @@
 <span id="cb14-4"><a href="#cb14-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;_protocol&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
 <span id="cb14-5"><a href="#cb14-5" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;version&quot;</span><span class="fu">:</span> <span class="st">&quot;1.0.0-alpha.1&quot;</span><span class="fu">,</span></span>
 <span id="cb14-6"><a href="#cb14-6" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;conformance&quot;</span><span class="fu">:</span> <span class="st">&quot;level-1&quot;</span><span class="fu">,</span></span>
-<span id="cb14-7"><a href="#cb14-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;mode&quot;</span><span class="fu">:</span> <span class="st">&quot;crude&quot;</span><span class="fu">,</span></span>
+<span id="cb14-7"><a href="#cb14-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;mode&quot;</span><span class="fu">:</span> <span class="st">&quot;semantic&quot;</span><span class="fu">,</span></span>
 <span id="cb14-8"><a href="#cb14-8" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;capabilities&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
 <span id="cb14-9"><a href="#cb14-9" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;batch&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
 <span id="cb14-10"><a href="#cb14-10" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;field_selection&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
@@ -396,47 +424,92 @@
 <span id="cb14-14"><a href="#cb14-14" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;operations&quot;</span><span class="fu">:</span> <span class="ot">[</span></span>
 <span id="cb14-15"><a href="#cb14-15" aria-hidden="true" tabindex="-1"></a>      <span class="fu">{</span></span>
 <span id="cb14-16"><a href="#cb14-16" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;create_entity&quot;</span><span class="fu">,</span></span>
-<span id="cb14-17"><a href="#cb14-17" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;endpoint&quot;</span><span class="fu">:</span> <span class="st">&quot;CREATE&quot;</span><span class="fu">,</span></span>
-<span id="cb14-18"><a href="#cb14-18" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Create a new entity&quot;</span></span>
-<span id="cb14-19"><a href="#cb14-19" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span><span class="ot">,</span></span>
-<span id="cb14-20"><a href="#cb14-20" aria-hidden="true" tabindex="-1"></a>      <span class="fu">{</span></span>
-<span id="cb14-21"><a href="#cb14-21" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;list_entities&quot;</span><span class="fu">,</span></span>
-<span id="cb14-22"><a href="#cb14-22" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;endpoint&quot;</span><span class="fu">:</span> <span class="st">&quot;READ&quot;</span><span class="fu">,</span></span>
-<span id="cb14-23"><a href="#cb14-23" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;List entities with filtering and pagination&quot;</span></span>
-<span id="cb14-24"><a href="#cb14-24" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span><span class="ot">,</span></span>
-<span id="cb14-25"><a href="#cb14-25" aria-hidden="true" tabindex="-1"></a>      <span class="fu">{</span></span>
-<span id="cb14-26"><a href="#cb14-26" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;get_entity&quot;</span><span class="fu">,</span></span>
-<span id="cb14-27"><a href="#cb14-27" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;endpoint&quot;</span><span class="fu">:</span> <span class="st">&quot;READ&quot;</span><span class="fu">,</span></span>
-<span id="cb14-28"><a href="#cb14-28" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Get an entity by identifier&quot;</span></span>
-<span id="cb14-29"><a href="#cb14-29" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span><span class="ot">,</span></span>
-<span id="cb14-30"><a href="#cb14-30" aria-hidden="true" tabindex="-1"></a>      <span class="fu">{</span></span>
-<span id="cb14-31"><a href="#cb14-31" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;update_entity&quot;</span><span class="fu">,</span></span>
-<span id="cb14-32"><a href="#cb14-32" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;endpoint&quot;</span><span class="fu">:</span> <span class="st">&quot;UPDATE&quot;</span><span class="fu">,</span></span>
-<span id="cb14-33"><a href="#cb14-33" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Update entity properties&quot;</span></span>
-<span id="cb14-34"><a href="#cb14-34" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span><span class="ot">,</span></span>
-<span id="cb14-35"><a href="#cb14-35" aria-hidden="true" tabindex="-1"></a>      <span class="fu">{</span></span>
-<span id="cb14-36"><a href="#cb14-36" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;delete_entity&quot;</span><span class="fu">,</span></span>
-<span id="cb14-37"><a href="#cb14-37" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;endpoint&quot;</span><span class="fu">:</span> <span class="st">&quot;DELETE&quot;</span><span class="fu">,</span></span>
-<span id="cb14-38"><a href="#cb14-38" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Delete an entity&quot;</span></span>
-<span id="cb14-39"><a href="#cb14-39" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span><span class="ot">,</span></span>
-<span id="cb14-40"><a href="#cb14-40" aria-hidden="true" tabindex="-1"></a>      <span class="fu">{</span></span>
-<span id="cb14-41"><a href="#cb14-41" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;execute_workflow&quot;</span><span class="fu">,</span></span>
-<span id="cb14-42"><a href="#cb14-42" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;endpoint&quot;</span><span class="fu">:</span> <span class="st">&quot;EXECUTE&quot;</span><span class="fu">,</span></span>
-<span id="cb14-43"><a href="#cb14-43" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Start execution of a workflow&quot;</span></span>
+<span id="cb14-17"><a href="#cb14-17" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;semantic_category&quot;</span><span class="fu">:</span> <span class="st">&quot;CREATE&quot;</span><span class="fu">,</span></span>
+<span id="cb14-18"><a href="#cb14-18" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;endpoint&quot;</span><span class="fu">:</span> <span class="st">&quot;manage&quot;</span><span class="fu">,</span></span>
+<span id="cb14-19"><a href="#cb14-19" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Create a new entity&quot;</span></span>
+<span id="cb14-20"><a href="#cb14-20" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb14-21"><a href="#cb14-21" aria-hidden="true" tabindex="-1"></a>      <span class="fu">{</span></span>
+<span id="cb14-22"><a href="#cb14-22" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;list_entities&quot;</span><span class="fu">,</span></span>
+<span id="cb14-23"><a href="#cb14-23" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;semantic_category&quot;</span><span class="fu">:</span> <span class="st">&quot;READ&quot;</span><span class="fu">,</span></span>
+<span id="cb14-24"><a href="#cb14-24" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;endpoint&quot;</span><span class="fu">:</span> <span class="st">&quot;query&quot;</span><span class="fu">,</span></span>
+<span id="cb14-25"><a href="#cb14-25" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;List entities with filtering and pagination&quot;</span></span>
+<span id="cb14-26"><a href="#cb14-26" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb14-27"><a href="#cb14-27" aria-hidden="true" tabindex="-1"></a>      <span class="fu">{</span></span>
+<span id="cb14-28"><a href="#cb14-28" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;get_entity&quot;</span><span class="fu">,</span></span>
+<span id="cb14-29"><a href="#cb14-29" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;semantic_category&quot;</span><span class="fu">:</span> <span class="st">&quot;READ&quot;</span><span class="fu">,</span></span>
+<span id="cb14-30"><a href="#cb14-30" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;endpoint&quot;</span><span class="fu">:</span> <span class="st">&quot;query&quot;</span><span class="fu">,</span></span>
+<span id="cb14-31"><a href="#cb14-31" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Get an entity by identifier&quot;</span></span>
+<span id="cb14-32"><a href="#cb14-32" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb14-33"><a href="#cb14-33" aria-hidden="true" tabindex="-1"></a>      <span class="fu">{</span></span>
+<span id="cb14-34"><a href="#cb14-34" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;update_entity&quot;</span><span class="fu">,</span></span>
+<span id="cb14-35"><a href="#cb14-35" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;semantic_category&quot;</span><span class="fu">:</span> <span class="st">&quot;UPDATE&quot;</span><span class="fu">,</span></span>
+<span id="cb14-36"><a href="#cb14-36" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;endpoint&quot;</span><span class="fu">:</span> <span class="st">&quot;manage&quot;</span><span class="fu">,</span></span>
+<span id="cb14-37"><a href="#cb14-37" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Update entity properties&quot;</span></span>
+<span id="cb14-38"><a href="#cb14-38" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb14-39"><a href="#cb14-39" aria-hidden="true" tabindex="-1"></a>      <span class="fu">{</span></span>
+<span id="cb14-40"><a href="#cb14-40" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;delete_entity&quot;</span><span class="fu">,</span></span>
+<span id="cb14-41"><a href="#cb14-41" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;semantic_category&quot;</span><span class="fu">:</span> <span class="st">&quot;DELETE&quot;</span><span class="fu">,</span></span>
+<span id="cb14-42"><a href="#cb14-42" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;endpoint&quot;</span><span class="fu">:</span> <span class="st">&quot;manage&quot;</span><span class="fu">,</span></span>
+<span id="cb14-43"><a href="#cb14-43" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Delete an entity&quot;</span></span>
 <span id="cb14-44"><a href="#cb14-44" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span><span class="ot">,</span></span>
 <span id="cb14-45"><a href="#cb14-45" aria-hidden="true" tabindex="-1"></a>      <span class="fu">{</span></span>
-<span id="cb14-46"><a href="#cb14-46" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;introspect&quot;</span><span class="fu">,</span></span>
-<span id="cb14-47"><a href="#cb14-47" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;endpoint&quot;</span><span class="fu">:</span> <span class="st">&quot;READ&quot;</span><span class="fu">,</span></span>
-<span id="cb14-48"><a href="#cb14-48" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Discover available operations and types&quot;</span></span>
-<span id="cb14-49"><a href="#cb14-49" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span></span>
-<span id="cb14-50"><a href="#cb14-50" aria-hidden="true" tabindex="-1"></a>    <span class="ot">]</span></span>
-<span id="cb14-51"><a href="#cb14-51" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
-<span id="cb14-52"><a href="#cb14-52" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<span id="cb14-46"><a href="#cb14-46" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;execute_workflow&quot;</span><span class="fu">,</span></span>
+<span id="cb14-47"><a href="#cb14-47" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;semantic_category&quot;</span><span class="fu">:</span> <span class="st">&quot;EXECUTE&quot;</span><span class="fu">,</span></span>
+<span id="cb14-48"><a href="#cb14-48" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;endpoint&quot;</span><span class="fu">:</span> <span class="st">&quot;operate&quot;</span><span class="fu">,</span></span>
+<span id="cb14-49"><a href="#cb14-49" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Start execution of a workflow&quot;</span></span>
+<span id="cb14-50"><a href="#cb14-50" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb14-51"><a href="#cb14-51" aria-hidden="true" tabindex="-1"></a>      <span class="fu">{</span></span>
+<span id="cb14-52"><a href="#cb14-52" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;introspect&quot;</span><span class="fu">,</span></span>
+<span id="cb14-53"><a href="#cb14-53" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;semantic_category&quot;</span><span class="fu">:</span> <span class="st">&quot;READ&quot;</span><span class="fu">,</span></span>
+<span id="cb14-54"><a href="#cb14-54" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;endpoint&quot;</span><span class="fu">:</span> <span class="st">&quot;query&quot;</span><span class="fu">,</span></span>
+<span id="cb14-55"><a href="#cb14-55" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Discover available operations and types&quot;</span></span>
+<span id="cb14-56"><a href="#cb14-56" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span></span>
+<span id="cb14-57"><a href="#cb14-57" aria-hidden="true" tabindex="-1"></a>    <span class="ot">]</span></span>
+<span id="cb14-58"><a href="#cb14-58" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb14-59"><a href="#cb14-59" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<p>For the standard CRUDE profile, which remains the default when no alternate semantic-endpoint profile is configured, the <code>endpoint</code> field SHOULD use the lowercase endpoint-family name rather than the MCP tool name:</p>
+<div class="sourceCode" id="cb15"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb15-1"><a href="#cb15-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb15-2"><a href="#cb15-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb15-3"><a href="#cb15-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;data&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb15-4"><a href="#cb15-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;operations&quot;</span><span class="fu">:</span> <span class="ot">[</span></span>
+<span id="cb15-5"><a href="#cb15-5" aria-hidden="true" tabindex="-1"></a>      <span class="fu">{</span></span>
+<span id="cb15-6"><a href="#cb15-6" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;create_entity&quot;</span><span class="fu">,</span></span>
+<span id="cb15-7"><a href="#cb15-7" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;semantic_category&quot;</span><span class="fu">:</span> <span class="st">&quot;CREATE&quot;</span><span class="fu">,</span></span>
+<span id="cb15-8"><a href="#cb15-8" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;endpoint&quot;</span><span class="fu">:</span> <span class="st">&quot;create&quot;</span><span class="fu">,</span></span>
+<span id="cb15-9"><a href="#cb15-9" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Create a new entity&quot;</span></span>
+<span id="cb15-10"><a href="#cb15-10" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb15-11"><a href="#cb15-11" aria-hidden="true" tabindex="-1"></a>      <span class="fu">{</span></span>
+<span id="cb15-12"><a href="#cb15-12" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;list_entities&quot;</span><span class="fu">,</span></span>
+<span id="cb15-13"><a href="#cb15-13" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;semantic_category&quot;</span><span class="fu">:</span> <span class="st">&quot;READ&quot;</span><span class="fu">,</span></span>
+<span id="cb15-14"><a href="#cb15-14" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;endpoint&quot;</span><span class="fu">:</span> <span class="st">&quot;read&quot;</span><span class="fu">,</span></span>
+<span id="cb15-15"><a href="#cb15-15" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;List entities with filtering and pagination&quot;</span></span>
+<span id="cb15-16"><a href="#cb15-16" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb15-17"><a href="#cb15-17" aria-hidden="true" tabindex="-1"></a>      <span class="fu">{</span></span>
+<span id="cb15-18"><a href="#cb15-18" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;update_entity&quot;</span><span class="fu">,</span></span>
+<span id="cb15-19"><a href="#cb15-19" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;semantic_category&quot;</span><span class="fu">:</span> <span class="st">&quot;UPDATE&quot;</span><span class="fu">,</span></span>
+<span id="cb15-20"><a href="#cb15-20" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;endpoint&quot;</span><span class="fu">:</span> <span class="st">&quot;update&quot;</span><span class="fu">,</span></span>
+<span id="cb15-21"><a href="#cb15-21" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Update entity properties&quot;</span></span>
+<span id="cb15-22"><a href="#cb15-22" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb15-23"><a href="#cb15-23" aria-hidden="true" tabindex="-1"></a>      <span class="fu">{</span></span>
+<span id="cb15-24"><a href="#cb15-24" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;delete_entity&quot;</span><span class="fu">,</span></span>
+<span id="cb15-25"><a href="#cb15-25" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;semantic_category&quot;</span><span class="fu">:</span> <span class="st">&quot;DELETE&quot;</span><span class="fu">,</span></span>
+<span id="cb15-26"><a href="#cb15-26" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;endpoint&quot;</span><span class="fu">:</span> <span class="st">&quot;delete&quot;</span><span class="fu">,</span></span>
+<span id="cb15-27"><a href="#cb15-27" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Delete an entity&quot;</span></span>
+<span id="cb15-28"><a href="#cb15-28" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb15-29"><a href="#cb15-29" aria-hidden="true" tabindex="-1"></a>      <span class="fu">{</span></span>
+<span id="cb15-30"><a href="#cb15-30" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;execute_workflow&quot;</span><span class="fu">,</span></span>
+<span id="cb15-31"><a href="#cb15-31" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;semantic_category&quot;</span><span class="fu">:</span> <span class="st">&quot;EXECUTE&quot;</span><span class="fu">,</span></span>
+<span id="cb15-32"><a href="#cb15-32" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;endpoint&quot;</span><span class="fu">:</span> <span class="st">&quot;execute&quot;</span><span class="fu">,</span></span>
+<span id="cb15-33"><a href="#cb15-33" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Start execution of a workflow&quot;</span></span>
+<span id="cb15-34"><a href="#cb15-34" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span></span>
+<span id="cb15-35"><a href="#cb15-35" aria-hidden="true" tabindex="-1"></a>    <span class="ot">]</span></span>
+<span id="cb15-36"><a href="#cb15-36" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb15-37"><a href="#cb15-37" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
 <h4 id="411-protocol-metadata">4.1.1 Protocol Metadata</h4>
 <p>The <code>_protocol</code> object in operations list responses provides version and capability information:</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Field</th>
 <th>Type</th>
 <th>Required</th>
@@ -444,25 +517,25 @@
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><code>version</code></td>
 <td>string</td>
 <td>MUST</td>
 <td>MCP-AQL spec version (semver format)</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>conformance</code></td>
 <td>string</td>
 <td>SHOULD</td>
 <td>Conformance level ("level-1", "level-2")</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>mode</code></td>
 <td>string</td>
 <td>SHOULD</td>
-<td>Endpoint mode ("crude", "single", "all")</td>
+<td>Endpoint mode ("semantic", "single", "all")</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>capabilities</code></td>
 <td>object</td>
 <td>MAY</td>
@@ -470,36 +543,49 @@
 </tr>
 </tbody>
 </table>
+<p><code>"semantic"</code> is the preferred mode value for both the standard CRUDE profile and alternate semantic-endpoint profiles. Earlier drafts may have described the standard profile as <code>"crude"</code>, but current introspection metadata SHOULD report <code>"semantic"</code>.</p>
 <p><strong>Capabilities flags:</strong></p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Capability</th>
 <th>Description</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><code>batch</code></td>
 <td>Supports batch operations</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>field_selection</code></td>
 <td>Supports field selection in responses</td>
 </tr>
-<tr>
+<tr class="odd">
+<td><code>aggregations</code></td>
+<td>Supports server-side aggregation controls</td>
+</tr>
+<tr class="even">
+<td><code>computed_fields</code></td>
+<td>Exposes adapter-declared computed fields</td>
+</tr>
+<tr class="odd">
 <td><code>pagination</code></td>
 <td>Supports cursor-based pagination</td>
 </tr>
-<tr>
+<tr class="even">
+<td><code>relationship_queries</code></td>
+<td>Supports graph and relationship traversal</td>
+</tr>
+<tr class="odd">
 <td><code>warnings</code></td>
 <td>Includes warnings array in responses</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>confirmation</code></td>
 <td>Supports confirmation token flow</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>dangerous_operations</code></td>
 <td>Has danger level classification</td>
 </tr>
@@ -511,257 +597,264 @@
 <li>Detect available features before use</li>
 <li>Enable graceful degradation for older adapters</li>
 </ul>
+<p>Operation detail responses MAY also expose richer query-language metadata:</p>
+<ul>
+<li><code>computed_fields</code> for adapter-declared derived values</li>
+<li><code>aggregation_support</code> for supported aggregation functions and fields</li>
+<li><code>relationship_capabilities</code> for traversal vocabulary and depth limits</li>
+</ul>
 <h3 id="42-getting-operation-details">4.2 Getting Operation Details</h3>
 <p><strong>Request:</strong></p>
-<div class="sourceCode" id="cb15"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb15-1"><a href="#cb15-1" aria-hidden="true" tabindex="-1"></a>{</span>
-<span id="cb15-2"><a href="#cb15-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;introspect&quot;</span><span class="op">,</span></span>
-<span id="cb15-3"><a href="#cb15-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> { <span class="dt">query</span><span class="op">:</span> <span class="st">&quot;operations&quot;</span><span class="op">,</span> <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;create_entity&quot;</span> }</span>
-<span id="cb15-4"><a href="#cb15-4" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<div class="sourceCode" id="cb16"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb16-1"><a href="#cb16-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb16-2"><a href="#cb16-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;introspect&quot;</span><span class="op">,</span></span>
+<span id="cb16-3"><a href="#cb16-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> { <span class="dt">query</span><span class="op">:</span> <span class="st">&quot;operations&quot;</span><span class="op">,</span> <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;create_entity&quot;</span> }</span>
+<span id="cb16-4"><a href="#cb16-4" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
 <p><strong>Response:</strong></p>
-<div class="sourceCode" id="cb16"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb16-1"><a href="#cb16-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
-<span id="cb16-2"><a href="#cb16-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
-<span id="cb16-3"><a href="#cb16-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;data&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb16-4"><a href="#cb16-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb16-5"><a href="#cb16-5" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;create_entity&quot;</span><span class="fu">,</span></span>
-<span id="cb16-6"><a href="#cb16-6" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;endpoint&quot;</span><span class="fu">:</span> <span class="st">&quot;CREATE&quot;</span><span class="fu">,</span></span>
-<span id="cb16-7"><a href="#cb16-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;mcpTool&quot;</span><span class="fu">:</span> <span class="st">&quot;mcp_aql_create&quot;</span><span class="fu">,</span></span>
-<span id="cb16-8"><a href="#cb16-8" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Create a new entity of any type&quot;</span><span class="fu">,</span></span>
-<span id="cb16-9"><a href="#cb16-9" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;permissions&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb16-10"><a href="#cb16-10" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;readOnly&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
-<span id="cb16-11"><a href="#cb16-11" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;destructive&quot;</span><span class="fu">:</span> <span class="kw">false</span></span>
-<span id="cb16-12"><a href="#cb16-12" aria-hidden="true" tabindex="-1"></a>      <span class="fu">},</span></span>
-<span id="cb16-13"><a href="#cb16-13" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;parameters&quot;</span><span class="fu">:</span> <span class="ot">[</span></span>
-<span id="cb16-14"><a href="#cb16-14" aria-hidden="true" tabindex="-1"></a>        <span class="fu">{</span></span>
-<span id="cb16-15"><a href="#cb16-15" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;entity_name&quot;</span><span class="fu">,</span></span>
-<span id="cb16-16"><a href="#cb16-16" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;string&quot;</span><span class="fu">,</span></span>
-<span id="cb16-17"><a href="#cb16-17" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;required&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
-<span id="cb16-18"><a href="#cb16-18" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Entity name&quot;</span><span class="fu">,</span></span>
-<span id="cb16-19"><a href="#cb16-19" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;minLength&quot;</span><span class="fu">:</span> <span class="dv">1</span><span class="fu">,</span></span>
-<span id="cb16-20"><a href="#cb16-20" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;maxLength&quot;</span><span class="fu">:</span> <span class="dv">100</span><span class="fu">,</span></span>
-<span id="cb16-21"><a href="#cb16-21" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;pattern&quot;</span><span class="fu">:</span> <span class="st">&quot;^[a-zA-Z][a-zA-Z0-9_-]*$&quot;</span></span>
-<span id="cb16-22"><a href="#cb16-22" aria-hidden="true" tabindex="-1"></a>        <span class="fu">}</span><span class="ot">,</span></span>
-<span id="cb16-23"><a href="#cb16-23" aria-hidden="true" tabindex="-1"></a>        <span class="fu">{</span></span>
-<span id="cb16-24"><a href="#cb16-24" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;entity_type&quot;</span><span class="fu">,</span></span>
-<span id="cb16-25"><a href="#cb16-25" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;string&quot;</span><span class="fu">,</span></span>
-<span id="cb16-26"><a href="#cb16-26" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;required&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
-<span id="cb16-27"><a href="#cb16-27" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Type of entity to create&quot;</span><span class="fu">,</span></span>
-<span id="cb16-28"><a href="#cb16-28" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;enum&quot;</span><span class="fu">:</span> <span class="ot">[</span><span class="st">&quot;resource&quot;</span><span class="ot">,</span> <span class="st">&quot;item&quot;</span><span class="ot">,</span> <span class="st">&quot;config&quot;</span><span class="ot">,</span> <span class="st">&quot;workflow&quot;</span><span class="ot">]</span></span>
-<span id="cb16-29"><a href="#cb16-29" aria-hidden="true" tabindex="-1"></a>        <span class="fu">}</span><span class="ot">,</span></span>
-<span id="cb16-30"><a href="#cb16-30" aria-hidden="true" tabindex="-1"></a>        <span class="fu">{</span></span>
-<span id="cb16-31"><a href="#cb16-31" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;description&quot;</span><span class="fu">,</span></span>
-<span id="cb16-32"><a href="#cb16-32" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;string&quot;</span><span class="fu">,</span></span>
-<span id="cb16-33"><a href="#cb16-33" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;required&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
-<span id="cb16-34"><a href="#cb16-34" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Entity description&quot;</span><span class="fu">,</span></span>
-<span id="cb16-35"><a href="#cb16-35" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;maxLength&quot;</span><span class="fu">:</span> <span class="dv">500</span></span>
-<span id="cb16-36"><a href="#cb16-36" aria-hidden="true" tabindex="-1"></a>        <span class="fu">}</span><span class="ot">,</span></span>
-<span id="cb16-37"><a href="#cb16-37" aria-hidden="true" tabindex="-1"></a>        <span class="fu">{</span></span>
-<span id="cb16-38"><a href="#cb16-38" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;priority&quot;</span><span class="fu">,</span></span>
-<span id="cb16-39"><a href="#cb16-39" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;integer&quot;</span><span class="fu">,</span></span>
-<span id="cb16-40"><a href="#cb16-40" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;required&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
-<span id="cb16-41"><a href="#cb16-41" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Priority level&quot;</span><span class="fu">,</span></span>
-<span id="cb16-42"><a href="#cb16-42" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;default&quot;</span><span class="fu">:</span> <span class="dv">5</span><span class="fu">,</span></span>
-<span id="cb16-43"><a href="#cb16-43" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;minimum&quot;</span><span class="fu">:</span> <span class="dv">1</span><span class="fu">,</span></span>
-<span id="cb16-44"><a href="#cb16-44" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;maximum&quot;</span><span class="fu">:</span> <span class="dv">10</span></span>
-<span id="cb16-45"><a href="#cb16-45" aria-hidden="true" tabindex="-1"></a>        <span class="fu">}</span><span class="ot">,</span></span>
-<span id="cb16-46"><a href="#cb16-46" aria-hidden="true" tabindex="-1"></a>        <span class="fu">{</span></span>
-<span id="cb16-47"><a href="#cb16-47" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;metadata&quot;</span><span class="fu">,</span></span>
-<span id="cb16-48"><a href="#cb16-48" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;object&quot;</span><span class="fu">,</span></span>
-<span id="cb16-49"><a href="#cb16-49" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;required&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
-<span id="cb16-50"><a href="#cb16-50" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Additional metadata&quot;</span></span>
-<span id="cb16-51"><a href="#cb16-51" aria-hidden="true" tabindex="-1"></a>        <span class="fu">}</span></span>
-<span id="cb16-52"><a href="#cb16-52" aria-hidden="true" tabindex="-1"></a>      <span class="ot">]</span><span class="fu">,</span></span>
-<span id="cb16-53"><a href="#cb16-53" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;returns&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb16-54"><a href="#cb16-54" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;Entity&quot;</span><span class="fu">,</span></span>
-<span id="cb16-55"><a href="#cb16-55" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;kind&quot;</span><span class="fu">:</span> <span class="st">&quot;object&quot;</span><span class="fu">,</span></span>
-<span id="cb16-56"><a href="#cb16-56" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Newly created entity&quot;</span></span>
-<span id="cb16-57"><a href="#cb16-57" aria-hidden="true" tabindex="-1"></a>      <span class="fu">},</span></span>
-<span id="cb16-58"><a href="#cb16-58" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;examples&quot;</span><span class="fu">:</span> <span class="ot">[</span></span>
-<span id="cb16-59"><a href="#cb16-59" aria-hidden="true" tabindex="-1"></a>        <span class="fu">{</span></span>
-<span id="cb16-60"><a href="#cb16-60" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Create a resource entity&quot;</span><span class="fu">,</span></span>
-<span id="cb16-61"><a href="#cb16-61" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;request&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb16-62"><a href="#cb16-62" aria-hidden="true" tabindex="-1"></a>            <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;create_entity&quot;</span><span class="fu">,</span></span>
-<span id="cb16-63"><a href="#cb16-63" aria-hidden="true" tabindex="-1"></a>            <span class="dt">&quot;element_type&quot;</span><span class="fu">:</span> <span class="st">&quot;resource&quot;</span><span class="fu">,</span></span>
-<span id="cb16-64"><a href="#cb16-64" aria-hidden="true" tabindex="-1"></a>            <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb16-65"><a href="#cb16-65" aria-hidden="true" tabindex="-1"></a>              <span class="dt">&quot;entity_name&quot;</span><span class="fu">:</span> <span class="st">&quot;MyResource&quot;</span><span class="fu">,</span></span>
-<span id="cb16-66"><a href="#cb16-66" aria-hidden="true" tabindex="-1"></a>              <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;A sample resource&quot;</span></span>
-<span id="cb16-67"><a href="#cb16-67" aria-hidden="true" tabindex="-1"></a>            <span class="fu">}</span></span>
-<span id="cb16-68"><a href="#cb16-68" aria-hidden="true" tabindex="-1"></a>          <span class="fu">}</span></span>
-<span id="cb16-69"><a href="#cb16-69" aria-hidden="true" tabindex="-1"></a>        <span class="fu">}</span></span>
-<span id="cb16-70"><a href="#cb16-70" aria-hidden="true" tabindex="-1"></a>      <span class="ot">]</span></span>
-<span id="cb16-71"><a href="#cb16-71" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
-<span id="cb16-72"><a href="#cb16-72" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
-<span id="cb16-73"><a href="#cb16-73" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<div class="sourceCode" id="cb17"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb17-1"><a href="#cb17-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb17-2"><a href="#cb17-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb17-3"><a href="#cb17-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;data&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb17-4"><a href="#cb17-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb17-5"><a href="#cb17-5" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;create_entity&quot;</span><span class="fu">,</span></span>
+<span id="cb17-6"><a href="#cb17-6" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;semantic_category&quot;</span><span class="fu">:</span> <span class="st">&quot;CREATE&quot;</span><span class="fu">,</span></span>
+<span id="cb17-7"><a href="#cb17-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;endpoint&quot;</span><span class="fu">:</span> <span class="st">&quot;manage&quot;</span><span class="fu">,</span></span>
+<span id="cb17-8"><a href="#cb17-8" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;mcpTool&quot;</span><span class="fu">:</span> <span class="st">&quot;mcp_aql_manage&quot;</span><span class="fu">,</span></span>
+<span id="cb17-9"><a href="#cb17-9" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Create a new entity of any type&quot;</span><span class="fu">,</span></span>
+<span id="cb17-10"><a href="#cb17-10" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;permissions&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb17-11"><a href="#cb17-11" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;readOnly&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb17-12"><a href="#cb17-12" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;destructive&quot;</span><span class="fu">:</span> <span class="kw">false</span></span>
+<span id="cb17-13"><a href="#cb17-13" aria-hidden="true" tabindex="-1"></a>      <span class="fu">},</span></span>
+<span id="cb17-14"><a href="#cb17-14" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;parameters&quot;</span><span class="fu">:</span> <span class="ot">[</span></span>
+<span id="cb17-15"><a href="#cb17-15" aria-hidden="true" tabindex="-1"></a>        <span class="fu">{</span></span>
+<span id="cb17-16"><a href="#cb17-16" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;entity_name&quot;</span><span class="fu">,</span></span>
+<span id="cb17-17"><a href="#cb17-17" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;string&quot;</span><span class="fu">,</span></span>
+<span id="cb17-18"><a href="#cb17-18" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;required&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb17-19"><a href="#cb17-19" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Entity name&quot;</span><span class="fu">,</span></span>
+<span id="cb17-20"><a href="#cb17-20" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;minLength&quot;</span><span class="fu">:</span> <span class="dv">1</span><span class="fu">,</span></span>
+<span id="cb17-21"><a href="#cb17-21" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;maxLength&quot;</span><span class="fu">:</span> <span class="dv">100</span><span class="fu">,</span></span>
+<span id="cb17-22"><a href="#cb17-22" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;pattern&quot;</span><span class="fu">:</span> <span class="st">&quot;^[a-zA-Z][a-zA-Z0-9_-]*$&quot;</span></span>
+<span id="cb17-23"><a href="#cb17-23" aria-hidden="true" tabindex="-1"></a>        <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb17-24"><a href="#cb17-24" aria-hidden="true" tabindex="-1"></a>        <span class="fu">{</span></span>
+<span id="cb17-25"><a href="#cb17-25" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;entity_type&quot;</span><span class="fu">,</span></span>
+<span id="cb17-26"><a href="#cb17-26" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;string&quot;</span><span class="fu">,</span></span>
+<span id="cb17-27"><a href="#cb17-27" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;required&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb17-28"><a href="#cb17-28" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Type of entity to create&quot;</span><span class="fu">,</span></span>
+<span id="cb17-29"><a href="#cb17-29" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;enum&quot;</span><span class="fu">:</span> <span class="ot">[</span><span class="st">&quot;resource&quot;</span><span class="ot">,</span> <span class="st">&quot;item&quot;</span><span class="ot">,</span> <span class="st">&quot;config&quot;</span><span class="ot">,</span> <span class="st">&quot;workflow&quot;</span><span class="ot">]</span></span>
+<span id="cb17-30"><a href="#cb17-30" aria-hidden="true" tabindex="-1"></a>        <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb17-31"><a href="#cb17-31" aria-hidden="true" tabindex="-1"></a>        <span class="fu">{</span></span>
+<span id="cb17-32"><a href="#cb17-32" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;description&quot;</span><span class="fu">,</span></span>
+<span id="cb17-33"><a href="#cb17-33" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;string&quot;</span><span class="fu">,</span></span>
+<span id="cb17-34"><a href="#cb17-34" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;required&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb17-35"><a href="#cb17-35" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Entity description&quot;</span><span class="fu">,</span></span>
+<span id="cb17-36"><a href="#cb17-36" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;maxLength&quot;</span><span class="fu">:</span> <span class="dv">500</span></span>
+<span id="cb17-37"><a href="#cb17-37" aria-hidden="true" tabindex="-1"></a>        <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb17-38"><a href="#cb17-38" aria-hidden="true" tabindex="-1"></a>        <span class="fu">{</span></span>
+<span id="cb17-39"><a href="#cb17-39" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;priority&quot;</span><span class="fu">,</span></span>
+<span id="cb17-40"><a href="#cb17-40" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;integer&quot;</span><span class="fu">,</span></span>
+<span id="cb17-41"><a href="#cb17-41" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;required&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb17-42"><a href="#cb17-42" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Priority level&quot;</span><span class="fu">,</span></span>
+<span id="cb17-43"><a href="#cb17-43" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;default&quot;</span><span class="fu">:</span> <span class="dv">5</span><span class="fu">,</span></span>
+<span id="cb17-44"><a href="#cb17-44" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;minimum&quot;</span><span class="fu">:</span> <span class="dv">1</span><span class="fu">,</span></span>
+<span id="cb17-45"><a href="#cb17-45" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;maximum&quot;</span><span class="fu">:</span> <span class="dv">10</span></span>
+<span id="cb17-46"><a href="#cb17-46" aria-hidden="true" tabindex="-1"></a>        <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb17-47"><a href="#cb17-47" aria-hidden="true" tabindex="-1"></a>        <span class="fu">{</span></span>
+<span id="cb17-48"><a href="#cb17-48" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;metadata&quot;</span><span class="fu">,</span></span>
+<span id="cb17-49"><a href="#cb17-49" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;object&quot;</span><span class="fu">,</span></span>
+<span id="cb17-50"><a href="#cb17-50" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;required&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb17-51"><a href="#cb17-51" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Additional metadata&quot;</span></span>
+<span id="cb17-52"><a href="#cb17-52" aria-hidden="true" tabindex="-1"></a>        <span class="fu">}</span></span>
+<span id="cb17-53"><a href="#cb17-53" aria-hidden="true" tabindex="-1"></a>      <span class="ot">]</span><span class="fu">,</span></span>
+<span id="cb17-54"><a href="#cb17-54" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;returns&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb17-55"><a href="#cb17-55" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;Entity&quot;</span><span class="fu">,</span></span>
+<span id="cb17-56"><a href="#cb17-56" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;kind&quot;</span><span class="fu">:</span> <span class="st">&quot;object&quot;</span><span class="fu">,</span></span>
+<span id="cb17-57"><a href="#cb17-57" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Newly created entity&quot;</span></span>
+<span id="cb17-58"><a href="#cb17-58" aria-hidden="true" tabindex="-1"></a>      <span class="fu">},</span></span>
+<span id="cb17-59"><a href="#cb17-59" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;examples&quot;</span><span class="fu">:</span> <span class="ot">[</span></span>
+<span id="cb17-60"><a href="#cb17-60" aria-hidden="true" tabindex="-1"></a>        <span class="fu">{</span></span>
+<span id="cb17-61"><a href="#cb17-61" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Create a resource entity&quot;</span><span class="fu">,</span></span>
+<span id="cb17-62"><a href="#cb17-62" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;request&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb17-63"><a href="#cb17-63" aria-hidden="true" tabindex="-1"></a>            <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;create_entity&quot;</span><span class="fu">,</span></span>
+<span id="cb17-64"><a href="#cb17-64" aria-hidden="true" tabindex="-1"></a>            <span class="dt">&quot;element_type&quot;</span><span class="fu">:</span> <span class="st">&quot;resource&quot;</span><span class="fu">,</span></span>
+<span id="cb17-65"><a href="#cb17-65" aria-hidden="true" tabindex="-1"></a>            <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb17-66"><a href="#cb17-66" aria-hidden="true" tabindex="-1"></a>              <span class="dt">&quot;entity_name&quot;</span><span class="fu">:</span> <span class="st">&quot;MyResource&quot;</span><span class="fu">,</span></span>
+<span id="cb17-67"><a href="#cb17-67" aria-hidden="true" tabindex="-1"></a>              <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;A sample resource&quot;</span></span>
+<span id="cb17-68"><a href="#cb17-68" aria-hidden="true" tabindex="-1"></a>            <span class="fu">}</span></span>
+<span id="cb17-69"><a href="#cb17-69" aria-hidden="true" tabindex="-1"></a>          <span class="fu">}</span></span>
+<span id="cb17-70"><a href="#cb17-70" aria-hidden="true" tabindex="-1"></a>        <span class="fu">}</span></span>
+<span id="cb17-71"><a href="#cb17-71" aria-hidden="true" tabindex="-1"></a>      <span class="ot">]</span></span>
+<span id="cb17-72"><a href="#cb17-72" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb17-73"><a href="#cb17-73" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb17-74"><a href="#cb17-74" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
 <h3 id="43-unknown-operation">4.3 Unknown Operation</h3>
 <p>When querying for an operation that does not exist, implementations MUST return a success response with null data:</p>
 <p><strong>Request:</strong></p>
-<div class="sourceCode" id="cb17"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb17-1"><a href="#cb17-1" aria-hidden="true" tabindex="-1"></a>{</span>
-<span id="cb17-2"><a href="#cb17-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;introspect&quot;</span><span class="op">,</span></span>
-<span id="cb17-3"><a href="#cb17-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> { <span class="dt">query</span><span class="op">:</span> <span class="st">&quot;operations&quot;</span><span class="op">,</span> <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;nonexistent_operation&quot;</span> }</span>
-<span id="cb17-4"><a href="#cb17-4" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<div class="sourceCode" id="cb18"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb18-1"><a href="#cb18-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb18-2"><a href="#cb18-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;introspect&quot;</span><span class="op">,</span></span>
+<span id="cb18-3"><a href="#cb18-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> { <span class="dt">query</span><span class="op">:</span> <span class="st">&quot;operations&quot;</span><span class="op">,</span> <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;nonexistent_operation&quot;</span> }</span>
+<span id="cb18-4"><a href="#cb18-4" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
 <p><strong>Response:</strong></p>
-<div class="sourceCode" id="cb18"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb18-1"><a href="#cb18-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
-<span id="cb18-2"><a href="#cb18-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
-<span id="cb18-3"><a href="#cb18-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;data&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb18-4"><a href="#cb18-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="kw">null</span></span>
-<span id="cb18-5"><a href="#cb18-5" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
-<span id="cb18-6"><a href="#cb18-6" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<div class="sourceCode" id="cb19"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb19-1"><a href="#cb19-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb19-2"><a href="#cb19-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb19-3"><a href="#cb19-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;data&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb19-4"><a href="#cb19-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="kw">null</span></span>
+<span id="cb19-5"><a href="#cb19-5" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb19-6"><a href="#cb19-6" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
 <hr />
 <h2 id="5-type-discovery">5. Type Discovery</h2>
 <h3 id="51-listing-all-types">5.1 Listing All Types</h3>
 <p><strong>Request:</strong></p>
-<div class="sourceCode" id="cb19"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb19-1"><a href="#cb19-1" aria-hidden="true" tabindex="-1"></a>{</span>
-<span id="cb19-2"><a href="#cb19-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;introspect&quot;</span><span class="op">,</span></span>
-<span id="cb19-3"><a href="#cb19-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> { <span class="dt">query</span><span class="op">:</span> <span class="st">&quot;types&quot;</span> }</span>
-<span id="cb19-4"><a href="#cb19-4" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<div class="sourceCode" id="cb20"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb20-1"><a href="#cb20-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb20-2"><a href="#cb20-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;introspect&quot;</span><span class="op">,</span></span>
+<span id="cb20-3"><a href="#cb20-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> { <span class="dt">query</span><span class="op">:</span> <span class="st">&quot;types&quot;</span> }</span>
+<span id="cb20-4"><a href="#cb20-4" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
 <p><strong>Response:</strong></p>
-<div class="sourceCode" id="cb20"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb20-1"><a href="#cb20-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
-<span id="cb20-2"><a href="#cb20-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
-<span id="cb20-3"><a href="#cb20-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;data&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb20-4"><a href="#cb20-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;types&quot;</span><span class="fu">:</span> <span class="ot">[</span></span>
-<span id="cb20-5"><a href="#cb20-5" aria-hidden="true" tabindex="-1"></a>      <span class="fu">{</span></span>
-<span id="cb20-6"><a href="#cb20-6" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;EntityType&quot;</span><span class="fu">,</span></span>
-<span id="cb20-7"><a href="#cb20-7" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;kind&quot;</span><span class="fu">:</span> <span class="st">&quot;enum&quot;</span><span class="fu">,</span></span>
-<span id="cb20-8"><a href="#cb20-8" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Available entity types&quot;</span></span>
-<span id="cb20-9"><a href="#cb20-9" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span><span class="ot">,</span></span>
-<span id="cb20-10"><a href="#cb20-10" aria-hidden="true" tabindex="-1"></a>      <span class="fu">{</span></span>
-<span id="cb20-11"><a href="#cb20-11" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;CRUDEndpoint&quot;</span><span class="fu">,</span></span>
-<span id="cb20-12"><a href="#cb20-12" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;kind&quot;</span><span class="fu">:</span> <span class="st">&quot;enum&quot;</span><span class="fu">,</span></span>
-<span id="cb20-13"><a href="#cb20-13" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;CRUDE endpoint categories for operation classification&quot;</span></span>
-<span id="cb20-14"><a href="#cb20-14" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span><span class="ot">,</span></span>
-<span id="cb20-15"><a href="#cb20-15" aria-hidden="true" tabindex="-1"></a>      <span class="fu">{</span></span>
-<span id="cb20-16"><a href="#cb20-16" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;OperationInput&quot;</span><span class="fu">,</span></span>
-<span id="cb20-17"><a href="#cb20-17" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;kind&quot;</span><span class="fu">:</span> <span class="st">&quot;object&quot;</span><span class="fu">,</span></span>
-<span id="cb20-18"><a href="#cb20-18" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Standard input structure for all MCP-AQL operations&quot;</span></span>
-<span id="cb20-19"><a href="#cb20-19" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span><span class="ot">,</span></span>
-<span id="cb20-20"><a href="#cb20-20" aria-hidden="true" tabindex="-1"></a>      <span class="fu">{</span></span>
-<span id="cb20-21"><a href="#cb20-21" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;OperationResult&quot;</span><span class="fu">,</span></span>
-<span id="cb20-22"><a href="#cb20-22" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;kind&quot;</span><span class="fu">:</span> <span class="st">&quot;union&quot;</span><span class="fu">,</span></span>
-<span id="cb20-23"><a href="#cb20-23" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Standard result type for all operations&quot;</span></span>
-<span id="cb20-24"><a href="#cb20-24" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span><span class="ot">,</span></span>
-<span id="cb20-25"><a href="#cb20-25" aria-hidden="true" tabindex="-1"></a>      <span class="fu">{</span></span>
-<span id="cb20-26"><a href="#cb20-26" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;OperationSuccess&quot;</span><span class="fu">,</span></span>
-<span id="cb20-27"><a href="#cb20-27" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;kind&quot;</span><span class="fu">:</span> <span class="st">&quot;object&quot;</span><span class="fu">,</span></span>
-<span id="cb20-28"><a href="#cb20-28" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Successful operation result&quot;</span></span>
-<span id="cb20-29"><a href="#cb20-29" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span><span class="ot">,</span></span>
-<span id="cb20-30"><a href="#cb20-30" aria-hidden="true" tabindex="-1"></a>      <span class="fu">{</span></span>
-<span id="cb20-31"><a href="#cb20-31" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;OperationFailure&quot;</span><span class="fu">,</span></span>
-<span id="cb20-32"><a href="#cb20-32" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;kind&quot;</span><span class="fu">:</span> <span class="st">&quot;object&quot;</span><span class="fu">,</span></span>
-<span id="cb20-33"><a href="#cb20-33" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Failed operation result&quot;</span></span>
-<span id="cb20-34"><a href="#cb20-34" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span></span>
-<span id="cb20-35"><a href="#cb20-35" aria-hidden="true" tabindex="-1"></a>    <span class="ot">]</span></span>
-<span id="cb20-36"><a href="#cb20-36" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
-<span id="cb20-37"><a href="#cb20-37" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<div class="sourceCode" id="cb21"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb21-1"><a href="#cb21-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb21-2"><a href="#cb21-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb21-3"><a href="#cb21-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;data&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb21-4"><a href="#cb21-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;types&quot;</span><span class="fu">:</span> <span class="ot">[</span></span>
+<span id="cb21-5"><a href="#cb21-5" aria-hidden="true" tabindex="-1"></a>      <span class="fu">{</span></span>
+<span id="cb21-6"><a href="#cb21-6" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;EntityType&quot;</span><span class="fu">,</span></span>
+<span id="cb21-7"><a href="#cb21-7" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;kind&quot;</span><span class="fu">:</span> <span class="st">&quot;enum&quot;</span><span class="fu">,</span></span>
+<span id="cb21-8"><a href="#cb21-8" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Available entity types&quot;</span></span>
+<span id="cb21-9"><a href="#cb21-9" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb21-10"><a href="#cb21-10" aria-hidden="true" tabindex="-1"></a>      <span class="fu">{</span></span>
+<span id="cb21-11"><a href="#cb21-11" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;SemanticCategory&quot;</span><span class="fu">,</span></span>
+<span id="cb21-12"><a href="#cb21-12" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;kind&quot;</span><span class="fu">:</span> <span class="st">&quot;enum&quot;</span><span class="fu">,</span></span>
+<span id="cb21-13"><a href="#cb21-13" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Standard semantic categories for operation classification&quot;</span></span>
+<span id="cb21-14"><a href="#cb21-14" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb21-15"><a href="#cb21-15" aria-hidden="true" tabindex="-1"></a>      <span class="fu">{</span></span>
+<span id="cb21-16"><a href="#cb21-16" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;OperationInput&quot;</span><span class="fu">,</span></span>
+<span id="cb21-17"><a href="#cb21-17" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;kind&quot;</span><span class="fu">:</span> <span class="st">&quot;object&quot;</span><span class="fu">,</span></span>
+<span id="cb21-18"><a href="#cb21-18" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Standard input structure for all MCP-AQL operations&quot;</span></span>
+<span id="cb21-19"><a href="#cb21-19" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb21-20"><a href="#cb21-20" aria-hidden="true" tabindex="-1"></a>      <span class="fu">{</span></span>
+<span id="cb21-21"><a href="#cb21-21" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;OperationResult&quot;</span><span class="fu">,</span></span>
+<span id="cb21-22"><a href="#cb21-22" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;kind&quot;</span><span class="fu">:</span> <span class="st">&quot;union&quot;</span><span class="fu">,</span></span>
+<span id="cb21-23"><a href="#cb21-23" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Standard result type for all operations&quot;</span></span>
+<span id="cb21-24"><a href="#cb21-24" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb21-25"><a href="#cb21-25" aria-hidden="true" tabindex="-1"></a>      <span class="fu">{</span></span>
+<span id="cb21-26"><a href="#cb21-26" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;OperationSuccess&quot;</span><span class="fu">,</span></span>
+<span id="cb21-27"><a href="#cb21-27" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;kind&quot;</span><span class="fu">:</span> <span class="st">&quot;object&quot;</span><span class="fu">,</span></span>
+<span id="cb21-28"><a href="#cb21-28" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Successful operation result&quot;</span></span>
+<span id="cb21-29"><a href="#cb21-29" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb21-30"><a href="#cb21-30" aria-hidden="true" tabindex="-1"></a>      <span class="fu">{</span></span>
+<span id="cb21-31"><a href="#cb21-31" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;OperationFailure&quot;</span><span class="fu">,</span></span>
+<span id="cb21-32"><a href="#cb21-32" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;kind&quot;</span><span class="fu">:</span> <span class="st">&quot;object&quot;</span><span class="fu">,</span></span>
+<span id="cb21-33"><a href="#cb21-33" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Failed operation result&quot;</span></span>
+<span id="cb21-34"><a href="#cb21-34" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span></span>
+<span id="cb21-35"><a href="#cb21-35" aria-hidden="true" tabindex="-1"></a>    <span class="ot">]</span></span>
+<span id="cb21-36"><a href="#cb21-36" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb21-37"><a href="#cb21-37" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
 <h3 id="52-getting-type-details">5.2 Getting Type Details</h3>
 <h4 id="521-enum-type">5.2.1 Enum Type</h4>
 <p><strong>Request:</strong></p>
-<div class="sourceCode" id="cb21"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb21-1"><a href="#cb21-1" aria-hidden="true" tabindex="-1"></a>{</span>
-<span id="cb21-2"><a href="#cb21-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;introspect&quot;</span><span class="op">,</span></span>
-<span id="cb21-3"><a href="#cb21-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> { <span class="dt">query</span><span class="op">:</span> <span class="st">&quot;types&quot;</span><span class="op">,</span> <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;EntityType&quot;</span> }</span>
-<span id="cb21-4"><a href="#cb21-4" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<div class="sourceCode" id="cb22"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb22-1"><a href="#cb22-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb22-2"><a href="#cb22-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;introspect&quot;</span><span class="op">,</span></span>
+<span id="cb22-3"><a href="#cb22-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> { <span class="dt">query</span><span class="op">:</span> <span class="st">&quot;types&quot;</span><span class="op">,</span> <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;EntityType&quot;</span> }</span>
+<span id="cb22-4"><a href="#cb22-4" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
 <p><strong>Response:</strong></p>
-<div class="sourceCode" id="cb22"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb22-1"><a href="#cb22-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
-<span id="cb22-2"><a href="#cb22-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
-<span id="cb22-3"><a href="#cb22-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;data&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb22-4"><a href="#cb22-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb22-5"><a href="#cb22-5" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;EntityType&quot;</span><span class="fu">,</span></span>
-<span id="cb22-6"><a href="#cb22-6" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;kind&quot;</span><span class="fu">:</span> <span class="st">&quot;enum&quot;</span><span class="fu">,</span></span>
-<span id="cb22-7"><a href="#cb22-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Available entity types&quot;</span><span class="fu">,</span></span>
-<span id="cb22-8"><a href="#cb22-8" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;values&quot;</span><span class="fu">:</span> <span class="ot">[</span><span class="st">&quot;resource&quot;</span><span class="ot">,</span> <span class="st">&quot;item&quot;</span><span class="ot">,</span> <span class="st">&quot;config&quot;</span><span class="ot">,</span> <span class="st">&quot;workflow&quot;</span><span class="ot">]</span></span>
-<span id="cb22-9"><a href="#cb22-9" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
-<span id="cb22-10"><a href="#cb22-10" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
-<span id="cb22-11"><a href="#cb22-11" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<div class="sourceCode" id="cb23"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb23-1"><a href="#cb23-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb23-2"><a href="#cb23-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb23-3"><a href="#cb23-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;data&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb23-4"><a href="#cb23-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb23-5"><a href="#cb23-5" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;EntityType&quot;</span><span class="fu">,</span></span>
+<span id="cb23-6"><a href="#cb23-6" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;kind&quot;</span><span class="fu">:</span> <span class="st">&quot;enum&quot;</span><span class="fu">,</span></span>
+<span id="cb23-7"><a href="#cb23-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Available entity types&quot;</span><span class="fu">,</span></span>
+<span id="cb23-8"><a href="#cb23-8" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;values&quot;</span><span class="fu">:</span> <span class="ot">[</span><span class="st">&quot;resource&quot;</span><span class="ot">,</span> <span class="st">&quot;item&quot;</span><span class="ot">,</span> <span class="st">&quot;config&quot;</span><span class="ot">,</span> <span class="st">&quot;workflow&quot;</span><span class="ot">]</span></span>
+<span id="cb23-9"><a href="#cb23-9" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb23-10"><a href="#cb23-10" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb23-11"><a href="#cb23-11" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
 <h4 id="522-object-type">5.2.2 Object Type</h4>
 <p><strong>Request:</strong></p>
-<div class="sourceCode" id="cb23"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb23-1"><a href="#cb23-1" aria-hidden="true" tabindex="-1"></a>{</span>
-<span id="cb23-2"><a href="#cb23-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;introspect&quot;</span><span class="op">,</span></span>
-<span id="cb23-3"><a href="#cb23-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> { <span class="dt">query</span><span class="op">:</span> <span class="st">&quot;types&quot;</span><span class="op">,</span> <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;OperationInput&quot;</span> }</span>
-<span id="cb23-4"><a href="#cb23-4" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<div class="sourceCode" id="cb24"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb24-1"><a href="#cb24-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb24-2"><a href="#cb24-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;introspect&quot;</span><span class="op">,</span></span>
+<span id="cb24-3"><a href="#cb24-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> { <span class="dt">query</span><span class="op">:</span> <span class="st">&quot;types&quot;</span><span class="op">,</span> <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;OperationInput&quot;</span> }</span>
+<span id="cb24-4"><a href="#cb24-4" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
 <p><strong>Response:</strong></p>
-<div class="sourceCode" id="cb24"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb24-1"><a href="#cb24-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
-<span id="cb24-2"><a href="#cb24-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
-<span id="cb24-3"><a href="#cb24-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;data&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb24-4"><a href="#cb24-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb24-5"><a href="#cb24-5" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;OperationInput&quot;</span><span class="fu">,</span></span>
-<span id="cb24-6"><a href="#cb24-6" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;kind&quot;</span><span class="fu">:</span> <span class="st">&quot;object&quot;</span><span class="fu">,</span></span>
-<span id="cb24-7"><a href="#cb24-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Standard input structure for all MCP-AQL operations&quot;</span><span class="fu">,</span></span>
-<span id="cb24-8"><a href="#cb24-8" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;fields&quot;</span><span class="fu">:</span> <span class="ot">[</span></span>
-<span id="cb24-9"><a href="#cb24-9" aria-hidden="true" tabindex="-1"></a>        <span class="fu">{</span></span>
-<span id="cb24-10"><a href="#cb24-10" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;operation&quot;</span><span class="fu">,</span></span>
-<span id="cb24-11"><a href="#cb24-11" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;string&quot;</span><span class="fu">,</span></span>
-<span id="cb24-12"><a href="#cb24-12" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;required&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
-<span id="cb24-13"><a href="#cb24-13" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;The operation to perform&quot;</span></span>
-<span id="cb24-14"><a href="#cb24-14" aria-hidden="true" tabindex="-1"></a>        <span class="fu">}</span><span class="ot">,</span></span>
-<span id="cb24-15"><a href="#cb24-15" aria-hidden="true" tabindex="-1"></a>        <span class="fu">{</span></span>
-<span id="cb24-16"><a href="#cb24-16" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;element_type&quot;</span><span class="fu">,</span></span>
-<span id="cb24-17"><a href="#cb24-17" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;string&quot;</span><span class="fu">,</span></span>
-<span id="cb24-18"><a href="#cb24-18" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;required&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
-<span id="cb24-19"><a href="#cb24-19" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Element type for element operations&quot;</span></span>
-<span id="cb24-20"><a href="#cb24-20" aria-hidden="true" tabindex="-1"></a>        <span class="fu">}</span><span class="ot">,</span></span>
-<span id="cb24-21"><a href="#cb24-21" aria-hidden="true" tabindex="-1"></a>        <span class="fu">{</span></span>
-<span id="cb24-22"><a href="#cb24-22" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;params&quot;</span><span class="fu">,</span></span>
-<span id="cb24-23"><a href="#cb24-23" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;object&quot;</span><span class="fu">,</span></span>
-<span id="cb24-24"><a href="#cb24-24" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;required&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
-<span id="cb24-25"><a href="#cb24-25" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Operation-specific parameters&quot;</span></span>
-<span id="cb24-26"><a href="#cb24-26" aria-hidden="true" tabindex="-1"></a>        <span class="fu">}</span></span>
-<span id="cb24-27"><a href="#cb24-27" aria-hidden="true" tabindex="-1"></a>      <span class="ot">]</span></span>
-<span id="cb24-28"><a href="#cb24-28" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
-<span id="cb24-29"><a href="#cb24-29" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
-<span id="cb24-30"><a href="#cb24-30" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<div class="sourceCode" id="cb25"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb25-1"><a href="#cb25-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb25-2"><a href="#cb25-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb25-3"><a href="#cb25-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;data&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb25-4"><a href="#cb25-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb25-5"><a href="#cb25-5" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;OperationInput&quot;</span><span class="fu">,</span></span>
+<span id="cb25-6"><a href="#cb25-6" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;kind&quot;</span><span class="fu">:</span> <span class="st">&quot;object&quot;</span><span class="fu">,</span></span>
+<span id="cb25-7"><a href="#cb25-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Standard input structure for all MCP-AQL operations&quot;</span><span class="fu">,</span></span>
+<span id="cb25-8"><a href="#cb25-8" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;fields&quot;</span><span class="fu">:</span> <span class="ot">[</span></span>
+<span id="cb25-9"><a href="#cb25-9" aria-hidden="true" tabindex="-1"></a>        <span class="fu">{</span></span>
+<span id="cb25-10"><a href="#cb25-10" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;operation&quot;</span><span class="fu">,</span></span>
+<span id="cb25-11"><a href="#cb25-11" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;string&quot;</span><span class="fu">,</span></span>
+<span id="cb25-12"><a href="#cb25-12" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;required&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb25-13"><a href="#cb25-13" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;The operation to perform&quot;</span></span>
+<span id="cb25-14"><a href="#cb25-14" aria-hidden="true" tabindex="-1"></a>        <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb25-15"><a href="#cb25-15" aria-hidden="true" tabindex="-1"></a>        <span class="fu">{</span></span>
+<span id="cb25-16"><a href="#cb25-16" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;element_type&quot;</span><span class="fu">,</span></span>
+<span id="cb25-17"><a href="#cb25-17" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;string&quot;</span><span class="fu">,</span></span>
+<span id="cb25-18"><a href="#cb25-18" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;required&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb25-19"><a href="#cb25-19" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Element type for element operations&quot;</span></span>
+<span id="cb25-20"><a href="#cb25-20" aria-hidden="true" tabindex="-1"></a>        <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb25-21"><a href="#cb25-21" aria-hidden="true" tabindex="-1"></a>        <span class="fu">{</span></span>
+<span id="cb25-22"><a href="#cb25-22" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;params&quot;</span><span class="fu">,</span></span>
+<span id="cb25-23"><a href="#cb25-23" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;object&quot;</span><span class="fu">,</span></span>
+<span id="cb25-24"><a href="#cb25-24" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;required&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb25-25"><a href="#cb25-25" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Operation-specific parameters&quot;</span></span>
+<span id="cb25-26"><a href="#cb25-26" aria-hidden="true" tabindex="-1"></a>        <span class="fu">}</span></span>
+<span id="cb25-27"><a href="#cb25-27" aria-hidden="true" tabindex="-1"></a>      <span class="ot">]</span></span>
+<span id="cb25-28"><a href="#cb25-28" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb25-29"><a href="#cb25-29" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb25-30"><a href="#cb25-30" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
 <h4 id="523-union-type">5.2.3 Union Type</h4>
 <p><strong>Request:</strong></p>
-<div class="sourceCode" id="cb25"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb25-1"><a href="#cb25-1" aria-hidden="true" tabindex="-1"></a>{</span>
-<span id="cb25-2"><a href="#cb25-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;introspect&quot;</span><span class="op">,</span></span>
-<span id="cb25-3"><a href="#cb25-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> { <span class="dt">query</span><span class="op">:</span> <span class="st">&quot;types&quot;</span><span class="op">,</span> <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;OperationResult&quot;</span> }</span>
-<span id="cb25-4"><a href="#cb25-4" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<div class="sourceCode" id="cb26"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb26-1"><a href="#cb26-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb26-2"><a href="#cb26-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;introspect&quot;</span><span class="op">,</span></span>
+<span id="cb26-3"><a href="#cb26-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> { <span class="dt">query</span><span class="op">:</span> <span class="st">&quot;types&quot;</span><span class="op">,</span> <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;OperationResult&quot;</span> }</span>
+<span id="cb26-4"><a href="#cb26-4" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
 <p><strong>Response:</strong></p>
-<div class="sourceCode" id="cb26"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb26-1"><a href="#cb26-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
-<span id="cb26-2"><a href="#cb26-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
-<span id="cb26-3"><a href="#cb26-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;data&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb26-4"><a href="#cb26-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb26-5"><a href="#cb26-5" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;OperationResult&quot;</span><span class="fu">,</span></span>
-<span id="cb26-6"><a href="#cb26-6" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;kind&quot;</span><span class="fu">:</span> <span class="st">&quot;union&quot;</span><span class="fu">,</span></span>
-<span id="cb26-7"><a href="#cb26-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Standard result type for all operations&quot;</span><span class="fu">,</span></span>
-<span id="cb26-8"><a href="#cb26-8" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;members&quot;</span><span class="fu">:</span> <span class="ot">[</span><span class="st">&quot;OperationSuccess&quot;</span><span class="ot">,</span> <span class="st">&quot;OperationFailure&quot;</span><span class="ot">]</span></span>
-<span id="cb26-9"><a href="#cb26-9" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
-<span id="cb26-10"><a href="#cb26-10" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
-<span id="cb26-11"><a href="#cb26-11" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<div class="sourceCode" id="cb27"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb27-1"><a href="#cb27-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb27-2"><a href="#cb27-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb27-3"><a href="#cb27-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;data&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb27-4"><a href="#cb27-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb27-5"><a href="#cb27-5" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;OperationResult&quot;</span><span class="fu">,</span></span>
+<span id="cb27-6"><a href="#cb27-6" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;kind&quot;</span><span class="fu">:</span> <span class="st">&quot;union&quot;</span><span class="fu">,</span></span>
+<span id="cb27-7"><a href="#cb27-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Standard result type for all operations&quot;</span><span class="fu">,</span></span>
+<span id="cb27-8"><a href="#cb27-8" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;members&quot;</span><span class="fu">:</span> <span class="ot">[</span><span class="st">&quot;OperationSuccess&quot;</span><span class="ot">,</span> <span class="st">&quot;OperationFailure&quot;</span><span class="ot">]</span></span>
+<span id="cb27-9"><a href="#cb27-9" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb27-10"><a href="#cb27-10" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb27-11"><a href="#cb27-11" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
 <h3 id="53-protocol-types">5.3 Protocol Types</h3>
 <p>MCP-AQL defines these protocol-level types that adapters SHOULD include in their type registry:</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Type Name</th>
 <th>Kind</th>
 <th>Description</th>
 </tr>
 </thead>
 <tbody>
-<tr>
-<td><code>CRUDEndpoint</code></td>
+<tr class="odd">
+<td><code>SemanticCategory</code></td>
 <td>enum</td>
-<td>Endpoints: CREATE, READ, UPDATE, DELETE, EXECUTE</td>
+<td>Standard categories: CREATE, READ, UPDATE, DELETE, EXECUTE</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>OperationInput</code></td>
 <td>object</td>
 <td>Standard input structure</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>OperationResult</code></td>
 <td>union</td>
 <td>Success or failure result</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>OperationSuccess</code></td>
 <td>object</td>
 <td>Successful result with data</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>OperationFailure</code></td>
 <td>object</td>
 <td>Failed result with error</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>EndpointPermissions</code></td>
 <td>object</td>
 <td>Permission flags for operations</td>
@@ -791,7 +884,8 @@
         -getOperationDetails(name) OperationDetails
         -listTypes() TypeInfo[]
         -getTypeDetails(name) TypeDetails
-        +getOperationsByEndpoint() Record
+        +getOperationsByEndpointFamily() Record
+        +getOperationsBySemanticCategory() Record
         +getSummary() string
     }
 
@@ -811,24 +905,32 @@
     IntrospectionHandler --&gt; TypeRegistry : queries</code></pre>
 <h3 id="63-utility-methods">6.3 Utility Methods</h3>
 <p>Implementations MAY provide utility methods for documentation and tooling:</p>
-<p><strong>Operations by Endpoint:</strong></p>
-<div class="sourceCode" id="cb29"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb29-1"><a href="#cb29-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Returns operations grouped by CRUDE endpoint</span></span>
-<span id="cb29-2"><a href="#cb29-2" aria-hidden="true" tabindex="-1"></a><span class="fu">getOperationsByEndpoint</span>()<span class="op">:</span> <span class="bu">Record</span><span class="op">&lt;</span>CRUDEndpoint<span class="op">,</span> OperationInfo[]<span class="op">&gt;</span></span></code></pre></div>
+<p><strong>Operations by Endpoint Family:</strong></p>
+<div class="sourceCode" id="cb30"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb30-1"><a href="#cb30-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Returns operations grouped by exposed endpoint family</span></span>
+<span id="cb30-2"><a href="#cb30-2" aria-hidden="true" tabindex="-1"></a><span class="fu">getOperationsByEndpointFamily</span>()<span class="op">:</span> <span class="bu">Record</span><span class="op">&lt;</span><span class="dt">string</span><span class="op">,</span> OperationInfo[]<span class="op">&gt;</span></span></code></pre></div>
+<p><strong>Operations by Semantic Category:</strong></p>
+<div class="sourceCode" id="cb31"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb31-1"><a href="#cb31-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Returns operations grouped by standard semantic category</span></span>
+<span id="cb31-2"><a href="#cb31-2" aria-hidden="true" tabindex="-1"></a><span class="fu">getOperationsBySemanticCategory</span>()<span class="op">:</span> <span class="bu">Record</span><span class="op">&lt;</span>SemanticCategory<span class="op">,</span> OperationInfo[]<span class="op">&gt;</span></span></code></pre></div>
 <p><strong>Summary Generation:</strong></p>
-<div class="sourceCode" id="cb30"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb30-1"><a href="#cb30-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Returns a human-readable summary of all operations</span></span>
-<span id="cb30-2"><a href="#cb30-2" aria-hidden="true" tabindex="-1"></a><span class="fu">getSummary</span>()<span class="op">:</span> <span class="dt">string</span></span>
-<span id="cb30-3"><a href="#cb30-3" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb30-4"><a href="#cb30-4" aria-hidden="true" tabindex="-1"></a><span class="co">// Example output:</span></span>
-<span id="cb30-5"><a href="#cb30-5" aria-hidden="true" tabindex="-1"></a><span class="co">// MCP-AQL Operations:</span></span>
-<span id="cb30-6"><a href="#cb30-6" aria-hidden="true" tabindex="-1"></a><span class="co">//   CREATE: create_entity, import_entity</span></span>
-<span id="cb30-7"><a href="#cb30-7" aria-hidden="true" tabindex="-1"></a><span class="co">//   READ: list_entities, get_entity, introspect</span></span>
-<span id="cb30-8"><a href="#cb30-8" aria-hidden="true" tabindex="-1"></a><span class="co">//   UPDATE: update_entity</span></span>
-<span id="cb30-9"><a href="#cb30-9" aria-hidden="true" tabindex="-1"></a><span class="co">//   DELETE: delete_entity</span></span>
-<span id="cb30-10"><a href="#cb30-10" aria-hidden="true" tabindex="-1"></a><span class="co">//   EXECUTE: execute_workflow</span></span>
-<span id="cb30-11"><a href="#cb30-11" aria-hidden="true" tabindex="-1"></a><span class="co">//</span></span>
-<span id="cb30-12"><a href="#cb30-12" aria-hidden="true" tabindex="-1"></a><span class="co">// Types: EntityType, CRUDEndpoint, OperationInput, OperationResult</span></span>
-<span id="cb30-13"><a href="#cb30-13" aria-hidden="true" tabindex="-1"></a><span class="co">//</span></span>
-<span id="cb30-14"><a href="#cb30-14" aria-hidden="true" tabindex="-1"></a><span class="co">// Use introspect with name parameter for details.</span></span></code></pre></div>
+<div class="sourceCode" id="cb32"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb32-1"><a href="#cb32-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Returns a human-readable summary of all operations</span></span>
+<span id="cb32-2"><a href="#cb32-2" aria-hidden="true" tabindex="-1"></a><span class="fu">getSummary</span>()<span class="op">:</span> <span class="dt">string</span></span>
+<span id="cb32-3"><a href="#cb32-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb32-4"><a href="#cb32-4" aria-hidden="true" tabindex="-1"></a><span class="co">// Example output:</span></span>
+<span id="cb32-5"><a href="#cb32-5" aria-hidden="true" tabindex="-1"></a><span class="co">// MCP-AQL Operations:</span></span>
+<span id="cb32-6"><a href="#cb32-6" aria-hidden="true" tabindex="-1"></a><span class="co">//   manage: create_entity, update_entity, delete_entity</span></span>
+<span id="cb32-7"><a href="#cb32-7" aria-hidden="true" tabindex="-1"></a><span class="co">//   query: list_entities, get_entity, introspect</span></span>
+<span id="cb32-8"><a href="#cb32-8" aria-hidden="true" tabindex="-1"></a><span class="co">//   operate: execute_workflow</span></span>
+<span id="cb32-9"><a href="#cb32-9" aria-hidden="true" tabindex="-1"></a><span class="co">//</span></span>
+<span id="cb32-10"><a href="#cb32-10" aria-hidden="true" tabindex="-1"></a><span class="co">// Semantic Categories:</span></span>
+<span id="cb32-11"><a href="#cb32-11" aria-hidden="true" tabindex="-1"></a><span class="co">//   CREATE: create_entity</span></span>
+<span id="cb32-12"><a href="#cb32-12" aria-hidden="true" tabindex="-1"></a><span class="co">//   READ: list_entities, get_entity, introspect</span></span>
+<span id="cb32-13"><a href="#cb32-13" aria-hidden="true" tabindex="-1"></a><span class="co">//   UPDATE: update_entity</span></span>
+<span id="cb32-14"><a href="#cb32-14" aria-hidden="true" tabindex="-1"></a><span class="co">//   DELETE: delete_entity</span></span>
+<span id="cb32-15"><a href="#cb32-15" aria-hidden="true" tabindex="-1"></a><span class="co">//   EXECUTE: execute_workflow</span></span>
+<span id="cb32-16"><a href="#cb32-16" aria-hidden="true" tabindex="-1"></a><span class="co">//</span></span>
+<span id="cb32-17"><a href="#cb32-17" aria-hidden="true" tabindex="-1"></a><span class="co">// Types: EntityType, SemanticCategory, OperationInput, OperationResult</span></span>
+<span id="cb32-18"><a href="#cb32-18" aria-hidden="true" tabindex="-1"></a><span class="co">//</span></span>
+<span id="cb32-19"><a href="#cb32-19" aria-hidden="true" tabindex="-1"></a><span class="co">// Use introspect with name parameter for details.</span></span></code></pre></div>
 <hr />
 <h2 id="7-token-efficiency">7. Token Efficiency</h2>
 <h3 id="71-discovery-pattern">7.1 Discovery Pattern</h3>
@@ -844,7 +946,7 @@ Step 3: Execute operation
 <h3 id="72-comparison-with-discrete-tools">7.2 Comparison with Discrete Tools</h3>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Approach</th>
 <th>Upfront Cost</th>
 <th>Per-Operation Cost</th>
@@ -852,13 +954,13 @@ Step 3: Execute operation
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td>Discrete tools</td>
 <td>~29,600 tokens</td>
 <td>0</td>
 <td>~29,600</td>
 </tr>
-<tr>
+<tr class="even">
 <td>MCP-AQL + introspect</td>
 <td>~1,100 tokens</td>
 <td>~150 tokens</td>
@@ -880,7 +982,7 @@ Step 3: Execute operation
 <h3 id="81-must-requirements">8.1 MUST Requirements</h3>
 <p>Conforming implementations MUST:</p>
 <ol type="1">
-<li>Implement the <code>introspect</code> operation on the READ endpoint</li>
+<li>Implement the <code>introspect</code> operation as a READ-category operation on a documented endpoint family</li>
 <li>Support both <code>operations</code> and <code>types</code> query types</li>
 <li>Return <code>OperationInfo</code> for all supported operations when listing</li>
 <li>Return <code>OperationDetails</code> when querying a specific operation by name</li>
@@ -929,8 +1031,8 @@ WARN IF: Introspection documents parameters not accepted</code></pre>
 <li>Include usage examples for all operations</li>
 <li>Provide meaningful descriptions for all parameters</li>
 <li>Document default values in parameter info</li>
-<li>Return operations grouped by endpoint in list responses</li>
-<li>Include the protocol types (<code>CRUDEndpoint</code>, <code>OperationResult</code>, etc.)</li>
+<li>Return each operation's endpoint family and semantic category in list responses</li>
+<li>Include the protocol types (<code>SemanticCategory</code>, <code>OperationResult</code>, etc.)</li>
 <li>Implement caching for introspection responses</li>
 <li>Include the <code>introspect</code> operation in the operations list</li>
 <li>Derive introspection data from a single source of truth (operation schema)</li>

--- a/public/spec/licensing-options.html
+++ b/public/spec/licensing-options.html
@@ -50,10 +50,10 @@
   <ul><li><a href="security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Features</h3>
-  <ul><li><a href="features/collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="features/field-selection.html">Field Selection Specification</a></li><li><a href="features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="features/warnings.html">Warnings Array Specification</a></li></ul>
+  <ul><li><a href="features/aggregations.html">MCP-AQL Aggregations</a></li><li><a href="features/collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="features/computed-fields.html">MCP-AQL Computed Fields</a></li><li><a href="features/field-selection.html">Field Selection Specification</a></li><li><a href="features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="features/relationship-queries.html">MCP-AQL Relationship Queries</a></li><li><a href="features/warnings.html">Warnings Array Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Guides</h3>
-  <ul><li><a href="guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="guides/README.html">Developer Guides</a></li></ul>
+  <ul><li><a href="guides/cross-domain-implementation.html">Cross-Domain Implementation Guide</a></li><li><a href="guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
   <ul><li><a href="process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="process/versioning.html">Versioning Strategy</a></li><li><a href="repo/CHANGELOG.html">Changelog</a></li></ul>

--- a/public/spec/mcp-integration.html
+++ b/public/spec/mcp-integration.html
@@ -50,10 +50,10 @@
   <ul><li><a href="security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Features</h3>
-  <ul><li><a href="features/collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="features/field-selection.html">Field Selection Specification</a></li><li><a href="features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="features/warnings.html">Warnings Array Specification</a></li></ul>
+  <ul><li><a href="features/aggregations.html">MCP-AQL Aggregations</a></li><li><a href="features/collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="features/computed-fields.html">MCP-AQL Computed Fields</a></li><li><a href="features/field-selection.html">Field Selection Specification</a></li><li><a href="features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="features/relationship-queries.html">MCP-AQL Relationship Queries</a></li><li><a href="features/warnings.html">Warnings Array Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Guides</h3>
-  <ul><li><a href="guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="guides/README.html">Developer Guides</a></li></ul>
+  <ul><li><a href="guides/cross-domain-implementation.html">Cross-Domain Implementation Guide</a></li><li><a href="guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
   <ul><li><a href="process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="process/versioning.html">Versioning Strategy</a></li><li><a href="repo/CHANGELOG.html">Changelog</a></li></ul>
@@ -133,13 +133,15 @@
 <li>Multi-adapter deployment patterns</li>
 </ul>
 <h3 id="14-relationship-to-mcp">1.4 Relationship to MCP</h3>
-<p>MCP-AQL adapters are MCP servers that expose operations through the CRUDE endpoint pattern. All MCP transport and lifecycle requirements apply. This specification defines additional requirements specific to MCP-AQL tool registration and error handling.</p>
+<p>MCP-AQL adapters are MCP servers that expose operations through semantic endpoint families or a single unified endpoint. The standard CRUDE profile is one semantic-endpoint pattern, but adapters MAY define alternate semantic endpoint families that better match the target domain. All MCP transport and lifecycle requirements apply. This specification defines additional requirements specific to MCP-AQL tool registration and error handling.</p>
 <hr />
 <h2 id="2-tool-registration">2. Tool Registration</h2>
 <h3 id="21-tool-description-requirements">2.1 Tool Description Requirements</h3>
 <p>MCP-AQL adapters MUST include the <code>introspect</code> operation in their tool descriptions. This solves the bootstrap problem by ensuring agents know how to discover available operations.</p>
-<h4 id="211-crude-mode-tool-descriptions">2.1.1 CRUDE Mode Tool Descriptions</h4>
-<p>In CRUDE mode, each endpoint registers as a separate MCP tool. Tool descriptions MUST follow this template:</p>
+<h4 id="211-semantic-endpoint-mode-tool-descriptions">2.1.1 Semantic Endpoint Mode Tool Descriptions</h4>
+<p>In semantic endpoint mode, each exposed endpoint family registers as a separate MCP tool. Tool descriptions MUST follow one of the semantic-endpoint patterns below.</p>
+<p><strong>Standard CRUDE Profile:</strong></p>
+<p>When the adapter exposes the standard CRUDE profile, tool descriptions SHOULD follow these templates:</p>
 <p><strong>CREATE Endpoint:</strong></p>
 <pre><code>[Semantic category description].
 
@@ -213,11 +215,41 @@ Quick start examples:
 
 Discover required parameters:
 { operation: &quot;introspect&quot;, params: { query: &quot;operations&quot;, name: &quot;[operation_name]&quot; } }</code></pre>
+<p><strong>Alternative Semantic Endpoint Profiles:</strong></p>
+<p>When the adapter exposes custom semantic endpoint families, each tool description SHOULD follow this template:</p>
+<pre><code>[Endpoint family purpose].
+
+Primary semantic categories: [category_list]
+
+Supported operations: [operation_list]
+
+[Domain notes if applicable]
+
+Quick start example:
+{ operation: &quot;[example_op]&quot;, params: { [example_params] } }
+
+Discover all operations and parameters:
+{ operation: &quot;introspect&quot;, params: { query: &quot;operations&quot; } }</code></pre>
+<p>Adapters SHOULD describe both the family purpose and the kinds of operations it contains so agents can choose between families before calling introspection details.</p>
+<p><strong>Concrete Example (<code>mcp_aql_query</code>):</strong></p>
+<pre class="text"><code>Query-oriented operations for retrieval, filtering, aggregation, and field selection.
+
+Primary semantic categories: READ
+
+Supported operations: list_datasets, get_dataset, search_datasets, introspect
+
+Use this endpoint when the task is to look up, inspect, search, or summarize existing data.
+
+Quick start example:
+{ operation: &quot;search_datasets&quot;, params: { query: &quot;pricing&quot;, limit: 10 } }
+
+Discover all operations and parameters:
+{ operation: &quot;introspect&quot;, params: { query: &quot;operations&quot; } }</code></pre>
 <h4 id="212-single-mode-tool-description">2.1.2 Single Mode Tool Description</h4>
 <p>In Single mode, a single MCP tool is registered with this template:</p>
 <pre><code>MCP-AQL [domain] adapter. All operations through unified entry point.
 
-Operations are automatically routed based on their semantic category (Create, Read, Update, Delete, Execute).
+Operations are automatically routed based on their documented semantic category and endpoint-family mapping.
 
 Supported operation categories:
 - Create: [brief list]
@@ -233,60 +265,71 @@ Use introspection to discover all available operations and their parameters.</co
 <h3 id="22-tool-naming">2.2 Tool Naming</h3>
 <h4 id="221-standard-tool-names">2.2.1 Standard Tool Names</h4>
 <p>Implementations SHOULD use these standard tool names:</p>
-<p><strong>CRUDE Mode:</strong> | Tool Name | Purpose | |-----------|---------| | <code>mcp_aql_create</code> | CREATE operations | | <code>mcp_aql_read</code> | READ operations | | <code>mcp_aql_update</code> | UPDATE operations | | <code>mcp_aql_delete</code> | DELETE operations | | <code>mcp_aql_execute</code> | EXECUTE operations |</p>
+<p><strong>Standard CRUDE Profile:</strong> | Tool Name | Purpose | |-----------|---------| | <code>mcp_aql_create</code> | CREATE operations | | <code>mcp_aql_read</code> | READ operations | | <code>mcp_aql_update</code> | UPDATE operations | | <code>mcp_aql_delete</code> | DELETE operations | | <code>mcp_aql_execute</code> | EXECUTE operations |</p>
+<p><strong>Alternative Semantic Endpoint Profiles:</strong></p>
+<p>Adapters MAY use semantically explicit tool names such as <code>mcp_aql_discover</code>, <code>mcp_aql_query</code>, <code>mcp_aql_manage</code>, or <code>mcp_aql_operate</code>. These names SHOULD remain stable within an adapter and MUST be discoverable via introspection.</p>
 <p><strong>Single Mode:</strong> | Tool Name | Purpose | |-----------|---------| | <code>mcp_aql</code> | All operations |</p>
 <h4 id="222-custom-tool-name-prefixes">2.2.2 Custom Tool Name Prefixes</h4>
 <p>When multiple MCP-AQL adapters are deployed in a single session, tool names MUST be disambiguated. See <a href="#6-multi-adapter-deployment">Section 6</a> for details.</p>
 <h3 id="23-mcp-tool-annotations">2.3 MCP Tool Annotations</h3>
 <p>Adapters SHOULD include MCP tool annotations to provide permission hints:</p>
-<p><strong>CRUDE Mode Annotations:</strong></p>
-<div class="sourceCode" id="cb7"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb7-1"><a href="#cb7-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
-<span id="cb7-2"><a href="#cb7-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;mcp_aql_read&quot;</span><span class="fu">,</span></span>
-<span id="cb7-3"><a href="#cb7-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;annotations&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb7-4"><a href="#cb7-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;readOnlyHint&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
-<span id="cb7-5"><a href="#cb7-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;destructiveHint&quot;</span><span class="fu">:</span> <span class="kw">false</span></span>
-<span id="cb7-6"><a href="#cb7-6" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
-<span id="cb7-7"><a href="#cb7-7" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span>
-<span id="cb7-8"><a href="#cb7-8" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb7-9"><a href="#cb7-9" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
-<span id="cb7-10"><a href="#cb7-10" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;mcp_aql_create&quot;</span><span class="fu">,</span></span>
-<span id="cb7-11"><a href="#cb7-11" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;annotations&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb7-12"><a href="#cb7-12" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;readOnlyHint&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
-<span id="cb7-13"><a href="#cb7-13" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;destructiveHint&quot;</span><span class="fu">:</span> <span class="kw">false</span></span>
-<span id="cb7-14"><a href="#cb7-14" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
-<span id="cb7-15"><a href="#cb7-15" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span>
-<span id="cb7-16"><a href="#cb7-16" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb7-17"><a href="#cb7-17" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
-<span id="cb7-18"><a href="#cb7-18" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;mcp_aql_update&quot;</span><span class="fu">,</span></span>
-<span id="cb7-19"><a href="#cb7-19" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;annotations&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb7-20"><a href="#cb7-20" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;readOnlyHint&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
-<span id="cb7-21"><a href="#cb7-21" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;destructiveHint&quot;</span><span class="fu">:</span> <span class="kw">true</span></span>
-<span id="cb7-22"><a href="#cb7-22" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
-<span id="cb7-23"><a href="#cb7-23" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span>
-<span id="cb7-24"><a href="#cb7-24" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb7-25"><a href="#cb7-25" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
-<span id="cb7-26"><a href="#cb7-26" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;mcp_aql_delete&quot;</span><span class="fu">,</span></span>
-<span id="cb7-27"><a href="#cb7-27" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;annotations&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb7-28"><a href="#cb7-28" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;readOnlyHint&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
-<span id="cb7-29"><a href="#cb7-29" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;destructiveHint&quot;</span><span class="fu">:</span> <span class="kw">true</span></span>
-<span id="cb7-30"><a href="#cb7-30" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
-<span id="cb7-31"><a href="#cb7-31" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span>
-<span id="cb7-32"><a href="#cb7-32" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb7-33"><a href="#cb7-33" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
-<span id="cb7-34"><a href="#cb7-34" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;mcp_aql_execute&quot;</span><span class="fu">,</span></span>
-<span id="cb7-35"><a href="#cb7-35" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;annotations&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb7-36"><a href="#cb7-36" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;readOnlyHint&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
-<span id="cb7-37"><a href="#cb7-37" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;destructiveHint&quot;</span><span class="fu">:</span> <span class="kw">true</span></span>
-<span id="cb7-38"><a href="#cb7-38" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
-<span id="cb7-39"><a href="#cb7-39" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<p><strong>Standard CRUDE Profile Annotations:</strong></p>
+<div class="sourceCode" id="cb9"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb9-1"><a href="#cb9-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb9-2"><a href="#cb9-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;mcp_aql_read&quot;</span><span class="fu">,</span></span>
+<span id="cb9-3"><a href="#cb9-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;annotations&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb9-4"><a href="#cb9-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;readOnlyHint&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb9-5"><a href="#cb9-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;destructiveHint&quot;</span><span class="fu">:</span> <span class="kw">false</span></span>
+<span id="cb9-6"><a href="#cb9-6" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb9-7"><a href="#cb9-7" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span>
+<span id="cb9-8"><a href="#cb9-8" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb9-9"><a href="#cb9-9" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb9-10"><a href="#cb9-10" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;mcp_aql_create&quot;</span><span class="fu">,</span></span>
+<span id="cb9-11"><a href="#cb9-11" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;annotations&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb9-12"><a href="#cb9-12" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;readOnlyHint&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb9-13"><a href="#cb9-13" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;destructiveHint&quot;</span><span class="fu">:</span> <span class="kw">false</span></span>
+<span id="cb9-14"><a href="#cb9-14" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb9-15"><a href="#cb9-15" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span>
+<span id="cb9-16"><a href="#cb9-16" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb9-17"><a href="#cb9-17" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb9-18"><a href="#cb9-18" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;mcp_aql_update&quot;</span><span class="fu">,</span></span>
+<span id="cb9-19"><a href="#cb9-19" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;annotations&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb9-20"><a href="#cb9-20" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;readOnlyHint&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb9-21"><a href="#cb9-21" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;destructiveHint&quot;</span><span class="fu">:</span> <span class="kw">true</span></span>
+<span id="cb9-22"><a href="#cb9-22" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb9-23"><a href="#cb9-23" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span>
+<span id="cb9-24"><a href="#cb9-24" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb9-25"><a href="#cb9-25" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb9-26"><a href="#cb9-26" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;mcp_aql_delete&quot;</span><span class="fu">,</span></span>
+<span id="cb9-27"><a href="#cb9-27" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;annotations&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb9-28"><a href="#cb9-28" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;readOnlyHint&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb9-29"><a href="#cb9-29" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;destructiveHint&quot;</span><span class="fu">:</span> <span class="kw">true</span></span>
+<span id="cb9-30"><a href="#cb9-30" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb9-31"><a href="#cb9-31" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span>
+<span id="cb9-32"><a href="#cb9-32" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb9-33"><a href="#cb9-33" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb9-34"><a href="#cb9-34" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;mcp_aql_execute&quot;</span><span class="fu">,</span></span>
+<span id="cb9-35"><a href="#cb9-35" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;annotations&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb9-36"><a href="#cb9-36" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;readOnlyHint&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb9-37"><a href="#cb9-37" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;destructiveHint&quot;</span><span class="fu">:</span> <span class="kw">true</span></span>
+<span id="cb9-38"><a href="#cb9-38" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb9-39"><a href="#cb9-39" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<p><strong>Alternative Semantic Endpoint Annotations:</strong></p>
+<div class="sourceCode" id="cb10"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb10-1"><a href="#cb10-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb10-2"><a href="#cb10-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;mcp_aql_control&quot;</span><span class="fu">,</span></span>
+<span id="cb10-3"><a href="#cb10-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;annotations&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb10-4"><a href="#cb10-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;readOnlyHint&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb10-5"><a href="#cb10-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;destructiveHint&quot;</span><span class="fu">:</span> <span class="kw">true</span></span>
+<span id="cb10-6"><a href="#cb10-6" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb10-7"><a href="#cb10-7" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<p>Semantic endpoint families SHOULD set annotations conservatively based on the riskiest operation the family exposes.</p>
 <p><strong>Single Mode Annotations:</strong></p>
-<div class="sourceCode" id="cb8"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb8-1"><a href="#cb8-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
-<span id="cb8-2"><a href="#cb8-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;mcp_aql&quot;</span><span class="fu">,</span></span>
-<span id="cb8-3"><a href="#cb8-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;annotations&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb8-4"><a href="#cb8-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;readOnlyHint&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
-<span id="cb8-5"><a href="#cb8-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;destructiveHint&quot;</span><span class="fu">:</span> <span class="kw">true</span></span>
-<span id="cb8-6"><a href="#cb8-6" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
-<span id="cb8-7"><a href="#cb8-7" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<div class="sourceCode" id="cb11"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb11-1"><a href="#cb11-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb11-2"><a href="#cb11-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;mcp_aql&quot;</span><span class="fu">,</span></span>
+<span id="cb11-3"><a href="#cb11-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;annotations&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb11-4"><a href="#cb11-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;readOnlyHint&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb11-5"><a href="#cb11-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;destructiveHint&quot;</span><span class="fu">:</span> <span class="kw">true</span></span>
+<span id="cb11-6"><a href="#cb11-6" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb11-7"><a href="#cb11-7" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
 <blockquote>
 <p><strong>Note:</strong> Single mode uses <code>destructiveHint: true</code> because the unified endpoint can route to destructive operations. Clients cannot determine safety from the endpoint alone.</p>
 </blockquote>
@@ -294,81 +337,81 @@ Use introspection to discover all available operations and their parameters.</co
 <h2 id="3-input-schema-composition">3. Input Schema Composition</h2>
 <h3 id="31-standard-input-schema">3.1 Standard Input Schema</h3>
 <p>All MCP-AQL tools MUST use this base input schema:</p>
-<div class="sourceCode" id="cb9"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb9-1"><a href="#cb9-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
-<span id="cb9-2"><a href="#cb9-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;object&quot;</span><span class="fu">,</span></span>
-<span id="cb9-3"><a href="#cb9-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;properties&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb9-4"><a href="#cb9-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb9-5"><a href="#cb9-5" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;string&quot;</span><span class="fu">,</span></span>
-<span id="cb9-6"><a href="#cb9-6" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Operation name to execute&quot;</span></span>
-<span id="cb9-7"><a href="#cb9-7" aria-hidden="true" tabindex="-1"></a>    <span class="fu">},</span></span>
-<span id="cb9-8"><a href="#cb9-8" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb9-9"><a href="#cb9-9" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;object&quot;</span><span class="fu">,</span></span>
-<span id="cb9-10"><a href="#cb9-10" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Operation parameters&quot;</span><span class="fu">,</span></span>
-<span id="cb9-11"><a href="#cb9-11" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;additionalProperties&quot;</span><span class="fu">:</span> <span class="kw">true</span></span>
-<span id="cb9-12"><a href="#cb9-12" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
-<span id="cb9-13"><a href="#cb9-13" aria-hidden="true" tabindex="-1"></a>  <span class="fu">},</span></span>
-<span id="cb9-14"><a href="#cb9-14" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;required&quot;</span><span class="fu">:</span> <span class="ot">[</span><span class="st">&quot;operation&quot;</span><span class="ot">]</span></span>
-<span id="cb9-15"><a href="#cb9-15" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<div class="sourceCode" id="cb12"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb12-1"><a href="#cb12-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb12-2"><a href="#cb12-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;object&quot;</span><span class="fu">,</span></span>
+<span id="cb12-3"><a href="#cb12-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;properties&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb12-4"><a href="#cb12-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb12-5"><a href="#cb12-5" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;string&quot;</span><span class="fu">,</span></span>
+<span id="cb12-6"><a href="#cb12-6" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Operation name to execute&quot;</span></span>
+<span id="cb12-7"><a href="#cb12-7" aria-hidden="true" tabindex="-1"></a>    <span class="fu">},</span></span>
+<span id="cb12-8"><a href="#cb12-8" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb12-9"><a href="#cb12-9" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;object&quot;</span><span class="fu">,</span></span>
+<span id="cb12-10"><a href="#cb12-10" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Operation parameters&quot;</span><span class="fu">,</span></span>
+<span id="cb12-11"><a href="#cb12-11" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;additionalProperties&quot;</span><span class="fu">:</span> <span class="kw">true</span></span>
+<span id="cb12-12"><a href="#cb12-12" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb12-13"><a href="#cb12-13" aria-hidden="true" tabindex="-1"></a>  <span class="fu">},</span></span>
+<span id="cb12-14"><a href="#cb12-14" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;required&quot;</span><span class="fu">:</span> <span class="ot">[</span><span class="st">&quot;operation&quot;</span><span class="ot">]</span></span>
+<span id="cb12-15"><a href="#cb12-15" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
 <h3 id="32-extended-input-schema">3.2 Extended Input Schema</h3>
 <p>Adapters MAY extend the base schema with additional top-level properties for common cross-cutting concerns:</p>
-<div class="sourceCode" id="cb10"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb10-1"><a href="#cb10-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
-<span id="cb10-2"><a href="#cb10-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;object&quot;</span><span class="fu">,</span></span>
-<span id="cb10-3"><a href="#cb10-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;properties&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb10-4"><a href="#cb10-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb10-5"><a href="#cb10-5" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;string&quot;</span><span class="fu">,</span></span>
-<span id="cb10-6"><a href="#cb10-6" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Operation name to execute&quot;</span></span>
-<span id="cb10-7"><a href="#cb10-7" aria-hidden="true" tabindex="-1"></a>    <span class="fu">},</span></span>
-<span id="cb10-8"><a href="#cb10-8" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;element_type&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb10-9"><a href="#cb10-9" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;string&quot;</span><span class="fu">,</span></span>
-<span id="cb10-10"><a href="#cb10-10" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Target element type (optional)&quot;</span></span>
-<span id="cb10-11"><a href="#cb10-11" aria-hidden="true" tabindex="-1"></a>    <span class="fu">},</span></span>
-<span id="cb10-12"><a href="#cb10-12" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb10-13"><a href="#cb10-13" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;object&quot;</span><span class="fu">,</span></span>
-<span id="cb10-14"><a href="#cb10-14" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Operation parameters&quot;</span><span class="fu">,</span></span>
-<span id="cb10-15"><a href="#cb10-15" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;additionalProperties&quot;</span><span class="fu">:</span> <span class="kw">true</span></span>
-<span id="cb10-16"><a href="#cb10-16" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
-<span id="cb10-17"><a href="#cb10-17" aria-hidden="true" tabindex="-1"></a>  <span class="fu">},</span></span>
-<span id="cb10-18"><a href="#cb10-18" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;required&quot;</span><span class="fu">:</span> <span class="ot">[</span><span class="st">&quot;operation&quot;</span><span class="ot">]</span></span>
-<span id="cb10-19"><a href="#cb10-19" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<div class="sourceCode" id="cb13"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb13-1"><a href="#cb13-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb13-2"><a href="#cb13-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;object&quot;</span><span class="fu">,</span></span>
+<span id="cb13-3"><a href="#cb13-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;properties&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb13-4"><a href="#cb13-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb13-5"><a href="#cb13-5" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;string&quot;</span><span class="fu">,</span></span>
+<span id="cb13-6"><a href="#cb13-6" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Operation name to execute&quot;</span></span>
+<span id="cb13-7"><a href="#cb13-7" aria-hidden="true" tabindex="-1"></a>    <span class="fu">},</span></span>
+<span id="cb13-8"><a href="#cb13-8" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;element_type&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb13-9"><a href="#cb13-9" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;string&quot;</span><span class="fu">,</span></span>
+<span id="cb13-10"><a href="#cb13-10" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Target element type (optional)&quot;</span></span>
+<span id="cb13-11"><a href="#cb13-11" aria-hidden="true" tabindex="-1"></a>    <span class="fu">},</span></span>
+<span id="cb13-12"><a href="#cb13-12" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb13-13"><a href="#cb13-13" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;object&quot;</span><span class="fu">,</span></span>
+<span id="cb13-14"><a href="#cb13-14" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Operation parameters&quot;</span><span class="fu">,</span></span>
+<span id="cb13-15"><a href="#cb13-15" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;additionalProperties&quot;</span><span class="fu">:</span> <span class="kw">true</span></span>
+<span id="cb13-16"><a href="#cb13-16" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb13-17"><a href="#cb13-17" aria-hidden="true" tabindex="-1"></a>  <span class="fu">},</span></span>
+<span id="cb13-18"><a href="#cb13-18" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;required&quot;</span><span class="fu">:</span> <span class="ot">[</span><span class="st">&quot;operation&quot;</span><span class="ot">]</span></span>
+<span id="cb13-19"><a href="#cb13-19" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
 <h3 id="33-dynamic-operation-enumeration">3.3 Dynamic Operation Enumeration</h3>
 <p>Adapters MAY use dynamic <code>enum</code> generation for the <code>operation</code> property to provide client-side validation and autocompletion:</p>
-<div class="sourceCode" id="cb11"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb11-1"><a href="#cb11-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
-<span id="cb11-2"><a href="#cb11-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;object&quot;</span><span class="fu">,</span></span>
-<span id="cb11-3"><a href="#cb11-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;properties&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb11-4"><a href="#cb11-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb11-5"><a href="#cb11-5" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;string&quot;</span><span class="fu">,</span></span>
-<span id="cb11-6"><a href="#cb11-6" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Operation name to execute&quot;</span><span class="fu">,</span></span>
-<span id="cb11-7"><a href="#cb11-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;enum&quot;</span><span class="fu">:</span> <span class="ot">[</span><span class="st">&quot;list_elements&quot;</span><span class="ot">,</span> <span class="st">&quot;get_element&quot;</span><span class="ot">,</span> <span class="st">&quot;search_elements&quot;</span><span class="ot">,</span> <span class="st">&quot;introspect&quot;</span><span class="ot">]</span></span>
-<span id="cb11-8"><a href="#cb11-8" aria-hidden="true" tabindex="-1"></a>    <span class="fu">},</span></span>
-<span id="cb11-9"><a href="#cb11-9" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb11-10"><a href="#cb11-10" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;object&quot;</span><span class="fu">,</span></span>
-<span id="cb11-11"><a href="#cb11-11" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Operation parameters&quot;</span></span>
-<span id="cb11-12"><a href="#cb11-12" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
-<span id="cb11-13"><a href="#cb11-13" aria-hidden="true" tabindex="-1"></a>  <span class="fu">},</span></span>
-<span id="cb11-14"><a href="#cb11-14" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;required&quot;</span><span class="fu">:</span> <span class="ot">[</span><span class="st">&quot;operation&quot;</span><span class="ot">]</span></span>
-<span id="cb11-15"><a href="#cb11-15" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<div class="sourceCode" id="cb14"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb14-1"><a href="#cb14-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb14-2"><a href="#cb14-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;object&quot;</span><span class="fu">,</span></span>
+<span id="cb14-3"><a href="#cb14-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;properties&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb14-4"><a href="#cb14-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb14-5"><a href="#cb14-5" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;string&quot;</span><span class="fu">,</span></span>
+<span id="cb14-6"><a href="#cb14-6" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Operation name to execute&quot;</span><span class="fu">,</span></span>
+<span id="cb14-7"><a href="#cb14-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;enum&quot;</span><span class="fu">:</span> <span class="ot">[</span><span class="st">&quot;list_elements&quot;</span><span class="ot">,</span> <span class="st">&quot;get_element&quot;</span><span class="ot">,</span> <span class="st">&quot;search_elements&quot;</span><span class="ot">,</span> <span class="st">&quot;introspect&quot;</span><span class="ot">]</span></span>
+<span id="cb14-8"><a href="#cb14-8" aria-hidden="true" tabindex="-1"></a>    <span class="fu">},</span></span>
+<span id="cb14-9"><a href="#cb14-9" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb14-10"><a href="#cb14-10" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;object&quot;</span><span class="fu">,</span></span>
+<span id="cb14-11"><a href="#cb14-11" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Operation parameters&quot;</span></span>
+<span id="cb14-12"><a href="#cb14-12" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb14-13"><a href="#cb14-13" aria-hidden="true" tabindex="-1"></a>  <span class="fu">},</span></span>
+<span id="cb14-14"><a href="#cb14-14" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;required&quot;</span><span class="fu">:</span> <span class="ot">[</span><span class="st">&quot;operation&quot;</span><span class="ot">]</span></span>
+<span id="cb14-15"><a href="#cb14-15" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
 <blockquote>
 <p><strong>Note:</strong> Dynamic enumeration increases tool registration token cost. Implementations SHOULD consider the trade-off between discoverability and token efficiency. For large operation sets, prefer introspection over enumeration.</p>
 </blockquote>
-<h3 id="34-crude-mode-schema-composition">3.4 CRUDE Mode Schema Composition</h3>
-<p>In CRUDE mode, each endpoint MAY have a schema that enumerates only operations valid for that endpoint:</p>
-<div class="sourceCode" id="cb12"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb12-1"><a href="#cb12-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
-<span id="cb12-2"><a href="#cb12-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;mcp_aql_read&quot;</span><span class="fu">,</span></span>
-<span id="cb12-3"><a href="#cb12-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;inputSchema&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb12-4"><a href="#cb12-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;object&quot;</span><span class="fu">,</span></span>
-<span id="cb12-5"><a href="#cb12-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;properties&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb12-6"><a href="#cb12-6" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb12-7"><a href="#cb12-7" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;string&quot;</span><span class="fu">,</span></span>
-<span id="cb12-8"><a href="#cb12-8" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;READ operation to execute&quot;</span><span class="fu">,</span></span>
-<span id="cb12-9"><a href="#cb12-9" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;enum&quot;</span><span class="fu">:</span> <span class="ot">[</span><span class="st">&quot;list_elements&quot;</span><span class="ot">,</span> <span class="st">&quot;get_element&quot;</span><span class="ot">,</span> <span class="st">&quot;search_elements&quot;</span><span class="ot">,</span> <span class="st">&quot;introspect&quot;</span><span class="ot">]</span></span>
-<span id="cb12-10"><a href="#cb12-10" aria-hidden="true" tabindex="-1"></a>      <span class="fu">},</span></span>
-<span id="cb12-11"><a href="#cb12-11" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb12-12"><a href="#cb12-12" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;object&quot;</span></span>
-<span id="cb12-13"><a href="#cb12-13" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span></span>
-<span id="cb12-14"><a href="#cb12-14" aria-hidden="true" tabindex="-1"></a>    <span class="fu">},</span></span>
-<span id="cb12-15"><a href="#cb12-15" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;required&quot;</span><span class="fu">:</span> <span class="ot">[</span><span class="st">&quot;operation&quot;</span><span class="ot">]</span></span>
-<span id="cb12-16"><a href="#cb12-16" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
-<span id="cb12-17"><a href="#cb12-17" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<h3 id="34-semantic-endpoint-mode-schema-composition">3.4 Semantic Endpoint Mode Schema Composition</h3>
+<p>In semantic endpoint mode, each exposed endpoint family MAY have a schema that enumerates only operations valid for that family:</p>
+<div class="sourceCode" id="cb15"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb15-1"><a href="#cb15-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb15-2"><a href="#cb15-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;mcp_aql_query&quot;</span><span class="fu">,</span></span>
+<span id="cb15-3"><a href="#cb15-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;inputSchema&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb15-4"><a href="#cb15-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;object&quot;</span><span class="fu">,</span></span>
+<span id="cb15-5"><a href="#cb15-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;properties&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb15-6"><a href="#cb15-6" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb15-7"><a href="#cb15-7" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;string&quot;</span><span class="fu">,</span></span>
+<span id="cb15-8"><a href="#cb15-8" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Query-family operation to execute&quot;</span><span class="fu">,</span></span>
+<span id="cb15-9"><a href="#cb15-9" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;enum&quot;</span><span class="fu">:</span> <span class="ot">[</span><span class="st">&quot;list_elements&quot;</span><span class="ot">,</span> <span class="st">&quot;get_element&quot;</span><span class="ot">,</span> <span class="st">&quot;search_elements&quot;</span><span class="ot">,</span> <span class="st">&quot;introspect&quot;</span><span class="ot">]</span></span>
+<span id="cb15-10"><a href="#cb15-10" aria-hidden="true" tabindex="-1"></a>      <span class="fu">},</span></span>
+<span id="cb15-11"><a href="#cb15-11" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb15-12"><a href="#cb15-12" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;object&quot;</span></span>
+<span id="cb15-13"><a href="#cb15-13" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span></span>
+<span id="cb15-14"><a href="#cb15-14" aria-hidden="true" tabindex="-1"></a>    <span class="fu">},</span></span>
+<span id="cb15-15"><a href="#cb15-15" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;required&quot;</span><span class="fu">:</span> <span class="ot">[</span><span class="st">&quot;operation&quot;</span><span class="ot">]</span></span>
+<span id="cb15-16"><a href="#cb15-16" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb15-17"><a href="#cb15-17" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
 <p>This approach:</p>
 <ul>
 <li>Prevents clients from sending operations to wrong endpoints</li>
@@ -382,24 +425,24 @@ Use introspection to discover all available operations and their parameters.</co
 <h4 id="411-mapping-table">4.1.1 Mapping Table</h4>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>MCP-AQL Response</th>
 <th>MCP <code>isError</code></th>
 <th>Rationale</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><code>success: true</code></td>
 <td><code>false</code></td>
 <td>Normal success</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>success: false</code>, recoverable error</td>
 <td><code>false</code></td>
 <td>Domain-level error; agent should interpret and recover</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>success: false</code>, unrecoverable error</td>
 <td><code>true</code></td>
 <td>Protocol failure; agent cannot recover without intervention</td>
@@ -425,63 +468,63 @@ Use introspection to discover all available operations and their parameters.</co
 <li>Transport failures</li>
 </ul>
 <h4 id="413-implementation-guidance">4.1.3 Implementation Guidance</h4>
-<div class="sourceCode" id="cb13"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb13-1"><a href="#cb13-1" aria-hidden="true" tabindex="-1"></a><span class="kw">function</span> <span class="fu">toCallToolResult</span>(response<span class="op">:</span> OperationResult)<span class="op">:</span> CallToolResult {</span>
-<span id="cb13-2"><a href="#cb13-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">const</span> content <span class="op">=</span> [{</span>
-<span id="cb13-3"><a href="#cb13-3" aria-hidden="true" tabindex="-1"></a>    type<span class="op">:</span> <span class="st">&quot;text&quot;</span><span class="op">,</span></span>
-<span id="cb13-4"><a href="#cb13-4" aria-hidden="true" tabindex="-1"></a>    text<span class="op">:</span> <span class="bu">JSON</span><span class="op">.</span><span class="fu">stringify</span>(response)</span>
-<span id="cb13-5"><a href="#cb13-5" aria-hidden="true" tabindex="-1"></a>  }]<span class="op">;</span></span>
-<span id="cb13-6"><a href="#cb13-6" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb13-7"><a href="#cb13-7" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> (response<span class="op">.</span><span class="at">success</span>) {</span>
-<span id="cb13-8"><a href="#cb13-8" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> { content<span class="op">,</span> isError<span class="op">:</span> <span class="kw">false</span> }<span class="op">;</span></span>
-<span id="cb13-9"><a href="#cb13-9" aria-hidden="true" tabindex="-1"></a>  }</span>
-<span id="cb13-10"><a href="#cb13-10" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb13-11"><a href="#cb13-11" aria-hidden="true" tabindex="-1"></a>  <span class="co">// Determine if error is recoverable</span></span>
-<span id="cb13-12"><a href="#cb13-12" aria-hidden="true" tabindex="-1"></a>  <span class="kw">const</span> recoverableErrors <span class="op">=</span> [</span>
-<span id="cb13-13"><a href="#cb13-13" aria-hidden="true" tabindex="-1"></a>    <span class="st">&quot;NOT_FOUND_RESOURCE&quot;</span><span class="op">,</span></span>
-<span id="cb13-14"><a href="#cb13-14" aria-hidden="true" tabindex="-1"></a>    <span class="st">&quot;NOT_FOUND_OPERATION&quot;</span><span class="op">,</span></span>
-<span id="cb13-15"><a href="#cb13-15" aria-hidden="true" tabindex="-1"></a>    <span class="st">&quot;VALIDATION_MISSING_PARAM&quot;</span><span class="op">,</span></span>
-<span id="cb13-16"><a href="#cb13-16" aria-hidden="true" tabindex="-1"></a>    <span class="st">&quot;VALIDATION_INVALID_TYPE&quot;</span><span class="op">,</span></span>
-<span id="cb13-17"><a href="#cb13-17" aria-hidden="true" tabindex="-1"></a>    <span class="st">&quot;VALIDATION_INVALID_VALUE&quot;</span><span class="op">,</span></span>
-<span id="cb13-18"><a href="#cb13-18" aria-hidden="true" tabindex="-1"></a>    <span class="st">&quot;PERMISSION_DENIED&quot;</span><span class="op">,</span></span>
-<span id="cb13-19"><a href="#cb13-19" aria-hidden="true" tabindex="-1"></a>    <span class="st">&quot;RATE_LIMIT_EXCEEDED&quot;</span><span class="op">,</span></span>
-<span id="cb13-20"><a href="#cb13-20" aria-hidden="true" tabindex="-1"></a>    <span class="st">&quot;RATE_LIMIT_QUOTA_PAUSE&quot;</span><span class="op">,</span></span>
-<span id="cb13-21"><a href="#cb13-21" aria-hidden="true" tabindex="-1"></a>    <span class="st">&quot;CONFIRMATION_REQUIRED&quot;</span></span>
-<span id="cb13-22"><a href="#cb13-22" aria-hidden="true" tabindex="-1"></a>  ]<span class="op">;</span></span>
-<span id="cb13-23"><a href="#cb13-23" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb13-24"><a href="#cb13-24" aria-hidden="true" tabindex="-1"></a>  <span class="kw">const</span> isRecoverable <span class="op">=</span> recoverableErrors<span class="op">.</span><span class="fu">includes</span>(response<span class="op">.</span><span class="at">error</span><span class="op">.</span><span class="at">code</span>)<span class="op">;</span></span>
-<span id="cb13-25"><a href="#cb13-25" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb13-26"><a href="#cb13-26" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> {</span>
-<span id="cb13-27"><a href="#cb13-27" aria-hidden="true" tabindex="-1"></a>    content<span class="op">,</span></span>
-<span id="cb13-28"><a href="#cb13-28" aria-hidden="true" tabindex="-1"></a>    isError<span class="op">:</span> <span class="op">!</span>isRecoverable</span>
-<span id="cb13-29"><a href="#cb13-29" aria-hidden="true" tabindex="-1"></a>  }<span class="op">;</span></span>
-<span id="cb13-30"><a href="#cb13-30" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<div class="sourceCode" id="cb16"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb16-1"><a href="#cb16-1" aria-hidden="true" tabindex="-1"></a><span class="kw">function</span> <span class="fu">toCallToolResult</span>(response<span class="op">:</span> OperationResult)<span class="op">:</span> CallToolResult {</span>
+<span id="cb16-2"><a href="#cb16-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">const</span> content <span class="op">=</span> [{</span>
+<span id="cb16-3"><a href="#cb16-3" aria-hidden="true" tabindex="-1"></a>    type<span class="op">:</span> <span class="st">&quot;text&quot;</span><span class="op">,</span></span>
+<span id="cb16-4"><a href="#cb16-4" aria-hidden="true" tabindex="-1"></a>    text<span class="op">:</span> <span class="bu">JSON</span><span class="op">.</span><span class="fu">stringify</span>(response)</span>
+<span id="cb16-5"><a href="#cb16-5" aria-hidden="true" tabindex="-1"></a>  }]<span class="op">;</span></span>
+<span id="cb16-6"><a href="#cb16-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb16-7"><a href="#cb16-7" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> (response<span class="op">.</span><span class="at">success</span>) {</span>
+<span id="cb16-8"><a href="#cb16-8" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> { content<span class="op">,</span> isError<span class="op">:</span> <span class="kw">false</span> }<span class="op">;</span></span>
+<span id="cb16-9"><a href="#cb16-9" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb16-10"><a href="#cb16-10" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb16-11"><a href="#cb16-11" aria-hidden="true" tabindex="-1"></a>  <span class="co">// Determine if error is recoverable</span></span>
+<span id="cb16-12"><a href="#cb16-12" aria-hidden="true" tabindex="-1"></a>  <span class="kw">const</span> recoverableErrors <span class="op">=</span> [</span>
+<span id="cb16-13"><a href="#cb16-13" aria-hidden="true" tabindex="-1"></a>    <span class="st">&quot;NOT_FOUND_RESOURCE&quot;</span><span class="op">,</span></span>
+<span id="cb16-14"><a href="#cb16-14" aria-hidden="true" tabindex="-1"></a>    <span class="st">&quot;NOT_FOUND_OPERATION&quot;</span><span class="op">,</span></span>
+<span id="cb16-15"><a href="#cb16-15" aria-hidden="true" tabindex="-1"></a>    <span class="st">&quot;VALIDATION_MISSING_PARAM&quot;</span><span class="op">,</span></span>
+<span id="cb16-16"><a href="#cb16-16" aria-hidden="true" tabindex="-1"></a>    <span class="st">&quot;VALIDATION_INVALID_TYPE&quot;</span><span class="op">,</span></span>
+<span id="cb16-17"><a href="#cb16-17" aria-hidden="true" tabindex="-1"></a>    <span class="st">&quot;VALIDATION_INVALID_VALUE&quot;</span><span class="op">,</span></span>
+<span id="cb16-18"><a href="#cb16-18" aria-hidden="true" tabindex="-1"></a>    <span class="st">&quot;PERMISSION_DENIED&quot;</span><span class="op">,</span></span>
+<span id="cb16-19"><a href="#cb16-19" aria-hidden="true" tabindex="-1"></a>    <span class="st">&quot;RATE_LIMIT_EXCEEDED&quot;</span><span class="op">,</span></span>
+<span id="cb16-20"><a href="#cb16-20" aria-hidden="true" tabindex="-1"></a>    <span class="st">&quot;RATE_LIMIT_QUOTA_PAUSE&quot;</span><span class="op">,</span></span>
+<span id="cb16-21"><a href="#cb16-21" aria-hidden="true" tabindex="-1"></a>    <span class="st">&quot;CONFIRMATION_REQUIRED&quot;</span></span>
+<span id="cb16-22"><a href="#cb16-22" aria-hidden="true" tabindex="-1"></a>  ]<span class="op">;</span></span>
+<span id="cb16-23"><a href="#cb16-23" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb16-24"><a href="#cb16-24" aria-hidden="true" tabindex="-1"></a>  <span class="kw">const</span> isRecoverable <span class="op">=</span> recoverableErrors<span class="op">.</span><span class="fu">includes</span>(response<span class="op">.</span><span class="at">error</span><span class="op">.</span><span class="at">code</span>)<span class="op">;</span></span>
+<span id="cb16-25"><a href="#cb16-25" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb16-26"><a href="#cb16-26" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> {</span>
+<span id="cb16-27"><a href="#cb16-27" aria-hidden="true" tabindex="-1"></a>    content<span class="op">,</span></span>
+<span id="cb16-28"><a href="#cb16-28" aria-hidden="true" tabindex="-1"></a>    isError<span class="op">:</span> <span class="op">!</span>isRecoverable</span>
+<span id="cb16-29"><a href="#cb16-29" aria-hidden="true" tabindex="-1"></a>  }<span class="op">;</span></span>
+<span id="cb16-30"><a href="#cb16-30" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
 <h3 id="42-mcp-json-rpc-error-codes">4.2 MCP JSON-RPC Error Codes</h3>
 <p>MCP JSON-RPC errors (-32600 to -32603) are reserved for transport and protocol-level failures. MCP-AQL adapters MUST NOT use these codes for domain-level errors.</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>JSON-RPC Code</th>
 <th>Description</th>
 <th>When Used</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td>-32600</td>
 <td>Invalid Request</td>
 <td>Malformed JSON-RPC request</td>
 </tr>
-<tr>
+<tr class="even">
 <td>-32601</td>
 <td>Method not found</td>
 <td>Unknown MCP method</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>-32602</td>
 <td>Invalid params</td>
 <td>Invalid MCP method parameters</td>
 </tr>
-<tr>
+<tr class="even">
 <td>-32603</td>
 <td>Internal error</td>
 <td>MCP server internal error</td>
@@ -493,49 +536,49 @@ Use introspection to discover all available operations and their parameters.</co
 <p>When adapters wrap HTTP APIs, HTTP status codes SHOULD be mapped to MCP-AQL error codes:</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>HTTP Status</th>
 <th>MCP-AQL Error Code</th>
 <th>Notes</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td>400</td>
 <td><code>VALIDATION_INVALID_TYPE</code></td>
 <td>Bad request</td>
 </tr>
-<tr>
+<tr class="even">
 <td>401</td>
 <td><code>PERMISSION_DENIED</code></td>
 <td>Authentication required</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>403</td>
 <td><code>PERMISSION_DENIED</code></td>
 <td>Forbidden</td>
 </tr>
-<tr>
+<tr class="even">
 <td>404</td>
 <td><code>NOT_FOUND_RESOURCE</code></td>
 <td>Not found</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>409</td>
 <td><code>CONFLICT_ALREADY_EXISTS</code></td>
 <td>Conflict</td>
 </tr>
-<tr>
+<tr class="even">
 <td>422</td>
 <td><code>VALIDATION_INVALID_TYPE</code></td>
 <td>Unprocessable entity</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>429</td>
 <td><code>RATE_LIMIT_EXCEEDED</code></td>
 <td>Rate limited</td>
 </tr>
-<tr>
+<tr class="even">
 <td>500+</td>
 <td><code>INTERNAL_ERROR</code></td>
 <td>Server errors</td>
@@ -554,51 +597,51 @@ Use introspection to discover all available operations and their parameters.</co
 </ul>
 <h3 id="52-progress-token-handling">5.2 Progress Token Handling</h3>
 <p>Clients MAY include a <code>_meta.progressToken</code> in requests to receive progress updates:</p>
-<div class="sourceCode" id="cb14"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb14-1"><a href="#cb14-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
-<span id="cb14-2"><a href="#cb14-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;execute_agent&quot;</span><span class="fu">,</span></span>
-<span id="cb14-3"><a href="#cb14-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb14-4"><a href="#cb14-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;element_name&quot;</span><span class="fu">:</span> <span class="st">&quot;MyAgent&quot;</span><span class="fu">,</span></span>
-<span id="cb14-5"><a href="#cb14-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;parameters&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;goal&quot;</span><span class="fu">:</span> <span class="st">&quot;Review code&quot;</span> <span class="fu">}</span></span>
-<span id="cb14-6"><a href="#cb14-6" aria-hidden="true" tabindex="-1"></a>  <span class="fu">},</span></span>
-<span id="cb14-7"><a href="#cb14-7" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;_meta&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb14-8"><a href="#cb14-8" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;progressToken&quot;</span><span class="fu">:</span> <span class="st">&quot;progress_abc123&quot;</span></span>
-<span id="cb14-9"><a href="#cb14-9" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
-<span id="cb14-10"><a href="#cb14-10" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<div class="sourceCode" id="cb17"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb17-1"><a href="#cb17-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb17-2"><a href="#cb17-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;execute_agent&quot;</span><span class="fu">,</span></span>
+<span id="cb17-3"><a href="#cb17-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb17-4"><a href="#cb17-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;element_name&quot;</span><span class="fu">:</span> <span class="st">&quot;MyAgent&quot;</span><span class="fu">,</span></span>
+<span id="cb17-5"><a href="#cb17-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;parameters&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;goal&quot;</span><span class="fu">:</span> <span class="st">&quot;Review code&quot;</span> <span class="fu">}</span></span>
+<span id="cb17-6"><a href="#cb17-6" aria-hidden="true" tabindex="-1"></a>  <span class="fu">},</span></span>
+<span id="cb17-7"><a href="#cb17-7" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;_meta&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb17-8"><a href="#cb17-8" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;progressToken&quot;</span><span class="fu">:</span> <span class="st">&quot;progress_abc123&quot;</span></span>
+<span id="cb17-9"><a href="#cb17-9" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb17-10"><a href="#cb17-10" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
 <p>Adapters receiving a progress token SHOULD emit progress notifications during EXECUTE operations.</p>
 <h3 id="53-progress-notification-format">5.3 Progress Notification Format</h3>
 <p>Progress notifications MUST follow the MCP progress notification format:</p>
-<div class="sourceCode" id="cb15"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb15-1"><a href="#cb15-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
-<span id="cb15-2"><a href="#cb15-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;jsonrpc&quot;</span><span class="fu">:</span> <span class="st">&quot;2.0&quot;</span><span class="fu">,</span></span>
-<span id="cb15-3"><a href="#cb15-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;method&quot;</span><span class="fu">:</span> <span class="st">&quot;notifications/progress&quot;</span><span class="fu">,</span></span>
-<span id="cb15-4"><a href="#cb15-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb15-5"><a href="#cb15-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;progressToken&quot;</span><span class="fu">:</span> <span class="st">&quot;progress_abc123&quot;</span><span class="fu">,</span></span>
-<span id="cb15-6"><a href="#cb15-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;progress&quot;</span><span class="fu">:</span> <span class="dv">50</span><span class="fu">,</span></span>
-<span id="cb15-7"><a href="#cb15-7" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;total&quot;</span><span class="fu">:</span> <span class="dv">100</span><span class="fu">,</span></span>
-<span id="cb15-8"><a href="#cb15-8" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;Processing step 5 of 10&quot;</span></span>
-<span id="cb15-9"><a href="#cb15-9" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
-<span id="cb15-10"><a href="#cb15-10" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<div class="sourceCode" id="cb18"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb18-1"><a href="#cb18-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb18-2"><a href="#cb18-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;jsonrpc&quot;</span><span class="fu">:</span> <span class="st">&quot;2.0&quot;</span><span class="fu">,</span></span>
+<span id="cb18-3"><a href="#cb18-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;method&quot;</span><span class="fu">:</span> <span class="st">&quot;notifications/progress&quot;</span><span class="fu">,</span></span>
+<span id="cb18-4"><a href="#cb18-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb18-5"><a href="#cb18-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;progressToken&quot;</span><span class="fu">:</span> <span class="st">&quot;progress_abc123&quot;</span><span class="fu">,</span></span>
+<span id="cb18-6"><a href="#cb18-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;progress&quot;</span><span class="fu">:</span> <span class="dv">50</span><span class="fu">,</span></span>
+<span id="cb18-7"><a href="#cb18-7" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;total&quot;</span><span class="fu">:</span> <span class="dv">100</span><span class="fu">,</span></span>
+<span id="cb18-8"><a href="#cb18-8" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;Processing step 5 of 10&quot;</span></span>
+<span id="cb18-9"><a href="#cb18-9" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb18-10"><a href="#cb18-10" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
 <h3 id="54-execute-operation-progress-mapping">5.4 EXECUTE Operation Progress Mapping</h3>
 <p>For EXECUTE operations with defined state machines, map states to progress:</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>EXECUTE State</th>
 <th>Progress Range</th>
 <th>Description</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td>Initializing</td>
 <td>0-10%</td>
 <td>Setting up execution context</td>
 </tr>
-<tr>
+<tr class="even">
 <td>Running</td>
 <td>10-90%</td>
 <td>Main execution phase</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>Completing</td>
 <td>90-100%</td>
 <td>Finalizing and cleaning up</td>
@@ -606,19 +649,19 @@ Use introspection to discover all available operations and their parameters.</co
 </tbody>
 </table>
 <p><strong>Example mapping:</strong></p>
-<div class="sourceCode" id="cb16"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb16-1"><a href="#cb16-1" aria-hidden="true" tabindex="-1"></a><span class="kw">function</span> <span class="fu">mapExecutionStateToProgress</span>(state<span class="op">:</span> ExecutionState)<span class="op">:</span> <span class="dt">number</span> {</span>
-<span id="cb16-2"><a href="#cb16-2" aria-hidden="true" tabindex="-1"></a>  <span class="cf">switch</span> (state<span class="op">.</span><span class="at">status</span>) {</span>
-<span id="cb16-3"><a href="#cb16-3" aria-hidden="true" tabindex="-1"></a>    <span class="cf">case</span> <span class="st">&quot;pending&quot;</span><span class="op">:</span> <span class="cf">return</span> <span class="dv">0</span><span class="op">;</span></span>
-<span id="cb16-4"><a href="#cb16-4" aria-hidden="true" tabindex="-1"></a>    <span class="cf">case</span> <span class="st">&quot;initializing&quot;</span><span class="op">:</span> <span class="cf">return</span> <span class="dv">5</span><span class="op">;</span></span>
-<span id="cb16-5"><a href="#cb16-5" aria-hidden="true" tabindex="-1"></a>    <span class="cf">case</span> <span class="st">&quot;running&quot;</span><span class="op">:</span></span>
-<span id="cb16-6"><a href="#cb16-6" aria-hidden="true" tabindex="-1"></a>      <span class="co">// Calculate progress within running phase</span></span>
-<span id="cb16-7"><a href="#cb16-7" aria-hidden="true" tabindex="-1"></a>      <span class="kw">const</span> runningProgress <span class="op">=</span> state<span class="op">.</span><span class="at">stepsCompleted</span> <span class="op">/</span> state<span class="op">.</span><span class="at">totalSteps</span><span class="op">;</span></span>
-<span id="cb16-8"><a href="#cb16-8" aria-hidden="true" tabindex="-1"></a>      <span class="cf">return</span> <span class="dv">10</span> <span class="op">+</span> (runningProgress <span class="op">*</span> <span class="dv">80</span>)<span class="op">;</span></span>
-<span id="cb16-9"><a href="#cb16-9" aria-hidden="true" tabindex="-1"></a>    <span class="cf">case</span> <span class="st">&quot;completing&quot;</span><span class="op">:</span> <span class="cf">return</span> <span class="dv">95</span><span class="op">;</span></span>
-<span id="cb16-10"><a href="#cb16-10" aria-hidden="true" tabindex="-1"></a>    <span class="cf">case</span> <span class="st">&quot;completed&quot;</span><span class="op">:</span> <span class="cf">return</span> <span class="dv">100</span><span class="op">;</span></span>
-<span id="cb16-11"><a href="#cb16-11" aria-hidden="true" tabindex="-1"></a>    <span class="cf">default</span><span class="op">:</span> <span class="cf">return</span> <span class="dv">0</span><span class="op">;</span></span>
-<span id="cb16-12"><a href="#cb16-12" aria-hidden="true" tabindex="-1"></a>  }</span>
-<span id="cb16-13"><a href="#cb16-13" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<div class="sourceCode" id="cb19"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb19-1"><a href="#cb19-1" aria-hidden="true" tabindex="-1"></a><span class="kw">function</span> <span class="fu">mapExecutionStateToProgress</span>(state<span class="op">:</span> ExecutionState)<span class="op">:</span> <span class="dt">number</span> {</span>
+<span id="cb19-2"><a href="#cb19-2" aria-hidden="true" tabindex="-1"></a>  <span class="cf">switch</span> (state<span class="op">.</span><span class="at">status</span>) {</span>
+<span id="cb19-3"><a href="#cb19-3" aria-hidden="true" tabindex="-1"></a>    <span class="cf">case</span> <span class="st">&quot;pending&quot;</span><span class="op">:</span> <span class="cf">return</span> <span class="dv">0</span><span class="op">;</span></span>
+<span id="cb19-4"><a href="#cb19-4" aria-hidden="true" tabindex="-1"></a>    <span class="cf">case</span> <span class="st">&quot;initializing&quot;</span><span class="op">:</span> <span class="cf">return</span> <span class="dv">5</span><span class="op">;</span></span>
+<span id="cb19-5"><a href="#cb19-5" aria-hidden="true" tabindex="-1"></a>    <span class="cf">case</span> <span class="st">&quot;running&quot;</span><span class="op">:</span></span>
+<span id="cb19-6"><a href="#cb19-6" aria-hidden="true" tabindex="-1"></a>      <span class="co">// Calculate progress within running phase</span></span>
+<span id="cb19-7"><a href="#cb19-7" aria-hidden="true" tabindex="-1"></a>      <span class="kw">const</span> runningProgress <span class="op">=</span> state<span class="op">.</span><span class="at">stepsCompleted</span> <span class="op">/</span> state<span class="op">.</span><span class="at">totalSteps</span><span class="op">;</span></span>
+<span id="cb19-8"><a href="#cb19-8" aria-hidden="true" tabindex="-1"></a>      <span class="cf">return</span> <span class="dv">10</span> <span class="op">+</span> (runningProgress <span class="op">*</span> <span class="dv">80</span>)<span class="op">;</span></span>
+<span id="cb19-9"><a href="#cb19-9" aria-hidden="true" tabindex="-1"></a>    <span class="cf">case</span> <span class="st">&quot;completing&quot;</span><span class="op">:</span> <span class="cf">return</span> <span class="dv">95</span><span class="op">;</span></span>
+<span id="cb19-10"><a href="#cb19-10" aria-hidden="true" tabindex="-1"></a>    <span class="cf">case</span> <span class="st">&quot;completed&quot;</span><span class="op">:</span> <span class="cf">return</span> <span class="dv">100</span><span class="op">;</span></span>
+<span id="cb19-11"><a href="#cb19-11" aria-hidden="true" tabindex="-1"></a>    <span class="cf">default</span><span class="op">:</span> <span class="cf">return</span> <span class="dv">0</span><span class="op">;</span></span>
+<span id="cb19-12"><a href="#cb19-12" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb19-13"><a href="#cb19-13" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
 <h3 id="55-progress-for-non-execute-operations">5.5 Progress for Non-EXECUTE Operations</h3>
 <p>READ, CREATE, UPDATE, and DELETE operations MAY emit progress notifications for long-running operations such as:</p>
 <ul>
@@ -630,7 +673,7 @@ Use introspection to discover all available operations and their parameters.</co
 <hr />
 <h2 id="6-multi-adapter-deployment">6. Multi-Adapter Deployment</h2>
 <h3 id="61-the-collision-problem">6.1 The Collision Problem</h3>
-<p>When multiple MCP-AQL adapters are deployed in a single MCP session, tool names may collide. Two adapters both registering <code>mcp_aql_read</code> creates ambiguity.</p>
+<p>When multiple MCP-AQL adapters are deployed in a single MCP session, tool names may collide. Two adapters both registering <code>mcp_aql_read</code> or <code>mcp_aql_query</code> creates ambiguity.</p>
 <h3 id="62-tool-name-prefixing">6.2 Tool Name Prefixing</h3>
 <p>Implementations SHOULD support a tool name prefix for disambiguation:</p>
 <p><strong>Environment Variable:</strong></p>
@@ -638,6 +681,7 @@ Use introspection to discover all available operations and their parameters.</co
 <p><strong>Result:</strong></p>
 <pre><code>github_mcp_aql_create
 github_mcp_aql_read
+github_mcp_aql_query
 github_mcp_aql_update
 github_mcp_aql_delete
 github_mcp_aql_execute</code></pre>
@@ -672,31 +716,31 @@ github_mcp_aql_execute</code></pre>
 <li>Present operations with adapter context to users</li>
 </ol>
 <p><strong>Example client logic:</strong></p>
-<div class="sourceCode" id="cb19"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb19-1"><a href="#cb19-1" aria-hidden="true" tabindex="-1"></a><span class="kw">function</span> <span class="fu">groupAdapterTools</span>(tools<span class="op">:</span> Tool[])<span class="op">:</span> <span class="bu">Map</span><span class="op">&lt;</span><span class="dt">string</span><span class="op">,</span> Tool[]<span class="op">&gt;</span> {</span>
-<span id="cb19-2"><a href="#cb19-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">const</span> groups <span class="op">=</span> <span class="kw">new</span> <span class="bu">Map</span><span class="op">&lt;</span><span class="dt">string</span><span class="op">,</span> Tool[]<span class="op">&gt;</span>()<span class="op">;</span></span>
-<span id="cb19-3"><a href="#cb19-3" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb19-4"><a href="#cb19-4" aria-hidden="true" tabindex="-1"></a>  <span class="cf">for</span> (<span class="kw">const</span> tool <span class="kw">of</span> tools) {</span>
-<span id="cb19-5"><a href="#cb19-5" aria-hidden="true" tabindex="-1"></a>    <span class="co">// Extract prefix from tool name</span></span>
-<span id="cb19-6"><a href="#cb19-6" aria-hidden="true" tabindex="-1"></a>    <span class="kw">const</span> match <span class="op">=</span> tool<span class="op">.</span><span class="at">name</span><span class="op">.</span><span class="fu">match</span>(<span class="ss">/</span><span class="sc">^(</span><span class="ss">.</span><span class="sc">+</span><span class="ss">_</span><span class="sc">)</span><span class="ss">mcp_aql_</span><span class="sc">(</span><span class="ss">create</span><span class="sc">|</span><span class="ss">read</span><span class="sc">|</span><span class="ss">update</span><span class="sc">|</span><span class="ss">delete</span><span class="sc">|</span><span class="ss">execute</span><span class="sc">)$</span><span class="ss">/</span>)<span class="op">;</span></span>
-<span id="cb19-7"><a href="#cb19-7" aria-hidden="true" tabindex="-1"></a>    <span class="kw">const</span> prefix <span class="op">=</span> match <span class="op">?</span> match[<span class="dv">1</span>] <span class="op">:</span> <span class="st">&quot;&quot;</span><span class="op">;</span></span>
-<span id="cb19-8"><a href="#cb19-8" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb19-9"><a href="#cb19-9" aria-hidden="true" tabindex="-1"></a>    <span class="cf">if</span> (<span class="op">!</span>groups<span class="op">.</span><span class="fu">has</span>(prefix)) {</span>
-<span id="cb19-10"><a href="#cb19-10" aria-hidden="true" tabindex="-1"></a>      groups<span class="op">.</span><span class="fu">set</span>(prefix<span class="op">,</span> [])<span class="op">;</span></span>
-<span id="cb19-11"><a href="#cb19-11" aria-hidden="true" tabindex="-1"></a>    }</span>
-<span id="cb19-12"><a href="#cb19-12" aria-hidden="true" tabindex="-1"></a>    groups<span class="op">.</span><span class="fu">get</span>(prefix)<span class="op">!.</span><span class="fu">push</span>(tool)<span class="op">;</span></span>
-<span id="cb19-13"><a href="#cb19-13" aria-hidden="true" tabindex="-1"></a>  }</span>
-<span id="cb19-14"><a href="#cb19-14" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb19-15"><a href="#cb19-15" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> groups<span class="op">;</span></span>
-<span id="cb19-16"><a href="#cb19-16" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<div class="sourceCode" id="cb22"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb22-1"><a href="#cb22-1" aria-hidden="true" tabindex="-1"></a><span class="kw">function</span> <span class="fu">groupAdapterTools</span>(tools<span class="op">:</span> Tool[])<span class="op">:</span> <span class="bu">Map</span><span class="op">&lt;</span><span class="dt">string</span><span class="op">,</span> Tool[]<span class="op">&gt;</span> {</span>
+<span id="cb22-2"><a href="#cb22-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">const</span> groups <span class="op">=</span> <span class="kw">new</span> <span class="bu">Map</span><span class="op">&lt;</span><span class="dt">string</span><span class="op">,</span> Tool[]<span class="op">&gt;</span>()<span class="op">;</span></span>
+<span id="cb22-3"><a href="#cb22-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb22-4"><a href="#cb22-4" aria-hidden="true" tabindex="-1"></a>  <span class="cf">for</span> (<span class="kw">const</span> tool <span class="kw">of</span> tools) {</span>
+<span id="cb22-5"><a href="#cb22-5" aria-hidden="true" tabindex="-1"></a>    <span class="co">// Extract prefix from tool name</span></span>
+<span id="cb22-6"><a href="#cb22-6" aria-hidden="true" tabindex="-1"></a>    <span class="kw">const</span> match <span class="op">=</span> tool<span class="op">.</span><span class="at">name</span><span class="op">.</span><span class="fu">match</span>(<span class="ss">/</span><span class="sc">^(</span><span class="ss">.</span><span class="sc">+</span><span class="ss">_</span><span class="sc">)?</span><span class="ss">mcp_aql</span><span class="sc">(?</span><span class="ss">:_</span><span class="sc">([a-z0-9_]+))?$</span><span class="ss">/</span>)<span class="op">;</span></span>
+<span id="cb22-7"><a href="#cb22-7" aria-hidden="true" tabindex="-1"></a>    <span class="kw">const</span> prefix <span class="op">=</span> match <span class="op">&amp;&amp;</span> match[<span class="dv">1</span>] <span class="op">?</span> match[<span class="dv">1</span>] <span class="op">:</span> <span class="st">&quot;&quot;</span><span class="op">;</span></span>
+<span id="cb22-8"><a href="#cb22-8" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb22-9"><a href="#cb22-9" aria-hidden="true" tabindex="-1"></a>    <span class="cf">if</span> (<span class="op">!</span>groups<span class="op">.</span><span class="fu">has</span>(prefix)) {</span>
+<span id="cb22-10"><a href="#cb22-10" aria-hidden="true" tabindex="-1"></a>      groups<span class="op">.</span><span class="fu">set</span>(prefix<span class="op">,</span> [])<span class="op">;</span></span>
+<span id="cb22-11"><a href="#cb22-11" aria-hidden="true" tabindex="-1"></a>    }</span>
+<span id="cb22-12"><a href="#cb22-12" aria-hidden="true" tabindex="-1"></a>    groups<span class="op">.</span><span class="fu">get</span>(prefix)<span class="op">!.</span><span class="fu">push</span>(tool)<span class="op">;</span></span>
+<span id="cb22-13"><a href="#cb22-13" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb22-14"><a href="#cb22-14" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb22-15"><a href="#cb22-15" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> groups<span class="op">;</span></span>
+<span id="cb22-16"><a href="#cb22-16" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
 <h3 id="66-introspection-disambiguation">6.6 Introspection Disambiguation</h3>
 <p>Each adapter's introspection returns only its own operations. Clients discover the full operation space by querying each adapter:</p>
-<div class="sourceCode" id="cb20"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb20-1"><a href="#cb20-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Query GitHub adapter</span></span>
-<span id="cb20-2"><a href="#cb20-2" aria-hidden="true" tabindex="-1"></a>{ <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;introspect&quot;</span><span class="op">,</span> <span class="dt">params</span><span class="op">:</span> { <span class="dt">query</span><span class="op">:</span> <span class="st">&quot;operations&quot;</span> } }</span>
-<span id="cb20-3"><a href="#cb20-3" aria-hidden="true" tabindex="-1"></a><span class="co">// Returns: list_repos, get_repo, create_issue, etc.</span></span>
-<span id="cb20-4"><a href="#cb20-4" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb20-5"><a href="#cb20-5" aria-hidden="true" tabindex="-1"></a><span class="co">// Query Jira adapter</span></span>
-<span id="cb20-6"><a href="#cb20-6" aria-hidden="true" tabindex="-1"></a>{ <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;introspect&quot;</span><span class="op">,</span> <span class="dt">params</span><span class="op">:</span> { <span class="dt">query</span><span class="op">:</span> <span class="st">&quot;operations&quot;</span> } }</span>
-<span id="cb20-7"><a href="#cb20-7" aria-hidden="true" tabindex="-1"></a><span class="co">// Returns: list_projects, get_issue, create_ticket, etc.</span></span></code></pre></div>
+<div class="sourceCode" id="cb23"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb23-1"><a href="#cb23-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Query GitHub adapter</span></span>
+<span id="cb23-2"><a href="#cb23-2" aria-hidden="true" tabindex="-1"></a>{ <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;introspect&quot;</span><span class="op">,</span> <span class="dt">params</span><span class="op">:</span> { <span class="dt">query</span><span class="op">:</span> <span class="st">&quot;operations&quot;</span> } }</span>
+<span id="cb23-3"><a href="#cb23-3" aria-hidden="true" tabindex="-1"></a><span class="co">// Returns: list_repos, get_repo, create_issue, etc.</span></span>
+<span id="cb23-4"><a href="#cb23-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb23-5"><a href="#cb23-5" aria-hidden="true" tabindex="-1"></a><span class="co">// Query Jira adapter</span></span>
+<span id="cb23-6"><a href="#cb23-6" aria-hidden="true" tabindex="-1"></a>{ <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;introspect&quot;</span><span class="op">,</span> <span class="dt">params</span><span class="op">:</span> { <span class="dt">query</span><span class="op">:</span> <span class="st">&quot;operations&quot;</span> } }</span>
+<span id="cb23-7"><a href="#cb23-7" aria-hidden="true" tabindex="-1"></a><span class="co">// Returns: list_projects, get_issue, create_ticket, etc.</span></span></code></pre></div>
 <hr />
 <h2 id="7-conformance-requirements">7. Conformance Requirements</h2>
 <h3 id="71-must-requirements">7.1 MUST Requirements</h3>
@@ -711,7 +755,7 @@ github_mcp_aql_execute</code></pre>
 <h3 id="72-should-requirements">7.2 SHOULD Requirements</h3>
 <p>Conforming implementations SHOULD:</p>
 <ol type="1">
-<li>Use the standard tool names (<code>mcp_aql_create</code>, etc.)</li>
+<li>Use the standard tool names (<code>mcp_aql_create</code>, etc.) when exposing the CRUDE profile</li>
 <li>Include MCP tool annotations for permission hints</li>
 <li>Support the <code>MCP_AQL_TOOL_PREFIX</code> environment variable</li>
 <li>Emit progress notifications for long-running EXECUTE operations</li>

--- a/public/spec/operations.html
+++ b/public/spec/operations.html
@@ -50,10 +50,10 @@
   <ul><li><a href="security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Features</h3>
-  <ul><li><a href="features/collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="features/field-selection.html">Field Selection Specification</a></li><li><a href="features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="features/warnings.html">Warnings Array Specification</a></li></ul>
+  <ul><li><a href="features/aggregations.html">MCP-AQL Aggregations</a></li><li><a href="features/collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="features/computed-fields.html">MCP-AQL Computed Fields</a></li><li><a href="features/field-selection.html">Field Selection Specification</a></li><li><a href="features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="features/relationship-queries.html">MCP-AQL Relationship Queries</a></li><li><a href="features/warnings.html">Warnings Array Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Guides</h3>
-  <ul><li><a href="guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="guides/README.html">Developer Guides</a></li></ul>
+  <ul><li><a href="guides/cross-domain-implementation.html">Cross-Domain Implementation Guide</a></li><li><a href="guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
   <ul><li><a href="process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="process/versioning.html">Versioning Strategy</a></li><li><a href="repo/CHANGELOG.html">Changelog</a></li></ul>
@@ -101,7 +101,7 @@
               <p class="page-toc-intro">Use the outline to move through longer pages without losing your place.</p>
             </div>
             <ol class="page-toc-list" data-page-toc-list>
-              <li class="page-toc-item level-2"><a href="#abstract" data-toc-target="abstract">Abstract</a></li><li class="page-toc-item level-2"><a href="#1-conformance-requirements" data-toc-target="1-conformance-requirements">1. Conformance Requirements</a></li><li class="page-toc-item level-2"><a href="#2-operation-input-format" data-toc-target="2-operation-input-format">2. Operation Input Format</a></li><li class="page-toc-item level-2"><a href="#3-response-format" data-toc-target="3-response-format">3. Response Format</a></li><li class="page-toc-item level-2"><a href="#4-parameter-conventions" data-toc-target="4-parameter-conventions">4. Parameter Conventions</a></li><li class="page-toc-item level-2"><a href="#5-operation-schema-definition" data-toc-target="5-operation-schema-definition">5. Operation Schema Definition</a></li><li class="page-toc-item level-2"><a href="#6-crude-endpoint-assignment" data-toc-target="6-crude-endpoint-assignment">6. CRUDE Endpoint Assignment</a></li><li class="page-toc-item level-2"><a href="#7-batch-operations" data-toc-target="7-batch-operations">7. Batch Operations</a></li><li class="page-toc-item level-2"><a href="#8-error-handling" data-toc-target="8-error-handling">8. Error Handling</a></li><li class="page-toc-item level-2"><a href="#9-the-introspect-operation" data-toc-target="9-the-introspect-operation">9. The introspect Operation</a></li><li class="page-toc-item level-2"><a href="#references" data-toc-target="references">References</a></li>
+              <li class="page-toc-item level-2"><a href="#abstract" data-toc-target="abstract">Abstract</a></li><li class="page-toc-item level-2"><a href="#1-conformance-requirements" data-toc-target="1-conformance-requirements">1. Conformance Requirements</a></li><li class="page-toc-item level-2"><a href="#2-operation-input-format" data-toc-target="2-operation-input-format">2. Operation Input Format</a></li><li class="page-toc-item level-2"><a href="#3-response-format" data-toc-target="3-response-format">3. Response Format</a></li><li class="page-toc-item level-2"><a href="#4-parameter-conventions" data-toc-target="4-parameter-conventions">4. Parameter Conventions</a></li><li class="page-toc-item level-2"><a href="#5-operation-schema-definition" data-toc-target="5-operation-schema-definition">5. Operation Schema Definition</a></li><li class="page-toc-item level-2"><a href="#6-semantic-endpoint-assignment" data-toc-target="6-semantic-endpoint-assignment">6. Semantic Endpoint Assignment</a></li><li class="page-toc-item level-2"><a href="#7-batch-operations" data-toc-target="7-batch-operations">7. Batch Operations</a></li><li class="page-toc-item level-2"><a href="#8-error-handling" data-toc-target="8-error-handling">8. Error Handling</a></li><li class="page-toc-item level-2"><a href="#9-the-introspect-operation" data-toc-target="9-the-introspect-operation">9. The introspect Operation</a></li><li class="page-toc-item level-2"><a href="#references" data-toc-target="references">References</a></li>
             </ol>
           </div>
         </section>
@@ -138,7 +138,7 @@
 <h3 id="22-required-fields">2.2 Required Fields</h3>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Field</th>
 <th>Type</th>
 <th>Required</th>
@@ -146,13 +146,13 @@
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><code>operation</code></td>
 <td>string</td>
 <td>REQUIRED</td>
 <td>The operation to perform</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>params</code></td>
 <td>object</td>
 <td>OPTIONAL</td>
@@ -297,15 +297,22 @@
 <div class="sourceCode" id="cb13"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb13-1"><a href="#cb13-1" aria-hidden="true" tabindex="-1"></a>{</span>
 <span id="cb13-2"><a href="#cb13-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">fields</span><span class="op">:</span> <span class="st">&quot;minimal&quot;</span>  <span class="co">// Or [&quot;id&quot;, &quot;name&quot;, &quot;email&quot;]</span></span>
 <span id="cb13-3"><a href="#cb13-3" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<p><strong>Aggregations:</strong></p>
+<div class="sourceCode" id="cb14"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb14-1"><a href="#cb14-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb14-2"><a href="#cb14-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">aggregate</span><span class="op">:</span> {</span>
+<span id="cb14-3"><a href="#cb14-3" aria-hidden="true" tabindex="-1"></a>    <span class="dt">total</span><span class="op">:</span> { <span class="dt">count</span><span class="op">:</span> <span class="kw">true</span> }<span class="op">,</span></span>
+<span id="cb14-4"><a href="#cb14-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">by_status</span><span class="op">:</span> { <span class="dt">group_by</span><span class="op">:</span> <span class="st">&quot;status&quot;</span><span class="op">,</span> <span class="dt">count</span><span class="op">:</span> <span class="kw">true</span> }</span>
+<span id="cb14-5"><a href="#cb14-5" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb14-6"><a href="#cb14-6" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
 <h3 id="43-required-vs-optional-parameters">4.3 Required vs Optional Parameters</h3>
 <p>Each parameter MUST be documented as either required or optional. The operation schema (Section 5) specifies this via the <code>required</code> attribute.</p>
 <h3 id="44-cross-cutting-parameters">4.4 Cross-Cutting Parameters</h3>
 <p>Cross-cutting parameters are parameters that apply across multiple operations. To ensure consistent discoverability, implementations SHOULD define these parameters once and reference them consistently.</p>
-<p>For the preferred collection-query contract that combines text search, filters, sorting, pagination, and field selection, see <a href="features/collection-querying.html">Collection Querying</a>.</p>
+<p>For the preferred collection-query contract that combines text search, filters, sorting, pagination, and field selection, see <a href="features/collection-querying.html">Collection Querying</a>. For summary-oriented server-side aggregation, see <a href="features/aggregations.html">Aggregations</a>. For adapter-declared derived values, see <a href="features/computed-fields.html">Computed Fields</a>. For graph traversal and relationship exploration, see <a href="features/relationship-queries.html">Relationship Queries</a>.</p>
 <h4 id="441-standard-cross-cutting-parameters">4.4.1 Standard Cross-Cutting Parameters</h4>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Parameter</th>
 <th>Type</th>
 <th>Operations</th>
@@ -313,43 +320,49 @@
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><code>fields</code></td>
 <td><code>string | string[]</code></td>
 <td>All READ operations returning data</td>
 <td>Field selection: preset name or array of field paths</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>query</code></td>
 <td><code>string | object</code></td>
 <td><code>search_*</code> and <code>query_*</code> collection operations</td>
 <td>Free-text search input or documented structured query object</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>filter</code></td>
 <td><code>object</code></td>
 <td>List/search/query operations</td>
 <td>Structured filtering criteria</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>sort</code></td>
 <td><code>object</code></td>
 <td>List/search/query operations</td>
 <td>Sort object with <code>field</code> and <code>order</code></td>
 </tr>
-<tr>
+<tr class="odd">
+<td><code>aggregate</code></td>
+<td><code>object</code></td>
+<td>Collection READ operations with aggregation support</td>
+<td>Named server-side summary expressions such as <code>count</code>, <code>group_by</code>, <code>sum</code>, <code>avg</code>, <code>min</code>, and <code>max</code></td>
+</tr>
+<tr class="even">
 <td><code>first</code>, <code>after</code>, <code>last</code>, <code>before</code></td>
 <td><code>number</code> / <code>string</code></td>
 <td>Cursor-paginated collection operations</td>
 <td>Cursor-based pagination parameters</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>limit</code>, <code>offset</code>, <code>page</code>, <code>page_size</code></td>
 <td><code>number</code></td>
 <td>Collection operations with adapter-specific pagination</td>
 <td>Offset or page-based compatibility parameters when documented</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>dry_run</code></td>
 <td><code>boolean</code></td>
 <td>All mutating operations</td>
@@ -359,89 +372,71 @@
 </table>
 <h4 id="442-shared-parameter-definitions">4.4.2 Shared Parameter Definitions</h4>
 <p>Implementations SHOULD use a shared definition mechanism to ensure consistency:</p>
-<div class="sourceCode" id="cb14"><pre class="sourceCode yaml"><code class="sourceCode yaml"><span id="cb14-1"><a href="#cb14-1" aria-hidden="true" tabindex="-1"></a><span class="fu">shared_parameters</span><span class="kw">:</span></span>
-<span id="cb14-2"><a href="#cb14-2" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">fields</span><span class="kw">:</span></span>
-<span id="cb14-3"><a href="#cb14-3" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">name</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;fields&quot;</span></span>
-<span id="cb14-4"><a href="#cb14-4" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">type</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;string | string[]&quot;</span></span>
-<span id="cb14-5"><a href="#cb14-5" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">required</span><span class="kw">:</span><span class="at"> </span><span class="ch">false</span></span>
-<span id="cb14-6"><a href="#cb14-6" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">description</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;Field selection: preset (&#39;minimal&#39;, &#39;standard&#39;, &#39;full&#39;) or array of field paths&quot;</span></span>
-<span id="cb14-7"><a href="#cb14-7" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb14-8"><a href="#cb14-8" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">filter</span><span class="kw">:</span></span>
-<span id="cb14-9"><a href="#cb14-9" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">name</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;filter&quot;</span></span>
-<span id="cb14-10"><a href="#cb14-10" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">type</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;object&quot;</span></span>
-<span id="cb14-11"><a href="#cb14-11" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">required</span><span class="kw">:</span><span class="at"> </span><span class="ch">false</span></span>
-<span id="cb14-12"><a href="#cb14-12" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">description</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;Structured filtering criteria&quot;</span></span>
-<span id="cb14-13"><a href="#cb14-13" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb14-14"><a href="#cb14-14" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">sorting</span><span class="kw">:</span></span>
-<span id="cb14-15"><a href="#cb14-15" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">name</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;sort&quot;</span></span>
-<span id="cb14-16"><a href="#cb14-16" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">type</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;object&quot;</span></span>
-<span id="cb14-17"><a href="#cb14-17" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">required</span><span class="kw">:</span><span class="at"> </span><span class="ch">false</span></span>
-<span id="cb14-18"><a href="#cb14-18" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">description</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;Sort object with &#39;field&#39; and &#39;order&#39;&quot;</span></span>
-<span id="cb14-19"><a href="#cb14-19" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb14-20"><a href="#cb14-20" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">cursor_pagination</span><span class="kw">:</span></span>
-<span id="cb14-21"><a href="#cb14-21" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="kw">-</span><span class="at"> </span><span class="fu">name</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;first&quot;</span></span>
-<span id="cb14-22"><a href="#cb14-22" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">type</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;number&quot;</span></span>
-<span id="cb14-23"><a href="#cb14-23" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">required</span><span class="kw">:</span><span class="at"> </span><span class="ch">false</span></span>
-<span id="cb14-24"><a href="#cb14-24" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">description</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;Maximum results to return from the start&quot;</span></span>
-<span id="cb14-25"><a href="#cb14-25" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">default</span><span class="kw">:</span><span class="at"> </span><span class="dv">25</span></span>
-<span id="cb14-26"><a href="#cb14-26" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="kw">-</span><span class="at"> </span><span class="fu">name</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;after&quot;</span></span>
-<span id="cb14-27"><a href="#cb14-27" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">type</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;string&quot;</span></span>
-<span id="cb14-28"><a href="#cb14-28" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">required</span><span class="kw">:</span><span class="at"> </span><span class="ch">false</span></span>
-<span id="cb14-29"><a href="#cb14-29" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">description</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;Opaque cursor to continue after&quot;</span></span>
-<span id="cb14-30"><a href="#cb14-30" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="kw">-</span><span class="at"> </span><span class="fu">name</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;last&quot;</span></span>
-<span id="cb14-31"><a href="#cb14-31" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">type</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;number&quot;</span></span>
-<span id="cb14-32"><a href="#cb14-32" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">required</span><span class="kw">:</span><span class="at"> </span><span class="ch">false</span></span>
-<span id="cb14-33"><a href="#cb14-33" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">description</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;Maximum results to return from the end&quot;</span></span>
-<span id="cb14-34"><a href="#cb14-34" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="kw">-</span><span class="at"> </span><span class="fu">name</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;before&quot;</span></span>
-<span id="cb14-35"><a href="#cb14-35" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">type</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;string&quot;</span></span>
-<span id="cb14-36"><a href="#cb14-36" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">required</span><span class="kw">:</span><span class="at"> </span><span class="ch">false</span></span>
-<span id="cb14-37"><a href="#cb14-37" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">description</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;Opaque cursor to continue before&quot;</span></span>
-<span id="cb14-38"><a href="#cb14-38" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb14-39"><a href="#cb14-39" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">offset_pagination</span><span class="kw">:</span></span>
-<span id="cb14-40"><a href="#cb14-40" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="kw">-</span><span class="at"> </span><span class="fu">name</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;limit&quot;</span></span>
-<span id="cb14-41"><a href="#cb14-41" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">type</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;number&quot;</span></span>
-<span id="cb14-42"><a href="#cb14-42" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">required</span><span class="kw">:</span><span class="at"> </span><span class="ch">false</span></span>
-<span id="cb14-43"><a href="#cb14-43" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">description</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;Maximum results to return&quot;</span></span>
-<span id="cb14-44"><a href="#cb14-44" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">default</span><span class="kw">:</span><span class="at"> </span><span class="dv">25</span></span>
-<span id="cb14-45"><a href="#cb14-45" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="kw">-</span><span class="at"> </span><span class="fu">name</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;offset&quot;</span></span>
-<span id="cb14-46"><a href="#cb14-46" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">type</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;number&quot;</span></span>
-<span id="cb14-47"><a href="#cb14-47" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">required</span><span class="kw">:</span><span class="at"> </span><span class="ch">false</span></span>
-<span id="cb14-48"><a href="#cb14-48" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">description</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;Number of results to skip&quot;</span></span>
-<span id="cb14-49"><a href="#cb14-49" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">default</span><span class="kw">:</span><span class="at"> </span><span class="dv">0</span></span>
-<span id="cb14-50"><a href="#cb14-50" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb14-51"><a href="#cb14-51" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">page_pagination</span><span class="kw">:</span></span>
-<span id="cb14-52"><a href="#cb14-52" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="kw">-</span><span class="at"> </span><span class="fu">name</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;page&quot;</span></span>
-<span id="cb14-53"><a href="#cb14-53" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">type</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;number&quot;</span></span>
-<span id="cb14-54"><a href="#cb14-54" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">required</span><span class="kw">:</span><span class="at"> </span><span class="ch">false</span></span>
-<span id="cb14-55"><a href="#cb14-55" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">description</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;Page number (1-indexed)&quot;</span></span>
-<span id="cb14-56"><a href="#cb14-56" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">default</span><span class="kw">:</span><span class="at"> </span><span class="dv">1</span></span>
-<span id="cb14-57"><a href="#cb14-57" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="kw">-</span><span class="at"> </span><span class="fu">name</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;page_size&quot;</span></span>
-<span id="cb14-58"><a href="#cb14-58" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">type</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;number&quot;</span></span>
-<span id="cb14-59"><a href="#cb14-59" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">required</span><span class="kw">:</span><span class="at"> </span><span class="ch">false</span></span>
-<span id="cb14-60"><a href="#cb14-60" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">description</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;Items per page&quot;</span></span>
-<span id="cb14-61"><a href="#cb14-61" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">default</span><span class="kw">:</span><span class="at"> </span><span class="dv">25</span></span></code></pre></div>
+<div class="sourceCode" id="cb15"><pre class="sourceCode yaml"><code class="sourceCode yaml"><span id="cb15-1"><a href="#cb15-1" aria-hidden="true" tabindex="-1"></a><span class="fu">shared_parameters</span><span class="kw">:</span></span>
+<span id="cb15-2"><a href="#cb15-2" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">fields</span><span class="kw">:</span></span>
+<span id="cb15-3"><a href="#cb15-3" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">name</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;fields&quot;</span></span>
+<span id="cb15-4"><a href="#cb15-4" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">type</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;string | string[]&quot;</span></span>
+<span id="cb15-5"><a href="#cb15-5" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">required</span><span class="kw">:</span><span class="at"> </span><span class="ch">false</span></span>
+<span id="cb15-6"><a href="#cb15-6" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">description</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;Field selection: preset (&#39;minimal&#39;, &#39;standard&#39;, &#39;full&#39;) or array of field paths&quot;</span></span>
+<span id="cb15-7"><a href="#cb15-7" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb15-8"><a href="#cb15-8" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">filter</span><span class="kw">:</span></span>
+<span id="cb15-9"><a href="#cb15-9" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">name</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;filter&quot;</span></span>
+<span id="cb15-10"><a href="#cb15-10" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">type</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;object&quot;</span></span>
+<span id="cb15-11"><a href="#cb15-11" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">required</span><span class="kw">:</span><span class="at"> </span><span class="ch">false</span></span>
+<span id="cb15-12"><a href="#cb15-12" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">description</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;Structured filtering criteria&quot;</span></span>
+<span id="cb15-13"><a href="#cb15-13" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb15-14"><a href="#cb15-14" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">sorting</span><span class="kw">:</span></span>
+<span id="cb15-15"><a href="#cb15-15" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">name</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;sort&quot;</span></span>
+<span id="cb15-16"><a href="#cb15-16" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">type</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;object&quot;</span></span>
+<span id="cb15-17"><a href="#cb15-17" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">required</span><span class="kw">:</span><span class="at"> </span><span class="ch">false</span></span>
+<span id="cb15-18"><a href="#cb15-18" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">description</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;Sort object with &#39;field&#39; and &#39;order&#39;&quot;</span></span>
+<span id="cb15-19"><a href="#cb15-19" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb15-20"><a href="#cb15-20" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">cursor_pagination</span><span class="kw">:</span></span>
+<span id="cb15-21"><a href="#cb15-21" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="kw">-</span><span class="at"> </span><span class="fu">name</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;first&quot;</span></span>
+<span id="cb15-22"><a href="#cb15-22" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">type</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;number&quot;</span></span>
+<span id="cb15-23"><a href="#cb15-23" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">required</span><span class="kw">:</span><span class="at"> </span><span class="ch">false</span></span>
+<span id="cb15-24"><a href="#cb15-24" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">description</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;Maximum results to return from the start&quot;</span></span>
+<span id="cb15-25"><a href="#cb15-25" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">default</span><span class="kw">:</span><span class="at"> </span><span class="dv">25</span></span>
+<span id="cb15-26"><a href="#cb15-26" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="kw">-</span><span class="at"> </span><span class="fu">name</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;after&quot;</span></span>
+<span id="cb15-27"><a href="#cb15-27" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">type</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;string&quot;</span></span>
+<span id="cb15-28"><a href="#cb15-28" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">required</span><span class="kw">:</span><span class="at"> </span><span class="ch">false</span></span>
+<span id="cb15-29"><a href="#cb15-29" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">description</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;Opaque cursor to continue after&quot;</span></span>
+<span id="cb15-30"><a href="#cb15-30" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="kw">-</span><span class="at"> </span><span class="fu">name</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;last&quot;</span></span>
+<span id="cb15-31"><a href="#cb15-31" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">type</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;number&quot;</span></span>
+<span id="cb15-32"><a href="#cb15-32" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">required</span><span class="kw">:</span><span class="at"> </span><span class="ch">false</span></span>
+<span id="cb15-33"><a href="#cb15-33" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">description</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;Maximum results to return from the end&quot;</span></span>
+<span id="cb15-34"><a href="#cb15-34" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="kw">-</span><span class="at"> </span><span class="fu">name</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;before&quot;</span></span>
+<span id="cb15-35"><a href="#cb15-35" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">type</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;string&quot;</span></span>
+<span id="cb15-36"><a href="#cb15-36" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">required</span><span class="kw">:</span><span class="at"> </span><span class="ch">false</span></span>
+<span id="cb15-37"><a href="#cb15-37" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">description</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;Opaque cursor to continue before&quot;</span></span>
+<span id="cb15-38"><a href="#cb15-38" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb15-39"><a href="#cb15-39" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">offset_pagination</span><span class="kw">:</span></span>
+<span id="cb15-40"><a href="#cb15-40" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="kw">-</span><span class="at"> </span><span class="fu">name</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;limit&quot;</span></span>
+<span id="cb15-41"><a href="#cb15-41" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">type</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;number&quot;</span></span>
+<span id="cb15-42"><a href="#cb15-42" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">required</span><span class="kw">:</span><span class="at"> </span><span class="ch">false</span></span>
+<span id="cb15-43"><a href="#cb15-43" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">description</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;Maximum results to return&quot;</span></span>
+<span id="cb15-44"><a href="#cb15-44" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">default</span><span class="kw">:</span><span class="at"> </span><span class="dv">25</span></span>
+<span id="cb15-45"><a href="#cb15-45" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="kw">-</span><span class="at"> </span><span class="fu">name</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;offset&quot;</span></span>
+<span id="cb15-46"><a href="#cb15-46" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">type</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;number&quot;</span></span>
+<span id="cb15-47"><a href="#cb15-47" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">required</span><span class="kw">:</span><span class="at"> </span><span class="ch">false</span></span>
+<span id="cb15-48"><a href="#cb15-48" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">description</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;Number of results to skip&quot;</span></span>
+<span id="cb15-49"><a href="#cb15-49" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">default</span><span class="kw">:</span><span class="at"> </span><span class="dv">0</span></span>
+<span id="cb15-50"><a href="#cb15-50" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb15-51"><a href="#cb15-51" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">page_pagination</span><span class="kw">:</span></span>
+<span id="cb15-52"><a href="#cb15-52" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="kw">-</span><span class="at"> </span><span class="fu">name</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;page&quot;</span></span>
+<span id="cb15-53"><a href="#cb15-53" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">type</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;number&quot;</span></span>
+<span id="cb15-54"><a href="#cb15-54" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">required</span><span class="kw">:</span><span class="at"> </span><span class="ch">false</span></span>
+<span id="cb15-55"><a href="#cb15-55" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">description</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;Page number (1-indexed)&quot;</span></span>
+<span id="cb15-56"><a href="#cb15-56" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">default</span><span class="kw">:</span><span class="at"> </span><span class="dv">1</span></span>
+<span id="cb15-57"><a href="#cb15-57" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="kw">-</span><span class="at"> </span><span class="fu">name</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;page_size&quot;</span></span>
+<span id="cb15-58"><a href="#cb15-58" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">type</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;number&quot;</span></span>
+<span id="cb15-59"><a href="#cb15-59" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">required</span><span class="kw">:</span><span class="at"> </span><span class="ch">false</span></span>
+<span id="cb15-60"><a href="#cb15-60" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">description</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;Items per page&quot;</span></span>
+<span id="cb15-61"><a href="#cb15-61" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">default</span><span class="kw">:</span><span class="at"> </span><span class="dv">25</span></span></code></pre></div>
 <p>These <code>shared_parameters</code> keys are illustrative rather than normative. Adapters that already expose <code>$ref</code> paths such as <code>#/shared_parameters/pagination</code> or legacy <code>sort</code>/<code>order</code> groups SHOULD preserve those existing references, or provide documented aliases, instead of renaming them silently.</p>
 <h4 id="443-pagination-response-structure">4.4.3 Pagination Response Structure</h4>
 <p>Operations returning paginated collections SHOULD include explicit pagination metadata in the response so clients can continue the query without reverse-engineering adapter-specific fields.</p>
 <p><strong>Preferred cursor-based response:</strong></p>
-<div class="sourceCode" id="cb15"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb15-1"><a href="#cb15-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
-<span id="cb15-2"><a href="#cb15-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
-<span id="cb15-3"><a href="#cb15-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;data&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb15-4"><a href="#cb15-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;items&quot;</span><span class="fu">:</span> <span class="ot">[</span></span>
-<span id="cb15-5"><a href="#cb15-5" aria-hidden="true" tabindex="-1"></a>      <span class="fu">{</span> <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;alice&quot;</span><span class="fu">,</span> <span class="dt">&quot;status&quot;</span><span class="fu">:</span> <span class="st">&quot;active&quot;</span> <span class="fu">}</span><span class="ot">,</span></span>
-<span id="cb15-6"><a href="#cb15-6" aria-hidden="true" tabindex="-1"></a>      <span class="fu">{</span> <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;bob&quot;</span><span class="fu">,</span> <span class="dt">&quot;status&quot;</span><span class="fu">:</span> <span class="st">&quot;active&quot;</span> <span class="fu">}</span></span>
-<span id="cb15-7"><a href="#cb15-7" aria-hidden="true" tabindex="-1"></a>    <span class="ot">]</span><span class="fu">,</span></span>
-<span id="cb15-8"><a href="#cb15-8" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;pageInfo&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb15-9"><a href="#cb15-9" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;hasNextPage&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
-<span id="cb15-10"><a href="#cb15-10" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;hasPreviousPage&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
-<span id="cb15-11"><a href="#cb15-11" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;startCursor&quot;</span><span class="fu">:</span> <span class="st">&quot;cursor_001&quot;</span><span class="fu">,</span></span>
-<span id="cb15-12"><a href="#cb15-12" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;endCursor&quot;</span><span class="fu">:</span> <span class="st">&quot;cursor_002&quot;</span><span class="fu">,</span></span>
-<span id="cb15-13"><a href="#cb15-13" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;totalCount&quot;</span><span class="fu">:</span> <span class="dv">142</span></span>
-<span id="cb15-14"><a href="#cb15-14" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
-<span id="cb15-15"><a href="#cb15-15" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
-<span id="cb15-16"><a href="#cb15-16" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
-<p>Cursor-paginated MCP-AQL-native operations SHOULD use the <code>pageInfo</code> connection-style metadata described in <a href="features/pagination.html">Pagination</a>.</p>
-<p><strong>Page-based compatibility response:</strong></p>
 <div class="sourceCode" id="cb16"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb16-1"><a href="#cb16-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
 <span id="cb16-2"><a href="#cb16-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
 <span id="cb16-3"><a href="#cb16-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;data&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
@@ -449,16 +444,17 @@
 <span id="cb16-5"><a href="#cb16-5" aria-hidden="true" tabindex="-1"></a>      <span class="fu">{</span> <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;alice&quot;</span><span class="fu">,</span> <span class="dt">&quot;status&quot;</span><span class="fu">:</span> <span class="st">&quot;active&quot;</span> <span class="fu">}</span><span class="ot">,</span></span>
 <span id="cb16-6"><a href="#cb16-6" aria-hidden="true" tabindex="-1"></a>      <span class="fu">{</span> <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;bob&quot;</span><span class="fu">,</span> <span class="dt">&quot;status&quot;</span><span class="fu">:</span> <span class="st">&quot;active&quot;</span> <span class="fu">}</span></span>
 <span id="cb16-7"><a href="#cb16-7" aria-hidden="true" tabindex="-1"></a>    <span class="ot">]</span><span class="fu">,</span></span>
-<span id="cb16-8"><a href="#cb16-8" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;pagination&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb16-9"><a href="#cb16-9" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;page&quot;</span><span class="fu">:</span> <span class="dv">2</span><span class="fu">,</span></span>
-<span id="cb16-10"><a href="#cb16-10" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;page_size&quot;</span><span class="fu">:</span> <span class="dv">25</span><span class="fu">,</span></span>
-<span id="cb16-11"><a href="#cb16-11" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;total_items&quot;</span><span class="fu">:</span> <span class="dv">142</span><span class="fu">,</span></span>
-<span id="cb16-12"><a href="#cb16-12" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;total_pages&quot;</span><span class="fu">:</span> <span class="dv">6</span><span class="fu">,</span></span>
-<span id="cb16-13"><a href="#cb16-13" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;has_more&quot;</span><span class="fu">:</span> <span class="kw">true</span></span>
+<span id="cb16-8"><a href="#cb16-8" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;pageInfo&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb16-9"><a href="#cb16-9" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;hasNextPage&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb16-10"><a href="#cb16-10" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;hasPreviousPage&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb16-11"><a href="#cb16-11" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;startCursor&quot;</span><span class="fu">:</span> <span class="st">&quot;cursor_001&quot;</span><span class="fu">,</span></span>
+<span id="cb16-12"><a href="#cb16-12" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;endCursor&quot;</span><span class="fu">:</span> <span class="st">&quot;cursor_002&quot;</span><span class="fu">,</span></span>
+<span id="cb16-13"><a href="#cb16-13" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;totalCount&quot;</span><span class="fu">:</span> <span class="dv">142</span></span>
 <span id="cb16-14"><a href="#cb16-14" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
 <span id="cb16-15"><a href="#cb16-15" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
 <span id="cb16-16"><a href="#cb16-16" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
-<p><strong>Offset-based compatibility response:</strong></p>
+<p>Cursor-paginated MCP-AQL-native operations SHOULD use the <code>pageInfo</code> connection-style metadata described in <a href="features/pagination.html">Pagination</a>.</p>
+<p><strong>Page-based compatibility response:</strong></p>
 <div class="sourceCode" id="cb17"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb17-1"><a href="#cb17-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
 <span id="cb17-2"><a href="#cb17-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
 <span id="cb17-3"><a href="#cb17-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;data&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
@@ -467,35 +463,52 @@
 <span id="cb17-6"><a href="#cb17-6" aria-hidden="true" tabindex="-1"></a>      <span class="fu">{</span> <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;bob&quot;</span><span class="fu">,</span> <span class="dt">&quot;status&quot;</span><span class="fu">:</span> <span class="st">&quot;active&quot;</span> <span class="fu">}</span></span>
 <span id="cb17-7"><a href="#cb17-7" aria-hidden="true" tabindex="-1"></a>    <span class="ot">]</span><span class="fu">,</span></span>
 <span id="cb17-8"><a href="#cb17-8" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;pagination&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb17-9"><a href="#cb17-9" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;limit&quot;</span><span class="fu">:</span> <span class="dv">25</span><span class="fu">,</span></span>
-<span id="cb17-10"><a href="#cb17-10" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;offset&quot;</span><span class="fu">:</span> <span class="dv">50</span><span class="fu">,</span></span>
-<span id="cb17-11"><a href="#cb17-11" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;returned&quot;</span><span class="fu">:</span> <span class="dv">25</span><span class="fu">,</span></span>
-<span id="cb17-12"><a href="#cb17-12" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;total_items&quot;</span><span class="fu">:</span> <span class="dv">142</span><span class="fu">,</span></span>
+<span id="cb17-9"><a href="#cb17-9" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;page&quot;</span><span class="fu">:</span> <span class="dv">2</span><span class="fu">,</span></span>
+<span id="cb17-10"><a href="#cb17-10" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;page_size&quot;</span><span class="fu">:</span> <span class="dv">25</span><span class="fu">,</span></span>
+<span id="cb17-11"><a href="#cb17-11" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;total_items&quot;</span><span class="fu">:</span> <span class="dv">142</span><span class="fu">,</span></span>
+<span id="cb17-12"><a href="#cb17-12" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;total_pages&quot;</span><span class="fu">:</span> <span class="dv">6</span><span class="fu">,</span></span>
 <span id="cb17-13"><a href="#cb17-13" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;has_more&quot;</span><span class="fu">:</span> <span class="kw">true</span></span>
 <span id="cb17-14"><a href="#cb17-14" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
 <span id="cb17-15"><a href="#cb17-15" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
 <span id="cb17-16"><a href="#cb17-16" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<p><strong>Offset-based compatibility response:</strong></p>
+<div class="sourceCode" id="cb18"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb18-1"><a href="#cb18-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb18-2"><a href="#cb18-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb18-3"><a href="#cb18-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;data&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb18-4"><a href="#cb18-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;items&quot;</span><span class="fu">:</span> <span class="ot">[</span></span>
+<span id="cb18-5"><a href="#cb18-5" aria-hidden="true" tabindex="-1"></a>      <span class="fu">{</span> <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;alice&quot;</span><span class="fu">,</span> <span class="dt">&quot;status&quot;</span><span class="fu">:</span> <span class="st">&quot;active&quot;</span> <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb18-6"><a href="#cb18-6" aria-hidden="true" tabindex="-1"></a>      <span class="fu">{</span> <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;bob&quot;</span><span class="fu">,</span> <span class="dt">&quot;status&quot;</span><span class="fu">:</span> <span class="st">&quot;active&quot;</span> <span class="fu">}</span></span>
+<span id="cb18-7"><a href="#cb18-7" aria-hidden="true" tabindex="-1"></a>    <span class="ot">]</span><span class="fu">,</span></span>
+<span id="cb18-8"><a href="#cb18-8" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;pagination&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb18-9"><a href="#cb18-9" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;limit&quot;</span><span class="fu">:</span> <span class="dv">25</span><span class="fu">,</span></span>
+<span id="cb18-10"><a href="#cb18-10" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;offset&quot;</span><span class="fu">:</span> <span class="dv">50</span><span class="fu">,</span></span>
+<span id="cb18-11"><a href="#cb18-11" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;returned&quot;</span><span class="fu">:</span> <span class="dv">25</span><span class="fu">,</span></span>
+<span id="cb18-12"><a href="#cb18-12" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;total_items&quot;</span><span class="fu">:</span> <span class="dv">142</span><span class="fu">,</span></span>
+<span id="cb18-13"><a href="#cb18-13" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;has_more&quot;</span><span class="fu">:</span> <span class="kw">true</span></span>
+<span id="cb18-14"><a href="#cb18-14" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb18-15"><a href="#cb18-15" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb18-16"><a href="#cb18-16" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
 <p>Recommended metadata by pagination style:</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Style</th>
 <th>Location</th>
 <th>Recommended Fields</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td>Cursor</td>
 <td><code>data.pageInfo</code></td>
 <td><code>hasNextPage</code>, <code>hasPreviousPage</code>, <code>startCursor</code>, <code>endCursor</code>, optional <code>totalCount</code></td>
 </tr>
-<tr>
+<tr class="even">
 <td>Page-based</td>
 <td><code>data.pagination</code></td>
 <td><code>page</code>, <code>page_size</code>, optional <code>total_items</code>, optional <code>total_pages</code>, optional <code>has_more</code></td>
 </tr>
-<tr>
+<tr class="odd">
 <td>Offset-based</td>
 <td><code>data.pagination</code></td>
 <td><code>limit</code>, <code>offset</code>, optional <code>returned</code>, optional <code>total_items</code>, optional <code>has_more</code></td>
@@ -515,51 +528,51 @@
 <h4 id="445-introspection-integration">4.4.5 Introspection Integration</h4>
 <p>When introspection is queried, shared parameters SHOULD be expanded inline with their full definitions. This ensures LLMs see consistent documentation regardless of which operation they query.</p>
 <p><strong>Example - Operations referencing shared parameters:</strong></p>
-<div class="sourceCode" id="cb18"><pre class="sourceCode yaml"><code class="sourceCode yaml"><span id="cb18-1"><a href="#cb18-1" aria-hidden="true" tabindex="-1"></a><span class="fu">operations</span><span class="kw">:</span></span>
-<span id="cb18-2"><a href="#cb18-2" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">list_items</span><span class="kw">:</span></span>
-<span id="cb18-3"><a href="#cb18-3" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">params</span><span class="kw">:</span></span>
-<span id="cb18-4"><a href="#cb18-4" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="kw">-</span><span class="at"> </span><span class="fu">$ref</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;#/shared_parameters/fields&quot;</span></span>
-<span id="cb18-5"><a href="#cb18-5" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="kw">-</span><span class="at"> </span><span class="fu">$ref</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;#/shared_parameters/filter&quot;</span></span>
-<span id="cb18-6"><a href="#cb18-6" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="kw">-</span><span class="at"> </span><span class="fu">$ref</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;#/shared_parameters/cursor_pagination&quot;</span></span>
-<span id="cb18-7"><a href="#cb18-7" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb18-8"><a href="#cb18-8" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">search_items</span><span class="kw">:</span></span>
-<span id="cb18-9"><a href="#cb18-9" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">params</span><span class="kw">:</span></span>
-<span id="cb18-10"><a href="#cb18-10" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="kw">-</span><span class="at"> </span><span class="fu">$ref</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;#/shared_parameters/fields&quot;</span></span>
-<span id="cb18-11"><a href="#cb18-11" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="kw">-</span><span class="at"> </span><span class="fu">$ref</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;#/shared_parameters/filter&quot;</span></span>
-<span id="cb18-12"><a href="#cb18-12" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="kw">-</span><span class="at"> </span><span class="fu">$ref</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;#/shared_parameters/sorting&quot;</span></span>
-<span id="cb18-13"><a href="#cb18-13" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="kw">-</span><span class="at"> </span><span class="fu">$ref</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;#/shared_parameters/cursor_pagination&quot;</span></span>
-<span id="cb18-14"><a href="#cb18-14" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="kw">-</span><span class="at"> </span><span class="fu">name</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;query&quot;</span></span>
-<span id="cb18-15"><a href="#cb18-15" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">type</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;string&quot;</span></span>
-<span id="cb18-16"><a href="#cb18-16" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">required</span><span class="kw">:</span><span class="at"> </span><span class="ch">true</span></span>
-<span id="cb18-17"><a href="#cb18-17" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">description</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;Search query&quot;</span></span></code></pre></div>
-<p><strong>Example - Inline expansion returned to clients:</strong></p>
 <div class="sourceCode" id="cb19"><pre class="sourceCode yaml"><code class="sourceCode yaml"><span id="cb19-1"><a href="#cb19-1" aria-hidden="true" tabindex="-1"></a><span class="fu">operations</span><span class="kw">:</span></span>
-<span id="cb19-2"><a href="#cb19-2" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">search_items</span><span class="kw">:</span></span>
+<span id="cb19-2"><a href="#cb19-2" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">list_items</span><span class="kw">:</span></span>
 <span id="cb19-3"><a href="#cb19-3" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">params</span><span class="kw">:</span></span>
-<span id="cb19-4"><a href="#cb19-4" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="kw">-</span><span class="at"> </span><span class="fu">name</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;fields&quot;</span></span>
-<span id="cb19-5"><a href="#cb19-5" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">type</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;string | string[]&quot;</span></span>
-<span id="cb19-6"><a href="#cb19-6" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">required</span><span class="kw">:</span><span class="at"> </span><span class="ch">false</span></span>
-<span id="cb19-7"><a href="#cb19-7" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">description</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;Field selection: preset (&#39;minimal&#39;, &#39;standard&#39;, &#39;full&#39;) or array of field paths&quot;</span></span>
-<span id="cb19-8"><a href="#cb19-8" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="kw">-</span><span class="at"> </span><span class="fu">name</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;filter&quot;</span></span>
-<span id="cb19-9"><a href="#cb19-9" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">type</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;object&quot;</span></span>
-<span id="cb19-10"><a href="#cb19-10" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">required</span><span class="kw">:</span><span class="at"> </span><span class="ch">false</span></span>
-<span id="cb19-11"><a href="#cb19-11" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">description</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;Structured filtering criteria&quot;</span></span>
-<span id="cb19-12"><a href="#cb19-12" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="kw">-</span><span class="at"> </span><span class="fu">name</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;sort&quot;</span></span>
-<span id="cb19-13"><a href="#cb19-13" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">type</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;object&quot;</span></span>
-<span id="cb19-14"><a href="#cb19-14" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">required</span><span class="kw">:</span><span class="at"> </span><span class="ch">false</span></span>
-<span id="cb19-15"><a href="#cb19-15" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">description</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;Sort object with &#39;field&#39; and &#39;order&#39;&quot;</span></span>
-<span id="cb19-16"><a href="#cb19-16" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="kw">-</span><span class="at"> </span><span class="fu">name</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;first&quot;</span></span>
-<span id="cb19-17"><a href="#cb19-17" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">type</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;number&quot;</span></span>
-<span id="cb19-18"><a href="#cb19-18" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">required</span><span class="kw">:</span><span class="at"> </span><span class="ch">false</span></span>
-<span id="cb19-19"><a href="#cb19-19" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">description</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;Maximum results to return from the start&quot;</span></span>
-<span id="cb19-20"><a href="#cb19-20" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="kw">-</span><span class="at"> </span><span class="fu">name</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;after&quot;</span></span>
-<span id="cb19-21"><a href="#cb19-21" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">type</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;string&quot;</span></span>
-<span id="cb19-22"><a href="#cb19-22" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">required</span><span class="kw">:</span><span class="at"> </span><span class="ch">false</span></span>
-<span id="cb19-23"><a href="#cb19-23" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">description</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;Opaque cursor to continue after&quot;</span></span>
-<span id="cb19-24"><a href="#cb19-24" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="kw">-</span><span class="at"> </span><span class="fu">name</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;query&quot;</span></span>
-<span id="cb19-25"><a href="#cb19-25" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">type</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;string&quot;</span></span>
-<span id="cb19-26"><a href="#cb19-26" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">required</span><span class="kw">:</span><span class="at"> </span><span class="ch">true</span></span>
-<span id="cb19-27"><a href="#cb19-27" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">description</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;Search query&quot;</span></span></code></pre></div>
+<span id="cb19-4"><a href="#cb19-4" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="kw">-</span><span class="at"> </span><span class="fu">$ref</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;#/shared_parameters/fields&quot;</span></span>
+<span id="cb19-5"><a href="#cb19-5" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="kw">-</span><span class="at"> </span><span class="fu">$ref</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;#/shared_parameters/filter&quot;</span></span>
+<span id="cb19-6"><a href="#cb19-6" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="kw">-</span><span class="at"> </span><span class="fu">$ref</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;#/shared_parameters/cursor_pagination&quot;</span></span>
+<span id="cb19-7"><a href="#cb19-7" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb19-8"><a href="#cb19-8" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">search_items</span><span class="kw">:</span></span>
+<span id="cb19-9"><a href="#cb19-9" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">params</span><span class="kw">:</span></span>
+<span id="cb19-10"><a href="#cb19-10" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="kw">-</span><span class="at"> </span><span class="fu">$ref</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;#/shared_parameters/fields&quot;</span></span>
+<span id="cb19-11"><a href="#cb19-11" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="kw">-</span><span class="at"> </span><span class="fu">$ref</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;#/shared_parameters/filter&quot;</span></span>
+<span id="cb19-12"><a href="#cb19-12" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="kw">-</span><span class="at"> </span><span class="fu">$ref</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;#/shared_parameters/sorting&quot;</span></span>
+<span id="cb19-13"><a href="#cb19-13" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="kw">-</span><span class="at"> </span><span class="fu">$ref</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;#/shared_parameters/cursor_pagination&quot;</span></span>
+<span id="cb19-14"><a href="#cb19-14" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="kw">-</span><span class="at"> </span><span class="fu">name</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;query&quot;</span></span>
+<span id="cb19-15"><a href="#cb19-15" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">type</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;string&quot;</span></span>
+<span id="cb19-16"><a href="#cb19-16" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">required</span><span class="kw">:</span><span class="at"> </span><span class="ch">true</span></span>
+<span id="cb19-17"><a href="#cb19-17" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">description</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;Search query&quot;</span></span></code></pre></div>
+<p><strong>Example - Inline expansion returned to clients:</strong></p>
+<div class="sourceCode" id="cb20"><pre class="sourceCode yaml"><code class="sourceCode yaml"><span id="cb20-1"><a href="#cb20-1" aria-hidden="true" tabindex="-1"></a><span class="fu">operations</span><span class="kw">:</span></span>
+<span id="cb20-2"><a href="#cb20-2" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">search_items</span><span class="kw">:</span></span>
+<span id="cb20-3"><a href="#cb20-3" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">params</span><span class="kw">:</span></span>
+<span id="cb20-4"><a href="#cb20-4" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="kw">-</span><span class="at"> </span><span class="fu">name</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;fields&quot;</span></span>
+<span id="cb20-5"><a href="#cb20-5" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">type</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;string | string[]&quot;</span></span>
+<span id="cb20-6"><a href="#cb20-6" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">required</span><span class="kw">:</span><span class="at"> </span><span class="ch">false</span></span>
+<span id="cb20-7"><a href="#cb20-7" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">description</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;Field selection: preset (&#39;minimal&#39;, &#39;standard&#39;, &#39;full&#39;) or array of field paths&quot;</span></span>
+<span id="cb20-8"><a href="#cb20-8" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="kw">-</span><span class="at"> </span><span class="fu">name</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;filter&quot;</span></span>
+<span id="cb20-9"><a href="#cb20-9" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">type</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;object&quot;</span></span>
+<span id="cb20-10"><a href="#cb20-10" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">required</span><span class="kw">:</span><span class="at"> </span><span class="ch">false</span></span>
+<span id="cb20-11"><a href="#cb20-11" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">description</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;Structured filtering criteria&quot;</span></span>
+<span id="cb20-12"><a href="#cb20-12" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="kw">-</span><span class="at"> </span><span class="fu">name</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;sort&quot;</span></span>
+<span id="cb20-13"><a href="#cb20-13" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">type</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;object&quot;</span></span>
+<span id="cb20-14"><a href="#cb20-14" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">required</span><span class="kw">:</span><span class="at"> </span><span class="ch">false</span></span>
+<span id="cb20-15"><a href="#cb20-15" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">description</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;Sort object with &#39;field&#39; and &#39;order&#39;&quot;</span></span>
+<span id="cb20-16"><a href="#cb20-16" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="kw">-</span><span class="at"> </span><span class="fu">name</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;first&quot;</span></span>
+<span id="cb20-17"><a href="#cb20-17" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">type</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;number&quot;</span></span>
+<span id="cb20-18"><a href="#cb20-18" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">required</span><span class="kw">:</span><span class="at"> </span><span class="ch">false</span></span>
+<span id="cb20-19"><a href="#cb20-19" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">description</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;Maximum results to return from the start&quot;</span></span>
+<span id="cb20-20"><a href="#cb20-20" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="kw">-</span><span class="at"> </span><span class="fu">name</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;after&quot;</span></span>
+<span id="cb20-21"><a href="#cb20-21" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">type</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;string&quot;</span></span>
+<span id="cb20-22"><a href="#cb20-22" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">required</span><span class="kw">:</span><span class="at"> </span><span class="ch">false</span></span>
+<span id="cb20-23"><a href="#cb20-23" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">description</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;Opaque cursor to continue after&quot;</span></span>
+<span id="cb20-24"><a href="#cb20-24" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="kw">-</span><span class="at"> </span><span class="fu">name</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;query&quot;</span></span>
+<span id="cb20-25"><a href="#cb20-25" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">type</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;string&quot;</span></span>
+<span id="cb20-26"><a href="#cb20-26" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">required</span><span class="kw">:</span><span class="at"> </span><span class="ch">true</span></span>
+<span id="cb20-27"><a href="#cb20-27" aria-hidden="true" tabindex="-1"></a><span class="at">        </span><span class="fu">description</span><span class="kw">:</span><span class="at"> </span><span class="st">&quot;Search query&quot;</span></span></code></pre></div>
 <h3 id="45-update-input-pattern">4.5 UPDATE Input Pattern</h3>
 <p>UPDATE operations SHOULD use a nested <code>input</code> object to separate identifier parameters from updateable fields. See <a href="versions/v1.0.0-draft.html#45-update-input-pattern">MCP-AQL Specification Section 4.5</a> for normative requirements including deep-merge semantics and field removal. See <a href="adr/ADR-002-graphql-style-input.html">ADR-002</a> for design rationale.</p>
 <hr />
@@ -569,7 +582,7 @@
 <p><strong>Schema Properties:</strong></p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Property</th>
 <th>Type</th>
 <th>Required</th>
@@ -577,31 +590,37 @@
 </tr>
 </thead>
 <tbody>
-<tr>
-<td><code>endpoint</code></td>
+<tr class="odd">
+<td><code>semantic_category</code></td>
 <td>string</td>
 <td>REQUIRED</td>
-<td>CRUDE endpoint: CREATE, READ, UPDATE, DELETE, or EXECUTE</td>
+<td>Standard semantic category: CREATE, READ, UPDATE, DELETE, or EXECUTE</td>
 </tr>
-<tr>
+<tr class="even">
+<td><code>endpoint</code></td>
+<td>string</td>
+<td>REQUIRED in semantic endpoint mode</td>
+<td>Exposed endpoint family that receives the operation</td>
+</tr>
+<tr class="odd">
 <td><code>description</code></td>
 <td>string</td>
 <td>REQUIRED</td>
 <td>Human-readable description</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>params</code></td>
 <td>object</td>
 <td>OPTIONAL</td>
 <td>Parameter definitions</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>handler</code></td>
 <td>string</td>
 <td>OPTIONAL</td>
 <td>Internal handler reference</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>dangerous</code></td>
 <td>boolean</td>
 <td>OPTIONAL</td>
@@ -613,7 +632,7 @@
 <p>Each parameter in the <code>params</code> object MUST include:</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Property</th>
 <th>Type</th>
 <th>Required</th>
@@ -621,25 +640,25 @@
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><code>type</code></td>
 <td>string</td>
 <td>REQUIRED</td>
 <td>Data type: "string", "number", "boolean", "object", "array"</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>required</code></td>
 <td>boolean</td>
 <td>OPTIONAL</td>
 <td>Whether parameter is required (default: false)</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>description</code></td>
 <td>string</td>
 <td>OPTIONAL</td>
 <td>Human-readable description</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>default</code></td>
 <td>any</td>
 <td>OPTIONAL</td>
@@ -650,39 +669,39 @@
 <p>Additional properties MAY be included:</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Property</th>
 <th>Type</th>
 <th>Description</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><code>mapTo</code></td>
 <td>string</td>
 <td>Internal parameter name mapping</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>sources</code></td>
 <td>array</td>
 <td>Ordered list of resolution paths</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>enum</code></td>
 <td>array</td>
 <td>Allowed values for string parameters</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>minimum</code></td>
 <td>number</td>
 <td>Minimum value for numeric parameters</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>maximum</code></td>
 <td>number</td>
 <td>Maximum value for numeric parameters</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>pattern</code></td>
 <td>string</td>
 <td>Regex pattern for string validation</td>
@@ -690,37 +709,37 @@
 </tbody>
 </table>
 <h3 id="53-example-schema-definition">5.3 Example Schema Definition</h3>
-<div class="sourceCode" id="cb20"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb20-1"><a href="#cb20-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Schema for a create operation</span></span>
-<span id="cb20-2"><a href="#cb20-2" aria-hidden="true" tabindex="-1"></a>{</span>
-<span id="cb20-3"><a href="#cb20-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">create_item</span><span class="op">:</span> {</span>
-<span id="cb20-4"><a href="#cb20-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">endpoint</span><span class="op">:</span> <span class="st">&quot;CREATE&quot;</span><span class="op">,</span></span>
-<span id="cb20-5"><a href="#cb20-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">description</span><span class="op">:</span> <span class="st">&quot;Create a new item in the system&quot;</span><span class="op">,</span></span>
-<span id="cb20-6"><a href="#cb20-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">params</span><span class="op">:</span> {</span>
-<span id="cb20-7"><a href="#cb20-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">name</span><span class="op">:</span> {</span>
-<span id="cb20-8"><a href="#cb20-8" aria-hidden="true" tabindex="-1"></a>        <span class="dt">type</span><span class="op">:</span> <span class="st">&quot;string&quot;</span><span class="op">,</span></span>
-<span id="cb20-9"><a href="#cb20-9" aria-hidden="true" tabindex="-1"></a>        <span class="dt">required</span><span class="op">:</span> <span class="kw">true</span><span class="op">,</span></span>
-<span id="cb20-10"><a href="#cb20-10" aria-hidden="true" tabindex="-1"></a>        <span class="dt">description</span><span class="op">:</span> <span class="st">&quot;Item name&quot;</span></span>
-<span id="cb20-11"><a href="#cb20-11" aria-hidden="true" tabindex="-1"></a>      }<span class="op">,</span></span>
-<span id="cb20-12"><a href="#cb20-12" aria-hidden="true" tabindex="-1"></a>      <span class="dt">category</span><span class="op">:</span> {</span>
-<span id="cb20-13"><a href="#cb20-13" aria-hidden="true" tabindex="-1"></a>        <span class="dt">type</span><span class="op">:</span> <span class="st">&quot;string&quot;</span><span class="op">,</span></span>
-<span id="cb20-14"><a href="#cb20-14" aria-hidden="true" tabindex="-1"></a>        <span class="dt">required</span><span class="op">:</span> <span class="kw">true</span><span class="op">,</span></span>
-<span id="cb20-15"><a href="#cb20-15" aria-hidden="true" tabindex="-1"></a>        <span class="dt">description</span><span class="op">:</span> <span class="st">&quot;Item category&quot;</span><span class="op">,</span></span>
-<span id="cb20-16"><a href="#cb20-16" aria-hidden="true" tabindex="-1"></a>        <span class="dt">enum</span><span class="op">:</span> [<span class="st">&quot;product&quot;</span><span class="op">,</span> <span class="st">&quot;service&quot;</span><span class="op">,</span> <span class="st">&quot;subscription&quot;</span>]</span>
-<span id="cb20-17"><a href="#cb20-17" aria-hidden="true" tabindex="-1"></a>      }<span class="op">,</span></span>
-<span id="cb20-18"><a href="#cb20-18" aria-hidden="true" tabindex="-1"></a>      <span class="dt">price</span><span class="op">:</span> {</span>
-<span id="cb20-19"><a href="#cb20-19" aria-hidden="true" tabindex="-1"></a>        <span class="dt">type</span><span class="op">:</span> <span class="st">&quot;number&quot;</span><span class="op">,</span></span>
-<span id="cb20-20"><a href="#cb20-20" aria-hidden="true" tabindex="-1"></a>        <span class="dt">required</span><span class="op">:</span> <span class="kw">false</span><span class="op">,</span></span>
-<span id="cb20-21"><a href="#cb20-21" aria-hidden="true" tabindex="-1"></a>        <span class="dt">minimum</span><span class="op">:</span> <span class="dv">0</span><span class="op">,</span></span>
-<span id="cb20-22"><a href="#cb20-22" aria-hidden="true" tabindex="-1"></a>        <span class="dt">description</span><span class="op">:</span> <span class="st">&quot;Item price in cents&quot;</span></span>
-<span id="cb20-23"><a href="#cb20-23" aria-hidden="true" tabindex="-1"></a>      }<span class="op">,</span></span>
-<span id="cb20-24"><a href="#cb20-24" aria-hidden="true" tabindex="-1"></a>      <span class="dt">metadata</span><span class="op">:</span> {</span>
-<span id="cb20-25"><a href="#cb20-25" aria-hidden="true" tabindex="-1"></a>        <span class="dt">type</span><span class="op">:</span> <span class="st">&quot;object&quot;</span><span class="op">,</span></span>
-<span id="cb20-26"><a href="#cb20-26" aria-hidden="true" tabindex="-1"></a>        <span class="dt">required</span><span class="op">:</span> <span class="kw">false</span><span class="op">,</span></span>
-<span id="cb20-27"><a href="#cb20-27" aria-hidden="true" tabindex="-1"></a>        <span class="dt">description</span><span class="op">:</span> <span class="st">&quot;Additional item metadata&quot;</span></span>
-<span id="cb20-28"><a href="#cb20-28" aria-hidden="true" tabindex="-1"></a>      }</span>
-<span id="cb20-29"><a href="#cb20-29" aria-hidden="true" tabindex="-1"></a>    }</span>
-<span id="cb20-30"><a href="#cb20-30" aria-hidden="true" tabindex="-1"></a>  }</span>
-<span id="cb20-31"><a href="#cb20-31" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<div class="sourceCode" id="cb21"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb21-1"><a href="#cb21-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Schema for a create operation</span></span>
+<span id="cb21-2"><a href="#cb21-2" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb21-3"><a href="#cb21-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">create_item</span><span class="op">:</span> {</span>
+<span id="cb21-4"><a href="#cb21-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">endpoint</span><span class="op">:</span> <span class="st">&quot;CREATE&quot;</span><span class="op">,</span></span>
+<span id="cb21-5"><a href="#cb21-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">description</span><span class="op">:</span> <span class="st">&quot;Create a new item in the system&quot;</span><span class="op">,</span></span>
+<span id="cb21-6"><a href="#cb21-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">params</span><span class="op">:</span> {</span>
+<span id="cb21-7"><a href="#cb21-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">name</span><span class="op">:</span> {</span>
+<span id="cb21-8"><a href="#cb21-8" aria-hidden="true" tabindex="-1"></a>        <span class="dt">type</span><span class="op">:</span> <span class="st">&quot;string&quot;</span><span class="op">,</span></span>
+<span id="cb21-9"><a href="#cb21-9" aria-hidden="true" tabindex="-1"></a>        <span class="dt">required</span><span class="op">:</span> <span class="kw">true</span><span class="op">,</span></span>
+<span id="cb21-10"><a href="#cb21-10" aria-hidden="true" tabindex="-1"></a>        <span class="dt">description</span><span class="op">:</span> <span class="st">&quot;Item name&quot;</span></span>
+<span id="cb21-11"><a href="#cb21-11" aria-hidden="true" tabindex="-1"></a>      }<span class="op">,</span></span>
+<span id="cb21-12"><a href="#cb21-12" aria-hidden="true" tabindex="-1"></a>      <span class="dt">category</span><span class="op">:</span> {</span>
+<span id="cb21-13"><a href="#cb21-13" aria-hidden="true" tabindex="-1"></a>        <span class="dt">type</span><span class="op">:</span> <span class="st">&quot;string&quot;</span><span class="op">,</span></span>
+<span id="cb21-14"><a href="#cb21-14" aria-hidden="true" tabindex="-1"></a>        <span class="dt">required</span><span class="op">:</span> <span class="kw">true</span><span class="op">,</span></span>
+<span id="cb21-15"><a href="#cb21-15" aria-hidden="true" tabindex="-1"></a>        <span class="dt">description</span><span class="op">:</span> <span class="st">&quot;Item category&quot;</span><span class="op">,</span></span>
+<span id="cb21-16"><a href="#cb21-16" aria-hidden="true" tabindex="-1"></a>        <span class="dt">enum</span><span class="op">:</span> [<span class="st">&quot;product&quot;</span><span class="op">,</span> <span class="st">&quot;service&quot;</span><span class="op">,</span> <span class="st">&quot;subscription&quot;</span>]</span>
+<span id="cb21-17"><a href="#cb21-17" aria-hidden="true" tabindex="-1"></a>      }<span class="op">,</span></span>
+<span id="cb21-18"><a href="#cb21-18" aria-hidden="true" tabindex="-1"></a>      <span class="dt">price</span><span class="op">:</span> {</span>
+<span id="cb21-19"><a href="#cb21-19" aria-hidden="true" tabindex="-1"></a>        <span class="dt">type</span><span class="op">:</span> <span class="st">&quot;number&quot;</span><span class="op">,</span></span>
+<span id="cb21-20"><a href="#cb21-20" aria-hidden="true" tabindex="-1"></a>        <span class="dt">required</span><span class="op">:</span> <span class="kw">false</span><span class="op">,</span></span>
+<span id="cb21-21"><a href="#cb21-21" aria-hidden="true" tabindex="-1"></a>        <span class="dt">minimum</span><span class="op">:</span> <span class="dv">0</span><span class="op">,</span></span>
+<span id="cb21-22"><a href="#cb21-22" aria-hidden="true" tabindex="-1"></a>        <span class="dt">description</span><span class="op">:</span> <span class="st">&quot;Item price in cents&quot;</span></span>
+<span id="cb21-23"><a href="#cb21-23" aria-hidden="true" tabindex="-1"></a>      }<span class="op">,</span></span>
+<span id="cb21-24"><a href="#cb21-24" aria-hidden="true" tabindex="-1"></a>      <span class="dt">metadata</span><span class="op">:</span> {</span>
+<span id="cb21-25"><a href="#cb21-25" aria-hidden="true" tabindex="-1"></a>        <span class="dt">type</span><span class="op">:</span> <span class="st">&quot;object&quot;</span><span class="op">,</span></span>
+<span id="cb21-26"><a href="#cb21-26" aria-hidden="true" tabindex="-1"></a>        <span class="dt">required</span><span class="op">:</span> <span class="kw">false</span><span class="op">,</span></span>
+<span id="cb21-27"><a href="#cb21-27" aria-hidden="true" tabindex="-1"></a>        <span class="dt">description</span><span class="op">:</span> <span class="st">&quot;Additional item metadata&quot;</span></span>
+<span id="cb21-28"><a href="#cb21-28" aria-hidden="true" tabindex="-1"></a>      }</span>
+<span id="cb21-29"><a href="#cb21-29" aria-hidden="true" tabindex="-1"></a>    }</span>
+<span id="cb21-30"><a href="#cb21-30" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb21-31"><a href="#cb21-31" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
 <h3 id="54-parameter-validation">5.4 Parameter Validation</h3>
 <p>Before executing an operation, adapters MUST:</p>
 <ol type="1">
@@ -735,77 +754,106 @@
 </blockquote>
 <p>Validation failures MUST return an error response (not throw exceptions).</p>
 <hr />
-<h2 id="6-crude-endpoint-assignment">6. CRUDE Endpoint Assignment</h2>
+<h2 id="6-semantic-endpoint-assignment">6. Semantic Endpoint Assignment</h2>
 <h3 id="61-endpoint-semantics">6.1 Endpoint Semantics</h3>
 <p>Operations MUST be assigned to endpoints based on their semantics:</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Endpoint</th>
 <th>Semantics</th>
 <th>Characteristics</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><strong>CREATE</strong></td>
 <td>Additive, non-destructive</td>
 <td>Creates new resources; idempotent if duplicate detection enabled</td>
 </tr>
-<tr>
+<tr class="even">
 <td><strong>READ</strong></td>
 <td>Safe, read-only</td>
 <td>No side effects; cacheable; always safe to retry</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><strong>UPDATE</strong></td>
 <td>Modifying</td>
 <td>Changes existing resources; may be partially idempotent</td>
 </tr>
-<tr>
+<tr class="even">
 <td><strong>DELETE</strong></td>
 <td>Destructive</td>
 <td>Removes resources; potentially irreversible</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><strong>EXECUTE</strong></td>
 <td>Lifecycle, non-idempotent</td>
 <td>Triggers actions; manages runtime state</td>
 </tr>
 </tbody>
 </table>
+<p>The standard CRUDE profile is the default semantic-endpoint profile for these semantics, but semantic endpoint mode MAY expose alternate semantic-endpoint profiles when the endpoint names still communicate intent clearly to clients.</p>
+<p><strong>Standard and Alternate Semantic-Endpoint Profiles</strong></p>
+<table>
+<thead>
+<tr class="header">
+<th>Profile</th>
+<th>Endpoint Set</th>
+<th>Typical Intent Split</th>
+</tr>
+</thead>
+<tbody>
+<tr class="odd">
+<td><strong>Standard CRUDE profile</strong></td>
+<td><code>create</code> / <code>read</code> / <code>update</code> / <code>delete</code> / <code>execute</code></td>
+<td>Direct alignment to the five standardized semantic categories</td>
+</tr>
+<tr class="even">
+<td><strong>Extended CRUDE-style profile</strong></td>
+<td><code>create</code> / <code>read</code> / <code>update</code> / <code>delete</code> / <code>execute</code> / <code>authorize</code></td>
+<td>Standard CRUDE plus a dedicated semantic endpoint for permissioning and approval workflows</td>
+</tr>
+<tr class="odd">
+<td><strong>Alternative semantic profile</strong></td>
+<td><code>discover</code> / <code>query</code> / <code>manage</code> / <code>operate</code></td>
+<td>Discovery and inspection, retrieval and filtering, mutating and administrative changes, runtime and lifecycle actions</td>
+</tr>
+</tbody>
+</table>
+<p>These alternate profiles remain in-spec because the endpoints are still semantically legible to an LLM or client. What matters is not that every adapter uses CRUDE, but that the chosen endpoint set communicates where an operation belongs.</p>
 <h3 id="62-common-verbs-by-endpoint">6.2 Common Verbs by Endpoint</h3>
 <p>Each endpoint has canonical verbs (shown in bold) that SHOULD be used for standard operations, plus additional verbs for domain-specific semantics. See <a href="versions/v1.0.0-draft.html#85-operation-naming-grammar">Section 8.5</a> of the normative specification for naming requirements.</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Endpoint</th>
 <th>Canonical</th>
 <th>Additional Verbs</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td>CREATE</td>
 <td><strong>create</strong></td>
 <td>add, upload, register, import, insert</td>
 </tr>
-<tr>
+<tr class="even">
 <td>READ</td>
 <td><strong>get</strong>, <strong>list</strong></td>
 <td>search, find, export, count</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>UPDATE</td>
 <td><strong>update</strong></td>
 <td>edit, set, rename, move, patch, merge</td>
 </tr>
-<tr>
+<tr class="even">
 <td>DELETE</td>
 <td><strong>delete</strong></td>
 <td>remove, purge, unregister, clear, drop</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>EXECUTE</td>
 <td><strong>execute</strong>, <strong>cancel</strong></td>
 <td>run, start, stop, resume, trigger, invoke</td>
@@ -818,18 +866,18 @@
 <h3 id="63-endpoint-routing-enforcement">6.3 Endpoint Routing Enforcement</h3>
 <p>Adapters MUST validate that operations are invoked via their designated endpoint. An operation assigned to CREATE MUST NOT execute when called via the DELETE endpoint.</p>
 <p>When an operation is routed to the wrong endpoint, adapters SHOULD return an error:</p>
-<div class="sourceCode" id="cb21"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb21-1"><a href="#cb21-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
-<span id="cb21-2"><a href="#cb21-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
-<span id="cb21-3"><a href="#cb21-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;error&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb21-4"><a href="#cb21-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;code&quot;</span><span class="fu">:</span> <span class="st">&quot;VALIDATION_ENDPOINT_MISMATCH&quot;</span><span class="fu">,</span></span>
-<span id="cb21-5"><a href="#cb21-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;Operation &#39;create_item&#39; must use CREATE endpoint, not DELETE&quot;</span><span class="fu">,</span></span>
-<span id="cb21-6"><a href="#cb21-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;details&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb21-7"><a href="#cb21-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;create_item&quot;</span><span class="fu">,</span></span>
-<span id="cb21-8"><a href="#cb21-8" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;expected_endpoint&quot;</span><span class="fu">:</span> <span class="st">&quot;CREATE&quot;</span><span class="fu">,</span></span>
-<span id="cb21-9"><a href="#cb21-9" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;actual_endpoint&quot;</span><span class="fu">:</span> <span class="st">&quot;DELETE&quot;</span></span>
-<span id="cb21-10"><a href="#cb21-10" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
-<span id="cb21-11"><a href="#cb21-11" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
-<span id="cb21-12"><a href="#cb21-12" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<div class="sourceCode" id="cb22"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb22-1"><a href="#cb22-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb22-2"><a href="#cb22-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb22-3"><a href="#cb22-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;error&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb22-4"><a href="#cb22-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;code&quot;</span><span class="fu">:</span> <span class="st">&quot;VALIDATION_ENDPOINT_MISMATCH&quot;</span><span class="fu">,</span></span>
+<span id="cb22-5"><a href="#cb22-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;Operation &#39;create_item&#39; must use CREATE endpoint, not DELETE&quot;</span><span class="fu">,</span></span>
+<span id="cb22-6"><a href="#cb22-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;details&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb22-7"><a href="#cb22-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;create_item&quot;</span><span class="fu">,</span></span>
+<span id="cb22-8"><a href="#cb22-8" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;expected_endpoint&quot;</span><span class="fu">:</span> <span class="st">&quot;CREATE&quot;</span><span class="fu">,</span></span>
+<span id="cb22-9"><a href="#cb22-9" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;actual_endpoint&quot;</span><span class="fu">:</span> <span class="st">&quot;DELETE&quot;</span></span>
+<span id="cb22-10"><a href="#cb22-10" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb22-11"><a href="#cb22-11" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb22-12"><a href="#cb22-12" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
 <h3 id="64-dangerous-operation-classification">6.4 Dangerous Operation Classification</h3>
 <p>Operations with significant consequences SHOULD be marked with <code>dangerous: true</code> in their schema. This enables clients to:</p>
 <ul>
@@ -848,29 +896,29 @@
 <h2 id="7-batch-operations">7. Batch Operations</h2>
 <h3 id="71-batch-request-format">7.1 Batch Request Format</h3>
 <p>Adapters MAY support batch operations. When supported, the format MUST be:</p>
-<div class="sourceCode" id="cb22"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb22-1"><a href="#cb22-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
-<span id="cb22-2"><a href="#cb22-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;operations&quot;</span><span class="fu">:</span> <span class="ot">[</span></span>
-<span id="cb22-3"><a href="#cb22-3" aria-hidden="true" tabindex="-1"></a>    <span class="fu">{</span> <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;create_item&quot;</span><span class="fu">,</span> <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;Item A&quot;</span><span class="fu">,</span> <span class="dt">&quot;category&quot;</span><span class="fu">:</span> <span class="st">&quot;product&quot;</span> <span class="fu">}</span> <span class="fu">}</span><span class="ot">,</span></span>
-<span id="cb22-4"><a href="#cb22-4" aria-hidden="true" tabindex="-1"></a>    <span class="fu">{</span> <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;create_item&quot;</span><span class="fu">,</span> <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;Item B&quot;</span><span class="fu">,</span> <span class="dt">&quot;category&quot;</span><span class="fu">:</span> <span class="st">&quot;service&quot;</span> <span class="fu">}</span> <span class="fu">}</span><span class="ot">,</span></span>
-<span id="cb22-5"><a href="#cb22-5" aria-hidden="true" tabindex="-1"></a>    <span class="fu">{</span> <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;create_item&quot;</span><span class="fu">,</span> <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;Item C&quot;</span><span class="fu">,</span> <span class="dt">&quot;category&quot;</span><span class="fu">:</span> <span class="st">&quot;product&quot;</span> <span class="fu">}</span> <span class="fu">}</span></span>
-<span id="cb22-6"><a href="#cb22-6" aria-hidden="true" tabindex="-1"></a>  <span class="ot">]</span></span>
-<span id="cb22-7"><a href="#cb22-7" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<div class="sourceCode" id="cb23"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb23-1"><a href="#cb23-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb23-2"><a href="#cb23-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;operations&quot;</span><span class="fu">:</span> <span class="ot">[</span></span>
+<span id="cb23-3"><a href="#cb23-3" aria-hidden="true" tabindex="-1"></a>    <span class="fu">{</span> <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;create_item&quot;</span><span class="fu">,</span> <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;Item A&quot;</span><span class="fu">,</span> <span class="dt">&quot;category&quot;</span><span class="fu">:</span> <span class="st">&quot;product&quot;</span> <span class="fu">}</span> <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb23-4"><a href="#cb23-4" aria-hidden="true" tabindex="-1"></a>    <span class="fu">{</span> <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;create_item&quot;</span><span class="fu">,</span> <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;Item B&quot;</span><span class="fu">,</span> <span class="dt">&quot;category&quot;</span><span class="fu">:</span> <span class="st">&quot;service&quot;</span> <span class="fu">}</span> <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb23-5"><a href="#cb23-5" aria-hidden="true" tabindex="-1"></a>    <span class="fu">{</span> <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;create_item&quot;</span><span class="fu">,</span> <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;Item C&quot;</span><span class="fu">,</span> <span class="dt">&quot;category&quot;</span><span class="fu">:</span> <span class="st">&quot;product&quot;</span> <span class="fu">}</span> <span class="fu">}</span></span>
+<span id="cb23-6"><a href="#cb23-6" aria-hidden="true" tabindex="-1"></a>  <span class="ot">]</span></span>
+<span id="cb23-7"><a href="#cb23-7" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
 <h3 id="72-batch-response-format">7.2 Batch Response Format</h3>
 <p>Batch responses MUST include individual results for each operation:</p>
-<div class="sourceCode" id="cb23"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb23-1"><a href="#cb23-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
-<span id="cb23-2"><a href="#cb23-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
-<span id="cb23-3"><a href="#cb23-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;data&quot;</span><span class="fu">:</span> <span class="kw">null</span><span class="fu">,</span></span>
-<span id="cb23-4"><a href="#cb23-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;results&quot;</span><span class="fu">:</span> <span class="ot">[</span></span>
-<span id="cb23-5"><a href="#cb23-5" aria-hidden="true" tabindex="-1"></a>    <span class="fu">{</span> <span class="dt">&quot;index&quot;</span><span class="fu">:</span> <span class="dv">0</span><span class="fu">,</span> <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;create_item&quot;</span><span class="fu">,</span> <span class="dt">&quot;result&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span> <span class="dt">&quot;data&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;id&quot;</span><span class="fu">:</span> <span class="st">&quot;item_1&quot;</span> <span class="fu">}</span> <span class="fu">}</span> <span class="fu">}</span><span class="ot">,</span></span>
-<span id="cb23-6"><a href="#cb23-6" aria-hidden="true" tabindex="-1"></a>    <span class="fu">{</span> <span class="dt">&quot;index&quot;</span><span class="fu">:</span> <span class="dv">1</span><span class="fu">,</span> <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;create_item&quot;</span><span class="fu">,</span> <span class="dt">&quot;result&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span> <span class="dt">&quot;data&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;id&quot;</span><span class="fu">:</span> <span class="st">&quot;item_2&quot;</span> <span class="fu">}</span> <span class="fu">}</span> <span class="fu">}</span><span class="ot">,</span></span>
-<span id="cb23-7"><a href="#cb23-7" aria-hidden="true" tabindex="-1"></a>    <span class="fu">{</span> <span class="dt">&quot;index&quot;</span><span class="fu">:</span> <span class="dv">2</span><span class="fu">,</span> <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;create_item&quot;</span><span class="fu">,</span> <span class="dt">&quot;result&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span> <span class="dt">&quot;error&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;code&quot;</span><span class="fu">:</span> <span class="st">&quot;CONFLICT_ALREADY_EXISTS&quot;</span><span class="fu">,</span> <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;Item with name &#39;Item C&#39; already exists&quot;</span> <span class="fu">}</span> <span class="fu">}</span> <span class="fu">}</span></span>
-<span id="cb23-8"><a href="#cb23-8" aria-hidden="true" tabindex="-1"></a>  <span class="ot">]</span><span class="fu">,</span></span>
-<span id="cb23-9"><a href="#cb23-9" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;summary&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb23-10"><a href="#cb23-10" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;total&quot;</span><span class="fu">:</span> <span class="dv">3</span><span class="fu">,</span></span>
-<span id="cb23-11"><a href="#cb23-11" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;succeeded&quot;</span><span class="fu">:</span> <span class="dv">2</span><span class="fu">,</span></span>
-<span id="cb23-12"><a href="#cb23-12" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;failed&quot;</span><span class="fu">:</span> <span class="dv">1</span></span>
-<span id="cb23-13"><a href="#cb23-13" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
-<span id="cb23-14"><a href="#cb23-14" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<div class="sourceCode" id="cb24"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb24-1"><a href="#cb24-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb24-2"><a href="#cb24-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb24-3"><a href="#cb24-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;data&quot;</span><span class="fu">:</span> <span class="kw">null</span><span class="fu">,</span></span>
+<span id="cb24-4"><a href="#cb24-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;results&quot;</span><span class="fu">:</span> <span class="ot">[</span></span>
+<span id="cb24-5"><a href="#cb24-5" aria-hidden="true" tabindex="-1"></a>    <span class="fu">{</span> <span class="dt">&quot;index&quot;</span><span class="fu">:</span> <span class="dv">0</span><span class="fu">,</span> <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;create_item&quot;</span><span class="fu">,</span> <span class="dt">&quot;result&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span> <span class="dt">&quot;data&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;id&quot;</span><span class="fu">:</span> <span class="st">&quot;item_1&quot;</span> <span class="fu">}</span> <span class="fu">}</span> <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb24-6"><a href="#cb24-6" aria-hidden="true" tabindex="-1"></a>    <span class="fu">{</span> <span class="dt">&quot;index&quot;</span><span class="fu">:</span> <span class="dv">1</span><span class="fu">,</span> <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;create_item&quot;</span><span class="fu">,</span> <span class="dt">&quot;result&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span> <span class="dt">&quot;data&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;id&quot;</span><span class="fu">:</span> <span class="st">&quot;item_2&quot;</span> <span class="fu">}</span> <span class="fu">}</span> <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb24-7"><a href="#cb24-7" aria-hidden="true" tabindex="-1"></a>    <span class="fu">{</span> <span class="dt">&quot;index&quot;</span><span class="fu">:</span> <span class="dv">2</span><span class="fu">,</span> <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;create_item&quot;</span><span class="fu">,</span> <span class="dt">&quot;result&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span> <span class="dt">&quot;error&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;code&quot;</span><span class="fu">:</span> <span class="st">&quot;CONFLICT_ALREADY_EXISTS&quot;</span><span class="fu">,</span> <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;Item with name &#39;Item C&#39; already exists&quot;</span> <span class="fu">}</span> <span class="fu">}</span> <span class="fu">}</span></span>
+<span id="cb24-8"><a href="#cb24-8" aria-hidden="true" tabindex="-1"></a>  <span class="ot">]</span><span class="fu">,</span></span>
+<span id="cb24-9"><a href="#cb24-9" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;summary&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb24-10"><a href="#cb24-10" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;total&quot;</span><span class="fu">:</span> <span class="dv">3</span><span class="fu">,</span></span>
+<span id="cb24-11"><a href="#cb24-11" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;succeeded&quot;</span><span class="fu">:</span> <span class="dv">2</span><span class="fu">,</span></span>
+<span id="cb24-12"><a href="#cb24-12" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;failed&quot;</span><span class="fu">:</span> <span class="dv">1</span></span>
+<span id="cb24-13"><a href="#cb24-13" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb24-14"><a href="#cb24-14" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
 <h3 id="73-batch-execution-semantics">7.3 Batch Execution Semantics</h3>
 <p>Conformant batch implementations MUST follow these semantics:</p>
 <ol type="1">
@@ -881,22 +929,22 @@
 <li>The overall <code>success</code> is <code>false</code> only for batch-level errors (malformed request, authentication failure)</li>
 </ol>
 <h3 id="74-cross-endpoint-batching">7.4 Cross-Endpoint Batching</h3>
-<p>When using CRUDE mode (separate endpoints), batch operations SHOULD be constrained to a single endpoint:</p>
+<p>When using semantic endpoint mode (separate endpoint families), batch operations SHOULD be constrained to a single endpoint family:</p>
 <ul>
-<li>All CREATE operations together in one batch to the CREATE endpoint</li>
-<li>All READ operations together in one batch to the READ endpoint</li>
+<li>All operations assigned to the same endpoint family together in one batch</li>
+<li>For the CRUDE profile, all CREATE operations together in one batch to the CREATE endpoint, all READ operations together in one batch to the READ endpoint, and so on</li>
 </ul>
 <p>Mixing operations across endpoints in a single batch is NOT RECOMMENDED. Implementations MAY reject mixed batches or MAY process them with explicit endpoint routing per operation.</p>
 <h3 id="75-confirmation-gated-batch-operations">7.5 Confirmation-Gated Batch Operations</h3>
 <p>When a batch operation encounters a <code>CONFIRMATION_REQUIRED</code> response, special handling is needed to maintain state consistency.</p>
 <h4 id="751-the-problem">7.5.1 The Problem</h4>
 <p>Consider a batch where operations depend on each other:</p>
-<div class="sourceCode" id="cb24"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb24-1"><a href="#cb24-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
-<span id="cb24-2"><a href="#cb24-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;operations&quot;</span><span class="fu">:</span> <span class="ot">[</span></span>
-<span id="cb24-3"><a href="#cb24-3" aria-hidden="true" tabindex="-1"></a>    <span class="fu">{</span> <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;delete_user&quot;</span><span class="fu">,</span> <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;user_id&quot;</span><span class="fu">:</span> <span class="st">&quot;alice&quot;</span> <span class="fu">}</span> <span class="fu">}</span><span class="ot">,</span></span>
-<span id="cb24-4"><a href="#cb24-4" aria-hidden="true" tabindex="-1"></a>    <span class="fu">{</span> <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;send_notification&quot;</span><span class="fu">,</span> <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;user_id&quot;</span><span class="fu">:</span> <span class="st">&quot;alice&quot;</span><span class="fu">,</span> <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;Account deleted&quot;</span> <span class="fu">}</span> <span class="fu">}</span></span>
-<span id="cb24-5"><a href="#cb24-5" aria-hidden="true" tabindex="-1"></a>  <span class="ot">]</span></span>
-<span id="cb24-6"><a href="#cb24-6" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<div class="sourceCode" id="cb25"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb25-1"><a href="#cb25-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb25-2"><a href="#cb25-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;operations&quot;</span><span class="fu">:</span> <span class="ot">[</span></span>
+<span id="cb25-3"><a href="#cb25-3" aria-hidden="true" tabindex="-1"></a>    <span class="fu">{</span> <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;delete_user&quot;</span><span class="fu">,</span> <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;user_id&quot;</span><span class="fu">:</span> <span class="st">&quot;alice&quot;</span> <span class="fu">}</span> <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb25-4"><a href="#cb25-4" aria-hidden="true" tabindex="-1"></a>    <span class="fu">{</span> <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;send_notification&quot;</span><span class="fu">,</span> <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;user_id&quot;</span><span class="fu">:</span> <span class="st">&quot;alice&quot;</span><span class="fu">,</span> <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;Account deleted&quot;</span> <span class="fu">}</span> <span class="fu">}</span></span>
+<span id="cb25-5"><a href="#cb25-5" aria-hidden="true" tabindex="-1"></a>  <span class="ot">]</span></span>
+<span id="cb25-6"><a href="#cb25-6" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
 <p>If <code>delete_user</code> requires confirmation, executing <code>send_notification</code> anyway would create inconsistent state (notification sent, but user not deleted).</p>
 <h4 id="752-batch-halting-recommended">7.5.2 Batch Halting (RECOMMENDED)</h4>
 <p>When an operation returns <code>CONFIRMATION_REQUIRED</code>, the batch SHOULD halt:</p>
@@ -906,58 +954,58 @@
 <li>Subsequent operations do NOT execute</li>
 <li>Response includes partial results and continuation information</li>
 </ol>
-<div class="sourceCode" id="cb25"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb25-1"><a href="#cb25-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
-<span id="cb25-2"><a href="#cb25-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
-<span id="cb25-3"><a href="#cb25-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;data&quot;</span><span class="fu">:</span> <span class="kw">null</span><span class="fu">,</span></span>
-<span id="cb25-4"><a href="#cb25-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;results&quot;</span><span class="fu">:</span> <span class="ot">[</span></span>
-<span id="cb25-5"><a href="#cb25-5" aria-hidden="true" tabindex="-1"></a>    <span class="fu">{</span> <span class="dt">&quot;index&quot;</span><span class="fu">:</span> <span class="dv">0</span><span class="fu">,</span> <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;update_user&quot;</span><span class="fu">,</span> <span class="dt">&quot;result&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span> <span class="dt">&quot;data&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;id&quot;</span><span class="fu">:</span> <span class="st">&quot;alice&quot;</span> <span class="fu">}</span> <span class="fu">}</span> <span class="fu">}</span></span>
-<span id="cb25-6"><a href="#cb25-6" aria-hidden="true" tabindex="-1"></a>  <span class="ot">]</span><span class="fu">,</span></span>
-<span id="cb25-7"><a href="#cb25-7" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;halted_at&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb25-8"><a href="#cb25-8" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;index&quot;</span><span class="fu">:</span> <span class="dv">1</span><span class="fu">,</span></span>
-<span id="cb25-9"><a href="#cb25-9" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;delete_user&quot;</span><span class="fu">,</span></span>
-<span id="cb25-10"><a href="#cb25-10" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;result&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb25-11"><a href="#cb25-11" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
-<span id="cb25-12"><a href="#cb25-12" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;error&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb25-13"><a href="#cb25-13" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;code&quot;</span><span class="fu">:</span> <span class="st">&quot;CONFIRMATION_REQUIRED&quot;</span><span class="fu">,</span></span>
-<span id="cb25-14"><a href="#cb25-14" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;This operation requires confirmation&quot;</span><span class="fu">,</span></span>
-<span id="cb25-15"><a href="#cb25-15" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;details&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb25-16"><a href="#cb25-16" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;delete_user&quot;</span><span class="fu">,</span></span>
-<span id="cb25-17"><a href="#cb25-17" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;danger_level&quot;</span><span class="fu">:</span> <span class="st">&quot;destructive&quot;</span><span class="fu">,</span></span>
-<span id="cb25-18"><a href="#cb25-18" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;reasons&quot;</span><span class="fu">:</span> <span class="ot">[</span><span class="st">&quot;Permanently deletes user account and associated data&quot;</span><span class="ot">]</span><span class="fu">,</span></span>
-<span id="cb25-19"><a href="#cb25-19" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;confirmation_token&quot;</span><span class="fu">:</span> <span class="st">&quot;conf_abc123&quot;</span><span class="fu">,</span></span>
-<span id="cb25-20"><a href="#cb25-20" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;expires_at&quot;</span><span class="fu">:</span> <span class="st">&quot;2026-02-04T12:05:00Z&quot;</span></span>
-<span id="cb25-21"><a href="#cb25-21" aria-hidden="true" tabindex="-1"></a>        <span class="fu">}</span></span>
-<span id="cb25-22"><a href="#cb25-22" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span></span>
-<span id="cb25-23"><a href="#cb25-23" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
-<span id="cb25-24"><a href="#cb25-24" aria-hidden="true" tabindex="-1"></a>  <span class="fu">},</span></span>
-<span id="cb25-25"><a href="#cb25-25" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;pending_operations&quot;</span><span class="fu">:</span> <span class="ot">[</span></span>
-<span id="cb25-26"><a href="#cb25-26" aria-hidden="true" tabindex="-1"></a>    <span class="fu">{</span> <span class="dt">&quot;index&quot;</span><span class="fu">:</span> <span class="dv">2</span><span class="fu">,</span> <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;send_notification&quot;</span><span class="fu">,</span> <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;user_id&quot;</span><span class="fu">:</span> <span class="st">&quot;alice&quot;</span><span class="fu">,</span> <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;Account deleted&quot;</span> <span class="fu">}</span> <span class="fu">}</span></span>
-<span id="cb25-27"><a href="#cb25-27" aria-hidden="true" tabindex="-1"></a>  <span class="ot">]</span><span class="fu">,</span></span>
-<span id="cb25-28"><a href="#cb25-28" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;summary&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb25-29"><a href="#cb25-29" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;total&quot;</span><span class="fu">:</span> <span class="dv">3</span><span class="fu">,</span></span>
-<span id="cb25-30"><a href="#cb25-30" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;succeeded&quot;</span><span class="fu">:</span> <span class="dv">1</span><span class="fu">,</span></span>
-<span id="cb25-31"><a href="#cb25-31" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;failed&quot;</span><span class="fu">:</span> <span class="dv">0</span><span class="fu">,</span></span>
-<span id="cb25-32"><a href="#cb25-32" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;halted&quot;</span><span class="fu">:</span> <span class="dv">1</span><span class="fu">,</span></span>
-<span id="cb25-33"><a href="#cb25-33" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;pending&quot;</span><span class="fu">:</span> <span class="dv">1</span></span>
-<span id="cb25-34"><a href="#cb25-34" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
-<span id="cb25-35"><a href="#cb25-35" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<div class="sourceCode" id="cb26"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb26-1"><a href="#cb26-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb26-2"><a href="#cb26-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb26-3"><a href="#cb26-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;data&quot;</span><span class="fu">:</span> <span class="kw">null</span><span class="fu">,</span></span>
+<span id="cb26-4"><a href="#cb26-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;results&quot;</span><span class="fu">:</span> <span class="ot">[</span></span>
+<span id="cb26-5"><a href="#cb26-5" aria-hidden="true" tabindex="-1"></a>    <span class="fu">{</span> <span class="dt">&quot;index&quot;</span><span class="fu">:</span> <span class="dv">0</span><span class="fu">,</span> <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;update_user&quot;</span><span class="fu">,</span> <span class="dt">&quot;result&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span> <span class="dt">&quot;data&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;id&quot;</span><span class="fu">:</span> <span class="st">&quot;alice&quot;</span> <span class="fu">}</span> <span class="fu">}</span> <span class="fu">}</span></span>
+<span id="cb26-6"><a href="#cb26-6" aria-hidden="true" tabindex="-1"></a>  <span class="ot">]</span><span class="fu">,</span></span>
+<span id="cb26-7"><a href="#cb26-7" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;halted_at&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb26-8"><a href="#cb26-8" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;index&quot;</span><span class="fu">:</span> <span class="dv">1</span><span class="fu">,</span></span>
+<span id="cb26-9"><a href="#cb26-9" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;delete_user&quot;</span><span class="fu">,</span></span>
+<span id="cb26-10"><a href="#cb26-10" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;result&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb26-11"><a href="#cb26-11" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb26-12"><a href="#cb26-12" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;error&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb26-13"><a href="#cb26-13" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;code&quot;</span><span class="fu">:</span> <span class="st">&quot;CONFIRMATION_REQUIRED&quot;</span><span class="fu">,</span></span>
+<span id="cb26-14"><a href="#cb26-14" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;This operation requires confirmation&quot;</span><span class="fu">,</span></span>
+<span id="cb26-15"><a href="#cb26-15" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;details&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb26-16"><a href="#cb26-16" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;delete_user&quot;</span><span class="fu">,</span></span>
+<span id="cb26-17"><a href="#cb26-17" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;danger_level&quot;</span><span class="fu">:</span> <span class="st">&quot;destructive&quot;</span><span class="fu">,</span></span>
+<span id="cb26-18"><a href="#cb26-18" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;reasons&quot;</span><span class="fu">:</span> <span class="ot">[</span><span class="st">&quot;Permanently deletes user account and associated data&quot;</span><span class="ot">]</span><span class="fu">,</span></span>
+<span id="cb26-19"><a href="#cb26-19" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;confirmation_token&quot;</span><span class="fu">:</span> <span class="st">&quot;conf_abc123&quot;</span><span class="fu">,</span></span>
+<span id="cb26-20"><a href="#cb26-20" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;expires_at&quot;</span><span class="fu">:</span> <span class="st">&quot;2026-02-04T12:05:00Z&quot;</span></span>
+<span id="cb26-21"><a href="#cb26-21" aria-hidden="true" tabindex="-1"></a>        <span class="fu">}</span></span>
+<span id="cb26-22"><a href="#cb26-22" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span></span>
+<span id="cb26-23"><a href="#cb26-23" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb26-24"><a href="#cb26-24" aria-hidden="true" tabindex="-1"></a>  <span class="fu">},</span></span>
+<span id="cb26-25"><a href="#cb26-25" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;pending_operations&quot;</span><span class="fu">:</span> <span class="ot">[</span></span>
+<span id="cb26-26"><a href="#cb26-26" aria-hidden="true" tabindex="-1"></a>    <span class="fu">{</span> <span class="dt">&quot;index&quot;</span><span class="fu">:</span> <span class="dv">2</span><span class="fu">,</span> <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;send_notification&quot;</span><span class="fu">,</span> <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;user_id&quot;</span><span class="fu">:</span> <span class="st">&quot;alice&quot;</span><span class="fu">,</span> <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;Account deleted&quot;</span> <span class="fu">}</span> <span class="fu">}</span></span>
+<span id="cb26-27"><a href="#cb26-27" aria-hidden="true" tabindex="-1"></a>  <span class="ot">]</span><span class="fu">,</span></span>
+<span id="cb26-28"><a href="#cb26-28" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;summary&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb26-29"><a href="#cb26-29" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;total&quot;</span><span class="fu">:</span> <span class="dv">3</span><span class="fu">,</span></span>
+<span id="cb26-30"><a href="#cb26-30" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;succeeded&quot;</span><span class="fu">:</span> <span class="dv">1</span><span class="fu">,</span></span>
+<span id="cb26-31"><a href="#cb26-31" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;failed&quot;</span><span class="fu">:</span> <span class="dv">0</span><span class="fu">,</span></span>
+<span id="cb26-32"><a href="#cb26-32" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;halted&quot;</span><span class="fu">:</span> <span class="dv">1</span><span class="fu">,</span></span>
+<span id="cb26-33"><a href="#cb26-33" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;pending&quot;</span><span class="fu">:</span> <span class="dv">1</span></span>
+<span id="cb26-34"><a href="#cb26-34" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb26-35"><a href="#cb26-35" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
 <h4 id="753-continuation-after-confirmation">7.5.3 Continuation After Confirmation</h4>
 <p>To continue after the user confirms, submit a new batch starting from the halted operation with the confirmation token:</p>
-<div class="sourceCode" id="cb26"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb26-1"><a href="#cb26-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
-<span id="cb26-2"><a href="#cb26-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;operations&quot;</span><span class="fu">:</span> <span class="ot">[</span></span>
-<span id="cb26-3"><a href="#cb26-3" aria-hidden="true" tabindex="-1"></a>    <span class="fu">{</span></span>
-<span id="cb26-4"><a href="#cb26-4" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;delete_user&quot;</span><span class="fu">,</span></span>
-<span id="cb26-5"><a href="#cb26-5" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb26-6"><a href="#cb26-6" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;user_id&quot;</span><span class="fu">:</span> <span class="st">&quot;alice&quot;</span><span class="fu">,</span></span>
-<span id="cb26-7"><a href="#cb26-7" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;confirmation_token&quot;</span><span class="fu">:</span> <span class="st">&quot;conf_abc123&quot;</span></span>
-<span id="cb26-8"><a href="#cb26-8" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span></span>
-<span id="cb26-9"><a href="#cb26-9" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span><span class="ot">,</span></span>
-<span id="cb26-10"><a href="#cb26-10" aria-hidden="true" tabindex="-1"></a>    <span class="fu">{</span></span>
-<span id="cb26-11"><a href="#cb26-11" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;send_notification&quot;</span><span class="fu">,</span></span>
-<span id="cb26-12"><a href="#cb26-12" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;user_id&quot;</span><span class="fu">:</span> <span class="st">&quot;alice&quot;</span><span class="fu">,</span> <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;Account deleted&quot;</span> <span class="fu">}</span></span>
-<span id="cb26-13"><a href="#cb26-13" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
-<span id="cb26-14"><a href="#cb26-14" aria-hidden="true" tabindex="-1"></a>  <span class="ot">]</span></span>
-<span id="cb26-15"><a href="#cb26-15" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<div class="sourceCode" id="cb27"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb27-1"><a href="#cb27-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb27-2"><a href="#cb27-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;operations&quot;</span><span class="fu">:</span> <span class="ot">[</span></span>
+<span id="cb27-3"><a href="#cb27-3" aria-hidden="true" tabindex="-1"></a>    <span class="fu">{</span></span>
+<span id="cb27-4"><a href="#cb27-4" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;delete_user&quot;</span><span class="fu">,</span></span>
+<span id="cb27-5"><a href="#cb27-5" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb27-6"><a href="#cb27-6" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;user_id&quot;</span><span class="fu">:</span> <span class="st">&quot;alice&quot;</span><span class="fu">,</span></span>
+<span id="cb27-7"><a href="#cb27-7" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;confirmation_token&quot;</span><span class="fu">:</span> <span class="st">&quot;conf_abc123&quot;</span></span>
+<span id="cb27-8"><a href="#cb27-8" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span></span>
+<span id="cb27-9"><a href="#cb27-9" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb27-10"><a href="#cb27-10" aria-hidden="true" tabindex="-1"></a>    <span class="fu">{</span></span>
+<span id="cb27-11"><a href="#cb27-11" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;send_notification&quot;</span><span class="fu">,</span></span>
+<span id="cb27-12"><a href="#cb27-12" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;user_id&quot;</span><span class="fu">:</span> <span class="st">&quot;alice&quot;</span><span class="fu">,</span> <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;Account deleted&quot;</span> <span class="fu">}</span></span>
+<span id="cb27-13"><a href="#cb27-13" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb27-14"><a href="#cb27-14" aria-hidden="true" tabindex="-1"></a>  <span class="ot">]</span></span>
+<span id="cb27-15"><a href="#cb27-15" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
 <p>Clients MAY use the <code>pending_operations</code> array from the halted response to construct the continuation batch.</p>
 <h4 id="754-alternative-skip-and-continue-may">7.5.4 Alternative: Skip and Continue (MAY)</h4>
 <p>Adapters MAY implement skip-and-continue behavior, where the gated operation is skipped and subsequent operations execute.</p>
@@ -968,16 +1016,16 @@
 <li><strong>Skip mode:</strong> Response includes results for all operations, with <code>status: "pending_confirmation"</code> on gated operations</li>
 </ul>
 </blockquote>
-<div class="sourceCode" id="cb27"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb27-1"><a href="#cb27-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
-<span id="cb27-2"><a href="#cb27-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
-<span id="cb27-3"><a href="#cb27-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;data&quot;</span><span class="fu">:</span> <span class="kw">null</span><span class="fu">,</span></span>
-<span id="cb27-4"><a href="#cb27-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;results&quot;</span><span class="fu">:</span> <span class="ot">[</span></span>
-<span id="cb27-5"><a href="#cb27-5" aria-hidden="true" tabindex="-1"></a>    <span class="fu">{</span> <span class="dt">&quot;index&quot;</span><span class="fu">:</span> <span class="dv">0</span><span class="fu">,</span> <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;update_user&quot;</span><span class="fu">,</span> <span class="dt">&quot;result&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span> <span class="dt">&quot;data&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;id&quot;</span><span class="fu">:</span> <span class="st">&quot;alice&quot;</span> <span class="fu">}</span> <span class="fu">}</span> <span class="fu">}</span><span class="ot">,</span></span>
-<span id="cb27-6"><a href="#cb27-6" aria-hidden="true" tabindex="-1"></a>    <span class="fu">{</span> <span class="dt">&quot;index&quot;</span><span class="fu">:</span> <span class="dv">1</span><span class="fu">,</span> <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;delete_user&quot;</span><span class="fu">,</span> <span class="dt">&quot;result&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span> <span class="dt">&quot;error&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;code&quot;</span><span class="fu">:</span> <span class="st">&quot;CONFIRMATION_REQUIRED&quot;</span><span class="fu">,</span> <span class="er">...</span> <span class="fu">}</span> <span class="fu">},</span> <span class="dt">&quot;status&quot;</span><span class="fu">:</span> <span class="st">&quot;pending_confirmation&quot;</span> <span class="fu">}</span><span class="ot">,</span></span>
-<span id="cb27-7"><a href="#cb27-7" aria-hidden="true" tabindex="-1"></a>    <span class="fu">{</span> <span class="dt">&quot;index&quot;</span><span class="fu">:</span> <span class="dv">2</span><span class="fu">,</span> <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;send_notification&quot;</span><span class="fu">,</span> <span class="dt">&quot;result&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span> <span class="dt">&quot;data&quot;</span><span class="fu">:</span> <span class="fu">{}</span> <span class="fu">}</span> <span class="fu">}</span></span>
-<span id="cb27-8"><a href="#cb27-8" aria-hidden="true" tabindex="-1"></a>  <span class="ot">]</span><span class="fu">,</span></span>
-<span id="cb27-9"><a href="#cb27-9" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;summary&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;total&quot;</span><span class="fu">:</span> <span class="dv">3</span><span class="fu">,</span> <span class="dt">&quot;succeeded&quot;</span><span class="fu">:</span> <span class="dv">2</span><span class="fu">,</span> <span class="dt">&quot;failed&quot;</span><span class="fu">:</span> <span class="dv">0</span><span class="fu">,</span> <span class="dt">&quot;pending_confirmation&quot;</span><span class="fu">:</span> <span class="dv">1</span> <span class="fu">}</span></span>
-<span id="cb27-10"><a href="#cb27-10" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<div class="sourceCode" id="cb28"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb28-1"><a href="#cb28-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb28-2"><a href="#cb28-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb28-3"><a href="#cb28-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;data&quot;</span><span class="fu">:</span> <span class="kw">null</span><span class="fu">,</span></span>
+<span id="cb28-4"><a href="#cb28-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;results&quot;</span><span class="fu">:</span> <span class="ot">[</span></span>
+<span id="cb28-5"><a href="#cb28-5" aria-hidden="true" tabindex="-1"></a>    <span class="fu">{</span> <span class="dt">&quot;index&quot;</span><span class="fu">:</span> <span class="dv">0</span><span class="fu">,</span> <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;update_user&quot;</span><span class="fu">,</span> <span class="dt">&quot;result&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span> <span class="dt">&quot;data&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;id&quot;</span><span class="fu">:</span> <span class="st">&quot;alice&quot;</span> <span class="fu">}</span> <span class="fu">}</span> <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb28-6"><a href="#cb28-6" aria-hidden="true" tabindex="-1"></a>    <span class="fu">{</span> <span class="dt">&quot;index&quot;</span><span class="fu">:</span> <span class="dv">1</span><span class="fu">,</span> <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;delete_user&quot;</span><span class="fu">,</span> <span class="dt">&quot;result&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span> <span class="dt">&quot;error&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;code&quot;</span><span class="fu">:</span> <span class="st">&quot;CONFIRMATION_REQUIRED&quot;</span><span class="fu">,</span> <span class="er">...</span> <span class="fu">}</span> <span class="fu">},</span> <span class="dt">&quot;status&quot;</span><span class="fu">:</span> <span class="st">&quot;pending_confirmation&quot;</span> <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb28-7"><a href="#cb28-7" aria-hidden="true" tabindex="-1"></a>    <span class="fu">{</span> <span class="dt">&quot;index&quot;</span><span class="fu">:</span> <span class="dv">2</span><span class="fu">,</span> <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;send_notification&quot;</span><span class="fu">,</span> <span class="dt">&quot;result&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span> <span class="dt">&quot;data&quot;</span><span class="fu">:</span> <span class="fu">{}</span> <span class="fu">}</span> <span class="fu">}</span></span>
+<span id="cb28-8"><a href="#cb28-8" aria-hidden="true" tabindex="-1"></a>  <span class="ot">]</span><span class="fu">,</span></span>
+<span id="cb28-9"><a href="#cb28-9" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;summary&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;total&quot;</span><span class="fu">:</span> <span class="dv">3</span><span class="fu">,</span> <span class="dt">&quot;succeeded&quot;</span><span class="fu">:</span> <span class="dv">2</span><span class="fu">,</span> <span class="dt">&quot;failed&quot;</span><span class="fu">:</span> <span class="dv">0</span><span class="fu">,</span> <span class="dt">&quot;pending_confirmation&quot;</span><span class="fu">:</span> <span class="dv">1</span> <span class="fu">}</span></span>
+<span id="cb28-10"><a href="#cb28-10" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
 <blockquote>
 <p><strong>Warning:</strong> Skip-and-continue risks inconsistent state when operations depend on each other. This approach is NOT RECOMMENDED unless operations are known to be independent.</p>
 </blockquote>
@@ -997,44 +1045,44 @@
 <p>Adapters MUST categorize errors using structured error codes. The table below shows error categories and their corresponding codes:</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Category</th>
 <th>Error Code</th>
 <th>Example Message</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td>Missing Parameter</td>
 <td><code>VALIDATION_MISSING_PARAM</code></td>
 <td>"Missing required parameter 'name'"</td>
 </tr>
-<tr>
+<tr class="even">
 <td>Invalid Type</td>
 <td><code>VALIDATION_INVALID_TYPE</code></td>
 <td>"Parameter 'price' expected 'number', got 'string'"</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>Resource Not Found</td>
 <td><code>NOT_FOUND_RESOURCE</code></td>
 <td>"Item 'item_999' not found"</td>
 </tr>
-<tr>
+<tr class="even">
 <td>Unknown Operation</td>
 <td><code>NOT_FOUND_OPERATION</code></td>
 <td>"Unknown operation: 'create_widget'"</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>Permission Denied</td>
 <td><code>PERMISSION_DENIED</code></td>
 <td>"Permission denied: requires 'admin' scope"</td>
 </tr>
-<tr>
+<tr class="even">
 <td>Rate Limited</td>
 <td><code>RATE_LIMIT_EXCEEDED</code></td>
 <td>"API rate limit exceeded"</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>Internal Error</td>
 <td><code>INTERNAL_ERROR</code></td>
 <td>"Internal error: database connection failed"</td>
@@ -1044,17 +1092,17 @@
 <p>See <a href="error-codes.html">Structured Error Codes Specification</a> for detailed error code definitions and usage.</p>
 <h3 id="82-error-response-structure">8.2 Error Response Structure</h3>
 <p>All error responses MUST use structured error objects:</p>
-<div class="sourceCode" id="cb28"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb28-1"><a href="#cb28-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
-<span id="cb28-2"><a href="#cb28-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
-<span id="cb28-3"><a href="#cb28-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;error&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb28-4"><a href="#cb28-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;code&quot;</span><span class="fu">:</span> <span class="st">&quot;NOT_FOUND_RESOURCE&quot;</span><span class="fu">,</span></span>
-<span id="cb28-5"><a href="#cb28-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;Item &#39;item_999&#39; not found&quot;</span><span class="fu">,</span></span>
-<span id="cb28-6"><a href="#cb28-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;details&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb28-7"><a href="#cb28-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;resource_type&quot;</span><span class="fu">:</span> <span class="st">&quot;item&quot;</span><span class="fu">,</span></span>
-<span id="cb28-8"><a href="#cb28-8" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;resource_id&quot;</span><span class="fu">:</span> <span class="st">&quot;item_999&quot;</span></span>
-<span id="cb28-9"><a href="#cb28-9" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
-<span id="cb28-10"><a href="#cb28-10" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
-<span id="cb28-11"><a href="#cb28-11" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<div class="sourceCode" id="cb29"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb29-1"><a href="#cb29-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb29-2"><a href="#cb29-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb29-3"><a href="#cb29-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;error&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb29-4"><a href="#cb29-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;code&quot;</span><span class="fu">:</span> <span class="st">&quot;NOT_FOUND_RESOURCE&quot;</span><span class="fu">,</span></span>
+<span id="cb29-5"><a href="#cb29-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;Item &#39;item_999&#39; not found&quot;</span><span class="fu">,</span></span>
+<span id="cb29-6"><a href="#cb29-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;details&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb29-7"><a href="#cb29-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;resource_type&quot;</span><span class="fu">:</span> <span class="st">&quot;item&quot;</span><span class="fu">,</span></span>
+<span id="cb29-8"><a href="#cb29-8" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;resource_id&quot;</span><span class="fu">:</span> <span class="st">&quot;item_999&quot;</span></span>
+<span id="cb29-9"><a href="#cb29-9" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb29-10"><a href="#cb29-10" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb29-11"><a href="#cb29-11" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
 <p>The <code>error</code> object:</p>
 <ul>
 <li>MUST include <code>code</code> - A machine-readable error code from the <a href="error-codes.html">error code taxonomy</a></li>
@@ -1066,37 +1114,37 @@
 <p>Adapters MUST use standardized error codes for programmatic handling. Common codes include:</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Code</th>
 <th>Description</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><code>VALIDATION_MISSING_PARAM</code></td>
 <td>Required parameter not provided</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>VALIDATION_INVALID_TYPE</code></td>
 <td>Parameter type mismatch</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>NOT_FOUND_OPERATION</code></td>
 <td>Operation name not recognized</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>NOT_FOUND_RESOURCE</code></td>
 <td>Resource not found</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>PERMISSION_DENIED</code></td>
 <td>Operation not permitted</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>RATE_LIMIT_EXCEEDED</code></td>
 <td>Too many requests</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>INTERNAL_ERROR</code></td>
 <td>Server error</td>
 </tr>
@@ -1113,150 +1161,156 @@
 <hr />
 <h2 id="9-the-introspect-operation">9. The introspect Operation</h2>
 <h3 id="91-required-implementation">9.1 Required Implementation</h3>
-<p>Every MCP-AQL adapter MUST implement the <code>introspect</code> operation on the READ endpoint. This operation enables runtime discovery of available operations and types.</p>
+<p>Every MCP-AQL adapter MUST implement the <code>introspect</code> operation as a READ-category operation on a documented endpoint family. This operation enables runtime discovery of available operations and types.</p>
 <h3 id="92-operation-schema">9.2 Operation Schema</h3>
-<div class="sourceCode" id="cb29"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb29-1"><a href="#cb29-1" aria-hidden="true" tabindex="-1"></a>{</span>
-<span id="cb29-2"><a href="#cb29-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">introspect</span><span class="op">:</span> {</span>
-<span id="cb29-3"><a href="#cb29-3" aria-hidden="true" tabindex="-1"></a>    <span class="dt">endpoint</span><span class="op">:</span> <span class="st">&quot;READ&quot;</span><span class="op">,</span></span>
-<span id="cb29-4"><a href="#cb29-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">description</span><span class="op">:</span> <span class="st">&quot;Discover available operations and types&quot;</span><span class="op">,</span></span>
-<span id="cb29-5"><a href="#cb29-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">params</span><span class="op">:</span> {</span>
-<span id="cb29-6"><a href="#cb29-6" aria-hidden="true" tabindex="-1"></a>      <span class="dt">query</span><span class="op">:</span> {</span>
-<span id="cb29-7"><a href="#cb29-7" aria-hidden="true" tabindex="-1"></a>        <span class="dt">type</span><span class="op">:</span> <span class="st">&quot;string&quot;</span><span class="op">,</span></span>
-<span id="cb29-8"><a href="#cb29-8" aria-hidden="true" tabindex="-1"></a>        <span class="dt">required</span><span class="op">:</span> <span class="kw">true</span><span class="op">,</span></span>
-<span id="cb29-9"><a href="#cb29-9" aria-hidden="true" tabindex="-1"></a>        <span class="dt">enum</span><span class="op">:</span> [<span class="st">&quot;operations&quot;</span><span class="op">,</span> <span class="st">&quot;types&quot;</span>]<span class="op">,</span></span>
-<span id="cb29-10"><a href="#cb29-10" aria-hidden="true" tabindex="-1"></a>        <span class="dt">description</span><span class="op">:</span> <span class="st">&quot;What to introspect&quot;</span></span>
-<span id="cb29-11"><a href="#cb29-11" aria-hidden="true" tabindex="-1"></a>      }<span class="op">,</span></span>
-<span id="cb29-12"><a href="#cb29-12" aria-hidden="true" tabindex="-1"></a>      <span class="dt">name</span><span class="op">:</span> {</span>
-<span id="cb29-13"><a href="#cb29-13" aria-hidden="true" tabindex="-1"></a>        <span class="dt">type</span><span class="op">:</span> <span class="st">&quot;string&quot;</span><span class="op">,</span></span>
-<span id="cb29-14"><a href="#cb29-14" aria-hidden="true" tabindex="-1"></a>        <span class="dt">required</span><span class="op">:</span> <span class="kw">false</span><span class="op">,</span></span>
-<span id="cb29-15"><a href="#cb29-15" aria-hidden="true" tabindex="-1"></a>        <span class="dt">description</span><span class="op">:</span> <span class="st">&quot;Specific operation or type name for detailed info&quot;</span></span>
-<span id="cb29-16"><a href="#cb29-16" aria-hidden="true" tabindex="-1"></a>      }</span>
-<span id="cb29-17"><a href="#cb29-17" aria-hidden="true" tabindex="-1"></a>    }</span>
-<span id="cb29-18"><a href="#cb29-18" aria-hidden="true" tabindex="-1"></a>  }</span>
-<span id="cb29-19"><a href="#cb29-19" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<div class="sourceCode" id="cb30"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb30-1"><a href="#cb30-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb30-2"><a href="#cb30-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">introspect</span><span class="op">:</span> {</span>
+<span id="cb30-3"><a href="#cb30-3" aria-hidden="true" tabindex="-1"></a>    <span class="dt">endpoint</span><span class="op">:</span> <span class="st">&quot;READ&quot;</span><span class="op">,</span></span>
+<span id="cb30-4"><a href="#cb30-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">description</span><span class="op">:</span> <span class="st">&quot;Discover available operations and types&quot;</span><span class="op">,</span></span>
+<span id="cb30-5"><a href="#cb30-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">params</span><span class="op">:</span> {</span>
+<span id="cb30-6"><a href="#cb30-6" aria-hidden="true" tabindex="-1"></a>      <span class="dt">query</span><span class="op">:</span> {</span>
+<span id="cb30-7"><a href="#cb30-7" aria-hidden="true" tabindex="-1"></a>        <span class="dt">type</span><span class="op">:</span> <span class="st">&quot;string&quot;</span><span class="op">,</span></span>
+<span id="cb30-8"><a href="#cb30-8" aria-hidden="true" tabindex="-1"></a>        <span class="dt">required</span><span class="op">:</span> <span class="kw">true</span><span class="op">,</span></span>
+<span id="cb30-9"><a href="#cb30-9" aria-hidden="true" tabindex="-1"></a>        <span class="dt">enum</span><span class="op">:</span> [<span class="st">&quot;operations&quot;</span><span class="op">,</span> <span class="st">&quot;types&quot;</span>]<span class="op">,</span></span>
+<span id="cb30-10"><a href="#cb30-10" aria-hidden="true" tabindex="-1"></a>        <span class="dt">description</span><span class="op">:</span> <span class="st">&quot;What to introspect&quot;</span></span>
+<span id="cb30-11"><a href="#cb30-11" aria-hidden="true" tabindex="-1"></a>      }<span class="op">,</span></span>
+<span id="cb30-12"><a href="#cb30-12" aria-hidden="true" tabindex="-1"></a>      <span class="dt">name</span><span class="op">:</span> {</span>
+<span id="cb30-13"><a href="#cb30-13" aria-hidden="true" tabindex="-1"></a>        <span class="dt">type</span><span class="op">:</span> <span class="st">&quot;string&quot;</span><span class="op">,</span></span>
+<span id="cb30-14"><a href="#cb30-14" aria-hidden="true" tabindex="-1"></a>        <span class="dt">required</span><span class="op">:</span> <span class="kw">false</span><span class="op">,</span></span>
+<span id="cb30-15"><a href="#cb30-15" aria-hidden="true" tabindex="-1"></a>        <span class="dt">description</span><span class="op">:</span> <span class="st">&quot;Specific operation or type name for detailed info&quot;</span></span>
+<span id="cb30-16"><a href="#cb30-16" aria-hidden="true" tabindex="-1"></a>      }</span>
+<span id="cb30-17"><a href="#cb30-17" aria-hidden="true" tabindex="-1"></a>    }</span>
+<span id="cb30-18"><a href="#cb30-18" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb30-19"><a href="#cb30-19" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
 <h3 id="93-query-types">9.3 Query Types</h3>
 <p><strong>List all operations:</strong></p>
-<div class="sourceCode" id="cb30"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb30-1"><a href="#cb30-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span> <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;introspect&quot;</span><span class="fu">,</span> <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;query&quot;</span><span class="fu">:</span> <span class="st">&quot;operations&quot;</span> <span class="fu">}</span> <span class="fu">}</span></span></code></pre></div>
+<div class="sourceCode" id="cb31"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb31-1"><a href="#cb31-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span> <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;introspect&quot;</span><span class="fu">,</span> <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;query&quot;</span><span class="fu">:</span> <span class="st">&quot;operations&quot;</span> <span class="fu">}</span> <span class="fu">}</span></span></code></pre></div>
 <p><strong>Get operation details:</strong></p>
-<div class="sourceCode" id="cb31"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb31-1"><a href="#cb31-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span> <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;introspect&quot;</span><span class="fu">,</span> <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;query&quot;</span><span class="fu">:</span> <span class="st">&quot;operations&quot;</span><span class="fu">,</span> <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;create_item&quot;</span> <span class="fu">}</span> <span class="fu">}</span></span></code></pre></div>
+<div class="sourceCode" id="cb32"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb32-1"><a href="#cb32-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span> <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;introspect&quot;</span><span class="fu">,</span> <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;query&quot;</span><span class="fu">:</span> <span class="st">&quot;operations&quot;</span><span class="fu">,</span> <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;create_item&quot;</span> <span class="fu">}</span> <span class="fu">}</span></span></code></pre></div>
 <p><strong>List all types:</strong></p>
-<div class="sourceCode" id="cb32"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb32-1"><a href="#cb32-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span> <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;introspect&quot;</span><span class="fu">,</span> <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;query&quot;</span><span class="fu">:</span> <span class="st">&quot;types&quot;</span> <span class="fu">}</span> <span class="fu">}</span></span></code></pre></div>
+<div class="sourceCode" id="cb33"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb33-1"><a href="#cb33-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span> <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;introspect&quot;</span><span class="fu">,</span> <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;query&quot;</span><span class="fu">:</span> <span class="st">&quot;types&quot;</span> <span class="fu">}</span> <span class="fu">}</span></span></code></pre></div>
 <p><strong>Get type details:</strong></p>
-<div class="sourceCode" id="cb33"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb33-1"><a href="#cb33-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span> <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;introspect&quot;</span><span class="fu">,</span> <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;query&quot;</span><span class="fu">:</span> <span class="st">&quot;types&quot;</span><span class="fu">,</span> <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;ItemCategory&quot;</span> <span class="fu">}</span> <span class="fu">}</span></span></code></pre></div>
+<div class="sourceCode" id="cb34"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb34-1"><a href="#cb34-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span> <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;introspect&quot;</span><span class="fu">,</span> <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;query&quot;</span><span class="fu">:</span> <span class="st">&quot;types&quot;</span><span class="fu">,</span> <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;ItemCategory&quot;</span> <span class="fu">}</span> <span class="fu">}</span></span></code></pre></div>
 <h3 id="94-operations-response">9.4 Operations Response</h3>
 <p>When <code>query</code> is "operations" without a <code>name</code>:</p>
-<div class="sourceCode" id="cb34"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb34-1"><a href="#cb34-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
-<span id="cb34-2"><a href="#cb34-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
-<span id="cb34-3"><a href="#cb34-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;data&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb34-4"><a href="#cb34-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;operations&quot;</span><span class="fu">:</span> <span class="ot">[</span></span>
-<span id="cb34-5"><a href="#cb34-5" aria-hidden="true" tabindex="-1"></a>      <span class="fu">{</span></span>
-<span id="cb34-6"><a href="#cb34-6" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;create_item&quot;</span><span class="fu">,</span></span>
-<span id="cb34-7"><a href="#cb34-7" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;endpoint&quot;</span><span class="fu">:</span> <span class="st">&quot;CREATE&quot;</span><span class="fu">,</span></span>
-<span id="cb34-8"><a href="#cb34-8" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Create a new item&quot;</span></span>
-<span id="cb34-9"><a href="#cb34-9" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span><span class="ot">,</span></span>
-<span id="cb34-10"><a href="#cb34-10" aria-hidden="true" tabindex="-1"></a>      <span class="fu">{</span></span>
-<span id="cb34-11"><a href="#cb34-11" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;list_items&quot;</span><span class="fu">,</span></span>
-<span id="cb34-12"><a href="#cb34-12" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;endpoint&quot;</span><span class="fu">:</span> <span class="st">&quot;READ&quot;</span><span class="fu">,</span></span>
-<span id="cb34-13"><a href="#cb34-13" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;List all items&quot;</span></span>
-<span id="cb34-14"><a href="#cb34-14" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span><span class="ot">,</span></span>
-<span id="cb34-15"><a href="#cb34-15" aria-hidden="true" tabindex="-1"></a>      <span class="fu">{</span></span>
-<span id="cb34-16"><a href="#cb34-16" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;update_item&quot;</span><span class="fu">,</span></span>
-<span id="cb34-17"><a href="#cb34-17" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;endpoint&quot;</span><span class="fu">:</span> <span class="st">&quot;UPDATE&quot;</span><span class="fu">,</span></span>
-<span id="cb34-18"><a href="#cb34-18" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Update item properties&quot;</span></span>
-<span id="cb34-19"><a href="#cb34-19" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span><span class="ot">,</span></span>
-<span id="cb34-20"><a href="#cb34-20" aria-hidden="true" tabindex="-1"></a>      <span class="fu">{</span></span>
-<span id="cb34-21"><a href="#cb34-21" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;delete_item&quot;</span><span class="fu">,</span></span>
-<span id="cb34-22"><a href="#cb34-22" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;endpoint&quot;</span><span class="fu">:</span> <span class="st">&quot;DELETE&quot;</span><span class="fu">,</span></span>
-<span id="cb34-23"><a href="#cb34-23" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Delete an item&quot;</span></span>
-<span id="cb34-24"><a href="#cb34-24" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span><span class="ot">,</span></span>
-<span id="cb34-25"><a href="#cb34-25" aria-hidden="true" tabindex="-1"></a>      <span class="fu">{</span></span>
-<span id="cb34-26"><a href="#cb34-26" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;introspect&quot;</span><span class="fu">,</span></span>
-<span id="cb34-27"><a href="#cb34-27" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;endpoint&quot;</span><span class="fu">:</span> <span class="st">&quot;READ&quot;</span><span class="fu">,</span></span>
-<span id="cb34-28"><a href="#cb34-28" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Discover available operations&quot;</span></span>
-<span id="cb34-29"><a href="#cb34-29" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span></span>
-<span id="cb34-30"><a href="#cb34-30" aria-hidden="true" tabindex="-1"></a>    <span class="ot">]</span></span>
-<span id="cb34-31"><a href="#cb34-31" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
-<span id="cb34-32"><a href="#cb34-32" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
-<h3 id="95-operation-details-response">9.5 Operation Details Response</h3>
-<p>When <code>query</code> is "operations" with a <code>name</code>:</p>
 <div class="sourceCode" id="cb35"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb35-1"><a href="#cb35-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
 <span id="cb35-2"><a href="#cb35-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
 <span id="cb35-3"><a href="#cb35-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;data&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb35-4"><a href="#cb35-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb35-5"><a href="#cb35-5" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;create_item&quot;</span><span class="fu">,</span></span>
-<span id="cb35-6"><a href="#cb35-6" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;endpoint&quot;</span><span class="fu">:</span> <span class="st">&quot;CREATE&quot;</span><span class="fu">,</span></span>
-<span id="cb35-7"><a href="#cb35-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;mcpTool&quot;</span><span class="fu">:</span> <span class="st">&quot;mcp_aql_create&quot;</span><span class="fu">,</span></span>
-<span id="cb35-8"><a href="#cb35-8" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Create a new item&quot;</span><span class="fu">,</span></span>
-<span id="cb35-9"><a href="#cb35-9" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;permissions&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb35-10"><a href="#cb35-10" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;readOnly&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
-<span id="cb35-11"><a href="#cb35-11" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;destructive&quot;</span><span class="fu">:</span> <span class="kw">false</span></span>
-<span id="cb35-12"><a href="#cb35-12" aria-hidden="true" tabindex="-1"></a>      <span class="fu">},</span></span>
-<span id="cb35-13"><a href="#cb35-13" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;parameters&quot;</span><span class="fu">:</span> <span class="ot">[</span></span>
-<span id="cb35-14"><a href="#cb35-14" aria-hidden="true" tabindex="-1"></a>        <span class="fu">{</span></span>
-<span id="cb35-15"><a href="#cb35-15" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;name&quot;</span><span class="fu">,</span></span>
-<span id="cb35-16"><a href="#cb35-16" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;string&quot;</span><span class="fu">,</span></span>
-<span id="cb35-17"><a href="#cb35-17" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;required&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
-<span id="cb35-18"><a href="#cb35-18" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Item name&quot;</span></span>
-<span id="cb35-19"><a href="#cb35-19" aria-hidden="true" tabindex="-1"></a>        <span class="fu">}</span><span class="ot">,</span></span>
-<span id="cb35-20"><a href="#cb35-20" aria-hidden="true" tabindex="-1"></a>        <span class="fu">{</span></span>
-<span id="cb35-21"><a href="#cb35-21" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;category&quot;</span><span class="fu">,</span></span>
-<span id="cb35-22"><a href="#cb35-22" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;string&quot;</span><span class="fu">,</span></span>
-<span id="cb35-23"><a href="#cb35-23" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;required&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
-<span id="cb35-24"><a href="#cb35-24" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Item category&quot;</span><span class="fu">,</span></span>
-<span id="cb35-25"><a href="#cb35-25" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;enum&quot;</span><span class="fu">:</span> <span class="ot">[</span><span class="st">&quot;product&quot;</span><span class="ot">,</span> <span class="st">&quot;service&quot;</span><span class="ot">,</span> <span class="st">&quot;subscription&quot;</span><span class="ot">]</span></span>
-<span id="cb35-26"><a href="#cb35-26" aria-hidden="true" tabindex="-1"></a>        <span class="fu">}</span><span class="ot">,</span></span>
-<span id="cb35-27"><a href="#cb35-27" aria-hidden="true" tabindex="-1"></a>        <span class="fu">{</span></span>
-<span id="cb35-28"><a href="#cb35-28" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;price&quot;</span><span class="fu">,</span></span>
-<span id="cb35-29"><a href="#cb35-29" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;number&quot;</span><span class="fu">,</span></span>
-<span id="cb35-30"><a href="#cb35-30" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;required&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
-<span id="cb35-31"><a href="#cb35-31" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;minimum&quot;</span><span class="fu">:</span> <span class="dv">0</span><span class="fu">,</span></span>
-<span id="cb35-32"><a href="#cb35-32" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Item price in cents&quot;</span></span>
-<span id="cb35-33"><a href="#cb35-33" aria-hidden="true" tabindex="-1"></a>        <span class="fu">}</span></span>
-<span id="cb35-34"><a href="#cb35-34" aria-hidden="true" tabindex="-1"></a>      <span class="ot">]</span><span class="fu">,</span></span>
-<span id="cb35-35"><a href="#cb35-35" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;returns&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb35-36"><a href="#cb35-36" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;Item&quot;</span><span class="fu">,</span></span>
-<span id="cb35-37"><a href="#cb35-37" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;kind&quot;</span><span class="fu">:</span> <span class="st">&quot;object&quot;</span><span class="fu">,</span></span>
-<span id="cb35-38"><a href="#cb35-38" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Newly created item&quot;</span></span>
-<span id="cb35-39"><a href="#cb35-39" aria-hidden="true" tabindex="-1"></a>      <span class="fu">},</span></span>
-<span id="cb35-40"><a href="#cb35-40" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;examples&quot;</span><span class="fu">:</span> <span class="ot">[</span></span>
-<span id="cb35-41"><a href="#cb35-41" aria-hidden="true" tabindex="-1"></a>        <span class="fu">{</span></span>
-<span id="cb35-42"><a href="#cb35-42" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Create a basic item&quot;</span><span class="fu">,</span></span>
-<span id="cb35-43"><a href="#cb35-43" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;request&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb35-44"><a href="#cb35-44" aria-hidden="true" tabindex="-1"></a>            <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;create_item&quot;</span><span class="fu">,</span></span>
-<span id="cb35-45"><a href="#cb35-45" aria-hidden="true" tabindex="-1"></a>            <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb35-46"><a href="#cb35-46" aria-hidden="true" tabindex="-1"></a>              <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;Widget&quot;</span><span class="fu">,</span></span>
-<span id="cb35-47"><a href="#cb35-47" aria-hidden="true" tabindex="-1"></a>              <span class="dt">&quot;category&quot;</span><span class="fu">:</span> <span class="st">&quot;product&quot;</span></span>
-<span id="cb35-48"><a href="#cb35-48" aria-hidden="true" tabindex="-1"></a>            <span class="fu">}</span></span>
-<span id="cb35-49"><a href="#cb35-49" aria-hidden="true" tabindex="-1"></a>          <span class="fu">}</span></span>
-<span id="cb35-50"><a href="#cb35-50" aria-hidden="true" tabindex="-1"></a>        <span class="fu">}</span></span>
-<span id="cb35-51"><a href="#cb35-51" aria-hidden="true" tabindex="-1"></a>      <span class="ot">]</span></span>
-<span id="cb35-52"><a href="#cb35-52" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
-<span id="cb35-53"><a href="#cb35-53" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
-<span id="cb35-54"><a href="#cb35-54" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
-<h3 id="96-types-response">9.6 Types Response</h3>
-<p>When <code>query</code> is "types":</p>
+<span id="cb35-4"><a href="#cb35-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;operations&quot;</span><span class="fu">:</span> <span class="ot">[</span></span>
+<span id="cb35-5"><a href="#cb35-5" aria-hidden="true" tabindex="-1"></a>      <span class="fu">{</span></span>
+<span id="cb35-6"><a href="#cb35-6" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;create_item&quot;</span><span class="fu">,</span></span>
+<span id="cb35-7"><a href="#cb35-7" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;semantic_category&quot;</span><span class="fu">:</span> <span class="st">&quot;CREATE&quot;</span><span class="fu">,</span></span>
+<span id="cb35-8"><a href="#cb35-8" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;endpoint&quot;</span><span class="fu">:</span> <span class="st">&quot;manage&quot;</span><span class="fu">,</span></span>
+<span id="cb35-9"><a href="#cb35-9" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Create a new item&quot;</span></span>
+<span id="cb35-10"><a href="#cb35-10" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb35-11"><a href="#cb35-11" aria-hidden="true" tabindex="-1"></a>      <span class="fu">{</span></span>
+<span id="cb35-12"><a href="#cb35-12" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;list_items&quot;</span><span class="fu">,</span></span>
+<span id="cb35-13"><a href="#cb35-13" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;semantic_category&quot;</span><span class="fu">:</span> <span class="st">&quot;READ&quot;</span><span class="fu">,</span></span>
+<span id="cb35-14"><a href="#cb35-14" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;endpoint&quot;</span><span class="fu">:</span> <span class="st">&quot;query&quot;</span><span class="fu">,</span></span>
+<span id="cb35-15"><a href="#cb35-15" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;List all items&quot;</span></span>
+<span id="cb35-16"><a href="#cb35-16" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb35-17"><a href="#cb35-17" aria-hidden="true" tabindex="-1"></a>      <span class="fu">{</span></span>
+<span id="cb35-18"><a href="#cb35-18" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;update_item&quot;</span><span class="fu">,</span></span>
+<span id="cb35-19"><a href="#cb35-19" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;semantic_category&quot;</span><span class="fu">:</span> <span class="st">&quot;UPDATE&quot;</span><span class="fu">,</span></span>
+<span id="cb35-20"><a href="#cb35-20" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;endpoint&quot;</span><span class="fu">:</span> <span class="st">&quot;manage&quot;</span><span class="fu">,</span></span>
+<span id="cb35-21"><a href="#cb35-21" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Update item properties&quot;</span></span>
+<span id="cb35-22"><a href="#cb35-22" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb35-23"><a href="#cb35-23" aria-hidden="true" tabindex="-1"></a>      <span class="fu">{</span></span>
+<span id="cb35-24"><a href="#cb35-24" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;delete_item&quot;</span><span class="fu">,</span></span>
+<span id="cb35-25"><a href="#cb35-25" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;semantic_category&quot;</span><span class="fu">:</span> <span class="st">&quot;DELETE&quot;</span><span class="fu">,</span></span>
+<span id="cb35-26"><a href="#cb35-26" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;endpoint&quot;</span><span class="fu">:</span> <span class="st">&quot;manage&quot;</span><span class="fu">,</span></span>
+<span id="cb35-27"><a href="#cb35-27" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Delete an item&quot;</span></span>
+<span id="cb35-28"><a href="#cb35-28" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb35-29"><a href="#cb35-29" aria-hidden="true" tabindex="-1"></a>      <span class="fu">{</span></span>
+<span id="cb35-30"><a href="#cb35-30" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;introspect&quot;</span><span class="fu">,</span></span>
+<span id="cb35-31"><a href="#cb35-31" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;semantic_category&quot;</span><span class="fu">:</span> <span class="st">&quot;READ&quot;</span><span class="fu">,</span></span>
+<span id="cb35-32"><a href="#cb35-32" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;endpoint&quot;</span><span class="fu">:</span> <span class="st">&quot;query&quot;</span><span class="fu">,</span></span>
+<span id="cb35-33"><a href="#cb35-33" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Discover available operations&quot;</span></span>
+<span id="cb35-34"><a href="#cb35-34" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span></span>
+<span id="cb35-35"><a href="#cb35-35" aria-hidden="true" tabindex="-1"></a>    <span class="ot">]</span></span>
+<span id="cb35-36"><a href="#cb35-36" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb35-37"><a href="#cb35-37" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<h3 id="95-operation-details-response">9.5 Operation Details Response</h3>
+<p>When <code>query</code> is "operations" with a <code>name</code>:</p>
 <div class="sourceCode" id="cb36"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb36-1"><a href="#cb36-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
 <span id="cb36-2"><a href="#cb36-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
 <span id="cb36-3"><a href="#cb36-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;data&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb36-4"><a href="#cb36-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;types&quot;</span><span class="fu">:</span> <span class="ot">[</span></span>
-<span id="cb36-5"><a href="#cb36-5" aria-hidden="true" tabindex="-1"></a>      <span class="fu">{</span></span>
-<span id="cb36-6"><a href="#cb36-6" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;ItemCategory&quot;</span><span class="fu">,</span></span>
-<span id="cb36-7"><a href="#cb36-7" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;kind&quot;</span><span class="fu">:</span> <span class="st">&quot;enum&quot;</span><span class="fu">,</span></span>
-<span id="cb36-8"><a href="#cb36-8" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;values&quot;</span><span class="fu">:</span> <span class="ot">[</span><span class="st">&quot;product&quot;</span><span class="ot">,</span> <span class="st">&quot;service&quot;</span><span class="ot">,</span> <span class="st">&quot;subscription&quot;</span><span class="ot">]</span></span>
-<span id="cb36-9"><a href="#cb36-9" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span><span class="ot">,</span></span>
-<span id="cb36-10"><a href="#cb36-10" aria-hidden="true" tabindex="-1"></a>      <span class="fu">{</span></span>
-<span id="cb36-11"><a href="#cb36-11" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;Item&quot;</span><span class="fu">,</span></span>
-<span id="cb36-12"><a href="#cb36-12" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;kind&quot;</span><span class="fu">:</span> <span class="st">&quot;object&quot;</span><span class="fu">,</span></span>
-<span id="cb36-13"><a href="#cb36-13" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;fields&quot;</span><span class="fu">:</span> <span class="ot">[</span></span>
-<span id="cb36-14"><a href="#cb36-14" aria-hidden="true" tabindex="-1"></a>          <span class="fu">{</span> <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;id&quot;</span><span class="fu">,</span> <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;string&quot;</span> <span class="fu">}</span><span class="ot">,</span></span>
-<span id="cb36-15"><a href="#cb36-15" aria-hidden="true" tabindex="-1"></a>          <span class="fu">{</span> <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;name&quot;</span><span class="fu">,</span> <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;string&quot;</span> <span class="fu">}</span><span class="ot">,</span></span>
-<span id="cb36-16"><a href="#cb36-16" aria-hidden="true" tabindex="-1"></a>          <span class="fu">{</span> <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;category&quot;</span><span class="fu">,</span> <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;ItemCategory&quot;</span> <span class="fu">}</span><span class="ot">,</span></span>
-<span id="cb36-17"><a href="#cb36-17" aria-hidden="true" tabindex="-1"></a>          <span class="fu">{</span> <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;price&quot;</span><span class="fu">,</span> <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;number&quot;</span> <span class="fu">}</span></span>
-<span id="cb36-18"><a href="#cb36-18" aria-hidden="true" tabindex="-1"></a>        <span class="ot">]</span></span>
-<span id="cb36-19"><a href="#cb36-19" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span></span>
-<span id="cb36-20"><a href="#cb36-20" aria-hidden="true" tabindex="-1"></a>    <span class="ot">]</span></span>
-<span id="cb36-21"><a href="#cb36-21" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
-<span id="cb36-22"><a href="#cb36-22" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<span id="cb36-4"><a href="#cb36-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb36-5"><a href="#cb36-5" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;create_item&quot;</span><span class="fu">,</span></span>
+<span id="cb36-6"><a href="#cb36-6" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;semantic_category&quot;</span><span class="fu">:</span> <span class="st">&quot;CREATE&quot;</span><span class="fu">,</span></span>
+<span id="cb36-7"><a href="#cb36-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;endpoint&quot;</span><span class="fu">:</span> <span class="st">&quot;manage&quot;</span><span class="fu">,</span></span>
+<span id="cb36-8"><a href="#cb36-8" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;mcpTool&quot;</span><span class="fu">:</span> <span class="st">&quot;mcp_aql_manage&quot;</span><span class="fu">,</span></span>
+<span id="cb36-9"><a href="#cb36-9" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Create a new item&quot;</span><span class="fu">,</span></span>
+<span id="cb36-10"><a href="#cb36-10" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;permissions&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb36-11"><a href="#cb36-11" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;readOnly&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb36-12"><a href="#cb36-12" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;destructive&quot;</span><span class="fu">:</span> <span class="kw">false</span></span>
+<span id="cb36-13"><a href="#cb36-13" aria-hidden="true" tabindex="-1"></a>      <span class="fu">},</span></span>
+<span id="cb36-14"><a href="#cb36-14" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;parameters&quot;</span><span class="fu">:</span> <span class="ot">[</span></span>
+<span id="cb36-15"><a href="#cb36-15" aria-hidden="true" tabindex="-1"></a>        <span class="fu">{</span></span>
+<span id="cb36-16"><a href="#cb36-16" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;name&quot;</span><span class="fu">,</span></span>
+<span id="cb36-17"><a href="#cb36-17" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;string&quot;</span><span class="fu">,</span></span>
+<span id="cb36-18"><a href="#cb36-18" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;required&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb36-19"><a href="#cb36-19" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Item name&quot;</span></span>
+<span id="cb36-20"><a href="#cb36-20" aria-hidden="true" tabindex="-1"></a>        <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb36-21"><a href="#cb36-21" aria-hidden="true" tabindex="-1"></a>        <span class="fu">{</span></span>
+<span id="cb36-22"><a href="#cb36-22" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;category&quot;</span><span class="fu">,</span></span>
+<span id="cb36-23"><a href="#cb36-23" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;string&quot;</span><span class="fu">,</span></span>
+<span id="cb36-24"><a href="#cb36-24" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;required&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb36-25"><a href="#cb36-25" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Item category&quot;</span><span class="fu">,</span></span>
+<span id="cb36-26"><a href="#cb36-26" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;enum&quot;</span><span class="fu">:</span> <span class="ot">[</span><span class="st">&quot;product&quot;</span><span class="ot">,</span> <span class="st">&quot;service&quot;</span><span class="ot">,</span> <span class="st">&quot;subscription&quot;</span><span class="ot">]</span></span>
+<span id="cb36-27"><a href="#cb36-27" aria-hidden="true" tabindex="-1"></a>        <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb36-28"><a href="#cb36-28" aria-hidden="true" tabindex="-1"></a>        <span class="fu">{</span></span>
+<span id="cb36-29"><a href="#cb36-29" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;price&quot;</span><span class="fu">,</span></span>
+<span id="cb36-30"><a href="#cb36-30" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;number&quot;</span><span class="fu">,</span></span>
+<span id="cb36-31"><a href="#cb36-31" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;required&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb36-32"><a href="#cb36-32" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;minimum&quot;</span><span class="fu">:</span> <span class="dv">0</span><span class="fu">,</span></span>
+<span id="cb36-33"><a href="#cb36-33" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Item price in cents&quot;</span></span>
+<span id="cb36-34"><a href="#cb36-34" aria-hidden="true" tabindex="-1"></a>        <span class="fu">}</span></span>
+<span id="cb36-35"><a href="#cb36-35" aria-hidden="true" tabindex="-1"></a>      <span class="ot">]</span><span class="fu">,</span></span>
+<span id="cb36-36"><a href="#cb36-36" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;returns&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb36-37"><a href="#cb36-37" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;Item&quot;</span><span class="fu">,</span></span>
+<span id="cb36-38"><a href="#cb36-38" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;kind&quot;</span><span class="fu">:</span> <span class="st">&quot;object&quot;</span><span class="fu">,</span></span>
+<span id="cb36-39"><a href="#cb36-39" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Newly created item&quot;</span></span>
+<span id="cb36-40"><a href="#cb36-40" aria-hidden="true" tabindex="-1"></a>      <span class="fu">},</span></span>
+<span id="cb36-41"><a href="#cb36-41" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;examples&quot;</span><span class="fu">:</span> <span class="ot">[</span></span>
+<span id="cb36-42"><a href="#cb36-42" aria-hidden="true" tabindex="-1"></a>        <span class="fu">{</span></span>
+<span id="cb36-43"><a href="#cb36-43" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;description&quot;</span><span class="fu">:</span> <span class="st">&quot;Create a basic item&quot;</span><span class="fu">,</span></span>
+<span id="cb36-44"><a href="#cb36-44" aria-hidden="true" tabindex="-1"></a>          <span class="dt">&quot;request&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb36-45"><a href="#cb36-45" aria-hidden="true" tabindex="-1"></a>            <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;create_item&quot;</span><span class="fu">,</span></span>
+<span id="cb36-46"><a href="#cb36-46" aria-hidden="true" tabindex="-1"></a>            <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb36-47"><a href="#cb36-47" aria-hidden="true" tabindex="-1"></a>              <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;Widget&quot;</span><span class="fu">,</span></span>
+<span id="cb36-48"><a href="#cb36-48" aria-hidden="true" tabindex="-1"></a>              <span class="dt">&quot;category&quot;</span><span class="fu">:</span> <span class="st">&quot;product&quot;</span></span>
+<span id="cb36-49"><a href="#cb36-49" aria-hidden="true" tabindex="-1"></a>            <span class="fu">}</span></span>
+<span id="cb36-50"><a href="#cb36-50" aria-hidden="true" tabindex="-1"></a>          <span class="fu">}</span></span>
+<span id="cb36-51"><a href="#cb36-51" aria-hidden="true" tabindex="-1"></a>        <span class="fu">}</span></span>
+<span id="cb36-52"><a href="#cb36-52" aria-hidden="true" tabindex="-1"></a>      <span class="ot">]</span></span>
+<span id="cb36-53"><a href="#cb36-53" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb36-54"><a href="#cb36-54" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb36-55"><a href="#cb36-55" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<h3 id="96-types-response">9.6 Types Response</h3>
+<p>When <code>query</code> is "types":</p>
+<div class="sourceCode" id="cb37"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb37-1"><a href="#cb37-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb37-2"><a href="#cb37-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb37-3"><a href="#cb37-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;data&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb37-4"><a href="#cb37-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;types&quot;</span><span class="fu">:</span> <span class="ot">[</span></span>
+<span id="cb37-5"><a href="#cb37-5" aria-hidden="true" tabindex="-1"></a>      <span class="fu">{</span></span>
+<span id="cb37-6"><a href="#cb37-6" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;ItemCategory&quot;</span><span class="fu">,</span></span>
+<span id="cb37-7"><a href="#cb37-7" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;kind&quot;</span><span class="fu">:</span> <span class="st">&quot;enum&quot;</span><span class="fu">,</span></span>
+<span id="cb37-8"><a href="#cb37-8" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;values&quot;</span><span class="fu">:</span> <span class="ot">[</span><span class="st">&quot;product&quot;</span><span class="ot">,</span> <span class="st">&quot;service&quot;</span><span class="ot">,</span> <span class="st">&quot;subscription&quot;</span><span class="ot">]</span></span>
+<span id="cb37-9"><a href="#cb37-9" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb37-10"><a href="#cb37-10" aria-hidden="true" tabindex="-1"></a>      <span class="fu">{</span></span>
+<span id="cb37-11"><a href="#cb37-11" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;Item&quot;</span><span class="fu">,</span></span>
+<span id="cb37-12"><a href="#cb37-12" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;kind&quot;</span><span class="fu">:</span> <span class="st">&quot;object&quot;</span><span class="fu">,</span></span>
+<span id="cb37-13"><a href="#cb37-13" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;fields&quot;</span><span class="fu">:</span> <span class="ot">[</span></span>
+<span id="cb37-14"><a href="#cb37-14" aria-hidden="true" tabindex="-1"></a>          <span class="fu">{</span> <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;id&quot;</span><span class="fu">,</span> <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;string&quot;</span> <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb37-15"><a href="#cb37-15" aria-hidden="true" tabindex="-1"></a>          <span class="fu">{</span> <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;name&quot;</span><span class="fu">,</span> <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;string&quot;</span> <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb37-16"><a href="#cb37-16" aria-hidden="true" tabindex="-1"></a>          <span class="fu">{</span> <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;category&quot;</span><span class="fu">,</span> <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;ItemCategory&quot;</span> <span class="fu">}</span><span class="ot">,</span></span>
+<span id="cb37-17"><a href="#cb37-17" aria-hidden="true" tabindex="-1"></a>          <span class="fu">{</span> <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;price&quot;</span><span class="fu">,</span> <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;number&quot;</span> <span class="fu">}</span></span>
+<span id="cb37-18"><a href="#cb37-18" aria-hidden="true" tabindex="-1"></a>        <span class="ot">]</span></span>
+<span id="cb37-19"><a href="#cb37-19" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span></span>
+<span id="cb37-20"><a href="#cb37-20" aria-hidden="true" tabindex="-1"></a>    <span class="ot">]</span></span>
+<span id="cb37-21"><a href="#cb37-21" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb37-22"><a href="#cb37-22" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
 <hr />
 <h2 id="references">References</h2>
 <ul>

--- a/public/spec/overview.html
+++ b/public/spec/overview.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="description" content="MCP-AQL (Model Context Protocol - Agent Query Language) is a protocol that consolidates discrete MCP tools into 5 CRUDE endpoints (Create, Read, Update, Delete, Execute), providing significant token reduction while maint">
+  <meta name="description" content="MCP-AQL (Model Context Protocol - Agent Query Language) is a protocol that consolidates discrete MCP tools into a small number of semantic endpoint families, providing significant token reduction while maintaining full f">
   <title>MCP-AQL Spec | MCP-AQL Protocol Overview</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -50,10 +50,10 @@
   <ul><li><a href="security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Features</h3>
-  <ul><li><a href="features/collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="features/field-selection.html">Field Selection Specification</a></li><li><a href="features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="features/warnings.html">Warnings Array Specification</a></li></ul>
+  <ul><li><a href="features/aggregations.html">MCP-AQL Aggregations</a></li><li><a href="features/collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="features/computed-fields.html">MCP-AQL Computed Fields</a></li><li><a href="features/field-selection.html">Field Selection Specification</a></li><li><a href="features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="features/relationship-queries.html">MCP-AQL Relationship Queries</a></li><li><a href="features/warnings.html">Warnings Array Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Guides</h3>
-  <ul><li><a href="guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="guides/README.html">Developer Guides</a></li></ul>
+  <ul><li><a href="guides/cross-domain-implementation.html">Cross-Domain Implementation Guide</a></li><li><a href="guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
   <ul><li><a href="process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="process/versioning.html">Versioning Strategy</a></li><li><a href="repo/CHANGELOG.html">Changelog</a></li></ul>
@@ -84,7 +84,7 @@
           <div class="hero-inner">
             <span class="status-pill">REPO-SYNCED SPEC DOC</span>
             <h1>MCP-AQL Protocol Overview</h1>
-            <p class="lede">MCP-AQL (Model Context Protocol - Agent Query Language) is a protocol that consolidates discrete MCP tools into 5 CRUDE endpoints (Create, Read, Update, Delete, Execute), providing significant token reduction while maint</p>
+            <p class="lede">MCP-AQL (Model Context Protocol - Agent Query Language) is a protocol that consolidates discrete MCP tools into a small number of semantic endpoint families, providing significant token reduction while maintaining full f</p>
             <div class="spec-meta"><span class="state-chip live">Support document</span></div>
             <p class="spec-source">Source: <a href="https://github.com/MCPAQL/spec/blob/main/docs/overview.md">spec/docs/overview.md</a></p>
             <div class="hero-actions">
@@ -101,7 +101,7 @@
               <p class="page-toc-intro">Use the outline to move through longer pages without losing your place.</p>
             </div>
             <ol class="page-toc-list" data-page-toc-list>
-              <li class="page-toc-item level-2"><a href="#protocol-summary" data-toc-target="protocol-summary">Protocol Summary</a></li><li class="page-toc-item level-2"><a href="#the-crude-pattern" data-toc-target="the-crude-pattern">The CRUDE Pattern</a></li><li class="page-toc-item level-3"><a href="#permission-characteristics" data-toc-target="permission-characteristics">Permission Characteristics</a></li><li class="page-toc-item level-3"><a href="#why-crude-not-crud" data-toc-target="why-crude-not-crud">Why CRUDE not CRUD?</a></li><li class="page-toc-item level-2"><a href="#endpoint-modes" data-toc-target="endpoint-modes">Endpoint Modes</a></li><li class="page-toc-item level-3"><a href="#crude-mode" data-toc-target="crude-mode">CRUDE Mode</a></li><li class="page-toc-item level-3"><a href="#single-mode" data-toc-target="single-mode">Single Mode</a></li><li class="page-toc-item level-2"><a href="#token-efficiency" data-toc-target="token-efficiency">Token Efficiency</a></li><li class="page-toc-item level-3"><a href="#token-reduction" data-toc-target="token-reduction">Token Reduction</a></li><li class="page-toc-item level-3"><a href="#runtime-discovery" data-toc-target="runtime-discovery">Runtime Discovery</a></li><li class="page-toc-item level-2"><a href="#core-concepts" data-toc-target="core-concepts">Core Concepts</a></li><li class="page-toc-item level-3"><a href="#schema-driven-operations" data-toc-target="schema-driven-operations">Schema-Driven Operations</a></li><li class="page-toc-item level-3"><a href="#gatekeeper" data-toc-target="gatekeeper">Gatekeeper</a></li><li class="page-toc-item level-3"><a href="#introspection" data-toc-target="introspection">Introspection</a></li><li class="page-toc-item level-2"><a href="#request-flow" data-toc-target="request-flow">Request Flow</a></li><li class="page-toc-item level-3"><a href="#standard-request" data-toc-target="standard-request">Standard Request</a></li><li class="page-toc-item level-3"><a href="#response-format" data-toc-target="response-format">Response Format</a></li><li class="page-toc-item level-2"><a href="#batch-operations" data-toc-target="batch-operations">Batch Operations</a></li><li class="page-toc-item level-3"><a href="#batch-request-format" data-toc-target="batch-request-format">Batch Request Format</a></li><li class="page-toc-item level-3"><a href="#batch-response-format" data-toc-target="batch-response-format">Batch Response Format</a></li><li class="page-toc-item level-2"><a href="#conformance" data-toc-target="conformance">Conformance</a></li><li class="page-toc-item level-2"><a href="#related-specifications" data-toc-target="related-specifications">Related Specifications</a></li>
+              <li class="page-toc-item level-2"><a href="#protocol-summary" data-toc-target="protocol-summary">Protocol Summary</a></li><li class="page-toc-item level-2"><a href="#the-crude-pattern" data-toc-target="the-crude-pattern">The CRUDE Pattern</a></li><li class="page-toc-item level-3"><a href="#permission-characteristics" data-toc-target="permission-characteristics">Permission Characteristics</a></li><li class="page-toc-item level-3"><a href="#why-crude-not-crud" data-toc-target="why-crude-not-crud">Why CRUDE not CRUD?</a></li><li class="page-toc-item level-2"><a href="#endpoint-modes" data-toc-target="endpoint-modes">Endpoint Modes</a></li><li class="page-toc-item level-3"><a href="#semantic-endpoint-mode" data-toc-target="semantic-endpoint-mode">Semantic Endpoint Mode</a></li><li class="page-toc-item level-3"><a href="#single-mode" data-toc-target="single-mode">Single Mode</a></li><li class="page-toc-item level-2"><a href="#token-efficiency" data-toc-target="token-efficiency">Token Efficiency</a></li><li class="page-toc-item level-3"><a href="#token-reduction" data-toc-target="token-reduction">Token Reduction</a></li><li class="page-toc-item level-3"><a href="#runtime-discovery" data-toc-target="runtime-discovery">Runtime Discovery</a></li><li class="page-toc-item level-2"><a href="#core-concepts" data-toc-target="core-concepts">Core Concepts</a></li><li class="page-toc-item level-3"><a href="#schema-driven-operations" data-toc-target="schema-driven-operations">Schema-Driven Operations</a></li><li class="page-toc-item level-3"><a href="#gatekeeper" data-toc-target="gatekeeper">Gatekeeper</a></li><li class="page-toc-item level-3"><a href="#introspection" data-toc-target="introspection">Introspection</a></li><li class="page-toc-item level-2"><a href="#request-flow" data-toc-target="request-flow">Request Flow</a></li><li class="page-toc-item level-3"><a href="#standard-request" data-toc-target="standard-request">Standard Request</a></li><li class="page-toc-item level-3"><a href="#response-format" data-toc-target="response-format">Response Format</a></li><li class="page-toc-item level-2"><a href="#batch-operations" data-toc-target="batch-operations">Batch Operations</a></li><li class="page-toc-item level-3"><a href="#batch-request-format" data-toc-target="batch-request-format">Batch Request Format</a></li><li class="page-toc-item level-3"><a href="#batch-response-format" data-toc-target="batch-response-format">Batch Response Format</a></li><li class="page-toc-item level-2"><a href="#conformance" data-toc-target="conformance">Conformance</a></li><li class="page-toc-item level-2"><a href="#related-specifications" data-toc-target="related-specifications">Related Specifications</a></li>
             </ol>
           </div>
         </section>
@@ -110,16 +110,16 @@
         <section>
           <div class="card spec-prose">
             <blockquote>
-<p><strong>MCP-AQL</strong> (Model Context Protocol - Agent Query Language) is a protocol that consolidates discrete MCP tools into 5 CRUDE endpoints (Create, Read, Update, Delete, Execute), providing significant token reduction while maintaining full functionality.</p>
+<p><strong>MCP-AQL</strong> (Model Context Protocol - Agent Query Language) is a protocol that consolidates discrete MCP tools into a small number of semantic endpoint families, providing significant token reduction while maintaining full functionality. The standard semantic-endpoint profile is CRUDE (Create, Read, Update, Delete, Execute), but adapters MAY define alternate semantic endpoint families.</p>
 <p><strong>Document Status:</strong> This document is <strong>informative</strong>. For normative requirements, see <a href="versions/v1.0.0-draft.html">MCP-AQL Specification v1.0.0</a>.</p>
 </blockquote>
 <h2 id="protocol-summary">Protocol Summary</h2>
 <p>MCP-AQL defines a schema-driven operation dispatch protocol that:</p>
 <ol type="1">
-<li><strong>Consolidates Operations</strong> - Many discrete tools into 5 semantic endpoints</li>
+<li><strong>Consolidates Operations</strong> - Many discrete tools into a small number of semantic endpoint families</li>
 <li><strong>Enables Discovery</strong> - GraphQL-style introspection for runtime operation discovery</li>
 <li><strong>Enforces Safety</strong> - Endpoint classification validates operation/endpoint matching</li>
-<li><strong>Supports Flexibility</strong> - Implementations MAY offer CRUDE mode (5 endpoints) or Single mode (1 endpoint)</li>
+<li><strong>Supports Flexibility</strong> - Implementations MAY offer semantic endpoint mode with the standard CRUDE profile or alternate semantic endpoint families, or Single mode</li>
 </ol>
 <pre><code>+-------------------+
 |    MCP Client     |
@@ -154,7 +154,7 @@
 <p>MCP-AQL extends traditional CRUD with an <strong>EXECUTE</strong> endpoint, creating the CRUDE pattern:</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Endpoint</th>
 <th>Safety</th>
 <th>Description</th>
@@ -162,31 +162,31 @@
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><strong>CREATE</strong></td>
 <td>Non-destructive</td>
 <td>Additive operations that create new state</td>
 <td><code>create_entity</code>, <code>import_resource</code></td>
 </tr>
-<tr>
+<tr class="even">
 <td><strong>READ</strong></td>
 <td>Read-only</td>
 <td>Safe operations that query state</td>
 <td><code>list_entities</code>, <code>get_entity</code>, <code>search</code>, <code>introspect</code></td>
 </tr>
-<tr>
+<tr class="odd">
 <td><strong>UPDATE</strong></td>
 <td>Modifying</td>
 <td>Operations that modify existing state</td>
 <td><code>update_entity</code>, <code>update_resource</code></td>
 </tr>
-<tr>
+<tr class="even">
 <td><strong>DELETE</strong></td>
 <td>Destructive</td>
 <td>Operations that remove state</td>
 <td><code>delete_entity</code>, <code>clear</code></td>
 </tr>
-<tr>
+<tr class="odd">
 <td><strong>EXECUTE</strong></td>
 <td>Runtime</td>
 <td>Lifecycle operations for executable elements</td>
@@ -198,34 +198,34 @@
 <p>Each endpoint MUST have defined permission characteristics:</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Endpoint</th>
 <th>Read-Only</th>
 <th>Destructive</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td>CREATE</td>
 <td>false</td>
 <td>false</td>
 </tr>
-<tr>
+<tr class="even">
 <td>READ</td>
 <td>true</td>
 <td>false</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>UPDATE</td>
 <td>false</td>
 <td>true</td>
 </tr>
-<tr>
+<tr class="even">
 <td>DELETE</td>
 <td>false</td>
 <td>true</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>EXECUTE</td>
 <td>false</td>
 <td>true</td>
@@ -259,18 +259,23 @@
                      | complete_execution|           | continue_execution|
                      +-------------------+           +-------------------+</code></pre>
 <blockquote>
-<p><strong>Note:</strong> This diagram shows a runtime lifecycle flow, not endpoint classification. Operations like <code>get_execution_state</code> that query execution state belong to the READ endpoint, not EXECUTE. See <a href="crude-pattern.html#61-classification-principle">CRUDE Pattern Classification</a> for details.</p>
+<p><strong>Note:</strong> This diagram shows a runtime lifecycle flow, not endpoint classification. Operations like <code>get_execution_state</code> that query execution state belong to the READ semantic category, not EXECUTE. In the standard CRUDE profile they are exposed on the READ endpoint. See <a href="crude-pattern.html#61-classification-principle">CRUDE Pattern Classification</a> for details.</p>
 </blockquote>
 <hr />
 <h2 id="endpoint-modes">Endpoint Modes</h2>
 <p>MCP-AQL supports two operational modes. Implementations MUST support at least one mode and SHOULD support both:</p>
-<h3 id="crude-mode">CRUDE Mode</h3>
-<p>Exposes 5 separate endpoints, each with semantic meaning:</p>
+<h3 id="semantic-endpoint-mode">Semantic Endpoint Mode</h3>
+<p>The standard CRUDE profile exposes 5 separate endpoints, each with semantic meaning:</p>
 <pre><code>mcp_aql_create  - CREATE operations
 mcp_aql_read    - READ operations
 mcp_aql_update  - UPDATE operations
 mcp_aql_delete  - DELETE operations
 mcp_aql_execute - EXECUTE operations</code></pre>
+<p>An alternate semantic-endpoint profile can expose a different but still semantically legible set:</p>
+<pre class="text"><code>mcp_aql_discover - Discovery and inspection operations
+mcp_aql_query    - Retrieval and filtering operations
+mcp_aql_manage   - Mutating and administrative operations
+mcp_aql_operate  - Runtime and lifecycle operations</code></pre>
 <p><strong>Advantages:</strong></p>
 <ul>
 <li>Clear semantic grouping</li>
@@ -293,24 +298,24 @@ mcp_aql_execute - EXECUTE operations</code></pre>
 <p>The primary motivation for MCP-AQL is reducing the token cost of tool registration. Empirical measurements demonstrate:</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Configuration</th>
 <th>Approximate Token Cost</th>
 <th>Reduction</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td>Discrete Tools (50+)</td>
 <td>~30,000 tokens</td>
 <td>baseline</td>
 </tr>
-<tr>
-<td>CRUDE Mode (5 endpoints)</td>
-<td>~4,500 tokens</td>
+<tr class="even">
+<td>Semantic Endpoint Mode (CRUDE profile, 5 endpoints)</td>
+<td>~4,300 tokens</td>
 <td>~85%</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>Single Mode (1 endpoint)</td>
 <td>~1,100 tokens</td>
 <td>~96%</td>
@@ -319,22 +324,23 @@ mcp_aql_execute - EXECUTE operations</code></pre>
 </table>
 <h3 id="runtime-discovery">Runtime Discovery</h3>
 <p>Instead of parsing many tool schemas at registration time, clients use introspection at runtime:</p>
-<div class="sourceCode" id="cb5"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb5-1"><a href="#cb5-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Query all available operations</span></span>
-<span id="cb5-2"><a href="#cb5-2" aria-hidden="true" tabindex="-1"></a>{ <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;introspect&quot;</span><span class="op">,</span> <span class="dt">params</span><span class="op">:</span> { <span class="dt">query</span><span class="op">:</span> <span class="st">&quot;operations&quot;</span> } }</span>
-<span id="cb5-3"><a href="#cb5-3" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb5-4"><a href="#cb5-4" aria-hidden="true" tabindex="-1"></a><span class="co">// Get details for a specific operation</span></span>
-<span id="cb5-5"><a href="#cb5-5" aria-hidden="true" tabindex="-1"></a>{ <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;introspect&quot;</span><span class="op">,</span> <span class="dt">params</span><span class="op">:</span> { <span class="dt">query</span><span class="op">:</span> <span class="st">&quot;operations&quot;</span><span class="op">,</span> <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;create_entity&quot;</span> } }</span>
-<span id="cb5-6"><a href="#cb5-6" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb5-7"><a href="#cb5-7" aria-hidden="true" tabindex="-1"></a><span class="co">// Query available types</span></span>
-<span id="cb5-8"><a href="#cb5-8" aria-hidden="true" tabindex="-1"></a>{ <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;introspect&quot;</span><span class="op">,</span> <span class="dt">params</span><span class="op">:</span> { <span class="dt">query</span><span class="op">:</span> <span class="st">&quot;types&quot;</span><span class="op">,</span> <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;EntityType&quot;</span> } }</span></code></pre></div>
-<p>Implementations MUST support the <code>introspect</code> operation on the READ endpoint.</p>
+<div class="sourceCode" id="cb6"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb6-1"><a href="#cb6-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Query all available operations</span></span>
+<span id="cb6-2"><a href="#cb6-2" aria-hidden="true" tabindex="-1"></a>{ <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;introspect&quot;</span><span class="op">,</span> <span class="dt">params</span><span class="op">:</span> { <span class="dt">query</span><span class="op">:</span> <span class="st">&quot;operations&quot;</span> } }</span>
+<span id="cb6-3"><a href="#cb6-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb6-4"><a href="#cb6-4" aria-hidden="true" tabindex="-1"></a><span class="co">// Get details for a specific operation</span></span>
+<span id="cb6-5"><a href="#cb6-5" aria-hidden="true" tabindex="-1"></a>{ <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;introspect&quot;</span><span class="op">,</span> <span class="dt">params</span><span class="op">:</span> { <span class="dt">query</span><span class="op">:</span> <span class="st">&quot;operations&quot;</span><span class="op">,</span> <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;create_entity&quot;</span> } }</span>
+<span id="cb6-6"><a href="#cb6-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb6-7"><a href="#cb6-7" aria-hidden="true" tabindex="-1"></a><span class="co">// Query available types</span></span>
+<span id="cb6-8"><a href="#cb6-8" aria-hidden="true" tabindex="-1"></a>{ <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;introspect&quot;</span><span class="op">,</span> <span class="dt">params</span><span class="op">:</span> { <span class="dt">query</span><span class="op">:</span> <span class="st">&quot;types&quot;</span><span class="op">,</span> <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;EntityType&quot;</span> } }</span></code></pre></div>
+<p>Implementations MUST support the <code>introspect</code> operation as a READ-category operation on a documented endpoint family.</p>
 <hr />
 <h2 id="core-concepts">Core Concepts</h2>
 <h3 id="schema-driven-operations">Schema-Driven Operations</h3>
 <p>Operations SHOULD be defined declaratively with:</p>
 <ul>
 <li><strong>name</strong> - The operation identifier</li>
-<li><strong>endpoint</strong> - The CRUDE endpoint classification</li>
+<li><strong>semantic_category</strong> - The standard CREATE/READ/UPDATE/DELETE/EXECUTE classification</li>
+<li><strong>endpoint</strong> - The exposed endpoint family name</li>
 <li><strong>description</strong> - Human-readable description</li>
 <li><strong>params</strong> - Required and optional parameter definitions</li>
 <li><strong>handler</strong> - Reference to the implementation handler</li>
@@ -367,40 +373,40 @@ mcp_aql_execute - EXECUTE operations</code></pre>
 <h3 id="response-format">Response Format</h3>
 <p>All MCP-AQL operations MUST return discriminated responses:</p>
 <p><strong>Success:</strong></p>
-<div class="sourceCode" id="cb7"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb7-1"><a href="#cb7-1" aria-hidden="true" tabindex="-1"></a>{</span>
-<span id="cb7-2"><a href="#cb7-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">success</span><span class="op">:</span> <span class="kw">true</span><span class="op">,</span></span>
-<span id="cb7-3"><a href="#cb7-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">data</span><span class="op">:</span> { <span class="co">/* operation result */</span> }</span>
-<span id="cb7-4"><a href="#cb7-4" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
-<p><strong>Failure:</strong></p>
 <div class="sourceCode" id="cb8"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb8-1"><a href="#cb8-1" aria-hidden="true" tabindex="-1"></a>{</span>
-<span id="cb8-2"><a href="#cb8-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">success</span><span class="op">:</span> <span class="kw">false</span><span class="op">,</span></span>
-<span id="cb8-3"><a href="#cb8-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">error</span><span class="op">:</span> {</span>
-<span id="cb8-4"><a href="#cb8-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">code</span><span class="op">:</span> <span class="st">&quot;VALIDATION_ERROR&quot;</span><span class="op">,</span></span>
-<span id="cb8-5"><a href="#cb8-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">message</span><span class="op">:</span> <span class="st">&quot;Required parameter &#39;entity_name&#39; is missing&quot;</span></span>
-<span id="cb8-6"><a href="#cb8-6" aria-hidden="true" tabindex="-1"></a>  }</span>
-<span id="cb8-7"><a href="#cb8-7" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<span id="cb8-2"><a href="#cb8-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">success</span><span class="op">:</span> <span class="kw">true</span><span class="op">,</span></span>
+<span id="cb8-3"><a href="#cb8-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">data</span><span class="op">:</span> { <span class="co">/* operation result */</span> }</span>
+<span id="cb8-4"><a href="#cb8-4" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<p><strong>Failure:</strong></p>
+<div class="sourceCode" id="cb9"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb9-1"><a href="#cb9-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb9-2"><a href="#cb9-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">success</span><span class="op">:</span> <span class="kw">false</span><span class="op">,</span></span>
+<span id="cb9-3"><a href="#cb9-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">error</span><span class="op">:</span> {</span>
+<span id="cb9-4"><a href="#cb9-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">code</span><span class="op">:</span> <span class="st">&quot;VALIDATION_ERROR&quot;</span><span class="op">,</span></span>
+<span id="cb9-5"><a href="#cb9-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">message</span><span class="op">:</span> <span class="st">&quot;Required parameter &#39;entity_name&#39; is missing&quot;</span></span>
+<span id="cb9-6"><a href="#cb9-6" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb9-7"><a href="#cb9-7" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
 <p>Implementations SHOULD include an error <code>code</code> for programmatic handling and MUST include a human-readable <code>message</code>.</p>
 <hr />
 <h2 id="batch-operations">Batch Operations</h2>
 <p>MCP-AQL implementations MAY support batch operations for executing multiple operations in a single request.</p>
 <h3 id="batch-request-format">Batch Request Format</h3>
-<div class="sourceCode" id="cb9"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb9-1"><a href="#cb9-1" aria-hidden="true" tabindex="-1"></a>{</span>
-<span id="cb9-2"><a href="#cb9-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operations</span><span class="op">:</span> [</span>
-<span id="cb9-3"><a href="#cb9-3" aria-hidden="true" tabindex="-1"></a>    { <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;create_entity&quot;</span><span class="op">,</span> <span class="dt">params</span><span class="op">:</span> { <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;entity1&quot;</span> } }<span class="op">,</span></span>
-<span id="cb9-4"><a href="#cb9-4" aria-hidden="true" tabindex="-1"></a>    { <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;create_entity&quot;</span><span class="op">,</span> <span class="dt">params</span><span class="op">:</span> { <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;entity2&quot;</span> } }<span class="op">,</span></span>
-<span id="cb9-5"><a href="#cb9-5" aria-hidden="true" tabindex="-1"></a>    { <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;activate_entity&quot;</span><span class="op">,</span> <span class="dt">params</span><span class="op">:</span> { <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;entity1&quot;</span> } }</span>
-<span id="cb9-6"><a href="#cb9-6" aria-hidden="true" tabindex="-1"></a>  ]</span>
-<span id="cb9-7"><a href="#cb9-7" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
-<h3 id="batch-response-format">Batch Response Format</h3>
 <div class="sourceCode" id="cb10"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb10-1"><a href="#cb10-1" aria-hidden="true" tabindex="-1"></a>{</span>
-<span id="cb10-2"><a href="#cb10-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">success</span><span class="op">:</span> <span class="kw">true</span><span class="op">,</span></span>
-<span id="cb10-3"><a href="#cb10-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">results</span><span class="op">:</span> [</span>
-<span id="cb10-4"><a href="#cb10-4" aria-hidden="true" tabindex="-1"></a>    { <span class="dt">index</span><span class="op">:</span> <span class="dv">0</span><span class="op">,</span> <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;create_entity&quot;</span><span class="op">,</span> <span class="dt">result</span><span class="op">:</span> { <span class="dt">success</span><span class="op">:</span> <span class="kw">true</span><span class="op">,</span> <span class="dt">data</span><span class="op">:</span> { <span class="co">/* ... */</span> } } }<span class="op">,</span></span>
-<span id="cb10-5"><a href="#cb10-5" aria-hidden="true" tabindex="-1"></a>    { <span class="dt">index</span><span class="op">:</span> <span class="dv">1</span><span class="op">,</span> <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;create_entity&quot;</span><span class="op">,</span> <span class="dt">result</span><span class="op">:</span> { <span class="dt">success</span><span class="op">:</span> <span class="kw">true</span><span class="op">,</span> <span class="dt">data</span><span class="op">:</span> { <span class="co">/* ... */</span> } } }<span class="op">,</span></span>
-<span id="cb10-6"><a href="#cb10-6" aria-hidden="true" tabindex="-1"></a>    { <span class="dt">index</span><span class="op">:</span> <span class="dv">2</span><span class="op">,</span> <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;activate_entity&quot;</span><span class="op">,</span> <span class="dt">result</span><span class="op">:</span> { <span class="dt">success</span><span class="op">:</span> <span class="kw">true</span><span class="op">,</span> <span class="dt">data</span><span class="op">:</span> { <span class="co">/* ... */</span> } } }</span>
-<span id="cb10-7"><a href="#cb10-7" aria-hidden="true" tabindex="-1"></a>  ]<span class="op">,</span></span>
-<span id="cb10-8"><a href="#cb10-8" aria-hidden="true" tabindex="-1"></a>  <span class="dt">summary</span><span class="op">:</span> { <span class="dt">total</span><span class="op">:</span> <span class="dv">3</span><span class="op">,</span> <span class="dt">succeeded</span><span class="op">:</span> <span class="dv">3</span><span class="op">,</span> <span class="dt">failed</span><span class="op">:</span> <span class="dv">0</span> }</span>
-<span id="cb10-9"><a href="#cb10-9" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<span id="cb10-2"><a href="#cb10-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operations</span><span class="op">:</span> [</span>
+<span id="cb10-3"><a href="#cb10-3" aria-hidden="true" tabindex="-1"></a>    { <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;create_entity&quot;</span><span class="op">,</span> <span class="dt">params</span><span class="op">:</span> { <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;entity1&quot;</span> } }<span class="op">,</span></span>
+<span id="cb10-4"><a href="#cb10-4" aria-hidden="true" tabindex="-1"></a>    { <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;create_entity&quot;</span><span class="op">,</span> <span class="dt">params</span><span class="op">:</span> { <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;entity2&quot;</span> } }<span class="op">,</span></span>
+<span id="cb10-5"><a href="#cb10-5" aria-hidden="true" tabindex="-1"></a>    { <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;activate_entity&quot;</span><span class="op">,</span> <span class="dt">params</span><span class="op">:</span> { <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;entity1&quot;</span> } }</span>
+<span id="cb10-6"><a href="#cb10-6" aria-hidden="true" tabindex="-1"></a>  ]</span>
+<span id="cb10-7"><a href="#cb10-7" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<h3 id="batch-response-format">Batch Response Format</h3>
+<div class="sourceCode" id="cb11"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb11-1"><a href="#cb11-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb11-2"><a href="#cb11-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">success</span><span class="op">:</span> <span class="kw">true</span><span class="op">,</span></span>
+<span id="cb11-3"><a href="#cb11-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">results</span><span class="op">:</span> [</span>
+<span id="cb11-4"><a href="#cb11-4" aria-hidden="true" tabindex="-1"></a>    { <span class="dt">index</span><span class="op">:</span> <span class="dv">0</span><span class="op">,</span> <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;create_entity&quot;</span><span class="op">,</span> <span class="dt">result</span><span class="op">:</span> { <span class="dt">success</span><span class="op">:</span> <span class="kw">true</span><span class="op">,</span> <span class="dt">data</span><span class="op">:</span> { <span class="co">/* ... */</span> } } }<span class="op">,</span></span>
+<span id="cb11-5"><a href="#cb11-5" aria-hidden="true" tabindex="-1"></a>    { <span class="dt">index</span><span class="op">:</span> <span class="dv">1</span><span class="op">,</span> <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;create_entity&quot;</span><span class="op">,</span> <span class="dt">result</span><span class="op">:</span> { <span class="dt">success</span><span class="op">:</span> <span class="kw">true</span><span class="op">,</span> <span class="dt">data</span><span class="op">:</span> { <span class="co">/* ... */</span> } } }<span class="op">,</span></span>
+<span id="cb11-6"><a href="#cb11-6" aria-hidden="true" tabindex="-1"></a>    { <span class="dt">index</span><span class="op">:</span> <span class="dv">2</span><span class="op">,</span> <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;activate_entity&quot;</span><span class="op">,</span> <span class="dt">result</span><span class="op">:</span> { <span class="dt">success</span><span class="op">:</span> <span class="kw">true</span><span class="op">,</span> <span class="dt">data</span><span class="op">:</span> { <span class="co">/* ... */</span> } } }</span>
+<span id="cb11-7"><a href="#cb11-7" aria-hidden="true" tabindex="-1"></a>  ]<span class="op">,</span></span>
+<span id="cb11-8"><a href="#cb11-8" aria-hidden="true" tabindex="-1"></a>  <span class="dt">summary</span><span class="op">:</span> { <span class="dt">total</span><span class="op">:</span> <span class="dv">3</span><span class="op">,</span> <span class="dt">succeeded</span><span class="op">:</span> <span class="dv">3</span><span class="op">,</span> <span class="dt">failed</span><span class="op">:</span> <span class="dv">0</span> }</span>
+<span id="cb11-9"><a href="#cb11-9" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
 <p>When batch operations are supported, implementations:</p>
 <ul>
 <li>MUST process operations in order</li>
@@ -412,9 +418,9 @@ mcp_aql_execute - EXECUTE operations</code></pre>
 <h2 id="conformance">Conformance</h2>
 <p>An MCP-AQL implementation is conformant if it:</p>
 <ol type="1">
-<li>Implements at least one endpoint mode (CRUDE or Single)</li>
+<li>Implements at least one endpoint mode (semantic or Single)</li>
 <li>Enforces endpoint classification for all operations</li>
-<li>Provides the <code>introspect</code> operation on the READ endpoint</li>
+<li>Provides the <code>introspect</code> operation as a READ-category operation on a documented endpoint family</li>
 <li>Returns discriminated responses for all operations</li>
 <li>Validates required parameters before dispatching</li>
 </ol>

--- a/public/spec/plugin-contracts.html
+++ b/public/spec/plugin-contracts.html
@@ -50,10 +50,10 @@
   <ul><li><a href="security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Features</h3>
-  <ul><li><a href="features/collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="features/field-selection.html">Field Selection Specification</a></li><li><a href="features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="features/warnings.html">Warnings Array Specification</a></li></ul>
+  <ul><li><a href="features/aggregations.html">MCP-AQL Aggregations</a></li><li><a href="features/collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="features/computed-fields.html">MCP-AQL Computed Fields</a></li><li><a href="features/field-selection.html">Field Selection Specification</a></li><li><a href="features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="features/relationship-queries.html">MCP-AQL Relationship Queries</a></li><li><a href="features/warnings.html">Warnings Array Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Guides</h3>
-  <ul><li><a href="guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="guides/README.html">Developer Guides</a></li></ul>
+  <ul><li><a href="guides/cross-domain-implementation.html">Cross-Domain Implementation Guide</a></li><li><a href="guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
   <ul><li><a href="process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="process/versioning.html">Versioning Strategy</a></li><li><a href="repo/CHANGELOG.html">Changelog</a></li></ul>
@@ -137,25 +137,25 @@
 <p><strong>Included:</strong></p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Category</th>
 <th>Plugins</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td>Transport</td>
 <td><code>http</code></td>
 </tr>
-<tr>
+<tr class="even">
 <td>Protocol</td>
 <td><code>rest</code></td>
 </tr>
-<tr>
+<tr class="odd">
 <td>Serialization</td>
 <td><code>json</code></td>
 </tr>
-<tr>
+<tr class="even">
 <td>Auth</td>
 <td><code>none</code>, <code>api_key</code>, <code>bearer</code></td>
 </tr>
@@ -164,29 +164,29 @@
 <p><strong>Deferred to future specifications:</strong></p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Category</th>
 <th>Deferred Plugins</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td>Transport</td>
 <td><code>websocket</code>, <code>serial</code>, <code>native-*</code></td>
 </tr>
-<tr>
+<tr class="even">
 <td>Protocol</td>
 <td><code>graphql</code>, <code>grpc</code>, <code>jsonrpc</code>, <code>custom</code></td>
 </tr>
-<tr>
+<tr class="odd">
 <td>Serialization</td>
 <td><code>xml</code>, <code>protobuf</code>, <code>msgpack</code>, <code>form</code>, <code>multipart</code></td>
 </tr>
-<tr>
+<tr class="even">
 <td>Auth</td>
 <td><code>basic</code>, <code>oauth</code>, <code>mtls</code>, <code>aws-sig4</code></td>
 </tr>
-<tr>
+<tr class="odd">
 <td>Pagination</td>
 <td>All pagination plugins (see #37)</td>
 </tr>
@@ -199,29 +199,29 @@
 <h3 id="21-category-summary">2.1 Category Summary</h3>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Category</th>
 <th>Responsibility</th>
 <th>MVP Plugin</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td>Transport</td>
 <td>Communication channel</td>
 <td><code>http</code></td>
 </tr>
-<tr>
+<tr class="even">
 <td>Protocol</td>
 <td>Request/response structure</td>
 <td><code>rest</code></td>
 </tr>
-<tr>
+<tr class="odd">
 <td>Serialization</td>
 <td>Data encoding/decoding</td>
 <td><code>json</code></td>
 </tr>
-<tr>
+<tr class="even">
 <td>Auth</td>
 <td>Credential attachment</td>
 <td><code>none</code>, <code>api_key</code>, <code>bearer</code></td>
@@ -510,69 +510,69 @@
 <h3 id="83-mvp-error-codes">8.3 MVP Error Codes</h3>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Code</th>
 <th>Category</th>
 <th>Description</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><code>PLUGIN_NOT_FOUND</code></td>
 <td>Runtime</td>
 <td>Requested plugin does not exist</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>TRANSPORT_DNS_ERROR</code></td>
 <td>Transport</td>
 <td>DNS resolution failed</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>TRANSPORT_CONNECTION_REFUSED</code></td>
 <td>Transport</td>
 <td>Connection refused</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>TRANSPORT_TIMEOUT</code></td>
 <td>Transport</td>
 <td>Request timed out</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>TRANSPORT_TLS_ERROR</code></td>
 <td>Transport</td>
 <td>TLS/SSL error</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>TRANSPORT_NETWORK_ERROR</code></td>
 <td>Transport</td>
 <td>General network error</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>PROTOCOL_INVALID_MAPPING</code></td>
 <td>Protocol</td>
 <td>Invalid maps_to format</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>PROTOCOL_MISSING_PARAM</code></td>
 <td>Protocol</td>
 <td>Path parameter missing</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>SERIALIZATION_CIRCULAR_REF</code></td>
 <td>Serialization</td>
 <td>Circular reference in data</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>SERIALIZATION_PARSE_ERROR</code></td>
 <td>Serialization</td>
 <td>Failed to parse response</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>AUTH_CONFIG_INVALID</code></td>
 <td>Auth</td>
 <td>Invalid auth configuration</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>AUTH_CREDENTIAL_MISSING</code></td>
 <td>Auth</td>
 <td>Credential not found</td>
@@ -585,7 +585,7 @@
 <li><a href="adapter/element-type.html">Adapter Element Type Specification</a></li>
 <li><a href="error-codes.html">Error Codes Specification</a></li>
 <li><a href="versions/v1.0.0-draft.html">MCP-AQL Specification</a></li>
-<li><a href="../adapter-reference/architecture/plugin-system.html">Plugin System Implementation</a> (implementation details)</li>
+<li><a href="https://github.com/MCPAQL/mcpaql-adapter/blob/develop/docs/architecture/plugin-system.md">Plugin System Implementation</a> (implementation details)</li>
 <li>GitHub Issue: <a href="https://github.com/MCPAQL/spec/issues/62">#62</a></li>
 </ul>
 

--- a/public/spec/process/breaking-changes.html
+++ b/public/spec/process/breaking-changes.html
@@ -50,10 +50,10 @@
   <ul><li><a href="../security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="../security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="../security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Features</h3>
-  <ul><li><a href="../features/collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
+  <ul><li><a href="../features/aggregations.html">MCP-AQL Aggregations</a></li><li><a href="../features/collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="../features/computed-fields.html">MCP-AQL Computed Fields</a></li><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/relationship-queries.html">MCP-AQL Relationship Queries</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Guides</h3>
-  <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
+  <ul><li><a href="../guides/cross-domain-implementation.html">Cross-Domain Implementation Guide</a></li><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
   <ul><li><a class="current" aria-current="page" href="breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="versioning.html">Versioning Strategy</a></li><li><a href="../repo/CHANGELOG.html">Changelog</a></li></ul>
@@ -145,41 +145,41 @@
 <p><strong>Examples of Breaking Changes:</strong></p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Change Type</th>
 <th>Example</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td>Removing required operations</td>
 <td>Removing the <code>introspect</code> operation</td>
 </tr>
-<tr>
+<tr class="even">
 <td>Incompatible request structure changes</td>
 <td>Changing <code>operation</code> field to <code>op</code></td>
 </tr>
-<tr>
+<tr class="odd">
 <td>Incompatible response structure changes</td>
 <td>Restructuring the success/error envelope</td>
 </tr>
-<tr>
+<tr class="even">
 <td>Removing CRUDE endpoints</td>
 <td>Eliminating the EXECUTE endpoint</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>Changing introspection response format</td>
 <td>Altering the structure of OperationDetails</td>
 </tr>
-<tr>
+<tr class="even">
 <td>Removing required fields from protocol types</td>
 <td>Removing <code>endpoint</code> from OperationInfo</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>Changing field types incompatibly</td>
 <td>Changing <code>required</code> from boolean to string</td>
 </tr>
-<tr>
+<tr class="even">
 <td>Changing endpoint routing rules</td>
 <td>Requiring different operation-to-endpoint mappings</td>
 </tr>
@@ -190,37 +190,37 @@
 <p><strong>Examples of Non-Breaking Changes:</strong></p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Change Type</th>
 <th>Example</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td>Adding new optional operations</td>
 <td>New <code>validate</code> operation on READ endpoint</td>
 </tr>
-<tr>
+<tr class="even">
 <td>Adding new optional parameters</td>
 <td>Adding <code>timeout</code> parameter to existing operations</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>Adding new fields to responses (additive)</td>
 <td>Adding <code>deprecated</code> flag to OperationInfo</td>
 </tr>
-<tr>
+<tr class="even">
 <td>New optional features</td>
 <td>Field selection support</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>Deprecating features (without removal)</td>
 <td>Marking an operation as deprecated</td>
 </tr>
-<tr>
+<tr class="even">
 <td>Adding new optional protocol types</td>
 <td>New TypeInfo subtypes</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>Extending enum values</td>
 <td>Adding new endpoint mode options</td>
 </tr>
@@ -231,33 +231,33 @@
 <p><strong>Examples of Patch Changes:</strong></p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Change Type</th>
 <th>Example</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td>Clarifications that don't change behavior</td>
 <td>Explaining existing edge case handling</td>
 </tr>
-<tr>
+<tr class="even">
 <td>Typo fixes</td>
 <td>Correcting spelling in specification text</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>Example corrections</td>
 <td>Fixing incorrect JSON in examples</td>
 </tr>
-<tr>
+<tr class="even">
 <td>Documentation improvements</td>
 <td>Adding diagrams or additional context</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>Formatting changes</td>
 <td>Restructuring sections for clarity</td>
 </tr>
-<tr>
+<tr class="even">
 <td>Non-normative additions</td>
 <td>Adding implementation notes</td>
 </tr>
@@ -308,7 +308,7 @@
 <p>When implementing deprecation warnings in introspection, include:</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Field</th>
 <th>Type</th>
 <th>Required</th>
@@ -316,25 +316,25 @@
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><code>deprecated</code></td>
 <td>boolean</td>
 <td>Yes</td>
 <td>Whether the item is deprecated</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>deprecationMessage</code></td>
 <td>string</td>
 <td>Yes</td>
 <td>Human-readable explanation and alternative</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>deprecatedSince</code></td>
 <td>string</td>
 <td>No</td>
 <td>Version when deprecation began</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>removalVersion</code></td>
 <td>string</td>
 <td>No</td>

--- a/public/spec/process/preliminary-public-launch-checklist.html
+++ b/public/spec/process/preliminary-public-launch-checklist.html
@@ -50,10 +50,10 @@
   <ul><li><a href="../security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="../security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="../security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Features</h3>
-  <ul><li><a href="../features/collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
+  <ul><li><a href="../features/aggregations.html">MCP-AQL Aggregations</a></li><li><a href="../features/collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="../features/computed-fields.html">MCP-AQL Computed Fields</a></li><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/relationship-queries.html">MCP-AQL Relationship Queries</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Guides</h3>
-  <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
+  <ul><li><a href="../guides/cross-domain-implementation.html">Cross-Domain Implementation Guide</a></li><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
   <ul><li><a href="breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a class="current" aria-current="page" href="preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="versioning.html">Versioning Strategy</a></li><li><a href="../repo/CHANGELOG.html">Changelog</a></li></ul>

--- a/public/spec/process/rfc-process.html
+++ b/public/spec/process/rfc-process.html
@@ -50,10 +50,10 @@
   <ul><li><a href="../security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="../security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="../security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Features</h3>
-  <ul><li><a href="../features/collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
+  <ul><li><a href="../features/aggregations.html">MCP-AQL Aggregations</a></li><li><a href="../features/collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="../features/computed-fields.html">MCP-AQL Computed Fields</a></li><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/relationship-queries.html">MCP-AQL Relationship Queries</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Guides</h3>
-  <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
+  <ul><li><a href="../guides/cross-domain-implementation.html">Cross-Domain Implementation Guide</a></li><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
   <ul><li><a href="breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a class="current" aria-current="page" href="rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="versioning.html">Versioning Strategy</a></li><li><a href="../repo/CHANGELOG.html">Changelog</a></li></ul>
@@ -428,7 +428,7 @@
 <h2 id="quick-reference">Quick Reference</h2>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Stage</th>
 <th>Name</th>
 <th>Duration</th>
@@ -436,31 +436,31 @@
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td>0</td>
 <td>Pre-RFC</td>
 <td>No minimum</td>
 <td>Ready to formalize</td>
 </tr>
-<tr>
+<tr class="even">
 <td>1</td>
 <td>Draft</td>
 <td>Immediate</td>
 <td>Complete submission</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>2</td>
 <td>Review</td>
 <td>14+ days</td>
 <td>Consensus reached</td>
 </tr>
-<tr>
+<tr class="even">
 <td>3</td>
 <td>Accepted</td>
 <td>Immediate</td>
 <td>Number assigned</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>4</td>
 <td>Integrated</td>
 <td>Varies</td>

--- a/public/spec/process/versioning.html
+++ b/public/spec/process/versioning.html
@@ -50,10 +50,10 @@
   <ul><li><a href="../security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="../security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="../security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Features</h3>
-  <ul><li><a href="../features/collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
+  <ul><li><a href="../features/aggregations.html">MCP-AQL Aggregations</a></li><li><a href="../features/collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="../features/computed-fields.html">MCP-AQL Computed Fields</a></li><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/relationship-queries.html">MCP-AQL Relationship Queries</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Guides</h3>
-  <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
+  <ul><li><a href="../guides/cross-domain-implementation.html">Cross-Domain Implementation Guide</a></li><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
   <ul><li><a href="breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a class="current" aria-current="page" href="versioning.html">Versioning Strategy</a></li><li><a href="../repo/CHANGELOG.html">Changelog</a></li></ul>
@@ -117,25 +117,25 @@
 <h3 id="components">Components</h3>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Component</th>
 <th>Description</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td>MAJOR</td>
 <td>Breaking changes that require implementation updates</td>
 </tr>
-<tr>
+<tr class="even">
 <td>MINOR</td>
 <td>New features, backward compatible</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>PATCH</td>
 <td>Bug fixes, clarifications, backward compatible</td>
 </tr>
-<tr>
+<tr class="even">
 <td>PRERELEASE</td>
 <td>Optional tag indicating release maturity</td>
 </tr>
@@ -144,29 +144,29 @@
 <h3 id="examples">Examples</h3>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Version</th>
 <th>Description</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><code>1.0.0-draft</code></td>
 <td>Current working draft</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>1.0.0</code></td>
 <td>First stable release</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>1.1.0</code></td>
 <td>New features added (backward compatible)</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>1.1.1</code></td>
 <td>Bug fixes or clarifications</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>2.0.0</code></td>
 <td>Breaking changes from v1.x</td>
 </tr>
@@ -277,21 +277,21 @@
 <p>Version information is maintained in the following locations:</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Location</th>
 <th>Purpose</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><code>docs/versions/vX.Y.Z.md</code></td>
 <td>Full specification document for each version</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>CHANGELOG.md</code></td>
 <td>Complete version history with changes</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>README.md</code></td>
 <td>Version badge showing current stable version</td>
 </tr>

--- a/public/spec/reference/README.html
+++ b/public/spec/reference/README.html
@@ -50,10 +50,10 @@
   <ul><li><a href="../security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="../security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="../security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Features</h3>
-  <ul><li><a href="../features/collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
+  <ul><li><a href="../features/aggregations.html">MCP-AQL Aggregations</a></li><li><a href="../features/collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="../features/computed-fields.html">MCP-AQL Computed Fields</a></li><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/relationship-queries.html">MCP-AQL Relationship Queries</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Guides</h3>
-  <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
+  <ul><li><a href="../guides/cross-domain-implementation.html">Cross-Domain Implementation Guide</a></li><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
   <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li><li><a href="../repo/CHANGELOG.html">Changelog</a></li></ul>

--- a/public/spec/repo/CHANGELOG.html
+++ b/public/spec/repo/CHANGELOG.html
@@ -50,10 +50,10 @@
   <ul><li><a href="../security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="../security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="../security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Features</h3>
-  <ul><li><a href="../features/collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
+  <ul><li><a href="../features/aggregations.html">MCP-AQL Aggregations</a></li><li><a href="../features/collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="../features/computed-fields.html">MCP-AQL Computed Fields</a></li><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/relationship-queries.html">MCP-AQL Relationship Queries</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Guides</h3>
-  <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
+  <ul><li><a href="../guides/cross-domain-implementation.html">Cross-Domain Implementation Guide</a></li><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
   <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li><li><a class="current" aria-current="page" href="CHANGELOG.html">Changelog</a></li></ul>
@@ -114,6 +114,35 @@
 <h2 id="unreleased">[Unreleased]</h2>
 <h3 id="added">Added</h3>
 <ul>
+<li>Generalized semantic-endpoint model alongside the standard CRUDE profile
+<ul>
+<li>Updated the normative draft to distinguish standardized semantic categories from exposed endpoint families</li>
+<li>Reframed <code>docs/endpoint-modes.md</code> around semantic endpoint mode versus single mode, with CRUDE as the standard profile inside semantic endpoint mode</li>
+<li>Updated introspection docs and schema so operations disclose both <code>semantic_category</code> and <code>endpoint</code></li>
+<li>Clarified MCP integration, conformance, and top-level docs so CRUDE remains the standard profile rather than the only in-spec semantic-endpoint shape</li>
+<li>Breaking draft change: introspection examples and schema guidance now require <code>semantic_category</code>, treat <code>endpoint</code> as the exposed endpoint-family name, and use <code>_protocol.mode: "semantic"</code> for both CRUDE and alternate semantic-endpoint profiles</li>
+</ul></li>
+<li>Query-language feature guides for aggregations, computed fields, and relationship traversal (#36, #42, #44)
+<ul>
+<li>Added <code>docs/features/aggregations.md</code> for the preferred <code>aggregate</code> request and <code>aggregations</code> response shape</li>
+<li>Added <code>docs/features/computed-fields.md</code> for the <code>_computed.</code> field path convention and metadata pattern</li>
+<li>Added <code>docs/features/relationship-queries.md</code> for <code>query_relationships</code>, graph traversal semantics, and relationship capability discovery</li>
+<li>Added non-normative helper schemas for aggregation, computed-field, and relationship-query shapes</li>
+<li>Extended <code>introspection-response.schema.json</code> and introspection docs with optional metadata for aggregation support, computed fields, and relationship capabilities</li>
+<li>Updated collection-querying, field-selection, operations, README, and schema index docs to wire the new query-language features into the existing collection-query surface</li>
+</ul></li>
+<li>Fixture-driven conformance runner and semantic evaluation baseline (#10, #56)
+<ul>
+<li>Added <code>scripts/run-conformance-tests.mjs</code> with <code>test</code>, <code>verify-fixtures</code>, <code>report</code>, and <code>version</code> commands</li>
+<li>Added <code>tests/conformance/</code> evidence bundles covering passing Level 1, passing Level 2, semantic-warning, and failing reference cases</li>
+<li>Added CI integration via <code>.github/workflows/conformance-tests.yml</code></li>
+<li>Updated conformance, README, and generator docs to reflect the implemented fixture-first runner model and two-tier semantic evaluation flow</li>
+</ul></li>
+<li>Cross-domain implementation guide for adapting MCP-AQL beyond the Dollhouse reference profile (#34)
+<ul>
+<li>Added <code>docs/guides/cross-domain-implementation.md</code> with domain mapping guidance, CRUDE design advice, introspection checklist, four non-Dollhouse examples, and reusable operation templates</li>
+<li>Linked the new guide from the root README, docs index, and guides index</li>
+</ul></li>
 <li>Pagination response structure guidance for collection operations (#164)
 <ul>
 <li>Added <code>docs/operations.md</code> guidance for cursor-native, page-based, and offset-based pagination metadata in responses</li>

--- a/public/spec/repo/README.html
+++ b/public/spec/repo/README.html
@@ -50,10 +50,10 @@
   <ul><li><a href="../security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="../security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="../security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Features</h3>
-  <ul><li><a href="../features/collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
+  <ul><li><a href="../features/aggregations.html">MCP-AQL Aggregations</a></li><li><a href="../features/collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="../features/computed-fields.html">MCP-AQL Computed Fields</a></li><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/relationship-queries.html">MCP-AQL Relationship Queries</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Guides</h3>
-  <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
+  <ul><li><a href="../guides/cross-domain-implementation.html">Cross-Domain Implementation Guide</a></li><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
   <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li><li><a href="CHANGELOG.html">Changelog</a></li></ul>
@@ -101,7 +101,7 @@
               <p class="page-toc-intro">Use the outline to move through longer pages without losing your place.</p>
             </div>
             <ol class="page-toc-list" data-page-toc-list>
-              <li class="page-toc-item level-2"><a href="#overview" data-toc-target="overview">Overview</a></li><li class="page-toc-item level-2"><a href="#preliminary-draft-positioning" data-toc-target="preliminary-draft-positioning">Preliminary Draft Positioning</a></li><li class="page-toc-item level-2"><a href="#the-crude-pattern" data-toc-target="the-crude-pattern">The CRUDE Pattern</a></li><li class="page-toc-item level-2"><a href="#token-efficiency" data-toc-target="token-efficiency">Token Efficiency</a></li><li class="page-toc-item level-2"><a href="#key-features" data-toc-target="key-features">Key Features</a></li><li class="page-toc-item level-2"><a href="#quick-start" data-toc-target="quick-start">Quick Start</a></li><li class="page-toc-item level-3"><a href="#discover-available-operations" data-toc-target="discover-available-operations">Discover Available Operations</a></li><li class="page-toc-item level-3"><a href="#get-operation-details" data-toc-target="get-operation-details">Get Operation Details</a></li><li class="page-toc-item level-3"><a href="#execute-an-operation" data-toc-target="execute-an-operation">Execute an Operation</a></li><li class="page-toc-item level-2"><a href="#specification-documents" data-toc-target="specification-documents">Specification Documents</a></li><li class="page-toc-item level-2"><a href="#reference-profile" data-toc-target="reference-profile">Reference Profile</a></li><li class="page-toc-item level-2"><a href="#conformance" data-toc-target="conformance">Conformance</a></li><li class="page-toc-item level-2"><a href="#contributing" data-toc-target="contributing">Contributing</a></li><li class="page-toc-item level-2"><a href="#license" data-toc-target="license">License</a></li><li class="page-toc-item level-2"><a href="#acknowledgments" data-toc-target="acknowledgments">Acknowledgments</a></li>
+              <li class="page-toc-item level-2"><a href="#overview" data-toc-target="overview">Overview</a></li><li class="page-toc-item level-2"><a href="#preliminary-draft-positioning" data-toc-target="preliminary-draft-positioning">Preliminary Draft Positioning</a></li><li class="page-toc-item level-2"><a href="#endpoint-families" data-toc-target="endpoint-families">Endpoint Families</a></li><li class="page-toc-item level-2"><a href="#token-efficiency" data-toc-target="token-efficiency">Token Efficiency</a></li><li class="page-toc-item level-2"><a href="#key-features" data-toc-target="key-features">Key Features</a></li><li class="page-toc-item level-2"><a href="#quick-start" data-toc-target="quick-start">Quick Start</a></li><li class="page-toc-item level-3"><a href="#discover-available-operations" data-toc-target="discover-available-operations">Discover Available Operations</a></li><li class="page-toc-item level-3"><a href="#get-operation-details" data-toc-target="get-operation-details">Get Operation Details</a></li><li class="page-toc-item level-3"><a href="#execute-an-operation" data-toc-target="execute-an-operation">Execute an Operation</a></li><li class="page-toc-item level-2"><a href="#specification-documents" data-toc-target="specification-documents">Specification Documents</a></li><li class="page-toc-item level-2"><a href="#reference-profile" data-toc-target="reference-profile">Reference Profile</a></li><li class="page-toc-item level-2"><a href="#conformance" data-toc-target="conformance">Conformance</a></li><li class="page-toc-item level-2"><a href="#contributing" data-toc-target="contributing">Contributing</a></li><li class="page-toc-item level-2"><a href="#license" data-toc-target="license">License</a></li><li class="page-toc-item level-2"><a href="#acknowledgments" data-toc-target="acknowledgments">Acknowledgments</a></li>
             </ol>
           </div>
         </section>
@@ -115,7 +115,7 @@
 </blockquote>
 <p><a href="../versions/v1.0.0-draft.html"><img src="https://img.shields.io/badge/spec-v1.0.0--draft-blue" alt="Spec Version" /></a> <a href="https://github.com/MCPAQL/spec/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-AGPL%20v3-blue.svg" alt="License: AGPL v3" /></a></p>
 <h2 id="overview">Overview</h2>
-<p>MCP-AQL is a protocol specification that consolidates multiple MCP (Model Context Protocol) tools into semantic endpoints, providing approximately <strong>96% token reduction</strong> while maintaining full functionality. It enables structured communication between AI models and context-providing services through a unified query language.</p>
+<p>MCP-AQL is a protocol specification that consolidates multiple MCP (Model Context Protocol) tools into semantic endpoint families, providing approximately <strong>96% token reduction</strong> while maintaining full functionality. It enables structured communication between AI models and context-providing services through a unified query language.</p>
 <h2 id="preliminary-draft-positioning">Preliminary Draft Positioning</h2>
 <p>The current publication target is a <strong>preliminary public draft</strong> of MCP-AQL.</p>
 <p>This draft is intended to:</p>
@@ -124,51 +124,58 @@
 <li>Show how semantic endpoint consolidation reduces token bloat</li>
 <li>Validate flexibility for modular integrations (security, execution, code/compute workflows)</li>
 </ul>
-<p>This draft is not yet a final certification baseline. Some conformance automation and ecosystem hardening work is still in progress.</p>
-<h2 id="the-crude-pattern">The CRUDE Pattern</h2>
-<p>MCP-AQL extends traditional CRUD with an <strong>Execute</strong> endpoint, creating the CRUDE pattern:</p>
+<p>This draft is not yet a final certification baseline. The repository now includes a fixture-driven conformance runner and semantic evaluation baseline, but broader ecosystem hardening is still in progress.</p>
+<h2 id="endpoint-families">Endpoint Families</h2>
+<p>MCP-AQL supports semantic endpoint mode or a single unified endpoint. The standard semantic-endpoint profile extends traditional CRUD with an <strong>Execute</strong> endpoint, creating the CRUDE pattern:</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Endpoint</th>
 <th>Safety</th>
 <th>Description</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><strong>Create</strong></td>
 <td>Non-destructive</td>
 <td>Additive operations that create new state</td>
 </tr>
-<tr>
+<tr class="even">
 <td><strong>Read</strong></td>
 <td>Read-only</td>
 <td>Safe operations that query state</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><strong>Update</strong></td>
 <td>Modifying</td>
 <td>Operations that modify existing state</td>
 </tr>
-<tr>
+<tr class="even">
 <td><strong>Delete</strong></td>
 <td>Destructive</td>
 <td>Operations that remove state</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><strong>Execute</strong></td>
 <td>Stateful</td>
 <td>Runtime lifecycle operations (non-idempotent)</td>
 </tr>
 </tbody>
 </table>
+<p>Adapters MAY also define alternate semantic endpoint families when the target API is better represented by semantically explicit sets such as <code>discover</code> / <code>query</code> / <code>manage</code> / <code>operate</code>, database-oriented profiles like <code>inspect</code> / <code>query</code> / <code>mutate</code> / <code>administer</code>, or hardware-oriented profiles like <code>discover</code> / <code>observe</code> / <code>control</code> / <code>maintain</code>. Operations still retain standardized semantic categories for CREATE, READ, UPDATE, DELETE, and EXECUTE.</p>
+<p>Examples of alternate semantic-endpoint profiles:</p>
+<pre class="text"><code>Extended CRUDE-style profile:
+create / read / update / delete / execute / authorize
+
+Alternative semantic profile:
+discover / query / manage / operate</code></pre>
 <h2 id="token-efficiency">Token Efficiency</h2>
 <p>MCP-AQL dramatically reduces token consumption for LLM interactions.</p>
 <p><strong>Per-tool overhead:</strong> A typical MCP tool definition consumes ~500-700 tokens in context.</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Configuration</th>
 <th>Tool Count</th>
 <th>Token Cost</th>
@@ -176,25 +183,25 @@
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td>Discrete Tools</td>
 <td>~30 tools</td>
 <td>~18,000</td>
 <td>Baseline</td>
 </tr>
-<tr>
+<tr class="even">
 <td>Discrete Tools</td>
 <td>~50 tools</td>
 <td>~30,000</td>
 <td>Baseline</td>
 </tr>
-<tr>
-<td><strong>CRUDE Mode</strong></td>
+<tr class="odd">
+<td><strong>Semantic Endpoint Mode (CRUDE profile)</strong></td>
 <td>5 endpoints</td>
-<td>~4,000</td>
+<td>~4,300</td>
 <td>~80-85%</td>
 </tr>
-<tr>
+<tr class="even">
 <td><strong>Single Mode</strong></td>
 <td>1 endpoint</td>
 <td>~1,000</td>
@@ -214,63 +221,83 @@
 </ul>
 <h2 id="quick-start">Quick Start</h2>
 <h3 id="discover-available-operations">Discover Available Operations</h3>
-<div class="sourceCode" id="cb1"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a>{</span>
-<span id="cb1-2"><a href="#cb1-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;introspect&quot;</span><span class="op">,</span></span>
-<span id="cb1-3"><a href="#cb1-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> { <span class="dt">query</span><span class="op">:</span> <span class="st">&quot;operations&quot;</span> }</span>
-<span id="cb1-4"><a href="#cb1-4" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
-<h3 id="get-operation-details">Get Operation Details</h3>
 <div class="sourceCode" id="cb2"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a>{</span>
 <span id="cb2-2"><a href="#cb2-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;introspect&quot;</span><span class="op">,</span></span>
-<span id="cb2-3"><a href="#cb2-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> { <span class="dt">query</span><span class="op">:</span> <span class="st">&quot;operations&quot;</span><span class="op">,</span> <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;create_user&quot;</span> }</span>
+<span id="cb2-3"><a href="#cb2-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> { <span class="dt">query</span><span class="op">:</span> <span class="st">&quot;operations&quot;</span> }</span>
 <span id="cb2-4"><a href="#cb2-4" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<h3 id="get-operation-details">Get Operation Details</h3>
+<div class="sourceCode" id="cb3"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb3-1"><a href="#cb3-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb3-2"><a href="#cb3-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;introspect&quot;</span><span class="op">,</span></span>
+<span id="cb3-3"><a href="#cb3-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> { <span class="dt">query</span><span class="op">:</span> <span class="st">&quot;operations&quot;</span><span class="op">,</span> <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;create_user&quot;</span> }</span>
+<span id="cb3-4"><a href="#cb3-4" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
 <h3 id="execute-an-operation">Execute an Operation</h3>
-<div class="sourceCode" id="cb3"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb3-1"><a href="#cb3-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Operations are adapter-specific - this example from a user management adapter</span></span>
-<span id="cb3-2"><a href="#cb3-2" aria-hidden="true" tabindex="-1"></a>{</span>
-<span id="cb3-3"><a href="#cb3-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;create_user&quot;</span><span class="op">,</span></span>
-<span id="cb3-4"><a href="#cb3-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> {</span>
-<span id="cb3-5"><a href="#cb3-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">email</span><span class="op">:</span> <span class="st">&quot;alice@example.com&quot;</span><span class="op">,</span></span>
-<span id="cb3-6"><a href="#cb3-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;Alice&quot;</span><span class="op">,</span></span>
-<span id="cb3-7"><a href="#cb3-7" aria-hidden="true" tabindex="-1"></a>    <span class="dt">role</span><span class="op">:</span> <span class="st">&quot;admin&quot;</span></span>
-<span id="cb3-8"><a href="#cb3-8" aria-hidden="true" tabindex="-1"></a>  }</span>
-<span id="cb3-9"><a href="#cb3-9" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<div class="sourceCode" id="cb4"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb4-1"><a href="#cb4-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Operations are adapter-specific - this example from a user management adapter</span></span>
+<span id="cb4-2"><a href="#cb4-2" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb4-3"><a href="#cb4-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">operation</span><span class="op">:</span> <span class="st">&quot;create_user&quot;</span><span class="op">,</span></span>
+<span id="cb4-4"><a href="#cb4-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">params</span><span class="op">:</span> {</span>
+<span id="cb4-5"><a href="#cb4-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">email</span><span class="op">:</span> <span class="st">&quot;alice@example.com&quot;</span><span class="op">,</span></span>
+<span id="cb4-6"><a href="#cb4-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">name</span><span class="op">:</span> <span class="st">&quot;Alice&quot;</span><span class="op">,</span></span>
+<span id="cb4-7"><a href="#cb4-7" aria-hidden="true" tabindex="-1"></a>    <span class="dt">role</span><span class="op">:</span> <span class="st">&quot;admin&quot;</span></span>
+<span id="cb4-8"><a href="#cb4-8" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb4-9"><a href="#cb4-9" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
 <h2 id="specification-documents">Specification Documents</h2>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Document</th>
 <th>Description</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><a href="../versions/v1.0.0-draft.html">Specification v1.0.0-draft</a></td>
 <td>Current working draft</td>
 </tr>
-<tr>
+<tr class="even">
 <td><a href="../crude-pattern.html">CRUDE Pattern</a></td>
-<td>Detailed endpoint semantics</td>
+<td>Standard semantic-endpoint profile</td>
 </tr>
-<tr>
+<tr class="odd">
+<td><a href="../endpoint-modes.html">Endpoint Modes</a></td>
+<td>CRUDE, semantic-endpoint, and single endpoint configuration</td>
+</tr>
+<tr class="even">
 <td><a href="../introspection.html">Introspection</a></td>
 <td>Discovery system specification</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><a href="../operations.html">Operations Guide</a></td>
 <td>Operation design patterns</td>
 </tr>
-<tr>
+<tr class="even">
 <td><a href="../features/collection-querying.html">Collection Querying</a></td>
 <td>Preferred query contract for list/search/query operations</td>
 </tr>
-<tr>
+<tr class="odd">
+<td><a href="../features/aggregations.html">Aggregations</a></td>
+<td>Preferred summary/query shape for server-side aggregations</td>
+</tr>
+<tr class="even">
+<td><a href="../features/computed-fields.html">Computed Fields</a></td>
+<td>Preferred <code>_computed.</code> convention for adapter-declared derived values</td>
+</tr>
+<tr class="odd">
+<td><a href="../features/relationship-queries.html">Relationship Queries</a></td>
+<td>Preferred traversal contract for graph-style READ operations</td>
+</tr>
+<tr class="even">
 <td><a href="../adapter/discovery-bundle.html">MCP Server Discovery Bundle</a></td>
 <td>Interrogation bundle contract for MCP-to-MCP-AQL generation</td>
 </tr>
-<tr>
+<tr class="odd">
+<td><a href="../guides/cross-domain-implementation.html">Cross-Domain Implementation Guide</a></td>
+<td>Step-by-step guide for adapting MCP-AQL to databases, filesystems, API gateways, IoT, and other domains</td>
+</tr>
+<tr class="even">
 <td><a href="../README.html">Documentation Index</a></td>
 <td>Full documentation structure</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><a href="CHANGELOG.html">Changelog</a></td>
 <td>Version history</td>
 </tr>
@@ -283,13 +310,13 @@
 <p>Implementations claiming MCP-AQL conformance MUST:</p>
 <ol type="1">
 <li>Implement the <code>introspect</code> operation for runtime discovery</li>
-<li>Use the CRUDE endpoint pattern (or single endpoint mode)</li>
+<li>Use semantic endpoint mode or single endpoint mode</li>
 <li>Return discriminated union responses (<code>{ success, data }</code> or <code>{ success, error }</code>)</li>
 <li>Document supported operations via introspection</li>
 </ol>
 <p>Implementations SHOULD also pass the conformance test suite in <a href="https://github.com/MCPAQL/spec/blob/main/tests/">tests/</a>.</p>
 <blockquote>
-<p><strong>Status Note:</strong> Schema/example validation is implemented in this repository. The full cross-implementation conformance runner described in <code>docs/conformance-testing.md</code> is still being finalized.</p>
+<p><strong>Status Note:</strong> This repository includes schema/example validation plus a fixture-driven conformance runner in <code>scripts/run-conformance-tests.mjs</code>. The future packaged runner described in <code>docs/conformance-testing.md</code> can still grow beyond this baseline into direct live-adapter execution.</p>
 </blockquote>
 <h2 id="contributing">Contributing</h2>
 <p>We welcome contributions to the specification. Please see <a href="https://github.com/MCPAQL/spec/blob/main/CONTRIBUTING.md">CONTRIBUTING.md</a> for guidelines.</p>

--- a/public/spec/research/mcp-vs-mcpaql-vs-a2a.html
+++ b/public/spec/research/mcp-vs-mcpaql-vs-a2a.html
@@ -50,10 +50,10 @@
   <ul><li><a href="../security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="../security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="../security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Features</h3>
-  <ul><li><a href="../features/collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
+  <ul><li><a href="../features/aggregations.html">MCP-AQL Aggregations</a></li><li><a href="../features/collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="../features/computed-fields.html">MCP-AQL Computed Fields</a></li><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/relationship-queries.html">MCP-AQL Relationship Queries</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Guides</h3>
-  <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
+  <ul><li><a href="../guides/cross-domain-implementation.html">Cross-Domain Implementation Guide</a></li><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
   <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li><li><a href="../repo/CHANGELOG.html">Changelog</a></li></ul>
@@ -182,7 +182,7 @@
 <h2 id="3-the-core-problem-each-solves">3. The Core Problem Each Solves</h2>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th></th>
 <th>MCP</th>
 <th>MCP-AQL</th>
@@ -190,19 +190,19 @@
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><strong>Core problem</strong></td>
 <td>Every AI app builds custom integrations for every tool/service (M x N explosion)</td>
 <td>LLMs can't reliably call arbitrary APIs -- they hallucinate parameters, miss constraints, and waste context on schemas</td>
 <td>Agents from different vendors/frameworks can't discover or collaborate with each other</td>
 </tr>
-<tr>
+<tr class="even">
 <td><strong>Solution</strong></td>
 <td>Standardize the connection protocol (one universal wire format)</td>
 <td>Translate any API into an LLM-native interface with self-describing operations, constraint metadata, and safety enforcement</td>
 <td>Standardize agent discovery and task delegation via Agent Cards and multi-turn task conversations</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><strong>Analogy</strong></td>
 <td>USB-C: a universal connector</td>
 <td>A universal interpreter that speaks every API dialect but presents one clean language</td>
@@ -298,7 +298,7 @@ Authorization: Bearer &lt;token&gt;</code></pre>
 <h3 id="discovery-and-self-description">Discovery and Self-Description</h3>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th></th>
 <th>MCP</th>
 <th>MCP-AQL</th>
@@ -306,25 +306,25 @@ Authorization: Bearer &lt;token&gt;</code></pre>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><strong>Discovery mechanism</strong></td>
 <td>Static -- client connects to pre-configured servers</td>
 <td>Runtime introspection -- <code>introspect</code> operation discovers operations on demand</td>
 <td>Agent Cards at well-known URLs</td>
 </tr>
-<tr>
+<tr class="even">
 <td><strong>Schema loading</strong></td>
 <td>All tool definitions loaded upfront into LLM context</td>
 <td>Progressive disclosure -- discover what you need, when you need it</td>
 <td>Agent Card skills are high-level descriptions, not detailed schemas</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><strong>Constraint metadata</strong></td>
 <td>Tool annotations (readOnly, destructive hints) + JSON Schema for inputs</td>
 <td>Rich constraints: enums, min/max, patterns, formats, sensitive markers, examples</td>
 <td>Minimal -- skill descriptions are natural language</td>
 </tr>
-<tr>
+<tr class="even">
 <td><strong>Token cost of discovery</strong></td>
 <td>~500-700 tokens per tool (50 tools = ~30,000 tokens upfront)</td>
 <td>~1,100 tokens total (single mode) for unlimited operations</td>
@@ -335,7 +335,7 @@ Authorization: Bearer &lt;token&gt;</code></pre>
 <h3 id="token-efficiency">Token Efficiency</h3>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th></th>
 <th>MCP</th>
 <th>MCP-AQL</th>
@@ -343,31 +343,31 @@ Authorization: Bearer &lt;token&gt;</code></pre>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><strong>Registration overhead</strong></td>
 <td>~30,000 tokens for 50 tools</td>
 <td>~1,100 (single mode) to ~4,300 (CRUDE mode) for 50+ operations</td>
 <td>N/A -- agents, not tools</td>
 </tr>
-<tr>
+<tr class="even">
 <td><strong>Reduction from baseline</strong></td>
 <td>Baseline (0%)</td>
 <td>85-96% reduction</td>
 <td>Not comparable</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><strong>Response efficiency</strong></td>
 <td>Raw tool output dumped to context</td>
 <td>Field selection (minimal/standard/full presets) provides 65-86% additional reduction</td>
 <td>Artifacts with structured Parts</td>
 </tr>
-<tr>
+<tr class="even">
 <td><strong>Repeated call optimization</strong></td>
 <td>Same cost every time</td>
 <td>"Ditto" shorthand pattern: 97% reduction on repeated calls (~15 tokens vs ~450)</td>
 <td>N/A</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><strong>Fire-and-forget</strong></td>
 <td>No -- every tool call requires full response processing</td>
 <td><code>notify</code> operation returns minimal <code>{ ack: true }</code> (~15 tokens)</td>
@@ -378,7 +378,7 @@ Authorization: Bearer &lt;token&gt;</code></pre>
 <h3 id="safety-and-security">Safety and Security</h3>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th></th>
 <th>MCP</th>
 <th>MCP-AQL</th>
@@ -386,43 +386,43 @@ Authorization: Bearer &lt;token&gt;</code></pre>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><strong>Safety model</strong></td>
 <td>Tool annotations are hints; client decides whether to honor them</td>
 <td><strong>Protocol-enforced Gatekeeper</strong> -- 4-layer defense-in-depth; server-side enforcement that LLM cannot bypass</td>
 <td>Agent can reject tasks; standard auth schemes</td>
 </tr>
-<tr>
+<tr class="even">
 <td><strong>Danger classification</strong></td>
 <td>Binary: readOnly or destructive annotation</td>
 <td>5-level system: safe → reversible → destructive → dangerous → forbidden</td>
 <td>N/A</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><strong>Trust model</strong></td>
 <td>Implicit trust in configured servers</td>
 <td>5-level trust: untested → generated → validated → community_reviewed → certified; gating matrix with danger levels</td>
 <td>Authentication schemes (OAuth, OIDC, mTLS)</td>
 </tr>
-<tr>
+<tr class="even">
 <td><strong>Hallucination prevention</strong></td>
 <td>Depends on tool description quality</td>
 <td>Unknown parameter rejection -- if LLM hallucinates <code>force: true</code>, adapter rejects and returns valid params</td>
 <td>Depends on Agent Card quality</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><strong>Confirmation workflow</strong></td>
 <td>Human-in-the-loop via Sampling</td>
 <td>Confirmation tokens for destructive operations; pattern-based auto-classification (<code>force_*</code> → dangerous, <code>drop_*</code> → forbidden)</td>
 <td>N/A</td>
 </tr>
-<tr>
+<tr class="even">
 <td><strong>Auth</strong></td>
 <td>OAuth 2.1 (as of Jun 2025)</td>
 <td>Inherits MCP + per-adapter auth plugins (API key, Bearer, OAuth, mTLS, AWS SigV4)</td>
 <td>OAuth 2.0, OIDC, mTLS, API keys, in-task auth escalation</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><strong>Core principle</strong></td>
 <td>Security by design (but client-enforced)</td>
 <td>"LLM instructions are suggestions. Adapter policies are enforcement."</td>
@@ -433,7 +433,7 @@ Authorization: Bearer &lt;token&gt;</code></pre>
 <h3 id="scope-and-reach">Scope and Reach</h3>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th></th>
 <th>MCP</th>
 <th>MCP-AQL</th>
@@ -441,25 +441,25 @@ Authorization: Bearer &lt;token&gt;</code></pre>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><strong>What it connects to</strong></td>
 <td>MCP-compatible servers</td>
 <td><strong>Any system with an API</strong>: REST, GraphQL, gRPC, MCP servers, OS native APIs, hardware (serial/USB), IoT, databases, file systems, other agents</td>
 <td>Other A2A-compatible agents</td>
 </tr>
-<tr>
+<tr class="even">
 <td><strong>Adapter creation</strong></td>
 <td>SDK integration + custom code per server</td>
 <td><strong>Declarative schema file</strong> (Markdown + YAML) -- no code generation, hot-reloadable</td>
 <td>SDK integration per agent</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><strong>Plugin system</strong></td>
 <td>N/A</td>
 <td>Transport (HTTP, WebSocket, serial, native OS), Protocol (REST, GraphQL, gRPC, JSON-RPC), Serialization (JSON, XML, Protobuf, MessagePack), Auth (multiple schemes), Pagination (cursor, offset, page)</td>
 <td>N/A</td>
 </tr>
-<tr>
+<tr class="even">
 <td><strong>Performance tiers</strong></td>
 <td>Single implementation</td>
 <td>Three-tier architecture planned: Standard (TypeScript) for MCP wrapping, Local Systems (Rust, 5-50x faster) for OS/hardware, Network API (Rust) for concurrent web API processing</td>
@@ -470,7 +470,7 @@ Authorization: Bearer &lt;token&gt;</code></pre>
 <h3 id="agent-to-agent-capabilities">Agent-to-Agent Capabilities</h3>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th></th>
 <th>MCP</th>
 <th>MCP-AQL</th>
@@ -478,25 +478,25 @@ Authorization: Bearer &lt;token&gt;</code></pre>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><strong>Agent-to-agent</strong></td>
 <td>No</td>
 <td>Yes -- via adapter chains, distributed tracing (W3C Trace Context), EXECUTE lifecycle</td>
 <td><strong>Primary purpose</strong></td>
 </tr>
-<tr>
+<tr class="even">
 <td><strong>Task delegation</strong></td>
 <td>No</td>
 <td>EXECUTE endpoint with state machine (pending → running → completed/failed/cancelled)</td>
 <td>First-class task lifecycle with 7-state machine and multi-turn conversation</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><strong>Multi-agent coordination</strong></td>
 <td>No</td>
 <td>Optimistic concurrency (ETags), notifications/telemetry for inter-agent signaling</td>
 <td>Discovery via Agent Cards, context IDs for conversation threading</td>
 </tr>
-<tr>
+<tr class="even">
 <td><strong>Distributed tracing</strong></td>
 <td>No</td>
 <td>W3C Trace Context propagation across adapter chains (traceId, spanId, parentSpanId)</td>
@@ -507,7 +507,7 @@ Authorization: Bearer &lt;token&gt;</code></pre>
 <h3 id="computational-middleware">Computational Middleware</h3>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th></th>
 <th>MCP</th>
 <th>MCP-AQL</th>
@@ -515,25 +515,25 @@ Authorization: Bearer &lt;token&gt;</code></pre>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><strong>Processing model</strong></td>
 <td>LLM calls tool → gets raw result → reasons about it</td>
 <td>Adapter can process server-side: computed fields, aggregations, multi-step API iteration <strong>without returning to the LLM</strong> -- LLM only sees final processed result</td>
 <td>Remote agent does all internal processing; returns artifacts</td>
 </tr>
-<tr>
+<tr class="even">
 <td><strong>Server-side computation</strong></td>
 <td>Not built in</td>
 <td>Computed fields (so LLM doesn't do math), server-side aggregations (counts, groupings without fetching all records)</td>
 <td>Agent handles internally</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><strong>Batch operations</strong></td>
 <td>No native batching</td>
 <td>Optional batch operations with per-item results, continueOnError, and atomic modes</td>
 <td>N/A</td>
 </tr>
-<tr>
+<tr class="even">
 <td><strong>Dry-run mode</strong></td>
 <td>No</td>
 <td>Preview consequences before committing, including policy checks and estimated token costs</td>
@@ -620,7 +620,7 @@ Authorization: Bearer &lt;token&gt;</code></pre>
 <p><strong>Partially, in a good way.</strong> There is genuine overlap at the agent-to-agent boundary:</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Capability</th>
 <th>MCP-AQL</th>
 <th>A2A</th>
@@ -628,31 +628,31 @@ Authorization: Bearer &lt;token&gt;</code></pre>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td>Agent discovery</td>
 <td>Introspection (what operations exist?)</td>
 <td>Agent Cards (what can this agent do?)</td>
 <td><strong>Complementary</strong> -- different granularity</td>
 </tr>
-<tr>
+<tr class="even">
 <td>Task delegation</td>
 <td>EXECUTE endpoint with lifecycle states</td>
 <td>Task lifecycle with 7-state machine</td>
 <td><strong>Overlapping</strong> -- but MCP-AQL is structured/typed while A2A is conversational</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>Multi-turn interaction</td>
 <td>Not native (each call is independent)</td>
 <td>First-class multi-turn with context IDs</td>
 <td><strong>A2A is stronger here</strong></td>
 </tr>
-<tr>
+<tr class="even">
 <td>Distributed tracing</td>
 <td>W3C Trace Context across adapter chains</td>
 <td>Not built in</td>
 <td><strong>MCP-AQL is stronger here</strong></td>
 </tr>
-<tr>
+<tr class="odd">
 <td>Safety enforcement</td>
 <td>Gatekeeper with danger/trust levels</td>
 <td>Agent-level accept/reject</td>
@@ -675,29 +675,29 @@ Authorization: Bearer &lt;token&gt;</code></pre>
 <h3 id="gaps-in-mcp-addressed-by-the-other-two">Gaps in MCP (Addressed by the Other Two)</h3>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Gap</th>
 <th>Who fills it</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td>Tool sprawl / context window bloat</td>
 <td><strong>MCP-AQL</strong> (85-96% token reduction)</td>
 </tr>
-<tr>
+<tr class="even">
 <td>No agent-to-agent communication</td>
 <td><strong>A2A</strong> (primary purpose) and <strong>MCP-AQL</strong> (via adapter chains)</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>Safety is advisory, not enforced</td>
 <td><strong>MCP-AQL</strong> (Gatekeeper with server-side authority)</td>
 </tr>
-<tr>
+<tr class="even">
 <td>No progressive discovery</td>
 <td><strong>MCP-AQL</strong> (introspection on demand)</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>Raw tool output wastes tokens</td>
 <td><strong>MCP-AQL</strong> (field selection, server-side computation)</td>
 </tr>
@@ -706,59 +706,59 @@ Authorization: Bearer &lt;token&gt;</code></pre>
 <h3 id="gaps-in-a2a-not-yet-addressed">Gaps in A2A (Not Yet Addressed)</h3>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Gap</th>
 <th>Description</th>
 <th>Potential fill</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><strong>No message persistence</strong></td>
 <td>The spec does not specify whether agents must persist messages after task completion, how long task state must be retained, or storage format. An A2A server could lose everything on restart and still be conformant.</td>
 <td><strong>COMMS element type</strong> (file-based, database, Redis backends)</td>
 </tr>
-<tr>
+<tr class="even">
 <td><strong>No message queuing</strong></td>
 <td>No guaranteed delivery, no ordering guarantees beyond streaming, no dead-letter queues, no backpressure mechanism. Push notification retry policy is the closest thing.</td>
 <td><strong>COMMS element type</strong> or external message broker</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><strong>No offline delivery</strong></td>
 <td>If the server agent is unreachable, the request fails. No store-and-forward, no inbox/outbox pattern.</td>
 <td><strong>COMMS element type</strong> (file-based persistence survives offline)</td>
 </tr>
-<tr>
+<tr class="even">
 <td><strong>No local agent-to-agent communication</strong></td>
 <td>All three standard bindings (JSON-RPC/HTTP, gRPC, REST) assume network communication. No Unix socket, shared memory, IPC, or localhost optimization.</td>
 <td><strong>COMMS element type</strong> (filesystem IPC at <code>~/.dollhouse/team-ipc/</code>)</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><strong>No state management between sessions</strong></td>
 <td>No session concept at the protocol level, no session tokens or resumption, no requirement that context IDs persist across restarts.</td>
 <td><strong>Memory elements</strong> + <strong>COMMS element type</strong></td>
 </tr>
-<tr>
+<tr class="even">
 <td><strong>No orchestration</strong></td>
 <td>No workflow definition, conditional branching, routing, fan-out/fan-in, saga patterns, circuit breakers, or load balancing. Explicitly out of scope.</td>
 <td>Application layer / <strong>TEAM element type</strong></td>
 </tr>
-<tr>
+<tr class="odd">
 <td><strong>No discovery registry</strong></td>
 <td>Agent Cards at well-known URLs require knowing the URL in advance. No search, marketplace, or broadcast discovery.</td>
 <td><strong>MCP-AQL adapter registry</strong> / <strong>COMMS discovery</strong></td>
 </tr>
-<tr>
+<tr class="even">
 <td><strong>No distributed tracing</strong></td>
 <td>No built-in tracing format; metadata maps can carry trace IDs but nothing is standardized.</td>
 <td><strong>MCP-AQL</strong> (W3C Trace Context)</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><strong>No economics</strong></td>
 <td>No pricing, SLAs, inter-agent billing, or dispute resolution.</td>
 <td>Not addressed by any protocol yet</td>
 </tr>
-<tr>
+<tr class="even">
 <td><strong>No streaming client-to-server</strong></td>
 <td>Clients cannot stream large inputs during task execution; only agents stream output back.</td>
 <td>Not addressed</td>
@@ -768,29 +768,29 @@ Authorization: Bearer &lt;token&gt;</code></pre>
 <h3 id="gaps-in-mcp-aql-not-yet-addressed">Gaps in MCP-AQL (Not Yet Addressed)</h3>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Gap</th>
 <th>Description</th>
 <th>Potential fill</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><strong>Multi-turn conversational context</strong></td>
 <td>Each MCP-AQL call is independent; no built-in context threading across calls</td>
 <td><strong>A2A</strong> (context IDs, multi-turn tasks)</td>
 </tr>
-<tr>
+<tr class="even">
 <td><strong>Agent opaqueness</strong></td>
 <td>MCP-AQL introspection reveals operation details; no mechanism to hide internals when that's desirable</td>
 <td><strong>A2A</strong> (opaque by design)</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><strong>Multimodal content exchange</strong></td>
 <td>MCP-AQL responses are structured JSON; no native audio, video, or rich media support</td>
 <td><strong>A2A</strong> (multimodal Parts)</td>
 </tr>
-<tr>
+<tr class="even">
 <td><strong>Cross-vendor interoperability</strong></td>
 <td>MCP-AQL requires MCP as transport; cannot directly interoperate with non-MCP agents</td>
 <td><strong>A2A</strong> (framework-agnostic)</td>
@@ -804,21 +804,21 @@ Authorization: Bearer &lt;token&gt;</code></pre>
 <p>A2A is a <strong>real protocol with real wire bindings</strong>, not just a description. It has three layers:</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Layer</th>
 <th>What A2A Defines</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><strong>Canonical Data Model</strong></td>
 <td>Protocol Buffers (<code>a2a.proto</code>) defining Task, Message, AgentCard, Artifact, Part types</td>
 </tr>
-<tr>
+<tr class="even">
 <td><strong>Abstract Operations</strong></td>
 <td>11 transport-agnostic operations (SendMessage, GetTask, ListTasks, CancelTask, SubscribeToTask, etc.)</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><strong>Protocol Bindings</strong></td>
 <td>Concrete mappings to JSON-RPC 2.0 over HTTP, gRPC over HTTP/2, and REST over HTTP</td>
 </tr>
@@ -829,45 +829,45 @@ Authorization: Bearer &lt;token&gt;</code></pre>
 <p>This is where the gaps are significant:</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Concern</th>
 <th>A2A's Position</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><strong>Message persistence</strong></td>
 <td>Completely unspecified</td>
 </tr>
-<tr>
+<tr class="even">
 <td><strong>Message queuing / guaranteed delivery</strong></td>
 <td>Not addressed; push notification retry is closest</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><strong>Offline delivery</strong></td>
 <td>Not supported; synchronous with async extensions</td>
 </tr>
-<tr>
+<tr class="even">
 <td><strong>Local IPC (same machine)</strong></td>
 <td>Not addressed; all bindings assume network</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><strong>Session state management</strong></td>
 <td>Not specified; no session concept</td>
 </tr>
-<tr>
+<tr class="even">
 <td><strong>Orchestration / routing</strong></td>
 <td>Explicitly out of scope</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><strong>Agent registry / search</strong></td>
 <td>Not provided; must know URL to fetch Agent Card</td>
 </tr>
-<tr>
+<tr class="even">
 <td><strong>Distributed tracing</strong></td>
 <td>Not standardized; metadata can carry trace IDs</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><strong>Economics / billing</strong></td>
 <td>Not addressed</td>
 </tr>
@@ -893,44 +893,44 @@ Authorization: Bearer &lt;token&gt;</code></pre>
 <p><strong>Potential COMMS variants:</strong></p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Variant</th>
 <th>Protocol</th>
 <th>Use Case</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><strong>A2A comms</strong></td>
 <td>Google A2A</td>
 <td>Cross-vendor agent-to-agent delegation with task lifecycle</td>
 </tr>
-<tr>
+<tr class="even">
 <td><strong>TCP/IP comms</strong></td>
 <td>Raw TCP/IP</td>
 <td>Low-level network communication, custom protocols</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><strong>HTTP comms</strong></td>
 <td>HTTP/REST</td>
 <td>Direct web API messaging, webhooks</td>
 </tr>
-<tr>
+<tr class="even">
 <td><strong>SMTP comms</strong></td>
 <td>SMTP/email</td>
 <td>Email-based notifications and async communication</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><strong>WebSocket comms</strong></td>
 <td>WebSocket</td>
 <td>Real-time bidirectional messaging</td>
 </tr>
-<tr>
+<tr class="even">
 <td><strong>Filesystem comms</strong></td>
 <td>Local IPC</td>
 <td>Same-machine agent-to-agent via file-based messaging</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><strong>Mesh comms</strong></td>
 <td>WireGuard/Tailscale</td>
 <td>Encrypted multi-node agent mesh networking</td>
@@ -951,34 +951,34 @@ Authorization: Bearer &lt;token&gt;</code></pre>
 <h3 id="transport-mechanisms">Transport Mechanisms</h3>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Scope</th>
 <th>Likely Variant</th>
 <th>Mechanism</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td>Same computer, different sessions</td>
 <td>Filesystem comms</td>
 <td>File-based IPC at <code>~/.dollhouse/team-ipc/</code></td>
 </tr>
-<tr>
+<tr class="even">
 <td>Different computers (network)</td>
 <td>HTTP comms / A2A comms</td>
 <td>REST/HTTP or A2A task delegation</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>Encrypted enterprise mesh</td>
 <td>Mesh comms</td>
 <td>WireGuard via Tailscale or Headscale (self-hosted)</td>
 </tr>
-<tr>
+<tr class="even">
 <td>Cross-vendor agent collaboration</td>
 <td>A2A comms</td>
 <td>A2A protocol with Agent Cards and task lifecycle</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>Async notifications</td>
 <td>SMTP comms / HTTP comms</td>
 <td>Email or webhook-based</td>
@@ -997,37 +997,37 @@ Authorization: Bearer &lt;token&gt;</code></pre>
 <p>A2A leaves significant infrastructure gaps (see Section 9). Different COMMS variants address different gaps:</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>A2A Gap</th>
 <th>Which COMMS Variant Fills It</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><strong>No message persistence</strong></td>
 <td>Filesystem comms, database-backed variants</td>
 </tr>
-<tr>
+<tr class="even">
 <td><strong>No message queuing</strong></td>
 <td>Filesystem comms (natural queue semantics), database variants</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><strong>No offline delivery</strong></td>
 <td>Filesystem comms (persists regardless of recipient availability)</td>
 </tr>
-<tr>
+<tr class="even">
 <td><strong>No local IPC</strong></td>
 <td>Filesystem comms at <code>~/.dollhouse/team-ipc/</code> (sub-100ms)</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><strong>No state between sessions</strong></td>
 <td>Memory elements + any persistent COMMS variant</td>
 </tr>
-<tr>
+<tr class="even">
 <td><strong>No orchestration</strong></td>
 <td>TEAM element coordinates across COMMS variants</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><strong>No discovery on local network</strong></td>
 <td>TEAM session discovery protocol (planned)</td>
 </tr>
@@ -1036,29 +1036,29 @@ Authorization: Bearer &lt;token&gt;</code></pre>
 <h3 id="where-a2a-provides-what-comms-variants-dont">Where A2A Provides What COMMS Variants Don't</h3>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Gap</th>
 <th>What A2A Provides</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><strong>Cross-vendor interoperability</strong></td>
 <td>A2A works across any framework; COMMS variants are DollhouseMCP elements</td>
 </tr>
-<tr>
+<tr class="even">
 <td><strong>Standardized Agent Cards</strong></td>
 <td>A2A's discovery model is an industry standard</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><strong>Multi-turn conversational protocol</strong></td>
 <td>A2A has formal message/task/artifact semantics</td>
 </tr>
-<tr>
+<tr class="even">
 <td><strong>Multimodal content</strong></td>
 <td>A2A's Part type supports text, files, data, UI components</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><strong>Industry governance</strong></td>
 <td>A2A is under the Linux Foundation with 150+ backers</td>
 </tr>
@@ -1121,84 +1121,84 @@ Authorization: Bearer &lt;token&gt;</code></pre>
 <h2 id="12-scenario-guide">12. Scenario Guide</h2>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Scenario</th>
 <th>Best fit</th>
 <th>Why</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td>Connect my LLM to a few specific tools quickly</td>
 <td><strong>MCP</strong></td>
 <td>Simple, direct, massive ecosystem</td>
 </tr>
-<tr>
+<tr class="even">
 <td>50+ MCP tools and context window is choking</td>
 <td><strong>MCP-AQL</strong></td>
 <td>85-96% token reduction; progressive disclosure</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>LLM needs to correctly call an unfamiliar REST API</td>
 <td><strong>MCP-AQL</strong></td>
 <td>Introspection with constraint metadata eliminates hallucination</td>
 </tr>
-<tr>
+<tr class="even">
 <td>Sales agent delegates to a research agent</td>
 <td><strong>A2A</strong></td>
 <td>Agent discovery and multi-turn task delegation</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>Agents from LangChain and CrewAI need to collaborate</td>
 <td><strong>A2A</strong></td>
 <td>Cross-framework interoperability</td>
 </tr>
-<tr>
+<tr class="even">
 <td>Permission control over destructive operations</td>
 <td><strong>MCP-AQL</strong></td>
 <td>CRUDE + Gatekeeper + danger levels + confirmation tokens</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>LLM needs to interact with OS or hardware APIs</td>
 <td><strong>MCP-AQL</strong></td>
 <td>Plugin system with native transport; Rust adapters planned</td>
 </tr>
-<tr>
+<tr class="even">
 <td>Multi-day async tasks across agent boundaries</td>
 <td><strong>A2A</strong></td>
 <td>First-class long-running task lifecycle with push notifications</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>Wrap any API for LLM access with zero code</td>
 <td><strong>MCP-AQL</strong></td>
 <td>Declarative adapter schemas; hot-reloadable</td>
 </tr>
-<tr>
+<tr class="even">
 <td>Trace operations across a chain of systems</td>
 <td><strong>MCP-AQL</strong></td>
 <td>W3C Trace Context propagation</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>Agents reasoning together about ambiguous problems</td>
 <td><strong>A2A</strong></td>
 <td>Unstructured multi-turn conversation between opaque peers</td>
 </tr>
-<tr>
+<tr class="even">
 <td>Same-machine agent-to-agent messaging</td>
 <td><strong>Filesystem comms</strong></td>
 <td>IPC, sub-100ms, no network overhead</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>Agent communication with offline persistence</td>
 <td><strong>Filesystem comms</strong></td>
 <td>File/database-backed; survives restarts and outages</td>
 </tr>
-<tr>
+<tr class="even">
 <td>Cross-vendor agent delegation over network</td>
 <td><strong>A2A comms</strong></td>
 <td>A2A protocol with Agent Cards and task lifecycle</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>Enterprise multi-computer agent orchestration</td>
 <td><strong>Mesh comms + TEAM</strong></td>
 <td>Encrypted WireGuard mesh, hierarchical coordination</td>
@@ -1209,7 +1209,7 @@ Authorization: Bearer &lt;token&gt;</code></pre>
 <h2 id="13-maturity-and-adoption">13. Maturity and Adoption</h2>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th></th>
 <th>MCP</th>
 <th>MCP-AQL</th>
@@ -1217,43 +1217,43 @@ Authorization: Bearer &lt;token&gt;</code></pre>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><strong>Announced</strong></td>
 <td>November 2024</td>
 <td>2025</td>
 <td>April 2025</td>
 </tr>
-<tr>
+<tr class="even">
 <td><strong>Current version</strong></td>
 <td>2025-11-25 (4th revision)</td>
 <td>v1.0.0-draft</td>
 <td>v0.3</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><strong>Governance</strong></td>
 <td>Agentic AI Foundation (Linux Foundation)</td>
 <td>Independent</td>
 <td>Linux Foundation (LF AI &amp; Data)</td>
 </tr>
-<tr>
+<tr class="even">
 <td><strong>Spec maturity</strong></td>
 <td>Production-stable, widely adopted</td>
 <td>Nearing v1.0-rc; launch imminent</td>
 <td>Draft; breaking changes expected</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><strong>Ecosystem</strong></td>
 <td>10,000+ servers, 300+ clients</td>
 <td>1 reference impl (DollhouseMCP V2 private beta)</td>
 <td>150+ backing organizations, Python SDK</td>
 </tr>
-<tr>
+<tr class="even">
 <td><strong>SDK availability</strong></td>
 <td>TypeScript, Python, Java, C#, Go, Rust</td>
 <td>Via MCP SDKs (runs on MCP transport)</td>
 <td>Python</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><strong>Notable adopters</strong></td>
 <td>OpenAI, Google, Microsoft, AWS, Cloudflare</td>
 <td>DollhouseMCP</td>

--- a/public/spec/security/confirmation-tokens.html
+++ b/public/spec/security/confirmation-tokens.html
@@ -50,10 +50,10 @@
   <ul><li><a class="current" aria-current="page" href="confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Features</h3>
-  <ul><li><a href="../features/collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
+  <ul><li><a href="../features/aggregations.html">MCP-AQL Aggregations</a></li><li><a href="../features/collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="../features/computed-fields.html">MCP-AQL Computed Fields</a></li><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/relationship-queries.html">MCP-AQL Relationship Queries</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Guides</h3>
-  <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
+  <ul><li><a href="../guides/cross-domain-implementation.html">Cross-Domain Implementation Guide</a></li><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
   <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li><li><a href="../repo/CHANGELOG.html">Changelog</a></li></ul>
@@ -163,19 +163,19 @@ Client Retry (with token)
 <p>Tokens are opaque strings with a prefix indicating their purpose:</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Prefix</th>
 <th>Purpose</th>
 <th>Example</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><code>conf_</code></td>
 <td>Dangerous operation confirmation</td>
 <td><code>conf_a1b2c3d4e5f6g7h8</code></td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>quota_continue_</code></td>
 <td>Quota pause continuation</td>
 <td><code>quota_continue_def456</code></td>
@@ -232,21 +232,21 @@ identifier = 1*64(ALPHA / DIGIT / &quot;_&quot; / &quot;-&quot;)</code></pre>
 <p>Token identifiers MUST be generated with sufficient entropy to prevent guessing:</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Requirement</th>
 <th>Specification</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td>Minimum entropy</td>
 <td>128 bits</td>
 </tr>
-<tr>
+<tr class="even">
 <td>Recommended</td>
 <td>256 bits</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>Source</td>
 <td>Cryptographically secure random number generator (CSPRNG)</td>
 </tr>
@@ -313,39 +313,39 @@ identifier = 1*64(ALPHA / DIGIT / &quot;_&quot; / &quot;-&quot;)</code></pre>
 <p>Token validation MUST perform all of the following checks:</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Check</th>
 <th>Error Code</th>
 <th>Description</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td>Token exists</td>
 <td><code>TOKEN_INVALID</code></td>
 <td>Token ID not found in store</td>
 </tr>
-<tr>
+<tr class="even">
 <td>Not expired</td>
 <td><code>TOKEN_EXPIRED</code></td>
 <td>Current time &gt; expires_at</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>Not consumed</td>
 <td><code>TOKEN_ALREADY_USED</code></td>
 <td>Token already redeemed</td>
 </tr>
-<tr>
+<tr class="even">
 <td>Operation matches</td>
 <td><code>TOKEN_SCOPE_MISMATCH</code></td>
 <td>Token issued for different operation</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>Parameters match</td>
 <td><code>TOKEN_SCOPE_MISMATCH</code></td>
 <td>Critical parameters changed</td>
 </tr>
-<tr>
+<tr class="even">
 <td>Adapter matches</td>
 <td><code>TOKEN_SCOPE_MISMATCH</code></td>
 <td>Token issued by different adapter</td>
@@ -401,24 +401,24 @@ identifier = 1*64(ALPHA / DIGIT / &quot;_&quot; / &quot;-&quot;)</code></pre>
 <p>Token expiration MUST be enforced:</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Context</th>
 <th>Default TTL</th>
 <th>Maximum TTL</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td>Dangerous operation (destructive/dangerous - levels 2-3)</td>
 <td>5 minutes</td>
 <td>15 minutes</td>
 </tr>
-<tr>
+<tr class="even">
 <td>Dangerous operation (forbidden - level 4)</td>
 <td>2 minutes</td>
 <td>5 minutes</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>Quota continuation</td>
 <td>5 minutes</td>
 <td>10 minutes</td>
@@ -436,7 +436,7 @@ identifier = 1*64(ALPHA / DIGIT / &quot;_&quot; / &quot;-&quot;)</code></pre>
 <p>Implementations SHOULD allow operators to configure the clock skew tolerance value:</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Setting</th>
 <th>Default</th>
 <th>Range</th>
@@ -444,7 +444,7 @@ identifier = 1*64(ALPHA / DIGIT / &quot;_&quot; / &quot;-&quot;)</code></pre>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><code>clock_skew_tolerance_seconds</code></td>
 <td>30</td>
 <td>0-300</td>
@@ -462,34 +462,34 @@ identifier = 1*64(ALPHA / DIGIT / &quot;_&quot; / &quot;-&quot;)</code></pre>
 <p><strong>Deployment environment recommendations:</strong></p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Environment</th>
 <th>Recommended Value</th>
 <th>Rationale</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td>Typical (NTP-synced)</td>
 <td>30s (default)</td>
 <td>Accommodates normal clock drift</td>
 </tr>
-<tr>
+<tr class="even">
 <td>Air-gapped systems</td>
 <td>60-120s</td>
 <td>May have significant clock sync drift</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>IoT / embedded</td>
 <td>60-120s</td>
 <td>Often lack reliable NTP access</td>
 </tr>
-<tr>
+<tr class="even">
 <td>High-security</td>
 <td>0-5s</td>
 <td>Minimize replay attack window</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>Zero-trust</td>
 <td>0s</td>
 <td>Strict timing, requires synchronized clocks</td>
@@ -582,21 +582,21 @@ identifier = 1*64(ALPHA / DIGIT / &quot;_&quot; / &quot;-&quot;)</code></pre>
 <h3 id="55-storage-requirements">5.5 Storage Requirements</h3>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Requirement</th>
 <th>Specification</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td>Persistence</td>
 <td>At minimum, in-memory with TTL eviction</td>
 </tr>
-<tr>
+<tr class="even">
 <td>Cleanup</td>
 <td>Expired tokens SHOULD be purged within 1 hour</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>Capacity</td>
 <td>SHOULD support at least 1000 active tokens per adapter</td>
 </tr>

--- a/public/spec/security/execution-safety-loop.html
+++ b/public/spec/security/execution-safety-loop.html
@@ -50,10 +50,10 @@
   <ul><li><a href="confirmation-tokens.html">Confirmation Token Specification</a></li><li><a class="current" aria-current="page" href="execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Features</h3>
-  <ul><li><a href="../features/collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
+  <ul><li><a href="../features/aggregations.html">MCP-AQL Aggregations</a></li><li><a href="../features/collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="../features/computed-fields.html">MCP-AQL Computed Fields</a></li><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/relationship-queries.html">MCP-AQL Relationship Queries</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Guides</h3>
-  <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
+  <ul><li><a href="../guides/cross-domain-implementation.html">Cross-Domain Implementation Guide</a></li><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
   <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li><li><a href="../repo/CHANGELOG.html">Changelog</a></li></ul>
@@ -192,34 +192,34 @@
 <p>The safety dongle and a full MCP-AQL adapter are both valid configurations of the same protocol. They differ only in scope:</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Aspect</th>
 <th>Safety Dongle</th>
 <th>Full MCP-AQL Adapter</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td>Purpose</td>
 <td>Safety enforcement only</td>
 <td>Domain operations + safety</td>
 </tr>
-<tr>
+<tr class="even">
 <td>Operations</td>
 <td>~7 (safety loop + introspection)</td>
 <td>Dozens (full CRUDE surface)</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>Elements</td>
 <td>None</td>
 <td>Personas, skills, agents, etc.</td>
 </tr>
-<tr>
+<tr class="even">
 <td>State</td>
 <td>Execution state + policies only</td>
 <td>Full domain state</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>Endpoints used</td>
 <td>CREATE, EXECUTE, READ (subset)</td>
 <td>All five CRUDE endpoints</td>
@@ -319,44 +319,44 @@
 <p>Key fields:</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Field</th>
 <th>Type</th>
 <th>Description</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><code>continue</code></td>
 <td>boolean</td>
 <td>Whether the LLM may proceed with the reported action</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>factors</code></td>
 <td>string[]</td>
 <td>Human-readable explanations of the evaluation decision</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>stopped</code></td>
 <td>boolean</td>
 <td>Whether the agent has been hard-blocked (Danger Zone)</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>reason</code></td>
 <td>string</td>
 <td>Why the agent was paused or stopped</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>stepsRemaining</code></td>
 <td>number</td>
 <td>Steps remaining before mandatory pause</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>nextStepRisk</code></td>
 <td>SafetyTier</td>
 <td>Safety tier assigned to the reported action</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>notifications</code></td>
 <td>AgentNotification[]</td>
 <td>Gatekeeper blocks, danger alerts, and other events</td>
@@ -375,44 +375,44 @@
 <p>A safety dongle implements a minimal set of operations:</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Operation</th>
 <th>Endpoint</th>
 <th>Purpose</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><code>execute_agent</code></td>
 <td>EXECUTE</td>
 <td>Start the execution safety loop</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>record_execution_step</code></td>
 <td>CREATE</td>
 <td>Report intended action, receive <code>AutonomyDirective</code></td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>complete_execution</code></td>
 <td>EXECUTE</td>
 <td>Signal normal completion of the safety loop</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>abort_execution</code></td>
 <td>EXECUTE</td>
 <td>Signal abnormal termination</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>confirm_operation</code></td>
 <td>EXECUTE</td>
 <td>Confirm Gatekeeper blocks or Autonomy Evaluator <code>confirm</code> tier pauses</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>verify_challenge</code></td>
 <td>CREATE</td>
 <td>Submit out-of-band verification code (<code>verify</code> tier and Danger Zone)</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>introspect</code></td>
 <td>READ</td>
 <td>Discover available operations and capabilities</td>
@@ -424,7 +424,7 @@
 <p>The endpoint placement of these operations is critical to the permission architecture:</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Endpoint</th>
 <th>Default Permission</th>
 <th>Operations</th>
@@ -432,19 +432,19 @@
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td>READ</td>
 <td><code>AUTO_APPROVE</code></td>
 <td><code>introspect</code></td>
 <td>Zero friction for discovery</td>
 </tr>
-<tr>
+<tr class="even">
 <td>CREATE</td>
 <td><code>CONFIRM_SESSION</code></td>
 <td><code>record_execution_step</code>, <code>verify_challenge</code></td>
 <td>Approve once, then frictionless for the session</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>EXECUTE</td>
 <td><code>CONFIRM_SINGLE_USE</code></td>
 <td><code>execute_agent</code>, <code>complete_execution</code>, <code>abort_execution</code>, <code>confirm_operation</code></td>
@@ -532,24 +532,24 @@ EXECUTE (CONFIRM_SINGLE_USE)
 <p>Notification types:</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Type</th>
 <th>Trigger</th>
 <th>Action Required</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><code>permission_pending</code></td>
 <td>Gatekeeper blocked an operation</td>
 <td>Call <code>confirm_operation</code> to approve</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>autonomy_pause</code></td>
 <td>Autonomy Evaluator returned <code>continue: false</code></td>
 <td>For <code>confirm</code> tier: call <code>confirm_operation</code>; for <code>verify</code> tier: out-of-band <code>verify_challenge</code> (Section 6)</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>danger_zone</code></td>
 <td>Hard block triggered (<code>danger_zone</code> tier or <code>deny</code> pattern)</td>
 <td>Out-of-band <code>verify_challenge</code> required (Section 6)</td>
@@ -563,29 +563,29 @@ EXECUTE (CONFIRM_SINGLE_USE)
 <p>When the Autonomy Evaluator assigns a high risk score to a <code>nextActionHint</code>, the action escalates through safety tiers defined in the <a href="../adapter/danger-levels.html">Danger Levels specification</a>:</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Risk Score</th>
 <th>Tier</th>
 <th>Behavior</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td>0-30</td>
 <td><code>advisory</code></td>
 <td>Log and continue</td>
 </tr>
-<tr>
+<tr class="even">
 <td>31-60</td>
 <td><code>confirm</code></td>
 <td>Pause for human review (<code>continue: false</code>)</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>61-85</td>
 <td><code>verify</code></td>
 <td>Pause + out-of-band verification via <code>verify_challenge</code> (Section 8.8)</td>
 </tr>
-<tr>
+<tr class="even">
 <td>86-100</td>
 <td><code>danger_zone</code></td>
 <td>Hard stop + out-of-band verification via <code>verify_challenge</code> (Section 8.8)</td>
@@ -813,104 +813,104 @@ Only proceed if the AutonomyDirective returns continue: true.</code></pre>
 <p>The following table maps each normative section to its corresponding Section 9 requirements, providing an audit trail for compliance verification.</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Normative Section</th>
 <th>Key Requirements</th>
 <th>Section 9 Coverage</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td>8.6.1 Opt-In Activation</td>
 <td>MUST document support; SHOULD expose capability value</td>
 <td>9.1 (introspection); 9.2 (capability value)</td>
 </tr>
-<tr>
+<tr class="even">
 <td>8.6.2 Enforcement Boundary</td>
 <td>MUST report and evaluate all actions</td>
 <td>9.1 (operations, AutonomyDirective on every call)</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>8.6.3 Action Reporting</td>
 <td>MUST/SHOULD/MAY parameter requirements</td>
 <td>9.1 (operations — parameter validation is part of implementing <code>record_execution_step</code>)</td>
 </tr>
-<tr>
+<tr class="even">
 <td>8.6.4 Continuous Enforcement</td>
 <td>MUST NOT proceed after stop; SHOULD NOT after pause; MUST NOT <code>stopped</code> in monitoring</td>
 <td>9.1 (stop directive, monitoring mode); 9.2 (SHOULD NOT after pause)</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>8.6.5 Non-Bypass Property</td>
 <td>Agent MUST NOT act outside loop</td>
 <td>Agent-side protocol obligation (not adapter-specific)</td>
 </tr>
-<tr>
+<tr class="even">
 <td>8.6.6 Scope of Monitoring</td>
 <td>Monitors all actions (informative)</td>
 <td>Described in Sections 3.2, 2.2 of this document</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>8.6.7 Disabling</td>
 <td>MAY disable; MUST indicate via introspection</td>
 <td>9.1 (introspection); 9.2 (monitoring); 9.3 (logging)</td>
 </tr>
-<tr>
+<tr class="even">
 <td>8.7.1 AutonomyDirective</td>
 <td>MUST include <code>continue</code> + <code>factors</code></td>
 <td>9.1 (AutonomyDirective fields)</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>8.7.2 Pipeline Stages 1–5</td>
 <td>MUST step limit; SHOULD stages 2–3; MAY stages 4–5</td>
 <td>9.1 (step limit MUST); 9.2 (stage 1 documentation SHOULDs, stages 2–3 SHOULDs); 9.3 (stages 4–5)</td>
 </tr>
-<tr>
+<tr class="even">
 <td>8.7.3 Notifications</td>
 <td>MUST notification contents; MUST prevent self-approval</td>
 <td>9.1 (notifications, self-approval); 9.2 (non-hard-block notifications)</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>8.7.4 Configurable Elements</td>
 <td>SHOULD configurable; SHOULD document</td>
 <td>9.2 (configuration, introspection)</td>
 </tr>
-<tr>
+<tr class="even">
 <td>8.7.5 Minimum Viable</td>
 <td>MUST Step Limit; SHOULD Previous Outcome + Pattern Matching; MAY Safety Tier + Risk Tolerance</td>
 <td>9.1 (step limit); 9.2 (outcome, patterns); 9.3 (tier, tolerance)</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>8.8 Introduction</td>
 <td>MUST require OOB for <code>verify</code>/<code>danger_zone</code></td>
 <td>9.1 (OOB verification)</td>
 </tr>
-<tr>
+<tr class="even">
 <td>8.8.1 Trigger Conditions</td>
 <td>MUST <code>stopped: true</code> + <code>danger_zone</code> notification</td>
 <td>9.1 (<code>stopped: true</code>, notification broadcast)</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>8.8.2 Challenge Protocol</td>
 <td>MUST entropy, display, notification, expiration</td>
 <td>9.1 (code generation, display, challenge ID, expiration); 9.2 (timeout)</td>
 </tr>
-<tr>
+<tr class="even">
 <td>8.8.3 Blocking Semantics</td>
 <td>MUST reject, persist, no bypass; SHOULD verify behavior</td>
 <td>9.1 (blocking); 9.2 (verify tier)</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>8.8.4 Channel Separation</td>
 <td>MUST NOT expose code (5 specific prohibitions)</td>
 <td>9.1 (display/channel separation — consolidated)</td>
 </tr>
-<tr>
+<tr class="even">
 <td>8.8.5 Rate Limiting</td>
 <td>SHOULD rate-limit, persist, audit; MAY progressive lockout</td>
 <td>9.2 (rate limiting); 9.3 (lockout)</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>8.8.6 Implementation Flexibility</td>
 <td>MAY any display channel</td>
 <td>9.3 (display channels)</td>

--- a/public/spec/security/gatekeeper.html
+++ b/public/spec/security/gatekeeper.html
@@ -50,10 +50,10 @@
   <ul><li><a href="confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a class="current" aria-current="page" href="gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Features</h3>
-  <ul><li><a href="../features/collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
+  <ul><li><a href="../features/aggregations.html">MCP-AQL Aggregations</a></li><li><a href="../features/collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="../features/computed-fields.html">MCP-AQL Computed Fields</a></li><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/relationship-queries.html">MCP-AQL Relationship Queries</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Guides</h3>
-  <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
+  <ul><li><a href="../guides/cross-domain-implementation.html">Cross-Domain Implementation Guide</a></li><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
   <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li><li><a href="../repo/CHANGELOG.html">Changelog</a></li></ul>
@@ -181,7 +181,7 @@
 <p><strong>Endpoint Safety Matrix:</strong></p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Endpoint</th>
 <th>readOnly</th>
 <th>destructive</th>
@@ -189,31 +189,31 @@
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td>CREATE</td>
 <td>false</td>
 <td>false</td>
 <td>Additive only</td>
 </tr>
-<tr>
+<tr class="even">
 <td>READ</td>
 <td>true</td>
 <td>false</td>
 <td>No state changes</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>UPDATE</td>
 <td>false</td>
 <td>true</td>
 <td>May overwrite data</td>
 </tr>
-<tr>
+<tr class="even">
 <td>DELETE</td>
 <td>false</td>
 <td>true</td>
 <td>Removes data permanently</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>EXECUTE</td>
 <td>false</td>
 <td>true</td>
@@ -238,21 +238,21 @@
 <h3 id="31-permission-types">3.1 Permission Types</h3>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Permission</th>
 <th>Behavior</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><code>allow</code></td>
 <td>Operation proceeds without additional checks</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>deny</code></td>
 <td>Operation rejected with error</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>confirm</code></td>
 <td>Operation requires explicit confirmation</td>
 </tr>
@@ -298,21 +298,21 @@
 <p>Adapters implementing security SHOULD log:</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Event</th>
 <th>Logged Data</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><code>OPERATION_DENIED</code></td>
 <td>Operation, reason</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>CONFIRMATION_REQUIRED</code></td>
 <td>Operation, token</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>CONFIRMATION_GRANTED</code></td>
 <td>Operation, token</td>
 </tr>
@@ -384,9 +384,9 @@
     <span class="page-nav-eyebrow">Previous page</span>
     <strong class="page-nav-label">Execution Safety Loop Specification</strong>
   </a>
-  <a class="page-nav-link next" href="../features/collection-querying.html">
+  <a class="page-nav-link next" href="../features/aggregations.html">
     <span class="page-nav-eyebrow">Next page</span>
-    <strong class="page-nav-label">MCP-AQL Collection Querying</strong>
+    <strong class="page-nav-label">MCP-AQL Aggregations</strong>
   </a>
 </nav>
       </article>

--- a/public/spec/versions/v1.0.0-draft.html
+++ b/public/spec/versions/v1.0.0-draft.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="description" content="MCP-AQL (Model Context Protocol - Advanced Agent API Adapter Query Language) is a protocol specification that consolidates multiple MCP tools into semantic CRUDE endpoints, providing significant token reduction while ena">
+  <meta name="description" content="MCP-AQL (Model Context Protocol - Advanced Agent API Adapter Query Language) is a protocol specification that consolidates multiple MCP tools into a small number of semantic endpoints, providing significant token reducti">
   <title>MCP-AQL Spec | MCP-AQL Specification</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -50,10 +50,10 @@
   <ul><li><a href="../security/confirmation-tokens.html">Confirmation Token Specification</a></li><li><a href="../security/execution-safety-loop.html">Execution Safety Loop Specification</a></li><li><a href="../security/gatekeeper.html">Security Model: Gatekeeper Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Features</h3>
-  <ul><li><a href="../features/collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
+  <ul><li><a href="../features/aggregations.html">MCP-AQL Aggregations</a></li><li><a href="../features/collection-querying.html">MCP-AQL Collection Querying</a></li><li><a href="../features/computed-fields.html">MCP-AQL Computed Fields</a></li><li><a href="../features/field-selection.html">Field Selection Specification</a></li><li><a href="../features/pagination.html">Cursor-Based Pagination Specification</a></li><li><a href="../features/relationship-queries.html">MCP-AQL Relationship Queries</a></li><li><a href="../features/warnings.html">Warnings Array Specification</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Guides</h3>
-  <ul><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
+  <ul><li><a href="../guides/cross-domain-implementation.html">Cross-Domain Implementation Guide</a></li><li><a href="../guides/protocol-comparison.html">Protocol Comparison Guide</a></li><li><a href="../guides/README.html">Developer Guides</a></li></ul>
 </div><div class="docs-side-group">
   <h3>Process</h3>
   <ul><li><a href="../process/breaking-changes.html">MCP-AQL Breaking Change Policy</a></li><li><a href="../process/preliminary-public-launch-checklist.html">Preliminary Public Launch Checklist</a></li><li><a href="../process/rfc-process.html">RFC Process for MCP-AQL Specification</a></li><li><a href="../process/versioning.html">Versioning Strategy</a></li><li><a href="../repo/CHANGELOG.html">Changelog</a></li></ul>
@@ -84,7 +84,7 @@
           <div class="hero-inner">
             <span class="status-pill">REPO-SYNCED SPEC DOC</span>
             <h1>MCP-AQL Specification</h1>
-            <p class="lede">MCP-AQL (Model Context Protocol - Advanced Agent API Adapter Query Language) is a protocol specification that consolidates multiple MCP tools into semantic CRUDE endpoints, providing significant token reduction while ena</p>
+            <p class="lede">MCP-AQL (Model Context Protocol - Advanced Agent API Adapter Query Language) is a protocol specification that consolidates multiple MCP tools into a small number of semantic endpoints, providing significant token reducti</p>
             <div class="spec-meta"><span class="state-chip live">Support document</span><span class="state-chip pending">Draft</span><span class="state-chip">1.0.0-draft</span><span class="state-chip">2026-04-15</span></div>
             <p class="spec-source">Source: <a href="https://github.com/MCPAQL/spec/blob/main/docs/versions/v1.0.0-draft.md">spec/docs/versions/v1.0.0-draft.md</a></p>
             <div class="hero-actions">
@@ -101,7 +101,7 @@
               <p class="page-toc-intro">Use the outline to move through longer pages without losing your place.</p>
             </div>
             <ol class="page-toc-list" data-page-toc-list>
-              <li class="page-toc-item level-2"><a href="#abstract" data-toc-target="abstract">Abstract</a></li><li class="page-toc-item level-2"><a href="#status-of-this-document" data-toc-target="status-of-this-document">Status of This Document</a></li><li class="page-toc-item level-2"><a href="#1-introduction" data-toc-target="1-introduction">1. Introduction</a></li><li class="page-toc-item level-2"><a href="#2-terminology" data-toc-target="2-terminology">2. Terminology</a></li><li class="page-toc-item level-2"><a href="#3-protocol-overview" data-toc-target="3-protocol-overview">3. Protocol Overview</a></li><li class="page-toc-item level-2"><a href="#4-request-format" data-toc-target="4-request-format">4. Request Format</a></li><li class="page-toc-item level-2"><a href="#5-response-format" data-toc-target="5-response-format">5. Response Format</a></li><li class="page-toc-item level-2"><a href="#6-crude-endpoints" data-toc-target="6-crude-endpoints">6. CRUDE Endpoints</a></li><li class="page-toc-item level-2"><a href="#7-introspection" data-toc-target="7-introspection">7. Introspection</a></li><li class="page-toc-item level-2"><a href="#8-operation-classification" data-toc-target="8-operation-classification">8. Operation Classification</a></li><li class="page-toc-item level-2"><a href="#9-type-system" data-toc-target="9-type-system">9. Type System</a></li><li class="page-toc-item level-2"><a href="#10-conformance" data-toc-target="10-conformance">10. Conformance</a></li><li class="page-toc-item level-2"><a href="#appendix-a-token-efficiency" data-toc-target="appendix-a-token-efficiency">Appendix A: Token Efficiency</a></li><li class="page-toc-item level-2"><a href="#appendix-b-references" data-toc-target="appendix-b-references">Appendix B: References</a></li><li class="page-toc-item level-2"><a href="#appendix-c-change-log" data-toc-target="appendix-c-change-log">Appendix C: Change Log</a></li><li class="page-toc-item level-2"><a href="#appendix-d-json-schemas" data-toc-target="appendix-d-json-schemas">Appendix D: JSON Schemas</a></li>
+              <li class="page-toc-item level-2"><a href="#abstract" data-toc-target="abstract">Abstract</a></li><li class="page-toc-item level-2"><a href="#status-of-this-document" data-toc-target="status-of-this-document">Status of This Document</a></li><li class="page-toc-item level-2"><a href="#1-introduction" data-toc-target="1-introduction">1. Introduction</a></li><li class="page-toc-item level-2"><a href="#2-terminology" data-toc-target="2-terminology">2. Terminology</a></li><li class="page-toc-item level-2"><a href="#3-protocol-overview" data-toc-target="3-protocol-overview">3. Protocol Overview</a></li><li class="page-toc-item level-2"><a href="#4-request-format" data-toc-target="4-request-format">4. Request Format</a></li><li class="page-toc-item level-2"><a href="#5-response-format" data-toc-target="5-response-format">5. Response Format</a></li><li class="page-toc-item level-2"><a href="#6-endpoint-families" data-toc-target="6-endpoint-families">6. Endpoint Families</a></li><li class="page-toc-item level-2"><a href="#7-introspection" data-toc-target="7-introspection">7. Introspection</a></li><li class="page-toc-item level-2"><a href="#8-operation-classification" data-toc-target="8-operation-classification">8. Operation Classification</a></li><li class="page-toc-item level-2"><a href="#9-type-system" data-toc-target="9-type-system">9. Type System</a></li><li class="page-toc-item level-2"><a href="#10-conformance" data-toc-target="10-conformance">10. Conformance</a></li><li class="page-toc-item level-2"><a href="#appendix-a-token-efficiency" data-toc-target="appendix-a-token-efficiency">Appendix A: Token Efficiency</a></li><li class="page-toc-item level-2"><a href="#appendix-b-references" data-toc-target="appendix-b-references">Appendix B: References</a></li><li class="page-toc-item level-2"><a href="#appendix-c-change-log" data-toc-target="appendix-c-change-log">Appendix C: Change Log</a></li><li class="page-toc-item level-2"><a href="#appendix-d-json-schemas" data-toc-target="appendix-d-json-schemas">Appendix D: JSON Schemas</a></li>
             </ol>
           </div>
         </section>
@@ -111,7 +111,7 @@
           <div class="card spec-prose">
             <p><strong>Version:</strong> 1.0.0-draft <strong>Status:</strong> Draft <strong>Last Updated:</strong> 2026-04-15</p>
 <h2 id="abstract">Abstract</h2>
-<p>MCP-AQL (Model Context Protocol - Advanced Agent API Adapter Query Language) is a protocol specification that consolidates multiple MCP tools into semantic CRUDE endpoints, providing significant token reduction while enabling runtime operation discovery through introspection.</p>
+<p>MCP-AQL (Model Context Protocol - Advanced Agent API Adapter Query Language) is a protocol specification that consolidates multiple MCP tools into a small number of semantic endpoints, providing significant token reduction while enabling runtime operation discovery through introspection. The standard CRUDE profile is one recommended semantic-endpoint pattern, but adapters MAY also define alternate semantic endpoint families that better match the target domain.</p>
 <h2 id="status-of-this-document">Status of This Document</h2>
 <p>This is the <strong>normative</strong> MCP-AQL specification. All conformance requirements (MUST, SHOULD, MAY) in this document are authoritative.</p>
 <p>Other documents in the <code>docs/</code> directory are <strong>informative</strong> and provide additional context, examples, and implementation guidance. In case of conflict between this specification and informative documents, this specification takes precedence.</p>
@@ -121,7 +121,7 @@
 <h2 id="1-introduction">1. Introduction</h2>
 <h3 id="11-purpose">1.1 Purpose</h3>
 <p>MCP-AQL addresses the token efficiency challenge in LLM-MCP interactions. Traditional MCP implementations expose discrete tools, each requiring schema definition in the model's context. With many tools, this can consume significant tokens before any work begins.</p>
-<p>MCP-AQL consolidates operations into five semantic endpoints, reducing token overhead by approximately 85-96% while maintaining full functionality.</p>
+<p>MCP-AQL consolidates operations into a small number of semantic endpoints, reducing token overhead by approximately 85-96% while maintaining full functionality.</p>
 <h3 id="12-goals">1.2 Goals</h3>
 <ol type="1">
 <li><strong>Token Efficiency</strong> - Minimize context consumed by tool definitions</li>
@@ -133,7 +133,8 @@
 <h3 id="13-scope">1.3 Scope</h3>
 <p>This specification defines:</p>
 <ul>
-<li>The CRUDE endpoint pattern</li>
+<li>Standard semantic operation categories</li>
+<li>Endpoint family patterns, including the standard CRUDE profile</li>
 <li>Request and response formats</li>
 <li>The introspection system for operation discovery</li>
 <li>Operation classification guidelines</li>
@@ -147,19 +148,21 @@
 <li>Transport-layer concerns (handled by MCP)</li>
 </ul>
 <h3 id="14-relationship-to-adapters">1.4 Relationship to Adapters</h3>
-<p>MCP-AQL is a <strong>protocol layer</strong>, not an application. Adapters implement MCP-AQL to expose their domain-specific operations through the unified CRUDE interface. Each adapter:</p>
+<p>MCP-AQL is a <strong>protocol layer</strong>, not an application. Adapters implement MCP-AQL to expose their domain-specific operations through semantic endpoints or a single unified endpoint. Each adapter:</p>
 <ul>
 <li>Defines its own operations</li>
 <li>Defines its own parameters</li>
-<li>Classifies operations into CRUDE endpoints</li>
+<li>Classifies operations into standard semantic categories</li>
+<li>Maps operations to exposed endpoint families</li>
 <li>Exposes operations via introspection</li>
 </ul>
 <hr />
 <h2 id="2-terminology">2. Terminology</h2>
 <h3 id="21-key-terms">2.1 Key Terms</h3>
 <p><strong>CRUDE Pattern</strong> : The five-endpoint pattern: Create, Read, Update, Delete, Execute</p>
+<p><strong>Semantic Category</strong> : One of the standard operation-effect categories: CREATE, READ, UPDATE, DELETE, EXECUTE</p>
 <p><strong>Operation</strong> : A specific action that an adapter provides (e.g., <code>create_user</code>, <code>run_report</code>, <code>search_documents</code>)</p>
-<p><strong>Endpoint</strong> : One of the five CRUDE categories to which operations are routed</p>
+<p><strong>Endpoint Family</strong> : A named exposed endpoint or tool grouping that contains one or more operations</p>
 <p><strong>Adapter</strong> : An MCP server that implements MCP-AQL to expose domain-specific operations</p>
 <p><strong>Introspection</strong> : The ability to query available operations and types at runtime</p>
 <p><strong>Resource</strong> : Any entity managed by an adapter (documents, users, configurations, workflows, etc.)</p>
@@ -171,25 +174,25 @@
 <h4 id="232-session-boundaries">2.3.2 Session Boundaries</h4>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Event</th>
 <th>Session Impact</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td>MCP <code>initialize</code> completes</td>
 <td>Session begins</td>
 </tr>
-<tr>
+<tr class="even">
 <td>MCP <code>shutdown</code> received</td>
 <td>Session ends gracefully</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>Transport disconnect</td>
 <td>Session ends abruptly</td>
 </tr>
-<tr>
+<tr class="even">
 <td>Transport reconnect</td>
 <td>New session begins</td>
 </tr>
@@ -237,8 +240,8 @@
 ┌─────────────────────────────────────────────────────────────┐
 │                     MCP-AQL Layer                           │
 │  ┌──────────────────────────────────────────────────────┐   │
-│  │              CRUDE Endpoints                         │   │
-│  │   CREATE │ READ │ UPDATE │ DELETE │ EXECUTE          │   │
+│  │        Exposed Endpoint Families                     │   │
+│  │  Semantic endpoint profile or unified endpoint       │   │
 │  └──────────────────────────────────────────────────────┘   │
 │                          │                                  │
 │  ┌──────────────────────────────────────────────────────┐   │
@@ -268,22 +271,29 @@
 </ol>
 <h3 id="33-endpoint-modes">3.3 Endpoint Modes</h3>
 <p>MCP-AQL supports two operational modes:</p>
-<p><strong>CRUDE Mode (5 endpoints)</strong></p>
+<p><strong>Semantic Endpoint Mode</strong></p>
+<p>The standard CRUDE profile:</p>
 <pre><code>mcp_aql_create   - CREATE operations
 mcp_aql_read     - READ operations
 mcp_aql_update   - UPDATE operations
 mcp_aql_delete   - DELETE operations
 mcp_aql_execute  - EXECUTE operations</code></pre>
+<p>An alternative semantic profile:</p>
+<pre><code>mcp_aql_discover  - Discovery and inspection operations
+mcp_aql_query     - Retrieval and filtering operations
+mcp_aql_manage    - Mutating and administrative operations
+mcp_aql_operate   - Runtime and lifecycle operations</code></pre>
+<p>Other valid semantic endpoint families might be shaped around semantically explicit profiles such as database access (<code>inspect</code>, <code>query</code>, <code>mutate</code>, <code>administer</code>) or hardware integrations (<code>discover</code>, <code>observe</code>, <code>control</code>, <code>maintain</code>).</p>
 <p><strong>Single Mode (1 endpoint)</strong></p>
 <pre><code>mcp_aql - All operations through unified entry point</code></pre>
 <p>Implementations MUST support at least one mode. Implementations SHOULD support both.</p>
 <hr />
 <h2 id="4-request-format">4. Request Format</h2>
 <h3 id="41-standard-request-structure">4.1 Standard Request Structure</h3>
-<div class="sourceCode" id="cb4"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb4-1"><a href="#cb4-1" aria-hidden="true" tabindex="-1"></a><span class="kw">interface</span> OperationInput {</span>
-<span id="cb4-2"><a href="#cb4-2" aria-hidden="true" tabindex="-1"></a>  operation<span class="op">:</span> <span class="dt">string</span><span class="op">;</span>              <span class="co">// REQUIRED: Operation to perform</span></span>
-<span id="cb4-3"><a href="#cb4-3" aria-hidden="true" tabindex="-1"></a>  params<span class="op">?:</span> <span class="bu">Record</span><span class="op">&lt;</span><span class="dt">string</span><span class="op">,</span> <span class="dt">any</span><span class="op">&gt;;</span>   <span class="co">// OPTIONAL: Operation parameters</span></span>
-<span id="cb4-4"><a href="#cb4-4" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<div class="sourceCode" id="cb5"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb5-1"><a href="#cb5-1" aria-hidden="true" tabindex="-1"></a><span class="kw">interface</span> OperationInput {</span>
+<span id="cb5-2"><a href="#cb5-2" aria-hidden="true" tabindex="-1"></a>  operation<span class="op">:</span> <span class="dt">string</span><span class="op">;</span>              <span class="co">// REQUIRED: Operation to perform</span></span>
+<span id="cb5-3"><a href="#cb5-3" aria-hidden="true" tabindex="-1"></a>  params<span class="op">?:</span> <span class="bu">Record</span><span class="op">&lt;</span><span class="dt">string</span><span class="op">,</span> <span class="dt">any</span><span class="op">&gt;;</span>   <span class="co">// OPTIONAL: Operation parameters</span></span>
+<span id="cb5-4"><a href="#cb5-4" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
 <h3 id="42-parameter-resolution">4.2 Parameter Resolution</h3>
 <p>Parameters MAY appear at multiple levels. Resolution follows this precedence:</p>
 <ol type="1">
@@ -297,41 +307,41 @@ mcp_aql_execute  - EXECUTE operations</code></pre>
 </blockquote>
 <h3 id="44-request-examples">4.4 Request Examples</h3>
 <p><strong>Minimal Request:</strong></p>
-<div class="sourceCode" id="cb5"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb5-1"><a href="#cb5-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
-<span id="cb5-2"><a href="#cb5-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;list_users&quot;</span></span>
-<span id="cb5-3"><a href="#cb5-3" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
-<p><strong>Request with Parameters:</strong></p>
 <div class="sourceCode" id="cb6"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb6-1"><a href="#cb6-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
-<span id="cb6-2"><a href="#cb6-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;create_document&quot;</span><span class="fu">,</span></span>
-<span id="cb6-3"><a href="#cb6-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb6-4"><a href="#cb6-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;title&quot;</span><span class="fu">:</span> <span class="st">&quot;Quarterly Report&quot;</span><span class="fu">,</span></span>
-<span id="cb6-5"><a href="#cb6-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;content&quot;</span><span class="fu">:</span> <span class="st">&quot;...&quot;</span><span class="fu">,</span></span>
-<span id="cb6-6"><a href="#cb6-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;folder_id&quot;</span><span class="fu">:</span> <span class="st">&quot;folder_123&quot;</span></span>
-<span id="cb6-7"><a href="#cb6-7" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
-<span id="cb6-8"><a href="#cb6-8" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
-<p><strong>Alternative Parameter Placement:</strong></p>
+<span id="cb6-2"><a href="#cb6-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;list_users&quot;</span></span>
+<span id="cb6-3"><a href="#cb6-3" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<p><strong>Request with Parameters:</strong></p>
 <div class="sourceCode" id="cb7"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb7-1"><a href="#cb7-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
-<span id="cb7-2"><a href="#cb7-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;get_user&quot;</span><span class="fu">,</span></span>
-<span id="cb7-3"><a href="#cb7-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;user_id&quot;</span><span class="fu">:</span> <span class="st">&quot;user_456&quot;</span></span>
-<span id="cb7-4"><a href="#cb7-4" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<span id="cb7-2"><a href="#cb7-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;create_document&quot;</span><span class="fu">,</span></span>
+<span id="cb7-3"><a href="#cb7-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb7-4"><a href="#cb7-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;title&quot;</span><span class="fu">:</span> <span class="st">&quot;Quarterly Report&quot;</span><span class="fu">,</span></span>
+<span id="cb7-5"><a href="#cb7-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;content&quot;</span><span class="fu">:</span> <span class="st">&quot;...&quot;</span><span class="fu">,</span></span>
+<span id="cb7-6"><a href="#cb7-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;folder_id&quot;</span><span class="fu">:</span> <span class="st">&quot;folder_123&quot;</span></span>
+<span id="cb7-7"><a href="#cb7-7" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb7-8"><a href="#cb7-8" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<p><strong>Alternative Parameter Placement:</strong></p>
+<div class="sourceCode" id="cb8"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb8-1"><a href="#cb8-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb8-2"><a href="#cb8-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;get_user&quot;</span><span class="fu">,</span></span>
+<span id="cb8-3"><a href="#cb8-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;user_id&quot;</span><span class="fu">:</span> <span class="st">&quot;user_456&quot;</span></span>
+<span id="cb8-4"><a href="#cb8-4" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
 <blockquote>
 <p><strong>Collection Querying Note:</strong> Collection-returning READ operations often combine field selection, filtering, sorting, and pagination. See the informative <a href="../features/collection-querying.html">Collection Querying</a> guide for the preferred cross-cutting request shape moving forward.</p>
 </blockquote>
 <h3 id="45-update-input-pattern">4.5 UPDATE Input Pattern</h3>
 <p>UPDATE operations MUST use a nested <code>input</code> object within <code>params</code> to contain all updateable fields. Identifier parameters (used to locate the resource) MUST remain at the <code>params</code> level.</p>
 <p><strong>Structure:</strong></p>
-<div class="sourceCode" id="cb8"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb8-1"><a href="#cb8-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
-<span id="cb8-2"><a href="#cb8-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;update_resource&quot;</span><span class="fu">,</span></span>
-<span id="cb8-3"><a href="#cb8-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb8-4"><a href="#cb8-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;resource_id&quot;</span><span class="fu">:</span> <span class="st">&quot;res_123&quot;</span><span class="fu">,</span></span>
-<span id="cb8-5"><a href="#cb8-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;input&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb8-6"><a href="#cb8-6" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;title&quot;</span><span class="fu">:</span> <span class="st">&quot;New Title&quot;</span><span class="fu">,</span></span>
-<span id="cb8-7"><a href="#cb8-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;metadata&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb8-8"><a href="#cb8-8" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;priority&quot;</span><span class="fu">:</span> <span class="st">&quot;high&quot;</span></span>
-<span id="cb8-9"><a href="#cb8-9" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span></span>
-<span id="cb8-10"><a href="#cb8-10" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
-<span id="cb8-11"><a href="#cb8-11" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
-<span id="cb8-12"><a href="#cb8-12" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<div class="sourceCode" id="cb9"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb9-1"><a href="#cb9-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb9-2"><a href="#cb9-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;update_resource&quot;</span><span class="fu">,</span></span>
+<span id="cb9-3"><a href="#cb9-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb9-4"><a href="#cb9-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;resource_id&quot;</span><span class="fu">:</span> <span class="st">&quot;res_123&quot;</span><span class="fu">,</span></span>
+<span id="cb9-5"><a href="#cb9-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;input&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb9-6"><a href="#cb9-6" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;title&quot;</span><span class="fu">:</span> <span class="st">&quot;New Title&quot;</span><span class="fu">,</span></span>
+<span id="cb9-7"><a href="#cb9-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;metadata&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb9-8"><a href="#cb9-8" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;priority&quot;</span><span class="fu">:</span> <span class="st">&quot;high&quot;</span></span>
+<span id="cb9-9"><a href="#cb9-9" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span></span>
+<span id="cb9-10"><a href="#cb9-10" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb9-11"><a href="#cb9-11" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb9-12"><a href="#cb9-12" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
 <h4 id="451-merge-semantics">4.5.1 Merge Semantics</h4>
 <p>When processing the <code>input</code> object, adapters MUST apply deep-merge semantics:</p>
 <ol type="1">
@@ -342,37 +352,37 @@ mcp_aql_execute  - EXECUTE operations</code></pre>
 </ol>
 <p><strong>Example — Deep Merge Behavior:</strong></p>
 <p>Given existing resource state:</p>
-<div class="sourceCode" id="cb9"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb9-1"><a href="#cb9-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
-<span id="cb9-2"><a href="#cb9-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;title&quot;</span><span class="fu">:</span> <span class="st">&quot;Old Title&quot;</span><span class="fu">,</span></span>
-<span id="cb9-3"><a href="#cb9-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;metadata&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb9-4"><a href="#cb9-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;priority&quot;</span><span class="fu">:</span> <span class="st">&quot;low&quot;</span><span class="fu">,</span></span>
-<span id="cb9-5"><a href="#cb9-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;tags&quot;</span><span class="fu">:</span> <span class="ot">[</span><span class="st">&quot;draft&quot;</span><span class="ot">]</span><span class="fu">,</span></span>
-<span id="cb9-6"><a href="#cb9-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;author&quot;</span><span class="fu">:</span> <span class="st">&quot;alice&quot;</span></span>
-<span id="cb9-7"><a href="#cb9-7" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
-<span id="cb9-8"><a href="#cb9-8" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
-<p>And update request:</p>
 <div class="sourceCode" id="cb10"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb10-1"><a href="#cb10-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
-<span id="cb10-2"><a href="#cb10-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;update_resource&quot;</span><span class="fu">,</span></span>
-<span id="cb10-3"><a href="#cb10-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb10-4"><a href="#cb10-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;resource_id&quot;</span><span class="fu">:</span> <span class="st">&quot;res_123&quot;</span><span class="fu">,</span></span>
-<span id="cb10-5"><a href="#cb10-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;input&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb10-6"><a href="#cb10-6" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;title&quot;</span><span class="fu">:</span> <span class="st">&quot;New Title&quot;</span><span class="fu">,</span></span>
-<span id="cb10-7"><a href="#cb10-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;metadata&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb10-8"><a href="#cb10-8" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;priority&quot;</span><span class="fu">:</span> <span class="st">&quot;high&quot;</span><span class="fu">,</span></span>
-<span id="cb10-9"><a href="#cb10-9" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;tags&quot;</span><span class="fu">:</span> <span class="ot">[</span><span class="st">&quot;published&quot;</span><span class="ot">,</span> <span class="st">&quot;reviewed&quot;</span><span class="ot">]</span></span>
-<span id="cb10-10"><a href="#cb10-10" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span></span>
-<span id="cb10-11"><a href="#cb10-11" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
-<span id="cb10-12"><a href="#cb10-12" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
-<span id="cb10-13"><a href="#cb10-13" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
-<p>The resulting state MUST be:</p>
+<span id="cb10-2"><a href="#cb10-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;title&quot;</span><span class="fu">:</span> <span class="st">&quot;Old Title&quot;</span><span class="fu">,</span></span>
+<span id="cb10-3"><a href="#cb10-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;metadata&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb10-4"><a href="#cb10-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;priority&quot;</span><span class="fu">:</span> <span class="st">&quot;low&quot;</span><span class="fu">,</span></span>
+<span id="cb10-5"><a href="#cb10-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;tags&quot;</span><span class="fu">:</span> <span class="ot">[</span><span class="st">&quot;draft&quot;</span><span class="ot">]</span><span class="fu">,</span></span>
+<span id="cb10-6"><a href="#cb10-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;author&quot;</span><span class="fu">:</span> <span class="st">&quot;alice&quot;</span></span>
+<span id="cb10-7"><a href="#cb10-7" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb10-8"><a href="#cb10-8" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<p>And update request:</p>
 <div class="sourceCode" id="cb11"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb11-1"><a href="#cb11-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
-<span id="cb11-2"><a href="#cb11-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;title&quot;</span><span class="fu">:</span> <span class="st">&quot;New Title&quot;</span><span class="fu">,</span></span>
-<span id="cb11-3"><a href="#cb11-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;metadata&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb11-4"><a href="#cb11-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;priority&quot;</span><span class="fu">:</span> <span class="st">&quot;high&quot;</span><span class="fu">,</span></span>
-<span id="cb11-5"><a href="#cb11-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;tags&quot;</span><span class="fu">:</span> <span class="ot">[</span><span class="st">&quot;published&quot;</span><span class="ot">,</span> <span class="st">&quot;reviewed&quot;</span><span class="ot">]</span><span class="fu">,</span></span>
-<span id="cb11-6"><a href="#cb11-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;author&quot;</span><span class="fu">:</span> <span class="st">&quot;alice&quot;</span></span>
-<span id="cb11-7"><a href="#cb11-7" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
-<span id="cb11-8"><a href="#cb11-8" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<span id="cb11-2"><a href="#cb11-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;update_resource&quot;</span><span class="fu">,</span></span>
+<span id="cb11-3"><a href="#cb11-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb11-4"><a href="#cb11-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;resource_id&quot;</span><span class="fu">:</span> <span class="st">&quot;res_123&quot;</span><span class="fu">,</span></span>
+<span id="cb11-5"><a href="#cb11-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;input&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb11-6"><a href="#cb11-6" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;title&quot;</span><span class="fu">:</span> <span class="st">&quot;New Title&quot;</span><span class="fu">,</span></span>
+<span id="cb11-7"><a href="#cb11-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;metadata&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb11-8"><a href="#cb11-8" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;priority&quot;</span><span class="fu">:</span> <span class="st">&quot;high&quot;</span><span class="fu">,</span></span>
+<span id="cb11-9"><a href="#cb11-9" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;tags&quot;</span><span class="fu">:</span> <span class="ot">[</span><span class="st">&quot;published&quot;</span><span class="ot">,</span> <span class="st">&quot;reviewed&quot;</span><span class="ot">]</span></span>
+<span id="cb11-10"><a href="#cb11-10" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span></span>
+<span id="cb11-11"><a href="#cb11-11" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb11-12"><a href="#cb11-12" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb11-13"><a href="#cb11-13" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<p>The resulting state MUST be:</p>
+<div class="sourceCode" id="cb12"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb12-1"><a href="#cb12-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb12-2"><a href="#cb12-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;title&quot;</span><span class="fu">:</span> <span class="st">&quot;New Title&quot;</span><span class="fu">,</span></span>
+<span id="cb12-3"><a href="#cb12-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;metadata&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb12-4"><a href="#cb12-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;priority&quot;</span><span class="fu">:</span> <span class="st">&quot;high&quot;</span><span class="fu">,</span></span>
+<span id="cb12-5"><a href="#cb12-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;tags&quot;</span><span class="fu">:</span> <span class="ot">[</span><span class="st">&quot;published&quot;</span><span class="ot">,</span> <span class="st">&quot;reviewed&quot;</span><span class="ot">]</span><span class="fu">,</span></span>
+<span id="cb12-6"><a href="#cb12-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;author&quot;</span><span class="fu">:</span> <span class="st">&quot;alice&quot;</span></span>
+<span id="cb12-7"><a href="#cb12-7" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb12-8"><a href="#cb12-8" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
 <ul>
 <li><code>title</code>: replaced (top-level field)</li>
 <li><code>metadata.priority</code>: replaced (present in input)</li>
@@ -381,17 +391,17 @@ mcp_aql_execute  - EXECUTE operations</code></pre>
 </ul>
 <h4 id="452-field-removal">4.5.2 Field Removal</h4>
 <p>To remove a field, clients MUST set its value to <code>null</code>:</p>
-<div class="sourceCode" id="cb12"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb12-1"><a href="#cb12-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
-<span id="cb12-2"><a href="#cb12-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;update_resource&quot;</span><span class="fu">,</span></span>
-<span id="cb12-3"><a href="#cb12-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb12-4"><a href="#cb12-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;resource_id&quot;</span><span class="fu">:</span> <span class="st">&quot;res_123&quot;</span><span class="fu">,</span></span>
-<span id="cb12-5"><a href="#cb12-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;input&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb12-6"><a href="#cb12-6" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;metadata&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb12-7"><a href="#cb12-7" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;deprecated_field&quot;</span><span class="fu">:</span> <span class="kw">null</span></span>
-<span id="cb12-8"><a href="#cb12-8" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span></span>
-<span id="cb12-9"><a href="#cb12-9" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
-<span id="cb12-10"><a href="#cb12-10" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
-<span id="cb12-11"><a href="#cb12-11" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<div class="sourceCode" id="cb13"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb13-1"><a href="#cb13-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb13-2"><a href="#cb13-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;update_resource&quot;</span><span class="fu">,</span></span>
+<span id="cb13-3"><a href="#cb13-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb13-4"><a href="#cb13-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;resource_id&quot;</span><span class="fu">:</span> <span class="st">&quot;res_123&quot;</span><span class="fu">,</span></span>
+<span id="cb13-5"><a href="#cb13-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;input&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb13-6"><a href="#cb13-6" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;metadata&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb13-7"><a href="#cb13-7" aria-hidden="true" tabindex="-1"></a>        <span class="dt">&quot;deprecated_field&quot;</span><span class="fu">:</span> <span class="kw">null</span></span>
+<span id="cb13-8"><a href="#cb13-8" aria-hidden="true" tabindex="-1"></a>      <span class="fu">}</span></span>
+<span id="cb13-9"><a href="#cb13-9" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb13-10"><a href="#cb13-10" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb13-11"><a href="#cb13-11" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
 <h4 id="453-validation">4.5.3 Validation</h4>
 <p>Adapters MUST validate the <code>input</code> object:</p>
 <ol type="1">
@@ -405,18 +415,18 @@ mcp_aql_execute  - EXECUTE operations</code></pre>
 <h3 id="46-unknown-parameter-handling">4.6 Unknown Parameter Handling</h3>
 <p>Adapters MUST reject requests containing parameters not defined in the operation schema.</p>
 <p>When an unknown parameter is detected, adapters MUST return a <code>VALIDATION_UNKNOWN_PARAM</code> error:</p>
-<div class="sourceCode" id="cb13"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb13-1"><a href="#cb13-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
-<span id="cb13-2"><a href="#cb13-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
-<span id="cb13-3"><a href="#cb13-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;error&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb13-4"><a href="#cb13-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;code&quot;</span><span class="fu">:</span> <span class="st">&quot;VALIDATION_UNKNOWN_PARAM&quot;</span><span class="fu">,</span></span>
-<span id="cb13-5"><a href="#cb13-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;Unknown parameter &#39;force_create&#39; for operation &#39;create_user&#39;&quot;</span><span class="fu">,</span></span>
-<span id="cb13-6"><a href="#cb13-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;details&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb13-7"><a href="#cb13-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;create_user&quot;</span><span class="fu">,</span></span>
-<span id="cb13-8"><a href="#cb13-8" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;unknown_params&quot;</span><span class="fu">:</span> <span class="ot">[</span><span class="st">&quot;force_create&quot;</span><span class="ot">,</span> <span class="st">&quot;admin_override&quot;</span><span class="ot">]</span><span class="fu">,</span></span>
-<span id="cb13-9"><a href="#cb13-9" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;valid_params&quot;</span><span class="fu">:</span> <span class="ot">[</span><span class="st">&quot;user_name&quot;</span><span class="ot">,</span> <span class="st">&quot;password&quot;</span><span class="ot">,</span> <span class="st">&quot;email&quot;</span><span class="ot">]</span></span>
-<span id="cb13-10"><a href="#cb13-10" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
-<span id="cb13-11"><a href="#cb13-11" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
-<span id="cb13-12"><a href="#cb13-12" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<div class="sourceCode" id="cb14"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb14-1"><a href="#cb14-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb14-2"><a href="#cb14-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb14-3"><a href="#cb14-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;error&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb14-4"><a href="#cb14-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;code&quot;</span><span class="fu">:</span> <span class="st">&quot;VALIDATION_UNKNOWN_PARAM&quot;</span><span class="fu">,</span></span>
+<span id="cb14-5"><a href="#cb14-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;Unknown parameter &#39;force_create&#39; for operation &#39;create_user&#39;&quot;</span><span class="fu">,</span></span>
+<span id="cb14-6"><a href="#cb14-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;details&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb14-7"><a href="#cb14-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;create_user&quot;</span><span class="fu">,</span></span>
+<span id="cb14-8"><a href="#cb14-8" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;unknown_params&quot;</span><span class="fu">:</span> <span class="ot">[</span><span class="st">&quot;force_create&quot;</span><span class="ot">,</span> <span class="st">&quot;admin_override&quot;</span><span class="ot">]</span><span class="fu">,</span></span>
+<span id="cb14-9"><a href="#cb14-9" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;valid_params&quot;</span><span class="fu">:</span> <span class="ot">[</span><span class="st">&quot;user_name&quot;</span><span class="ot">,</span> <span class="st">&quot;password&quot;</span><span class="ot">,</span> <span class="st">&quot;email&quot;</span><span class="ot">]</span></span>
+<span id="cb14-10"><a href="#cb14-10" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb14-11"><a href="#cb14-11" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb14-12"><a href="#cb14-12" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
 <p>This requirement:</p>
 <ul>
 <li>Prevents typos from silently failing</li>
@@ -467,54 +477,54 @@ mcp_aql_execute  - EXECUTE operations</code></pre>
 <li><strong>Precision:</strong> Approximately 15-17 significant decimal digits</li>
 </ul>
 <p>For values requiring higher precision (e.g., financial amounts, large identifiers), adapters SHOULD use string representation:</p>
-<div class="sourceCode" id="cb14"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb14-1"><a href="#cb14-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
-<span id="cb14-2"><a href="#cb14-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;amount&quot;</span><span class="fu">:</span> <span class="st">&quot;12345678901234567890&quot;</span><span class="fu">,</span></span>
-<span id="cb14-3"><a href="#cb14-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;amount_type&quot;</span><span class="fu">:</span> <span class="st">&quot;bigint&quot;</span></span>
-<span id="cb14-4"><a href="#cb14-4" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<div class="sourceCode" id="cb15"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb15-1"><a href="#cb15-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb15-2"><a href="#cb15-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;amount&quot;</span><span class="fu">:</span> <span class="st">&quot;12345678901234567890&quot;</span><span class="fu">,</span></span>
+<span id="cb15-3"><a href="#cb15-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;amount_type&quot;</span><span class="fu">:</span> <span class="st">&quot;bigint&quot;</span></span>
+<span id="cb15-4"><a href="#cb15-4" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
 <blockquote>
 <p><strong>Note:</strong> The type indicator field name (e.g., <code>amount_type</code>) is adapter-specific. Adapters SHOULD document their conventions for distinguishing string-encoded numbers from regular strings.</p>
 </blockquote>
 <p>Adapters MUST document when string representation is required for numeric parameters.</p>
 <h4 id="474-binary-data">4.7.4 Binary Data</h4>
 <p>Binary data MUST be encoded as base64 (<a href="https://www.rfc-editor.org/rfc/rfc4648">RFC 4648</a>) with standard padding (<code>=</code> characters) and metadata:</p>
-<div class="sourceCode" id="cb15"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb15-1"><a href="#cb15-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
-<span id="cb15-2"><a href="#cb15-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;file_content&quot;</span><span class="fu">:</span> <span class="st">&quot;SGVsbG8gV29ybGQ=&quot;</span><span class="fu">,</span></span>
-<span id="cb15-3"><a href="#cb15-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;file_encoding&quot;</span><span class="fu">:</span> <span class="st">&quot;base64&quot;</span><span class="fu">,</span></span>
-<span id="cb15-4"><a href="#cb15-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;file_mime_type&quot;</span><span class="fu">:</span> <span class="st">&quot;text/plain&quot;</span></span>
-<span id="cb15-5"><a href="#cb15-5" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<div class="sourceCode" id="cb16"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb16-1"><a href="#cb16-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb16-2"><a href="#cb16-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;file_content&quot;</span><span class="fu">:</span> <span class="st">&quot;SGVsbG8gV29ybGQ=&quot;</span><span class="fu">,</span></span>
+<span id="cb16-3"><a href="#cb16-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;file_encoding&quot;</span><span class="fu">:</span> <span class="st">&quot;base64&quot;</span><span class="fu">,</span></span>
+<span id="cb16-4"><a href="#cb16-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;file_mime_type&quot;</span><span class="fu">:</span> <span class="st">&quot;text/plain&quot;</span></span>
+<span id="cb16-5"><a href="#cb16-5" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
 <p>Adapters MAY support alternative binary handling (e.g., URL references, multipart) but MUST document this behavior via introspection.</p>
 <h4 id="475-payload-size-limits">4.7.5 Payload Size Limits</h4>
 <p>Adapters MUST enforce payload size limits to prevent resource exhaustion:</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Limit</th>
 <th>Default</th>
 <th>Configurable Range</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td>Request payload</td>
 <td>1 MB</td>
 <td>64 KB – 10 MB</td>
 </tr>
-<tr>
+<tr class="even">
 <td>Response payload</td>
 <td>10 MB</td>
 <td>1 MB – 100 MB</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>Single string value</td>
 <td>1 MB</td>
 <td>64 KB – 10 MB</td>
 </tr>
-<tr>
+<tr class="even">
 <td>Array elements</td>
 <td>10,000</td>
 <td>100 – 100,000</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>Object nesting depth</td>
 <td>32 levels</td>
 <td>8 – 64 levels</td>
@@ -526,17 +536,17 @@ mcp_aql_execute  - EXECUTE operations</code></pre>
 </blockquote>
 <p>When a limit is exceeded, adapters MUST return a <code>VALIDATION_PAYLOAD_TOO_LARGE</code> error with details indicating which limit was exceeded.</p>
 <p>Adapters MUST document their configured limits via introspection or adapter documentation. Adapters SHOULD expose limits in protocol metadata (see Section 9.3.3) to enable client-side pre-validation:</p>
-<div class="sourceCode" id="cb16"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb16-1"><a href="#cb16-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
-<span id="cb16-2"><a href="#cb16-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;_protocol&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb16-3"><a href="#cb16-3" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;limits&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb16-4"><a href="#cb16-4" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;max_request_size&quot;</span><span class="fu">:</span> <span class="dv">1048576</span><span class="fu">,</span></span>
-<span id="cb16-5"><a href="#cb16-5" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;max_response_size&quot;</span><span class="fu">:</span> <span class="dv">10485760</span><span class="fu">,</span></span>
-<span id="cb16-6"><a href="#cb16-6" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;max_string_length&quot;</span><span class="fu">:</span> <span class="dv">1048576</span><span class="fu">,</span></span>
-<span id="cb16-7"><a href="#cb16-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;max_array_elements&quot;</span><span class="fu">:</span> <span class="dv">10000</span><span class="fu">,</span></span>
-<span id="cb16-8"><a href="#cb16-8" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;max_nesting_depth&quot;</span><span class="fu">:</span> <span class="dv">32</span></span>
-<span id="cb16-9"><a href="#cb16-9" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
-<span id="cb16-10"><a href="#cb16-10" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
-<span id="cb16-11"><a href="#cb16-11" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<div class="sourceCode" id="cb17"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb17-1"><a href="#cb17-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb17-2"><a href="#cb17-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;_protocol&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb17-3"><a href="#cb17-3" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;limits&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb17-4"><a href="#cb17-4" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;max_request_size&quot;</span><span class="fu">:</span> <span class="dv">1048576</span><span class="fu">,</span></span>
+<span id="cb17-5"><a href="#cb17-5" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;max_response_size&quot;</span><span class="fu">:</span> <span class="dv">10485760</span><span class="fu">,</span></span>
+<span id="cb17-6"><a href="#cb17-6" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;max_string_length&quot;</span><span class="fu">:</span> <span class="dv">1048576</span><span class="fu">,</span></span>
+<span id="cb17-7"><a href="#cb17-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;max_array_elements&quot;</span><span class="fu">:</span> <span class="dv">10000</span><span class="fu">,</span></span>
+<span id="cb17-8"><a href="#cb17-8" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;max_nesting_depth&quot;</span><span class="fu">:</span> <span class="dv">32</span></span>
+<span id="cb17-9"><a href="#cb17-9" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb17-10"><a href="#cb17-10" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb17-11"><a href="#cb17-11" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
 <h4 id="476-null-handling">4.7.6 Null Handling</h4>
 <p>JSON <code>null</code> represents the absence of a value:</p>
 <ul>
@@ -548,85 +558,85 @@ mcp_aql_execute  - EXECUTE operations</code></pre>
 <h2 id="5-response-format">5. Response Format</h2>
 <h3 id="51-discriminated-union">5.1 Discriminated Union</h3>
 <p>All operations return a discriminated union result:</p>
-<div class="sourceCode" id="cb17"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb17-1"><a href="#cb17-1" aria-hidden="true" tabindex="-1"></a><span class="kw">type</span> OperationResult <span class="op">=</span> OperationSuccess <span class="op">|</span> OperationFailure<span class="op">;</span></span>
-<span id="cb17-2"><a href="#cb17-2" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb17-3"><a href="#cb17-3" aria-hidden="true" tabindex="-1"></a><span class="kw">interface</span> OperationSuccess {</span>
-<span id="cb17-4"><a href="#cb17-4" aria-hidden="true" tabindex="-1"></a>  success<span class="op">:</span> <span class="kw">true</span><span class="op">;</span></span>
-<span id="cb17-5"><a href="#cb17-5" aria-hidden="true" tabindex="-1"></a>  data<span class="op">:</span> <span class="dt">any</span><span class="op">;</span>      <span class="co">// Operation-specific payload</span></span>
-<span id="cb17-6"><a href="#cb17-6" aria-hidden="true" tabindex="-1"></a>}</span>
-<span id="cb17-7"><a href="#cb17-7" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb17-8"><a href="#cb17-8" aria-hidden="true" tabindex="-1"></a><span class="kw">interface</span> OperationFailure {</span>
-<span id="cb17-9"><a href="#cb17-9" aria-hidden="true" tabindex="-1"></a>  success<span class="op">:</span> <span class="kw">false</span><span class="op">;</span></span>
-<span id="cb17-10"><a href="#cb17-10" aria-hidden="true" tabindex="-1"></a>  error<span class="op">:</span> ErrorDetail<span class="op">;</span></span>
-<span id="cb17-11"><a href="#cb17-11" aria-hidden="true" tabindex="-1"></a>}</span>
-<span id="cb17-12"><a href="#cb17-12" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb17-13"><a href="#cb17-13" aria-hidden="true" tabindex="-1"></a><span class="kw">interface</span> ErrorDetail {</span>
-<span id="cb17-14"><a href="#cb17-14" aria-hidden="true" tabindex="-1"></a>  code<span class="op">:</span> <span class="dt">string</span><span class="op">;</span>     <span class="co">// Machine-readable error code (e.g., &quot;VALIDATION_MISSING_PARAM&quot;)</span></span>
-<span id="cb17-15"><a href="#cb17-15" aria-hidden="true" tabindex="-1"></a>  message<span class="op">:</span> <span class="dt">string</span><span class="op">;</span>  <span class="co">// Human-readable error message</span></span>
-<span id="cb17-16"><a href="#cb17-16" aria-hidden="true" tabindex="-1"></a>  details<span class="op">?:</span> <span class="bu">Record</span><span class="op">&lt;</span><span class="dt">string</span><span class="op">,</span> <span class="dt">unknown</span><span class="op">&gt;;</span>  <span class="co">// Optional contextual information</span></span>
-<span id="cb17-17"><a href="#cb17-17" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<div class="sourceCode" id="cb18"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb18-1"><a href="#cb18-1" aria-hidden="true" tabindex="-1"></a><span class="kw">type</span> OperationResult <span class="op">=</span> OperationSuccess <span class="op">|</span> OperationFailure<span class="op">;</span></span>
+<span id="cb18-2"><a href="#cb18-2" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb18-3"><a href="#cb18-3" aria-hidden="true" tabindex="-1"></a><span class="kw">interface</span> OperationSuccess {</span>
+<span id="cb18-4"><a href="#cb18-4" aria-hidden="true" tabindex="-1"></a>  success<span class="op">:</span> <span class="kw">true</span><span class="op">;</span></span>
+<span id="cb18-5"><a href="#cb18-5" aria-hidden="true" tabindex="-1"></a>  data<span class="op">:</span> <span class="dt">any</span><span class="op">;</span>      <span class="co">// Operation-specific payload</span></span>
+<span id="cb18-6"><a href="#cb18-6" aria-hidden="true" tabindex="-1"></a>}</span>
+<span id="cb18-7"><a href="#cb18-7" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb18-8"><a href="#cb18-8" aria-hidden="true" tabindex="-1"></a><span class="kw">interface</span> OperationFailure {</span>
+<span id="cb18-9"><a href="#cb18-9" aria-hidden="true" tabindex="-1"></a>  success<span class="op">:</span> <span class="kw">false</span><span class="op">;</span></span>
+<span id="cb18-10"><a href="#cb18-10" aria-hidden="true" tabindex="-1"></a>  error<span class="op">:</span> ErrorDetail<span class="op">;</span></span>
+<span id="cb18-11"><a href="#cb18-11" aria-hidden="true" tabindex="-1"></a>}</span>
+<span id="cb18-12"><a href="#cb18-12" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb18-13"><a href="#cb18-13" aria-hidden="true" tabindex="-1"></a><span class="kw">interface</span> ErrorDetail {</span>
+<span id="cb18-14"><a href="#cb18-14" aria-hidden="true" tabindex="-1"></a>  code<span class="op">:</span> <span class="dt">string</span><span class="op">;</span>     <span class="co">// Machine-readable error code (e.g., &quot;VALIDATION_MISSING_PARAM&quot;)</span></span>
+<span id="cb18-15"><a href="#cb18-15" aria-hidden="true" tabindex="-1"></a>  message<span class="op">:</span> <span class="dt">string</span><span class="op">;</span>  <span class="co">// Human-readable error message</span></span>
+<span id="cb18-16"><a href="#cb18-16" aria-hidden="true" tabindex="-1"></a>  details<span class="op">?:</span> <span class="bu">Record</span><span class="op">&lt;</span><span class="dt">string</span><span class="op">,</span> <span class="dt">unknown</span><span class="op">&gt;;</span>  <span class="co">// Optional contextual information</span></span>
+<span id="cb18-17"><a href="#cb18-17" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
 <blockquote>
 <p><strong>Note:</strong> See <a href="../error-codes.html">Structured Error Codes Specification</a> for the complete error code taxonomy and usage guidelines.</p>
 </blockquote>
 <h3 id="52-success-response">5.2 Success Response</h3>
-<div class="sourceCode" id="cb18"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb18-1"><a href="#cb18-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
-<span id="cb18-2"><a href="#cb18-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
-<span id="cb18-3"><a href="#cb18-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;data&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb18-4"><a href="#cb18-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;id&quot;</span><span class="fu">:</span> <span class="st">&quot;doc_789&quot;</span><span class="fu">,</span></span>
-<span id="cb18-5"><a href="#cb18-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;title&quot;</span><span class="fu">:</span> <span class="st">&quot;Quarterly Report&quot;</span><span class="fu">,</span></span>
-<span id="cb18-6"><a href="#cb18-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;created_at&quot;</span><span class="fu">:</span> <span class="st">&quot;2024-01-15T10:30:00Z&quot;</span></span>
-<span id="cb18-7"><a href="#cb18-7" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
-<span id="cb18-8"><a href="#cb18-8" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
-<h3 id="53-error-response">5.3 Error Response</h3>
 <div class="sourceCode" id="cb19"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb19-1"><a href="#cb19-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
-<span id="cb19-2"><a href="#cb19-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
-<span id="cb19-3"><a href="#cb19-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;error&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb19-4"><a href="#cb19-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;code&quot;</span><span class="fu">:</span> <span class="st">&quot;VALIDATION_MISSING_PARAM&quot;</span><span class="fu">,</span></span>
-<span id="cb19-5"><a href="#cb19-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;Missing required parameter &#39;title&#39; for operation &#39;create_document&#39;&quot;</span><span class="fu">,</span></span>
-<span id="cb19-6"><a href="#cb19-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;details&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb19-7"><a href="#cb19-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;param_name&quot;</span><span class="fu">:</span> <span class="st">&quot;title&quot;</span><span class="fu">,</span></span>
-<span id="cb19-8"><a href="#cb19-8" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;create_document&quot;</span></span>
-<span id="cb19-9"><a href="#cb19-9" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
-<span id="cb19-10"><a href="#cb19-10" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
-<span id="cb19-11"><a href="#cb19-11" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<span id="cb19-2"><a href="#cb19-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb19-3"><a href="#cb19-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;data&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb19-4"><a href="#cb19-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;id&quot;</span><span class="fu">:</span> <span class="st">&quot;doc_789&quot;</span><span class="fu">,</span></span>
+<span id="cb19-5"><a href="#cb19-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;title&quot;</span><span class="fu">:</span> <span class="st">&quot;Quarterly Report&quot;</span><span class="fu">,</span></span>
+<span id="cb19-6"><a href="#cb19-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;created_at&quot;</span><span class="fu">:</span> <span class="st">&quot;2024-01-15T10:30:00Z&quot;</span></span>
+<span id="cb19-7"><a href="#cb19-7" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb19-8"><a href="#cb19-8" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<h3 id="53-error-response">5.3 Error Response</h3>
+<div class="sourceCode" id="cb20"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb20-1"><a href="#cb20-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb20-2"><a href="#cb20-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb20-3"><a href="#cb20-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;error&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb20-4"><a href="#cb20-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;code&quot;</span><span class="fu">:</span> <span class="st">&quot;VALIDATION_MISSING_PARAM&quot;</span><span class="fu">,</span></span>
+<span id="cb20-5"><a href="#cb20-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;Missing required parameter &#39;title&#39; for operation &#39;create_document&#39;&quot;</span><span class="fu">,</span></span>
+<span id="cb20-6"><a href="#cb20-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;details&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb20-7"><a href="#cb20-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;param_name&quot;</span><span class="fu">:</span> <span class="st">&quot;title&quot;</span><span class="fu">,</span></span>
+<span id="cb20-8"><a href="#cb20-8" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;create_document&quot;</span></span>
+<span id="cb20-9"><a href="#cb20-9" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb20-10"><a href="#cb20-10" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb20-11"><a href="#cb20-11" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
 <hr />
-<h2 id="6-crude-endpoints">6. CRUDE Endpoints</h2>
-<h3 id="61-endpoint-summary">6.1 Endpoint Summary</h3>
+<h2 id="6-endpoint-families">6. Endpoint Families</h2>
+<h3 id="61-standard-semantic-categories">6.1 Standard Semantic Categories</h3>
 <table>
 <thead>
-<tr>
-<th>Endpoint</th>
+<tr class="header">
+<th>Category</th>
 <th>Read-Only</th>
 <th>Destructive</th>
 <th>Description</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td>CREATE</td>
 <td>false</td>
 <td>false</td>
 <td>Additive operations</td>
 </tr>
-<tr>
+<tr class="even">
 <td>READ</td>
 <td>true</td>
 <td>false</td>
 <td>Query operations</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>UPDATE</td>
 <td>false</td>
 <td>true</td>
 <td>Modification operations</td>
 </tr>
-<tr>
+<tr class="even">
 <td>DELETE</td>
 <td>false</td>
 <td>true</td>
 <td>Removal operations</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>EXECUTE</td>
 <td>false</td>
 <td>true</td>
@@ -635,7 +645,7 @@ mcp_aql_execute  - EXECUTE operations</code></pre>
 </tbody>
 </table>
 <h3 id="62-operation-routing">6.2 Operation Routing</h3>
-<p>Each operation MUST be routed to exactly one endpoint based on its characteristics. Implementations MUST reject operations sent to incorrect endpoints in CRUDE mode.</p>
+<p>Each operation MUST be assigned exactly one standard semantic category based on its characteristics. In semantic endpoint mode, each operation MUST also be routed to exactly one exposed endpoint family. Implementations MUST reject operations sent to incorrect endpoints in semantic endpoint mode.</p>
 <p>See <a href="../overview.html">Protocol Overview</a> for detailed endpoint definitions and classification guidelines.</p>
 <hr />
 <h2 id="7-introspection">7. Introspection</h2>
@@ -653,18 +663,18 @@ mcp_aql_execute  - EXECUTE operations</code></pre>
 <p><strong>Parameters:</strong> | Parameter | Type | Required | Description | |-----------|------|----------|-------------| | <code>query</code> | string | Yes | Query type: "operations" or "types" | | <code>name</code> | string | No | Specific item name for details |</p>
 <h3 id="73-query-types">7.3 Query Types</h3>
 <p><strong>List Operations:</strong></p>
-<div class="sourceCode" id="cb20"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb20-1"><a href="#cb20-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span> <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;introspect&quot;</span><span class="fu">,</span> <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;query&quot;</span><span class="fu">:</span> <span class="st">&quot;operations&quot;</span> <span class="fu">}</span> <span class="fu">}</span></span></code></pre></div>
+<div class="sourceCode" id="cb21"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb21-1"><a href="#cb21-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span> <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;introspect&quot;</span><span class="fu">,</span> <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;query&quot;</span><span class="fu">:</span> <span class="st">&quot;operations&quot;</span> <span class="fu">}</span> <span class="fu">}</span></span></code></pre></div>
 <p><strong>Operation Details:</strong></p>
-<div class="sourceCode" id="cb21"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb21-1"><a href="#cb21-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span> <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;introspect&quot;</span><span class="fu">,</span> <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;query&quot;</span><span class="fu">:</span> <span class="st">&quot;operations&quot;</span><span class="fu">,</span> <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;create_document&quot;</span> <span class="fu">}</span> <span class="fu">}</span></span></code></pre></div>
+<div class="sourceCode" id="cb22"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb22-1"><a href="#cb22-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span> <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;introspect&quot;</span><span class="fu">,</span> <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;query&quot;</span><span class="fu">:</span> <span class="st">&quot;operations&quot;</span><span class="fu">,</span> <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;create_document&quot;</span> <span class="fu">}</span> <span class="fu">}</span></span></code></pre></div>
 <p><strong>List Types:</strong></p>
-<div class="sourceCode" id="cb22"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb22-1"><a href="#cb22-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span> <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;introspect&quot;</span><span class="fu">,</span> <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;query&quot;</span><span class="fu">:</span> <span class="st">&quot;types&quot;</span> <span class="fu">}</span> <span class="fu">}</span></span></code></pre></div>
+<div class="sourceCode" id="cb23"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb23-1"><a href="#cb23-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span> <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;introspect&quot;</span><span class="fu">,</span> <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;query&quot;</span><span class="fu">:</span> <span class="st">&quot;types&quot;</span> <span class="fu">}</span> <span class="fu">}</span></span></code></pre></div>
 <p><strong>Type Details:</strong></p>
-<div class="sourceCode" id="cb23"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb23-1"><a href="#cb23-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span> <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;introspect&quot;</span><span class="fu">,</span> <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;query&quot;</span><span class="fu">:</span> <span class="st">&quot;types&quot;</span><span class="fu">,</span> <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;DocumentStatus&quot;</span> <span class="fu">}</span> <span class="fu">}</span></span></code></pre></div>
+<div class="sourceCode" id="cb24"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb24-1"><a href="#cb24-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span> <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;introspect&quot;</span><span class="fu">,</span> <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;query&quot;</span><span class="fu">:</span> <span class="st">&quot;types&quot;</span><span class="fu">,</span> <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;DocumentStatus&quot;</span> <span class="fu">}</span> <span class="fu">}</span></span></code></pre></div>
 <p>See <a href="../introspection.html">Introspection Specification</a> for detailed response structures.</p>
 <hr />
 <h2 id="8-operation-classification">8. Operation Classification</h2>
 <h3 id="81-classification-guidelines">8.1 Classification Guidelines</h3>
-<p>Adapters classify their operations into CRUDE endpoints based on characteristics:</p>
+<p>Adapters classify their operations into standard semantic categories based on characteristics:</p>
 <p><strong>CREATE</strong> - Operations that:</p>
 <ul>
 <li>Add new resources or state</li>
@@ -698,64 +708,64 @@ mcp_aql_execute  - EXECUTE operations</code></pre>
 <h3 id="82-classification-examples">8.2 Classification Examples</h3>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Operation</th>
-<th>Endpoint</th>
+<th>Semantic Category</th>
 <th>Rationale</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><code>create_user</code></td>
 <td>CREATE</td>
 <td>Adds new user</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>upload_file</code></td>
 <td>CREATE</td>
 <td>Adds new file</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>list_users</code></td>
 <td>READ</td>
 <td>Queries without modification</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>search</code></td>
 <td>READ</td>
 <td>Queries without modification</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>get_status</code></td>
 <td>READ</td>
 <td>Retrieves state</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>update_profile</code></td>
 <td>UPDATE</td>
 <td>Modifies existing resource</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>rename_file</code></td>
 <td>UPDATE</td>
 <td>Modifies existing resource</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>delete_user</code></td>
 <td>DELETE</td>
 <td>Removes permanently</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>purge_cache</code></td>
 <td>DELETE</td>
 <td>Removes data</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>execute_job</code></td>
 <td>EXECUTE</td>
 <td>Starts runtime process</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>cancel_task</code></td>
 <td>EXECUTE</td>
 <td>Lifecycle management</td>
@@ -775,29 +785,29 @@ mcp_aql_execute  - EXECUTE operations</code></pre>
 <h4 id="841-core-states">8.4.1 Core States</h4>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>State</th>
 <th>Description</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><code>pending</code></td>
 <td>Execution created but not yet started</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>running</code></td>
 <td>Execution actively processing</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>completed</code></td>
 <td>Execution finished successfully</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>failed</code></td>
 <td>Execution terminated with error</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>cancelled</code></td>
 <td>Execution terminated by user request</td>
 </tr>
@@ -836,40 +846,40 @@ mcp_aql_execute  - EXECUTE operations</code></pre>
 </ul>
 <h4 id="843-state-response-format">8.4.3 State Response Format</h4>
 <p>Operations that return execution state SHOULD include:</p>
-<div class="sourceCode" id="cb25"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb25-1"><a href="#cb25-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
-<span id="cb25-2"><a href="#cb25-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;execution_id&quot;</span><span class="fu">:</span> <span class="st">&quot;exec_123&quot;</span><span class="fu">,</span></span>
-<span id="cb25-3"><a href="#cb25-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;status&quot;</span><span class="fu">:</span> <span class="st">&quot;running&quot;</span><span class="fu">,</span></span>
-<span id="cb25-4"><a href="#cb25-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;started_at&quot;</span><span class="fu">:</span> <span class="st">&quot;2026-02-04T10:00:00Z&quot;</span><span class="fu">,</span></span>
-<span id="cb25-5"><a href="#cb25-5" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;progress&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb25-6"><a href="#cb25-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;current&quot;</span><span class="fu">:</span> <span class="dv">45</span><span class="fu">,</span></span>
-<span id="cb25-7"><a href="#cb25-7" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;total&quot;</span><span class="fu">:</span> <span class="dv">100</span><span class="fu">,</span></span>
-<span id="cb25-8"><a href="#cb25-8" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;Processing step 5 of 10&quot;</span></span>
-<span id="cb25-9"><a href="#cb25-9" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
-<span id="cb25-10"><a href="#cb25-10" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<div class="sourceCode" id="cb26"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb26-1"><a href="#cb26-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb26-2"><a href="#cb26-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;execution_id&quot;</span><span class="fu">:</span> <span class="st">&quot;exec_123&quot;</span><span class="fu">,</span></span>
+<span id="cb26-3"><a href="#cb26-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;status&quot;</span><span class="fu">:</span> <span class="st">&quot;running&quot;</span><span class="fu">,</span></span>
+<span id="cb26-4"><a href="#cb26-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;started_at&quot;</span><span class="fu">:</span> <span class="st">&quot;2026-02-04T10:00:00Z&quot;</span><span class="fu">,</span></span>
+<span id="cb26-5"><a href="#cb26-5" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;progress&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb26-6"><a href="#cb26-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;current&quot;</span><span class="fu">:</span> <span class="dv">45</span><span class="fu">,</span></span>
+<span id="cb26-7"><a href="#cb26-7" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;total&quot;</span><span class="fu">:</span> <span class="dv">100</span><span class="fu">,</span></span>
+<span id="cb26-8"><a href="#cb26-8" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;Processing step 5 of 10&quot;</span></span>
+<span id="cb26-9"><a href="#cb26-9" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb26-10"><a href="#cb26-10" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
 <p><strong>Required Fields:</strong> | Field | Type | Description | |-------|------|-------------| | <code>execution_id</code> | string | Unique identifier for the execution | | <code>status</code> | string | Current state (one of the core states) |</p>
 <p><strong>Optional Fields:</strong> | Field | Type | Description | |-------|------|-------------| | <code>started_at</code> | string (ISO 8601) | When execution started | | <code>finished_at</code> | string (ISO 8601) | When execution reached a terminal state | | <code>progress</code> | object | Progress information (see below) | | <code>error</code> | object | Error details if <code>status</code> is <code>failed</code> (see <a href="#53-error-response">Error Response Format</a>) |</p>
 <p><strong>Progress Object:</strong></p>
 <p>When <code>progress</code> is present, at least one of the following SHOULD be included:</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Field</th>
 <th>Type</th>
 <th>Description</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><code>percentage</code></td>
 <td>number</td>
 <td>Completion percentage (0-100) — use for determinate progress</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>current</code> + <code>total</code></td>
 <td>number</td>
 <td>Current and total values — use when count information is available</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>message</code></td>
 <td>string</td>
 <td>Human-readable status — use for indeterminate progress or additional context</td>
@@ -877,35 +887,35 @@ mcp_aql_execute  - EXECUTE operations</code></pre>
 </tbody>
 </table>
 <p><strong>Example — Completed Execution:</strong></p>
-<div class="sourceCode" id="cb26"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb26-1"><a href="#cb26-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
-<span id="cb26-2"><a href="#cb26-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;execution_id&quot;</span><span class="fu">:</span> <span class="st">&quot;exec_123&quot;</span><span class="fu">,</span></span>
-<span id="cb26-3"><a href="#cb26-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;status&quot;</span><span class="fu">:</span> <span class="st">&quot;completed&quot;</span><span class="fu">,</span></span>
-<span id="cb26-4"><a href="#cb26-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;started_at&quot;</span><span class="fu">:</span> <span class="st">&quot;2026-02-04T10:00:00Z&quot;</span><span class="fu">,</span></span>
-<span id="cb26-5"><a href="#cb26-5" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;finished_at&quot;</span><span class="fu">:</span> <span class="st">&quot;2026-02-04T10:05:32Z&quot;</span></span>
-<span id="cb26-6"><a href="#cb26-6" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
-<p><strong>Example — Failed Execution:</strong></p>
 <div class="sourceCode" id="cb27"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb27-1"><a href="#cb27-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
-<span id="cb27-2"><a href="#cb27-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;execution_id&quot;</span><span class="fu">:</span> <span class="st">&quot;exec_456&quot;</span><span class="fu">,</span></span>
-<span id="cb27-3"><a href="#cb27-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;status&quot;</span><span class="fu">:</span> <span class="st">&quot;failed&quot;</span><span class="fu">,</span></span>
+<span id="cb27-2"><a href="#cb27-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;execution_id&quot;</span><span class="fu">:</span> <span class="st">&quot;exec_123&quot;</span><span class="fu">,</span></span>
+<span id="cb27-3"><a href="#cb27-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;status&quot;</span><span class="fu">:</span> <span class="st">&quot;completed&quot;</span><span class="fu">,</span></span>
 <span id="cb27-4"><a href="#cb27-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;started_at&quot;</span><span class="fu">:</span> <span class="st">&quot;2026-02-04T10:00:00Z&quot;</span><span class="fu">,</span></span>
-<span id="cb27-5"><a href="#cb27-5" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;finished_at&quot;</span><span class="fu">:</span> <span class="st">&quot;2026-02-04T10:02:15Z&quot;</span><span class="fu">,</span></span>
-<span id="cb27-6"><a href="#cb27-6" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;error&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb27-7"><a href="#cb27-7" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;code&quot;</span><span class="fu">:</span> <span class="st">&quot;INTERNAL_ERROR&quot;</span><span class="fu">,</span></span>
-<span id="cb27-8"><a href="#cb27-8" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;Connection timeout while processing&quot;</span><span class="fu">,</span></span>
-<span id="cb27-9"><a href="#cb27-9" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;details&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;step&quot;</span><span class="fu">:</span> <span class="st">&quot;data_fetch&quot;</span><span class="fu">,</span> <span class="dt">&quot;attempt&quot;</span><span class="fu">:</span> <span class="dv">3</span> <span class="fu">}</span></span>
-<span id="cb27-10"><a href="#cb27-10" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
-<span id="cb27-11"><a href="#cb27-11" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
-<p><strong>Example — Cancelled Execution:</strong></p>
+<span id="cb27-5"><a href="#cb27-5" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;finished_at&quot;</span><span class="fu">:</span> <span class="st">&quot;2026-02-04T10:05:32Z&quot;</span></span>
+<span id="cb27-6"><a href="#cb27-6" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<p><strong>Example — Failed Execution:</strong></p>
 <div class="sourceCode" id="cb28"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb28-1"><a href="#cb28-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
-<span id="cb28-2"><a href="#cb28-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;execution_id&quot;</span><span class="fu">:</span> <span class="st">&quot;exec_789&quot;</span><span class="fu">,</span></span>
-<span id="cb28-3"><a href="#cb28-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;status&quot;</span><span class="fu">:</span> <span class="st">&quot;cancelled&quot;</span><span class="fu">,</span></span>
+<span id="cb28-2"><a href="#cb28-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;execution_id&quot;</span><span class="fu">:</span> <span class="st">&quot;exec_456&quot;</span><span class="fu">,</span></span>
+<span id="cb28-3"><a href="#cb28-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;status&quot;</span><span class="fu">:</span> <span class="st">&quot;failed&quot;</span><span class="fu">,</span></span>
 <span id="cb28-4"><a href="#cb28-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;started_at&quot;</span><span class="fu">:</span> <span class="st">&quot;2026-02-04T10:00:00Z&quot;</span><span class="fu">,</span></span>
-<span id="cb28-5"><a href="#cb28-5" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;finished_at&quot;</span><span class="fu">:</span> <span class="st">&quot;2026-02-04T10:01:45Z&quot;</span><span class="fu">,</span></span>
-<span id="cb28-6"><a href="#cb28-6" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;progress&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb28-7"><a href="#cb28-7" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;percentage&quot;</span><span class="fu">:</span> <span class="dv">35</span><span class="fu">,</span></span>
-<span id="cb28-8"><a href="#cb28-8" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;Cancelled by user during data processing&quot;</span></span>
-<span id="cb28-9"><a href="#cb28-9" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
-<span id="cb28-10"><a href="#cb28-10" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<span id="cb28-5"><a href="#cb28-5" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;finished_at&quot;</span><span class="fu">:</span> <span class="st">&quot;2026-02-04T10:02:15Z&quot;</span><span class="fu">,</span></span>
+<span id="cb28-6"><a href="#cb28-6" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;error&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb28-7"><a href="#cb28-7" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;code&quot;</span><span class="fu">:</span> <span class="st">&quot;INTERNAL_ERROR&quot;</span><span class="fu">,</span></span>
+<span id="cb28-8"><a href="#cb28-8" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;Connection timeout while processing&quot;</span><span class="fu">,</span></span>
+<span id="cb28-9"><a href="#cb28-9" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;details&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;step&quot;</span><span class="fu">:</span> <span class="st">&quot;data_fetch&quot;</span><span class="fu">,</span> <span class="dt">&quot;attempt&quot;</span><span class="fu">:</span> <span class="dv">3</span> <span class="fu">}</span></span>
+<span id="cb28-10"><a href="#cb28-10" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb28-11"><a href="#cb28-11" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<p><strong>Example — Cancelled Execution:</strong></p>
+<div class="sourceCode" id="cb29"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb29-1"><a href="#cb29-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb29-2"><a href="#cb29-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;execution_id&quot;</span><span class="fu">:</span> <span class="st">&quot;exec_789&quot;</span><span class="fu">,</span></span>
+<span id="cb29-3"><a href="#cb29-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;status&quot;</span><span class="fu">:</span> <span class="st">&quot;cancelled&quot;</span><span class="fu">,</span></span>
+<span id="cb29-4"><a href="#cb29-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;started_at&quot;</span><span class="fu">:</span> <span class="st">&quot;2026-02-04T10:00:00Z&quot;</span><span class="fu">,</span></span>
+<span id="cb29-5"><a href="#cb29-5" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;finished_at&quot;</span><span class="fu">:</span> <span class="st">&quot;2026-02-04T10:01:45Z&quot;</span><span class="fu">,</span></span>
+<span id="cb29-6"><a href="#cb29-6" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;progress&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb29-7"><a href="#cb29-7" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;percentage&quot;</span><span class="fu">:</span> <span class="dv">35</span><span class="fu">,</span></span>
+<span id="cb29-8"><a href="#cb29-8" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;message&quot;</span><span class="fu">:</span> <span class="st">&quot;Cancelled by user during data processing&quot;</span></span>
+<span id="cb29-9"><a href="#cb29-9" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb29-10"><a href="#cb29-10" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
 <h4 id="844-adapter-extensions">8.4.4 Adapter Extensions</h4>
 <p>Adapters MAY define additional states beyond the core set (e.g., <code>paused</code>, <code>queued</code>, <code>retrying</code>). When extending the state machine:</p>
 <ol type="1">
@@ -917,52 +927,53 @@ mcp_aql_execute  - EXECUTE operations</code></pre>
 <p><strong>Example Extended State Mapping:</strong> | Adapter State | Maps To | Description | |---------------|---------|-------------| | <code>queued</code> | <code>pending</code> | Waiting in job queue | | <code>paused</code> | <code>running</code> | Temporarily suspended | | <code>retrying</code> | <code>running</code> | Automatic retry in progress |</p>
 <h4 id="845-introspection-support">8.4.5 Introspection Support</h4>
 <p>EXECUTE operations that manage lifecycle SHOULD expose their supported states via introspection. The <code>lifecycle</code> field in operation details indicates lifecycle support:</p>
-<div class="sourceCode" id="cb29"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb29-1"><a href="#cb29-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
-<span id="cb29-2"><a href="#cb29-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb29-3"><a href="#cb29-3" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;execute_job&quot;</span><span class="fu">,</span></span>
-<span id="cb29-4"><a href="#cb29-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;endpoint&quot;</span><span class="fu">:</span> <span class="st">&quot;EXECUTE&quot;</span><span class="fu">,</span></span>
-<span id="cb29-5"><a href="#cb29-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;lifecycle&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb29-6"><a href="#cb29-6" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;states&quot;</span><span class="fu">:</span> <span class="ot">[</span><span class="st">&quot;pending&quot;</span><span class="ot">,</span> <span class="st">&quot;queued&quot;</span><span class="ot">,</span> <span class="st">&quot;running&quot;</span><span class="ot">,</span> <span class="st">&quot;completed&quot;</span><span class="ot">,</span> <span class="st">&quot;failed&quot;</span><span class="ot">,</span> <span class="st">&quot;cancelled&quot;</span><span class="ot">]</span><span class="fu">,</span></span>
-<span id="cb29-7"><a href="#cb29-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;supports_cancel&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
-<span id="cb29-8"><a href="#cb29-8" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;supports_retry&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
-<span id="cb29-9"><a href="#cb29-9" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;progress_reporting&quot;</span><span class="fu">:</span> <span class="kw">true</span></span>
-<span id="cb29-10"><a href="#cb29-10" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
-<span id="cb29-11"><a href="#cb29-11" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
-<span id="cb29-12"><a href="#cb29-12" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<div class="sourceCode" id="cb30"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb30-1"><a href="#cb30-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb30-2"><a href="#cb30-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb30-3"><a href="#cb30-3" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;execute_job&quot;</span><span class="fu">,</span></span>
+<span id="cb30-4"><a href="#cb30-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;semantic_category&quot;</span><span class="fu">:</span> <span class="st">&quot;EXECUTE&quot;</span><span class="fu">,</span></span>
+<span id="cb30-5"><a href="#cb30-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;endpoint&quot;</span><span class="fu">:</span> <span class="st">&quot;operate&quot;</span><span class="fu">,</span></span>
+<span id="cb30-6"><a href="#cb30-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;lifecycle&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb30-7"><a href="#cb30-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;states&quot;</span><span class="fu">:</span> <span class="ot">[</span><span class="st">&quot;pending&quot;</span><span class="ot">,</span> <span class="st">&quot;queued&quot;</span><span class="ot">,</span> <span class="st">&quot;running&quot;</span><span class="ot">,</span> <span class="st">&quot;completed&quot;</span><span class="ot">,</span> <span class="st">&quot;failed&quot;</span><span class="ot">,</span> <span class="st">&quot;cancelled&quot;</span><span class="ot">]</span><span class="fu">,</span></span>
+<span id="cb30-8"><a href="#cb30-8" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;supports_cancel&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb30-9"><a href="#cb30-9" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;supports_retry&quot;</span><span class="fu">:</span> <span class="kw">false</span><span class="fu">,</span></span>
+<span id="cb30-10"><a href="#cb30-10" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;progress_reporting&quot;</span><span class="fu">:</span> <span class="kw">true</span></span>
+<span id="cb30-11"><a href="#cb30-11" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb30-12"><a href="#cb30-12" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb30-13"><a href="#cb30-13" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
 <p>See <a href="../introspection.html">Introspection Specification</a> for the complete schema.</p>
 <h3 id="85-operation-naming-grammar">8.5 Operation Naming Grammar</h3>
 <h4 id="851-canonical-verbs">8.5.1 Canonical Verbs</h4>
 <p>Each endpoint has one or more canonical verbs that SHOULD be used for standard operations:</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Endpoint</th>
 <th>Canonical Verb</th>
 <th>Usage</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td>CREATE</td>
 <td><code>create</code></td>
 <td>Creating new resources</td>
 </tr>
-<tr>
+<tr class="even">
 <td>READ</td>
 <td><code>get</code> (single), <code>list</code> (multiple)</td>
 <td>Retrieving resources</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>UPDATE</td>
 <td><code>update</code></td>
 <td>Modifying existing resources</td>
 </tr>
-<tr>
+<tr class="even">
 <td>DELETE</td>
 <td><code>delete</code></td>
 <td>Removing resources</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>EXECUTE</td>
 <td><code>execute</code> (initiate), <code>cancel</code> (terminate)</td>
 <td>Lifecycle operations</td>
@@ -974,34 +985,34 @@ mcp_aql_execute  - EXECUTE operations</code></pre>
 <p>For developers familiar with REST conventions, the following mapping provides context:</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Canonical Verb</th>
 <th>Typical HTTP Method</th>
 <th>Semantics</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><code>create</code></td>
 <td>POST</td>
 <td>Add new resource</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>get</code> / <code>list</code></td>
 <td>GET</td>
 <td>Retrieve resource(s)</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>update</code></td>
 <td>PUT / PATCH</td>
 <td>Modify resource</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>delete</code></td>
 <td>DELETE</td>
 <td>Remove resource</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>execute</code> / <code>cancel</code></td>
 <td>POST</td>
 <td>Lifecycle control</td>
@@ -1036,44 +1047,44 @@ mcp_aql_execute  - EXECUTE operations</code></pre>
 <p>The following operation names are reserved for protocol use and MUST NOT be used by adapters for other purposes:</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Operation</th>
 <th>Endpoint</th>
 <th>Purpose</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><code>introspect</code></td>
 <td>READ</td>
 <td>Protocol introspection (Section 7)</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>execute_agent</code></td>
 <td>EXECUTE</td>
 <td>Start execution safety loop (Section 8.6)</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>record_execution_step</code></td>
 <td>CREATE</td>
 <td>Report intended action for safety evaluation (Section 8.6)</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>complete_execution</code></td>
 <td>EXECUTE</td>
 <td>Signal normal execution completion (Section 8.6)</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>abort_execution</code></td>
 <td>EXECUTE</td>
 <td>Signal abnormal execution termination (Section 8.6)</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>confirm_operation</code></td>
 <td>EXECUTE</td>
 <td>Confirm a Gatekeeper-blocked operation or Autonomy Evaluator <code>confirm</code> tier pause (Section 8.7.3)</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>verify_challenge</code></td>
 <td>CREATE</td>
 <td>Submit out-of-band verification code (Section 8.8)</td>
@@ -1095,33 +1106,33 @@ mcp_aql_execute  - EXECUTE operations</code></pre>
 <li>Adapters MUST document whether they support the execution safety loop via introspection</li>
 </ul>
 <p>Adapters that support the execution safety loop SHOULD expose this capability in their introspection response:</p>
-<div class="sourceCode" id="cb30"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb30-1"><a href="#cb30-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
-<span id="cb30-2"><a href="#cb30-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;capabilities&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb30-3"><a href="#cb30-3" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;execution_safety_loop&quot;</span><span class="fu">:</span> <span class="st">&quot;enforcing&quot;</span></span>
-<span id="cb30-4"><a href="#cb30-4" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
-<span id="cb30-5"><a href="#cb30-5" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<div class="sourceCode" id="cb31"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb31-1"><a href="#cb31-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb31-2"><a href="#cb31-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;capabilities&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb31-3"><a href="#cb31-3" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;execution_safety_loop&quot;</span><span class="fu">:</span> <span class="st">&quot;enforcing&quot;</span></span>
+<span id="cb31-4"><a href="#cb31-4" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb31-5"><a href="#cb31-5" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
 <p>Valid values for <code>execution_safety_loop</code>:</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Value</th>
 <th>Meaning</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><code>"enforcing"</code></td>
 <td>Full enforcement — actions are evaluated and directives are authoritative</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>"monitoring"</code></td>
 <td>Actions are evaluated but <code>continue</code> is always <code>true</code> (advisory only)</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>"logging"</code></td>
 <td>Actions are recorded for audit purposes without evaluation</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>"disabled"</code></td>
 <td>Safety loop is supported but currently disabled</td>
 </tr>
@@ -1155,7 +1166,7 @@ mcp_aql_execute  - EXECUTE operations</code></pre>
 <p>The <code>record_execution_step</code> operation accepts the following parameters:</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Parameter</th>
 <th>Type</th>
 <th>Required</th>
@@ -1163,31 +1174,31 @@ mcp_aql_execute  - EXECUTE operations</code></pre>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><code>element_name</code></td>
 <td>string</td>
 <td>MUST</td>
 <td>The agent reporting the step</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>stepDescription</code></td>
 <td>string</td>
 <td>SHOULD</td>
 <td>Description of the action just completed</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>outcome</code></td>
 <td>string</td>
 <td>SHOULD</td>
 <td>Result of the previous step: <code>"success"</code>, <code>"failure"</code>, or <code>"skipped"</code></td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>nextActionHint</code></td>
 <td>string</td>
 <td>MUST</td>
 <td>Description of the intended next action</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>findings</code></td>
 <td>string</td>
 <td>MAY</td>
@@ -1237,26 +1248,26 @@ mcp_aql_execute  - EXECUTE operations</code></pre>
 <li>No action reporting is required</li>
 </ul>
 <p>The adapter MUST clearly indicate via introspection whether safety enforcement is active or disabled:</p>
-<div class="sourceCode" id="cb31"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb31-1"><a href="#cb31-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
-<span id="cb31-2"><a href="#cb31-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;capabilities&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb31-3"><a href="#cb31-3" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;execution_safety_loop&quot;</span><span class="fu">:</span> <span class="st">&quot;disabled&quot;</span></span>
-<span id="cb31-4"><a href="#cb31-4" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
-<span id="cb31-5"><a href="#cb31-5" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<div class="sourceCode" id="cb32"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb32-1"><a href="#cb32-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb32-2"><a href="#cb32-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;capabilities&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb32-3"><a href="#cb32-3" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;execution_safety_loop&quot;</span><span class="fu">:</span> <span class="st">&quot;disabled&quot;</span></span>
+<span id="cb32-4"><a href="#cb32-4" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb32-5"><a href="#cb32-5" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
 <h3 id="87-autonomy-evaluation">8.7 Autonomy Evaluation</h3>
 <p>When the execution safety loop is active, every <code>record_execution_step</code> call triggers an autonomy evaluation. This section defines the evaluation pipeline and the <code>AutonomyDirective</code> response contract.</p>
 <h4 id="871-the-autonomydirective-contract">8.7.1 The AutonomyDirective Contract</h4>
 <p>The <code>AutonomyDirective</code> is returned as part of the <code>record_execution_step</code> response. It is the authoritative signal for whether the agent may proceed.</p>
-<div class="sourceCode" id="cb32"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb32-1"><a href="#cb32-1" aria-hidden="true" tabindex="-1"></a><span class="kw">interface</span> AutonomyDirective {</span>
-<span id="cb32-2"><a href="#cb32-2" aria-hidden="true" tabindex="-1"></a>  <span class="cf">continue</span><span class="op">:</span> <span class="dt">boolean</span><span class="op">;</span>              <span class="co">// Whether the agent may proceed</span></span>
-<span id="cb32-3"><a href="#cb32-3" aria-hidden="true" tabindex="-1"></a>  factors<span class="op">:</span> <span class="dt">string</span>[]<span class="op">;</span>              <span class="co">// Human-readable decision factors</span></span>
-<span id="cb32-4"><a href="#cb32-4" aria-hidden="true" tabindex="-1"></a>  stopped<span class="op">?:</span> <span class="dt">boolean</span><span class="op">;</span>              <span class="co">// True if hard-blocked (Section 8.8)</span></span>
-<span id="cb32-5"><a href="#cb32-5" aria-hidden="true" tabindex="-1"></a>  reason<span class="op">?:</span> <span class="dt">string</span><span class="op">;</span>                <span class="co">// Why paused or stopped</span></span>
-<span id="cb32-6"><a href="#cb32-6" aria-hidden="true" tabindex="-1"></a>  stepsRemaining<span class="op">?:</span> <span class="dt">number</span><span class="op">;</span>        <span class="co">// Steps before mandatory pause</span></span>
-<span id="cb32-7"><a href="#cb32-7" aria-hidden="true" tabindex="-1"></a>  nextStepRisk<span class="op">?:</span> SafetyTier<span class="op">;</span>      <span class="co">// Risk tier of the evaluated action</span></span>
-<span id="cb32-8"><a href="#cb32-8" aria-hidden="true" tabindex="-1"></a>  notifications<span class="op">?:</span> AgentNotification[]<span class="op">;</span> <span class="co">// Pending events (Section 8.7.3)</span></span>
-<span id="cb32-9"><a href="#cb32-9" aria-hidden="true" tabindex="-1"></a>}</span>
-<span id="cb32-10"><a href="#cb32-10" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb32-11"><a href="#cb32-11" aria-hidden="true" tabindex="-1"></a><span class="kw">type</span> SafetyTier <span class="op">=</span> <span class="st">&quot;advisory&quot;</span> <span class="op">|</span> <span class="st">&quot;confirm&quot;</span> <span class="op">|</span> <span class="st">&quot;verify&quot;</span> <span class="op">|</span> <span class="st">&quot;danger_zone&quot;</span><span class="op">;</span></span></code></pre></div>
+<div class="sourceCode" id="cb33"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb33-1"><a href="#cb33-1" aria-hidden="true" tabindex="-1"></a><span class="kw">interface</span> AutonomyDirective {</span>
+<span id="cb33-2"><a href="#cb33-2" aria-hidden="true" tabindex="-1"></a>  <span class="cf">continue</span><span class="op">:</span> <span class="dt">boolean</span><span class="op">;</span>              <span class="co">// Whether the agent may proceed</span></span>
+<span id="cb33-3"><a href="#cb33-3" aria-hidden="true" tabindex="-1"></a>  factors<span class="op">:</span> <span class="dt">string</span>[]<span class="op">;</span>              <span class="co">// Human-readable decision factors</span></span>
+<span id="cb33-4"><a href="#cb33-4" aria-hidden="true" tabindex="-1"></a>  stopped<span class="op">?:</span> <span class="dt">boolean</span><span class="op">;</span>              <span class="co">// True if hard-blocked (Section 8.8)</span></span>
+<span id="cb33-5"><a href="#cb33-5" aria-hidden="true" tabindex="-1"></a>  reason<span class="op">?:</span> <span class="dt">string</span><span class="op">;</span>                <span class="co">// Why paused or stopped</span></span>
+<span id="cb33-6"><a href="#cb33-6" aria-hidden="true" tabindex="-1"></a>  stepsRemaining<span class="op">?:</span> <span class="dt">number</span><span class="op">;</span>        <span class="co">// Steps before mandatory pause</span></span>
+<span id="cb33-7"><a href="#cb33-7" aria-hidden="true" tabindex="-1"></a>  nextStepRisk<span class="op">?:</span> SafetyTier<span class="op">;</span>      <span class="co">// Risk tier of the evaluated action</span></span>
+<span id="cb33-8"><a href="#cb33-8" aria-hidden="true" tabindex="-1"></a>  notifications<span class="op">?:</span> AgentNotification[]<span class="op">;</span> <span class="co">// Pending events (Section 8.7.3)</span></span>
+<span id="cb33-9"><a href="#cb33-9" aria-hidden="true" tabindex="-1"></a>}</span>
+<span id="cb33-10"><a href="#cb33-10" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb33-11"><a href="#cb33-11" aria-hidden="true" tabindex="-1"></a><span class="kw">type</span> SafetyTier <span class="op">=</span> <span class="st">&quot;advisory&quot;</span> <span class="op">|</span> <span class="st">&quot;confirm&quot;</span> <span class="op">|</span> <span class="st">&quot;verify&quot;</span> <span class="op">|</span> <span class="st">&quot;danger_zone&quot;</span><span class="op">;</span></span></code></pre></div>
 <p>Implementations MUST include <code>continue</code> and <code>factors</code> in every <code>AutonomyDirective</code>. All other fields are OPTIONAL except where specific sections impose MUST requirements (see Sections 8.8.1 and 8.8.2 for mandatory <code>notifications</code> in <code>verify</code> tier, <code>danger_zone</code> tier, and <code>deny</code> pattern scenarios).</p>
 <h4 id="872-evaluation-pipeline">8.7.2 Evaluation Pipeline</h4>
 <p>Implementations SHOULD evaluate actions through a multi-stage pipeline. The stages are evaluated in order; the first stage that triggers a pause or stop ends the evaluation:</p>
@@ -1284,38 +1295,38 @@ mcp_aql_execute  - EXECUTE operations</code></pre>
 <li>Unmatched actions fall through to Stage 4</li>
 </ul>
 <p>Pattern examples:</p>
-<div class="sourceCode" id="cb33"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb33-1"><a href="#cb33-1" aria-hidden="true" tabindex="-1"></a>{</span>
-<span id="cb33-2"><a href="#cb33-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">deny</span><span class="op">:</span> [<span class="st">&quot;drop_*&quot;</span><span class="op">,</span> <span class="st">&quot;delete_all*&quot;</span><span class="op">,</span> <span class="st">&quot;rm -rf*&quot;</span>]<span class="op">,</span></span>
-<span id="cb33-3"><a href="#cb33-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">requiresApproval</span><span class="op">:</span> [<span class="st">&quot;delete_*&quot;</span><span class="op">,</span> <span class="st">&quot;*force*&quot;</span><span class="op">,</span> <span class="st">&quot;deploy_*&quot;</span><span class="op">,</span> <span class="st">&quot;git push*&quot;</span>]<span class="op">,</span></span>
-<span id="cb33-4"><a href="#cb33-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">autoApprove</span><span class="op">:</span> [<span class="st">&quot;read_*&quot;</span><span class="op">,</span> <span class="st">&quot;list_*&quot;</span><span class="op">,</span> <span class="st">&quot;get_*&quot;</span><span class="op">,</span> <span class="st">&quot;search_*&quot;</span>]</span>
-<span id="cb33-5"><a href="#cb33-5" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<div class="sourceCode" id="cb34"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb34-1"><a href="#cb34-1" aria-hidden="true" tabindex="-1"></a>{</span>
+<span id="cb34-2"><a href="#cb34-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">deny</span><span class="op">:</span> [<span class="st">&quot;drop_*&quot;</span><span class="op">,</span> <span class="st">&quot;delete_all*&quot;</span><span class="op">,</span> <span class="st">&quot;rm -rf*&quot;</span>]<span class="op">,</span></span>
+<span id="cb34-3"><a href="#cb34-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">requiresApproval</span><span class="op">:</span> [<span class="st">&quot;delete_*&quot;</span><span class="op">,</span> <span class="st">&quot;*force*&quot;</span><span class="op">,</span> <span class="st">&quot;deploy_*&quot;</span><span class="op">,</span> <span class="st">&quot;git push*&quot;</span>]<span class="op">,</span></span>
+<span id="cb34-4"><a href="#cb34-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">autoApprove</span><span class="op">:</span> [<span class="st">&quot;read_*&quot;</span><span class="op">,</span> <span class="st">&quot;list_*&quot;</span><span class="op">,</span> <span class="st">&quot;get_*&quot;</span><span class="op">,</span> <span class="st">&quot;search_*&quot;</span>]</span>
+<span id="cb34-5"><a href="#cb34-5" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
 <p><strong>Stage 4 — Safety Tier Evaluation:</strong></p>
 <p>Assigns a risk score (0-100) to the action and maps it to a safety tier:</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Risk Score</th>
 <th>Tier</th>
 <th>Default Behavior</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td>0-30</td>
 <td><code>advisory</code></td>
 <td>Continue (log only)</td>
 </tr>
-<tr>
+<tr class="even">
 <td>31-60</td>
 <td><code>confirm</code></td>
 <td>Pause for human review via <code>confirm_operation</code></td>
 </tr>
-<tr>
+<tr class="odd">
 <td>61-85</td>
 <td><code>verify</code></td>
 <td>Pause + out-of-band verification via <code>verify_challenge</code> (Section 8.8)</td>
 </tr>
-<tr>
+<tr class="even">
 <td>86-100</td>
 <td><code>danger_zone</code></td>
 <td>Hard stop + out-of-band verification via <code>verify_challenge</code> (Section 8.8)</td>
@@ -1328,24 +1339,24 @@ mcp_aql_execute  - EXECUTE operations</code></pre>
 <p>Compares the risk score against the agent's configured tolerance:</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Tolerance</th>
 <th>Threshold</th>
 <th>Behavior</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><code>conservative</code></td>
 <td>25</td>
 <td>Pause for any risk above 25</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>moderate</code></td>
 <td>50</td>
 <td>Pause for risk above 50 (default)</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>aggressive</code></td>
 <td>75</td>
 <td>Pause only for high risk above 75</td>
@@ -1355,24 +1366,24 @@ mcp_aql_execute  - EXECUTE operations</code></pre>
 <p>Actions with risk scores below the threshold in the <code>advisory</code> tier MAY proceed without pausing.</p>
 <h4 id="873-agent-notification-system">8.7.3 Agent Notification System</h4>
 <p>Notifications inform the agent of events that occurred since the last <code>record_execution_step</code> call. They are included in the <code>AutonomyDirective</code> response.</p>
-<div class="sourceCode" id="cb34"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb34-1"><a href="#cb34-1" aria-hidden="true" tabindex="-1"></a><span class="kw">interface</span> AgentNotification {</span>
-<span id="cb34-2"><a href="#cb34-2" aria-hidden="true" tabindex="-1"></a>  type<span class="op">:</span> NotificationType<span class="op">;</span></span>
-<span id="cb34-3"><a href="#cb34-3" aria-hidden="true" tabindex="-1"></a>  message<span class="op">:</span> <span class="dt">string</span><span class="op">;</span>               <span class="co">// Human-readable description</span></span>
-<span id="cb34-4"><a href="#cb34-4" aria-hidden="true" tabindex="-1"></a>  metadata<span class="op">?:</span> {</span>
-<span id="cb34-5"><a href="#cb34-5" aria-hidden="true" tabindex="-1"></a>    operation<span class="op">?:</span> <span class="dt">string</span><span class="op">;</span>          <span class="co">// Operation that triggered the event</span></span>
-<span id="cb34-6"><a href="#cb34-6" aria-hidden="true" tabindex="-1"></a>    reason<span class="op">?:</span> <span class="dt">string</span><span class="op">;</span>             <span class="co">// Detailed reason</span></span>
-<span id="cb34-7"><a href="#cb34-7" aria-hidden="true" tabindex="-1"></a>    level<span class="op">?:</span> <span class="dt">string</span><span class="op">;</span>              <span class="co">// Permission level that caused the block</span></span>
-<span id="cb34-8"><a href="#cb34-8" aria-hidden="true" tabindex="-1"></a>    verificationId<span class="op">?:</span> <span class="dt">string</span><span class="op">;</span>     <span class="co">// For verify and danger_zone challenges</span></span>
-<span id="cb34-9"><a href="#cb34-9" aria-hidden="true" tabindex="-1"></a>  }<span class="op">;</span></span>
-<span id="cb34-10"><a href="#cb34-10" aria-hidden="true" tabindex="-1"></a>  timestamp<span class="op">:</span> <span class="dt">string</span><span class="op">;</span>             <span class="co">// ISO 8601</span></span>
-<span id="cb34-11"><a href="#cb34-11" aria-hidden="true" tabindex="-1"></a>}</span>
-<span id="cb34-12"><a href="#cb34-12" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb34-13"><a href="#cb34-13" aria-hidden="true" tabindex="-1"></a><span class="kw">type</span> NotificationType <span class="op">=</span></span>
-<span id="cb34-14"><a href="#cb34-14" aria-hidden="true" tabindex="-1"></a>  <span class="op">|</span> <span class="st">&quot;permission_pending&quot;</span>    <span class="co">// Gatekeeper blocked an operation</span></span>
-<span id="cb34-15"><a href="#cb34-15" aria-hidden="true" tabindex="-1"></a>  <span class="op">|</span> <span class="st">&quot;autonomy_pause&quot;</span>        <span class="co">// Autonomy Evaluator paused execution</span></span>
-<span id="cb34-16"><a href="#cb34-16" aria-hidden="true" tabindex="-1"></a>  <span class="op">|</span> <span class="st">&quot;danger_zone&quot;</span>           <span class="co">// Danger Zone hard block (system-wide broadcast)</span></span>
-<span id="cb34-17"><a href="#cb34-17" aria-hidden="true" tabindex="-1"></a>  <span class="op">|</span> <span class="st">&quot;status&quot;</span>                <span class="co">// Informational status update</span></span>
-<span id="cb34-18"><a href="#cb34-18" aria-hidden="true" tabindex="-1"></a>  <span class="op">|</span> <span class="st">&quot;error&quot;</span><span class="op">;</span>                <span class="co">// Error condition</span></span></code></pre></div>
+<div class="sourceCode" id="cb35"><pre class="sourceCode typescript"><code class="sourceCode typescript"><span id="cb35-1"><a href="#cb35-1" aria-hidden="true" tabindex="-1"></a><span class="kw">interface</span> AgentNotification {</span>
+<span id="cb35-2"><a href="#cb35-2" aria-hidden="true" tabindex="-1"></a>  type<span class="op">:</span> NotificationType<span class="op">;</span></span>
+<span id="cb35-3"><a href="#cb35-3" aria-hidden="true" tabindex="-1"></a>  message<span class="op">:</span> <span class="dt">string</span><span class="op">;</span>               <span class="co">// Human-readable description</span></span>
+<span id="cb35-4"><a href="#cb35-4" aria-hidden="true" tabindex="-1"></a>  metadata<span class="op">?:</span> {</span>
+<span id="cb35-5"><a href="#cb35-5" aria-hidden="true" tabindex="-1"></a>    operation<span class="op">?:</span> <span class="dt">string</span><span class="op">;</span>          <span class="co">// Operation that triggered the event</span></span>
+<span id="cb35-6"><a href="#cb35-6" aria-hidden="true" tabindex="-1"></a>    reason<span class="op">?:</span> <span class="dt">string</span><span class="op">;</span>             <span class="co">// Detailed reason</span></span>
+<span id="cb35-7"><a href="#cb35-7" aria-hidden="true" tabindex="-1"></a>    level<span class="op">?:</span> <span class="dt">string</span><span class="op">;</span>              <span class="co">// Permission level that caused the block</span></span>
+<span id="cb35-8"><a href="#cb35-8" aria-hidden="true" tabindex="-1"></a>    verificationId<span class="op">?:</span> <span class="dt">string</span><span class="op">;</span>     <span class="co">// For verify and danger_zone challenges</span></span>
+<span id="cb35-9"><a href="#cb35-9" aria-hidden="true" tabindex="-1"></a>  }<span class="op">;</span></span>
+<span id="cb35-10"><a href="#cb35-10" aria-hidden="true" tabindex="-1"></a>  timestamp<span class="op">:</span> <span class="dt">string</span><span class="op">;</span>             <span class="co">// ISO 8601</span></span>
+<span id="cb35-11"><a href="#cb35-11" aria-hidden="true" tabindex="-1"></a>}</span>
+<span id="cb35-12"><a href="#cb35-12" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb35-13"><a href="#cb35-13" aria-hidden="true" tabindex="-1"></a><span class="kw">type</span> NotificationType <span class="op">=</span></span>
+<span id="cb35-14"><a href="#cb35-14" aria-hidden="true" tabindex="-1"></a>  <span class="op">|</span> <span class="st">&quot;permission_pending&quot;</span>    <span class="co">// Gatekeeper blocked an operation</span></span>
+<span id="cb35-15"><a href="#cb35-15" aria-hidden="true" tabindex="-1"></a>  <span class="op">|</span> <span class="st">&quot;autonomy_pause&quot;</span>        <span class="co">// Autonomy Evaluator paused execution</span></span>
+<span id="cb35-16"><a href="#cb35-16" aria-hidden="true" tabindex="-1"></a>  <span class="op">|</span> <span class="st">&quot;danger_zone&quot;</span>           <span class="co">// Danger Zone hard block (system-wide broadcast)</span></span>
+<span id="cb35-17"><a href="#cb35-17" aria-hidden="true" tabindex="-1"></a>  <span class="op">|</span> <span class="st">&quot;status&quot;</span>                <span class="co">// Informational status update</span></span>
+<span id="cb35-18"><a href="#cb35-18" aria-hidden="true" tabindex="-1"></a>  <span class="op">|</span> <span class="st">&quot;error&quot;</span><span class="op">;</span>                <span class="co">// Error condition</span></span></code></pre></div>
 <p><strong>Notification sources:</strong></p>
 <ul>
 <li><strong><code>permission_pending</code>:</strong> Generated when the Gatekeeper denies an operation that requires confirmation. Cleared when <code>confirm_operation</code> is called with a valid confirmation token for the blocked operation. Failed or invalid confirmation attempts do not clear the notification.</li>
@@ -1385,34 +1396,34 @@ mcp_aql_execute  - EXECUTE operations</code></pre>
 <p>The following elements of the evaluation pipeline SHOULD be configurable per agent or per adapter:</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Element</th>
 <th>Type</th>
 <th>Description</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><code>maxAutonomousSteps</code></td>
 <td>number</td>
 <td>Maximum steps before mandatory pause</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>riskTolerance</code></td>
 <td>string</td>
 <td><code>"conservative"</code>, <code>"moderate"</code>, or <code>"aggressive"</code></td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>deny</code></td>
 <td>string[]</td>
 <td>Glob patterns that trigger hard block and out-of-band verification (Section 8.8)</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>requiresApproval</code></td>
 <td>string[]</td>
 <td>Glob patterns that always require human review</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>autoApprove</code></td>
 <td>string[]</td>
 <td>Glob patterns that bypass evaluation</td>
@@ -1424,34 +1435,34 @@ mcp_aql_execute  - EXECUTE operations</code></pre>
 <p>Not all stages of the evaluation pipeline are equally important. The following defines the minimum requirements:</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Stage</th>
 <th>Requirement</th>
 <th>Rationale</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td>Step Limit</td>
 <td>MUST</td>
 <td>Prevents runaway autonomous execution</td>
 </tr>
-<tr>
+<tr class="even">
 <td>Previous Outcome</td>
 <td>SHOULD</td>
 <td>Prevents cascading failures</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>Pattern Matching</td>
 <td>SHOULD</td>
 <td>Primary safety control mechanism</td>
 </tr>
-<tr>
+<tr class="even">
 <td>Safety Tier</td>
 <td>MAY</td>
 <td>Requires risk scoring capability</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>Risk Tolerance</td>
 <td>MAY</td>
 <td>Depends on Safety Tier implementation</td>
@@ -1536,34 +1547,34 @@ mcp_aql_execute  - EXECUTE operations</code></pre>
 <p>This specification defines the <strong>verification protocol</strong>, not the display mechanism. Implementations MAY use any display channel that satisfies the channel separation requirements (Section 8.8.4):</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Channel</th>
 <th>Platform</th>
 <th>Notes</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td>OS dialog</td>
 <td>Desktop</td>
 <td>AppleScript, zenity, PowerShell</td>
 </tr>
-<tr>
+<tr class="even">
 <td>Hardware token</td>
 <td>Any</td>
 <td>Physical device with display</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>SMS/Email</td>
 <td>Any</td>
 <td>Requires operator contact info</td>
 </tr>
-<tr>
+<tr class="even">
 <td>Security dashboard</td>
 <td>Web</td>
 <td>Dedicated approval interface</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>Mobile push notification</td>
 <td>Any</td>
 <td>Requires companion app</td>
@@ -1575,7 +1586,7 @@ mcp_aql_execute  - EXECUTE operations</code></pre>
 <h2 id="9-type-system">9. Type System</h2>
 <h3 id="91-protocol-types">9.1 Protocol Types</h3>
 <p>MCP-AQL defines these protocol-level types:</p>
-<p><strong>EndpointCategory</strong> (enum)</p>
+<p><strong>SemanticCategory</strong> (enum)</p>
 <pre><code>CREATE | READ | UPDATE | DELETE | EXECUTE</code></pre>
 <p><strong>OperationResult</strong> (union)</p>
 <pre><code>OperationSuccess | OperationFailure</code></pre>
@@ -1588,25 +1599,25 @@ mcp_aql_execute  - EXECUTE operations</code></pre>
 <p>Adapters MUST document their concurrency behavior. The following concurrency categories are defined:</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Category</th>
 <th>Description</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><code>serialized</code></td>
 <td>All requests processed sequentially in arrival order</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>read-concurrent</code></td>
 <td>READ operations may execute concurrently; writes serialized</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><code>fully-concurrent</code></td>
 <td>All operations may execute concurrently</td>
 </tr>
-<tr>
+<tr class="even">
 <td><code>resource-locked</code></td>
 <td>Concurrent on different resources; serialized per resource</td>
 </tr>
@@ -1620,47 +1631,48 @@ mcp_aql_execute  - EXECUTE operations</code></pre>
 <li><strong>Conflict Detection:</strong> Return <code>CONFLICT_VERSION_MISMATCH</code> error when precondition fails</li>
 </ol>
 <p><strong>Example response with version:</strong></p>
-<div class="sourceCode" id="cb37"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb37-1"><a href="#cb37-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
-<span id="cb37-2"><a href="#cb37-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
-<span id="cb37-3"><a href="#cb37-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;data&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb37-4"><a href="#cb37-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;id&quot;</span><span class="fu">:</span> <span class="st">&quot;doc_123&quot;</span><span class="fu">,</span></span>
-<span id="cb37-5"><a href="#cb37-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;title&quot;</span><span class="fu">:</span> <span class="st">&quot;My Document&quot;</span><span class="fu">,</span></span>
-<span id="cb37-6"><a href="#cb37-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;_etag&quot;</span><span class="fu">:</span> <span class="st">&quot;W/</span><span class="ch">\&quot;</span><span class="st">a1b2c3d4</span><span class="ch">\&quot;</span><span class="st">&quot;</span></span>
-<span id="cb37-7"><a href="#cb37-7" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
-<span id="cb37-8"><a href="#cb37-8" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
-<p><strong>Example conditional update:</strong></p>
 <div class="sourceCode" id="cb38"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb38-1"><a href="#cb38-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
-<span id="cb38-2"><a href="#cb38-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;update_document&quot;</span><span class="fu">,</span></span>
-<span id="cb38-3"><a href="#cb38-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb38-2"><a href="#cb38-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;success&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb38-3"><a href="#cb38-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;data&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
 <span id="cb38-4"><a href="#cb38-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;id&quot;</span><span class="fu">:</span> <span class="st">&quot;doc_123&quot;</span><span class="fu">,</span></span>
-<span id="cb38-5"><a href="#cb38-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;title&quot;</span><span class="fu">:</span> <span class="st">&quot;Updated Title&quot;</span><span class="fu">,</span></span>
-<span id="cb38-6"><a href="#cb38-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;if_match&quot;</span><span class="fu">:</span> <span class="st">&quot;W/</span><span class="ch">\&quot;</span><span class="st">a1b2c3d4</span><span class="ch">\&quot;</span><span class="st">&quot;</span></span>
+<span id="cb38-5"><a href="#cb38-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;title&quot;</span><span class="fu">:</span> <span class="st">&quot;My Document&quot;</span><span class="fu">,</span></span>
+<span id="cb38-6"><a href="#cb38-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;_etag&quot;</span><span class="fu">:</span> <span class="st">&quot;W/</span><span class="ch">\&quot;</span><span class="st">a1b2c3d4</span><span class="ch">\&quot;</span><span class="st">&quot;</span></span>
 <span id="cb38-7"><a href="#cb38-7" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
 <span id="cb38-8"><a href="#cb38-8" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<p><strong>Example conditional update:</strong></p>
+<div class="sourceCode" id="cb39"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb39-1"><a href="#cb39-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb39-2"><a href="#cb39-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;operation&quot;</span><span class="fu">:</span> <span class="st">&quot;update_document&quot;</span><span class="fu">,</span></span>
+<span id="cb39-3"><a href="#cb39-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;params&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb39-4"><a href="#cb39-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;id&quot;</span><span class="fu">:</span> <span class="st">&quot;doc_123&quot;</span><span class="fu">,</span></span>
+<span id="cb39-5"><a href="#cb39-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;title&quot;</span><span class="fu">:</span> <span class="st">&quot;Updated Title&quot;</span><span class="fu">,</span></span>
+<span id="cb39-6"><a href="#cb39-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;if_match&quot;</span><span class="fu">:</span> <span class="st">&quot;W/</span><span class="ch">\&quot;</span><span class="st">a1b2c3d4</span><span class="ch">\&quot;</span><span class="st">&quot;</span></span>
+<span id="cb39-7"><a href="#cb39-7" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb39-8"><a href="#cb39-8" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
 <h4 id="933-concurrency-metadata">9.3.3 Concurrency Metadata</h4>
 <p>Adapters MAY expose concurrency behavior via introspection in protocol metadata:</p>
-<div class="sourceCode" id="cb39"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb39-1"><a href="#cb39-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
-<span id="cb39-2"><a href="#cb39-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;_protocol&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb39-3"><a href="#cb39-3" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;concurrency&quot;</span><span class="fu">:</span> <span class="st">&quot;resource-locked&quot;</span><span class="fu">,</span></span>
-<span id="cb39-4"><a href="#cb39-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;supports_etag&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
-<span id="cb39-5"><a href="#cb39-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;max_concurrent_requests&quot;</span><span class="fu">:</span> <span class="dv">10</span></span>
-<span id="cb39-6"><a href="#cb39-6" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
-<span id="cb39-7"><a href="#cb39-7" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<div class="sourceCode" id="cb40"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb40-1"><a href="#cb40-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb40-2"><a href="#cb40-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;_protocol&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb40-3"><a href="#cb40-3" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;concurrency&quot;</span><span class="fu">:</span> <span class="st">&quot;resource-locked&quot;</span><span class="fu">,</span></span>
+<span id="cb40-4"><a href="#cb40-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;supports_etag&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
+<span id="cb40-5"><a href="#cb40-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;max_concurrent_requests&quot;</span><span class="fu">:</span> <span class="dv">10</span></span>
+<span id="cb40-6"><a href="#cb40-6" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb40-7"><a href="#cb40-7" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
 <hr />
 <h2 id="10-conformance">10. Conformance</h2>
 <h3 id="101-conformance-levels">10.1 Conformance Levels</h3>
 <p><strong>Level 1: Basic Conformance</strong></p>
 <ul>
-<li>MUST support at least one endpoint mode (CRUDE or Single)</li>
+<li>MUST support at least one endpoint mode (<code>semantic</code> or <code>single</code>)</li>
 <li>MUST implement the <code>introspect</code> operation</li>
 <li>MUST use standard request/response formats</li>
-<li>MUST classify operations correctly into CRUDE endpoints</li>
-<li>MUST reject operations sent to wrong endpoints (CRUDE mode)</li>
+<li>MUST classify operations correctly into standard semantic categories</li>
+<li>MUST document each operation's exposed endpoint family and semantic category via introspection</li>
+<li>MUST reject operations sent to wrong endpoints in semantic endpoint mode</li>
 </ul>
 <p><strong>Level 2: Full Conformance</strong></p>
 <ul>
 <li>MUST meet Level 1 requirements</li>
-<li>MUST support both CRUDE and Single endpoint modes</li>
+<li>MUST support both <code>semantic</code> and <code>single</code> endpoint modes</li>
 <li>MUST pass the conformance test suite</li>
 <li>SHOULD implement field selection</li>
 <li>SHOULD implement batch operations</li>
@@ -1684,7 +1696,7 @@ mcp_aql_execute  - EXECUTE operations</code></pre>
 <h3 id="a1-measured-token-costs">A.1 Measured Token Costs</h3>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Configuration</th>
 <th>Tools</th>
 <th>Tokens</th>
@@ -1692,19 +1704,19 @@ mcp_aql_execute  - EXECUTE operations</code></pre>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td>Discrete Tools</td>
 <td>50+</td>
 <td>~29,600</td>
 <td>Baseline</td>
 </tr>
-<tr>
-<td>CRUDE Mode</td>
+<tr class="even">
+<td>Semantic Endpoint Mode (CRUDE profile)</td>
 <td>5</td>
 <td>~4,300</td>
 <td>~85%</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>Single Mode</td>
 <td>1</td>
 <td>~1,100</td>
@@ -1731,10 +1743,10 @@ mcp_aql_execute  - EXECUTE operations</code></pre>
 </ul>
 <h3 id="implementation-documentation">Implementation Documentation</h3>
 <ul>
-<li><a href="../../adapter-reference/architecture/overview.html">Architecture Overview</a> (in mcpaql-adapter repo)</li>
-<li><a href="../../adapter-reference/architecture/runtime.html">Universal Adapter Runtime</a> (in mcpaql-adapter repo)</li>
-<li><a href="../../adapter-reference/architecture/plugin-system.html">Plugin System Implementation</a> (in mcpaql-adapter repo)</li>
-<li><a href="../../adapter-reference/guides/development.html">Development Guide</a> (in mcpaql-adapter repo)</li>
+<li><a href="https://github.com/MCPAQL/mcpaql-adapter/blob/develop/docs/architecture/overview.md">Architecture Overview</a> (in mcpaql-adapter repo)</li>
+<li><a href="https://github.com/MCPAQL/mcpaql-adapter/blob/develop/docs/architecture/runtime.md">Universal Adapter Runtime</a> (in mcpaql-adapter repo)</li>
+<li><a href="https://github.com/MCPAQL/mcpaql-adapter/blob/develop/docs/architecture/plugin-system.md">Plugin System Implementation</a> (in mcpaql-adapter repo)</li>
+<li><a href="https://github.com/MCPAQL/mcpaql-adapter/blob/develop/docs/guides/development.md">Development Guide</a> (in mcpaql-adapter repo)</li>
 </ul>
 <h3 id="examples">Examples</h3>
 <ul>
@@ -1757,24 +1769,24 @@ mcp_aql_execute  - EXECUTE operations</code></pre>
 <h2 id="appendix-c-change-log">Appendix C: Change Log</h2>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Version</th>
 <th>Date</th>
 <th>Changes</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td>1.0.0-draft</td>
 <td>2026-01-05</td>
 <td>Initial draft specification</td>
 </tr>
-<tr>
+<tr class="even">
 <td>1.0.0-draft</td>
 <td>2026-01-14</td>
 <td>Revised to be adapter-agnostic</td>
 </tr>
-<tr>
+<tr class="odd">
 <td>1.0.0-draft</td>
 <td>2026-01-16</td>
 <td>Added schema references, updated documentation links, renamed EndpointCategory</td>
@@ -1786,25 +1798,25 @@ mcp_aql_execute  - EXECUTE operations</code></pre>
 <p>Formal JSON Schema definitions are provided for validation:</p>
 <table>
 <thead>
-<tr>
+<tr class="header">
 <th>Schema</th>
 <th>Description</th>
 </tr>
 </thead>
 <tbody>
-<tr>
+<tr class="odd">
 <td><a href="https://github.com/MCPAQL/spec/blob/main/schemas/operation-input.schema.json">operation-input.schema.json</a></td>
 <td>Request format validation</td>
 </tr>
-<tr>
+<tr class="even">
 <td><a href="https://github.com/MCPAQL/spec/blob/main/schemas/operation-result.schema.json">operation-result.schema.json</a></td>
 <td>Response format validation</td>
 </tr>
-<tr>
+<tr class="odd">
 <td><a href="https://github.com/MCPAQL/spec/blob/main/schemas/introspection-response.schema.json">introspection-response.schema.json</a></td>
 <td>Introspection response validation</td>
 </tr>
-<tr>
+<tr class="even">
 <td><a href="https://github.com/MCPAQL/spec/blob/main/schemas/danger-level.schema.json">danger-level.schema.json</a></td>
 <td>Operation danger classification</td>
 </tr>


### PR DESCRIPTION
## Summary
- regenerate the website-hosted spec mirror from the latest `MCPAQL/spec` `main`
- refresh website search entries for the generated spec pages

## Notes
- this PR was generated by the spec sync workflow, but Actions is currently not permitted to create PRs in this repo
- adapter mirror content is intentionally left untouched by this sync