### PR TITLE
chore: sync website spec mirror from latest spec main

### DIFF
--- a/.lighthouserc.json
+++ b/.lighthouserc.json
@@ -2,7 +2,7 @@
   "ci": {
     "collect": {
       "staticDistDir": "./public",
-      "numberOfRuns": 1,
+      "numberOfRuns": 3,
       "url": [
         "/index.html",
         "/docs/index.html",

--- a/public/adapter-reference/adr/ADR-001-plugin-pipeline-order.html
+++ b/public/adapter-reference/adr/ADR-001-plugin-pipeline-order.html
@@ -7,7 +7,9 @@
   <title>MCP-AQL Adapter Reference | ADR-001: Plugin Pipeline Order</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="../../css/style.css">
 </head>
 <body>
@@ -158,6 +160,6 @@
     </div>
   </footer>
 
-  <script src="../../js/search.js"></script>
+  <script src="../../js/search.js" defer></script>
 </body>
 </html>

--- a/public/adapter-reference/adr/ADR-002-schema-driven-dispatch.html
+++ b/public/adapter-reference/adr/ADR-002-schema-driven-dispatch.html
@@ -7,7 +7,9 @@
   <title>MCP-AQL Adapter Reference | ADR-002: Schema-Driven Dispatch over Code Generation</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="../../css/style.css">
 </head>
 <body>
@@ -188,6 +190,6 @@
     </div>
   </footer>
 
-  <script src="../../js/search.js"></script>
+  <script src="../../js/search.js" defer></script>
 </body>
 </html>

--- a/public/adapter-reference/adr/ADR-003-stateless-plugins.html
+++ b/public/adapter-reference/adr/ADR-003-stateless-plugins.html
@@ -7,7 +7,9 @@
   <title>MCP-AQL Adapter Reference | ADR-003: Stateless Singleton Plugins</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="../../css/style.css">
 </head>
 <body>
@@ -153,6 +155,6 @@
     </div>
   </footer>
 
-  <script src="../../js/search.js"></script>
+  <script src="../../js/search.js" defer></script>
 </body>
 </html>

--- a/public/adapter-reference/adr/README.html
+++ b/public/adapter-reference/adr/README.html
@@ -7,7 +7,9 @@
   <title>MCP-AQL Adapter Reference | Architecture Decision Records</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="../../css/style.css">
 </head>
 <body>
@@ -133,6 +135,6 @@
     </div>
   </footer>
 
-  <script src="../../js/search.js"></script>
+  <script src="../../js/search.js" defer></script>
 </body>
 </html>

--- a/public/adapter-reference/architecture/dispatch.html
+++ b/public/adapter-reference/architecture/dispatch.html
@@ -7,7 +7,9 @@
   <title>MCP-AQL Adapter Reference | Schema-Driven Dispatch</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="../../css/style.css">
 </head>
 <body>
@@ -447,6 +449,6 @@
     </div>
   </footer>
 
-  <script src="../../js/search.js"></script>
+  <script src="../../js/search.js" defer></script>
 </body>
 </html>

--- a/public/adapter-reference/architecture/overview.html
+++ b/public/adapter-reference/architecture/overview.html
@@ -7,7 +7,9 @@
   <title>MCP-AQL Adapter Reference | MCP-AQL Architecture Overview</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="../../css/style.css">
 </head>
 <body>
@@ -381,6 +383,6 @@ DELETE → DELETE</code></pre>
     </div>
   </footer>
 
-  <script src="../../js/search.js"></script>
+  <script src="../../js/search.js" defer></script>
 </body>
 </html>

--- a/public/adapter-reference/architecture/plugin-system.html
+++ b/public/adapter-reference/architecture/plugin-system.html
@@ -7,7 +7,9 @@
   <title>MCP-AQL Adapter Reference | Plugin System Implementation</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="../../css/style.css">
 </head>
 <body>
@@ -604,6 +606,6 @@ result: &quot;GET /repos/octocat/Hello-World/issues/42&quot;</code></pre>
     </div>
   </footer>
 
-  <script src="../../js/search.js"></script>
+  <script src="../../js/search.js" defer></script>
 </body>
 </html>

--- a/public/adapter-reference/architecture/runtime.html
+++ b/public/adapter-reference/architecture/runtime.html
@@ -7,7 +7,9 @@
   <title>MCP-AQL Adapter Reference | Universal Adapter Runtime Specification</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="../../css/style.css">
 </head>
 <body>
@@ -1121,6 +1123,6 @@ result: &quot;GET /repos/octocat/Hello-World&quot;</code></pre>
     </div>
   </footer>
 
-  <script src="../../js/search.js"></script>
+  <script src="../../js/search.js" defer></script>
 </body>
 </html>

--- a/public/adapter-reference/examples/README.html
+++ b/public/adapter-reference/examples/README.html
@@ -7,7 +7,9 @@
   <title>MCP-AQL Adapter Reference | Examples</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="../../css/style.css">
 </head>
 <body>
@@ -146,6 +148,6 @@
     </div>
   </footer>
 
-  <script src="../../js/search.js"></script>
+  <script src="../../js/search.js" defer></script>
 </body>
 </html>

--- a/public/adapter-reference/guides/development.html
+++ b/public/adapter-reference/guides/development.html
@@ -7,7 +7,9 @@
   <title>MCP-AQL Adapter Reference | MCP-AQL Adapter Development Guide</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="../../css/style.css">
 </head>
 <body>
@@ -674,6 +676,6 @@ Deviations: None</code></pre>
     </div>
   </footer>
 
-  <script src="../../js/search.js"></script>
+  <script src="../../js/search.js" defer></script>
 </body>
 </html>

--- a/public/adapter-reference/guides/migration.html
+++ b/public/adapter-reference/guides/migration.html
@@ -7,7 +7,9 @@
   <title>MCP-AQL Adapter Reference | Migration Guide: MCP Server to MCP-AQL Adapter</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="../../css/style.css">
 </head>
 <body>
@@ -456,6 +458,6 @@
     </div>
   </footer>
 
-  <script src="../../js/search.js"></script>
+  <script src="../../js/search.js" defer></script>
 </body>
 </html>

--- a/public/adapter-reference/guides/testing.html
+++ b/public/adapter-reference/guides/testing.html
@@ -7,7 +7,9 @@
   <title>MCP-AQL Adapter Reference | MCP-AQL Adapter Testing Guide</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="../../css/style.css">
 </head>
 <body>
@@ -533,6 +535,6 @@
     </div>
   </footer>
 
-  <script src="../../js/search.js"></script>
+  <script src="../../js/search.js" defer></script>
 </body>
 </html>

--- a/public/adapter-reference/index.html
+++ b/public/adapter-reference/index.html
@@ -7,7 +7,9 @@
   <title>MCP-AQL Adapter Reference | Reference Adapter Docs</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="../css/style.css">
 </head>
 <body>
@@ -201,6 +203,6 @@
     </div>
   </footer>
 
-  <script src="../js/search.js"></script>
+  <script src="../js/search.js" defer></script>
 </body>
 </html>

--- a/public/adapter-reference/repo/README.html
+++ b/public/adapter-reference/repo/README.html
@@ -7,7 +7,9 @@
   <title>MCP-AQL Adapter Reference | MCP-AQL Reference Adapter</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="../../css/style.css">
 </head>
 <body>
@@ -282,6 +284,6 @@
     </div>
   </footer>
 
-  <script src="../../js/search.js"></script>
+  <script src="../../js/search.js" defer></script>
 </body>
 </html>

--- a/public/apis/application.html
+++ b/public/apis/application.html
@@ -7,7 +7,9 @@
   <title>Application Integration | MCP-AQL</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="../css/style.css">
 </head>
 <body>
@@ -209,6 +211,6 @@
     </div>
   </footer>
 
-  <script src="../js/search.js"></script>
+  <script src="../js/search.js" defer></script>
 </body>
 </html>

--- a/public/apis/cloud-service.html
+++ b/public/apis/cloud-service.html
@@ -7,7 +7,9 @@
   <title>Cloud Service Integration | MCP-AQL</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="../css/style.css">
 </head>
 <body>
@@ -209,6 +211,6 @@
     </div>
   </footer>
 
-  <script src="../js/search.js"></script>
+  <script src="../js/search.js" defer></script>
 </body>
 </html>

--- a/public/apis/index.html
+++ b/public/apis/index.html
@@ -7,7 +7,9 @@
   <title>Adapter Patterns | MCP-AQL</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="../css/style.css">
 </head>
 <body>
@@ -208,6 +210,6 @@
     </div>
   </footer>
 
-  <script src="../js/search.js"></script>
+  <script src="../js/search.js" defer></script>
 </body>
 </html>

--- a/public/apis/mcp-server.html
+++ b/public/apis/mcp-server.html
@@ -7,7 +7,9 @@
   <title>MCP Server Integration | MCP-AQL</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="../css/style.css">
 </head>
 <body>
@@ -226,6 +228,6 @@
     </div>
   </footer>
 
-  <script src="../js/search.js"></script>
+  <script src="../js/search.js" defer></script>
 </body>
 </html>

--- a/public/apis/operating-system.html
+++ b/public/apis/operating-system.html
@@ -7,7 +7,9 @@
   <title>Operating System Integration | MCP-AQL</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="../css/style.css">
 </head>
 <body>
@@ -210,6 +212,6 @@
     </div>
   </footer>
 
-  <script src="../js/search.js"></script>
+  <script src="../js/search.js" defer></script>
 </body>
 </html>

--- a/public/apis/website.html
+++ b/public/apis/website.html
@@ -7,7 +7,9 @@
   <title>Website Integration | MCP-AQL</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="../css/style.css">
 </head>
 <body>
@@ -209,6 +211,6 @@
     </div>
   </footer>
 
-  <script src="../js/search.js"></script>
+  <script src="../js/search.js" defer></script>
 </body>
 </html>

--- a/public/docs/adapter-contracts.html
+++ b/public/docs/adapter-contracts.html
@@ -7,7 +7,9 @@
   <title>MCP-AQL Docs | Adapter Contracts</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="../css/style.css">
 </head>
 <body>
@@ -183,6 +185,6 @@
     </div>
   </footer>
 
-  <script src="../js/search.js"></script>
+  <script src="../js/search.js" defer></script>
 </body>
 </html>

--- a/public/docs/conformance.html
+++ b/public/docs/conformance.html
@@ -7,7 +7,9 @@
   <title>MCP-AQL Docs | Conformance</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="../css/style.css">
 </head>
 <body>
@@ -213,6 +215,6 @@
     </div>
   </footer>
 
-  <script src="../js/search.js"></script>
+  <script src="../js/search.js" defer></script>
 </body>
 </html>

--- a/public/docs/error-model.html
+++ b/public/docs/error-model.html
@@ -7,7 +7,9 @@
   <title>MCP-AQL Docs | Error Model</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="../css/style.css">
 </head>
 <body>
@@ -355,6 +357,6 @@
     </div>
   </footer>
 
-  <script src="../js/search.js"></script>
+  <script src="../js/search.js" defer></script>
 </body>
 </html>

--- a/public/docs/getting-started.html
+++ b/public/docs/getting-started.html
@@ -7,7 +7,9 @@
   <title>MCP-AQL Docs | Getting Started</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="../css/style.css">
 </head>
 <body>
@@ -414,6 +416,6 @@
     </div>
   </footer>
 
-  <script src="../js/search.js"></script>
+  <script src="../js/search.js" defer></script>
 </body>
 </html>

--- a/public/docs/implementation-profiles.html
+++ b/public/docs/implementation-profiles.html
@@ -7,7 +7,9 @@
   <title>MCP-AQL Docs | Implementation Profiles</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="../css/style.css">
 </head>
 <body>
@@ -230,6 +232,6 @@
     </div>
   </footer>
 
-  <script src="../js/search.js"></script>
+  <script src="../js/search.js" defer></script>
 </body>
 </html>

--- a/public/docs/index.html
+++ b/public/docs/index.html
@@ -7,7 +7,9 @@
   <title>MCP-AQL Docs | Library</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="../css/style.css">
 </head>
 <body>
@@ -352,6 +354,6 @@
     </div>
   </footer>
 
-  <script src="../js/search.js"></script>
+  <script src="../js/search.js" defer></script>
 </body>
 </html>

--- a/public/docs/protocol-core.html
+++ b/public/docs/protocol-core.html
@@ -7,7 +7,9 @@
   <title>MCP-AQL Docs | Protocol Core</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="../css/style.css">
 </head>
 <body>
@@ -325,6 +327,6 @@ mcp_aql_execute</pre>
     </div>
   </footer>
 
-  <script src="../js/search.js"></script>
+  <script src="../js/search.js" defer></script>
 </body>
 </html>

--- a/public/docs/release-notes.html
+++ b/public/docs/release-notes.html
@@ -7,7 +7,9 @@
   <title>MCP-AQL Docs | Release Notes</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="../css/style.css">
 </head>
 <body>
@@ -162,6 +164,6 @@
     </div>
   </footer>
 
-  <script src="../js/search.js"></script>
+  <script src="../js/search.js" defer></script>
 </body>
 </html>

--- a/public/docs/roadmap.html
+++ b/public/docs/roadmap.html
@@ -7,7 +7,9 @@
   <title>MCP-AQL Docs | Roadmap</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="../css/style.css">
 </head>
 <body>
@@ -245,6 +247,6 @@
     </div>
   </footer>
 
-  <script src="../js/search.js"></script>
+  <script src="../js/search.js" defer></script>
 </body>
 </html>

--- a/public/docs/security-model.html
+++ b/public/docs/security-model.html
@@ -7,7 +7,9 @@
   <title>MCP-AQL Docs | Security Model</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="../css/style.css">
 </head>
 <body>
@@ -314,6 +316,6 @@
     </div>
   </footer>
 
-  <script src="../js/search.js"></script>
+  <script src="../js/search.js" defer></script>
 </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -7,7 +7,9 @@
   <title>MCP-AQL | Protocol Documentation Portal</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
@@ -387,6 +389,6 @@
     </div>
   </footer>
 
-  <script src="js/search.js"></script>
+  <script src="js/search.js" defer></script>
 </body>
 </html>

--- a/public/launch-checklist.html
+++ b/public/launch-checklist.html
@@ -7,7 +7,9 @@
   <title>Launch Checklist | MCP-AQL</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
@@ -149,6 +151,6 @@
     </div>
   </footer>
 
-  <script src="js/search.js"></script>
+  <script src="js/search.js" defer></script>
 </body>
 </html>

--- a/public/search.html
+++ b/public/search.html
@@ -7,7 +7,9 @@
   <title>MCP-AQL Search</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
@@ -79,6 +81,6 @@
     </div>
   </footer>
 
-  <script src="js/search.js"></script>
+  <script src="js/search.js" defer></script>
 </body>
 </html>

--- a/public/spec/README.html
+++ b/public/spec/README.html
@@ -120,44 +120,44 @@
 <h3 id="core-specification">Core Specification</h3>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Document</th>
 <th>Description</th>
 <th>Status</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><a href="versions/v1.0.0-draft.html">v1.0.0-draft</a></td>
 <td>Current specification version</td>
 <td>Draft</td>
 </tr>
-<tr class="even">
+<tr>
 <td><a href="crude-pattern.html">CRUDE Pattern</a></td>
 <td>Standard semantic-endpoint profile and routing</td>
 <td>Draft</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><a href="endpoint-modes.html">Endpoint Modes</a></td>
 <td>Semantic endpoint mode and Single mode configuration</td>
 <td>Draft</td>
 </tr>
-<tr class="even">
+<tr>
 <td><a href="introspection.html">Introspection</a></td>
 <td>Runtime discovery system</td>
 <td>Draft</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><a href="operations.html">Operations</a></td>
 <td>Operation design guide</td>
 <td>Draft</td>
 </tr>
-<tr class="even">
+<tr>
 <td><a href="error-codes.html">Error Codes</a></td>
 <td>Structured error code system</td>
 <td>Draft (MVP)</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><a href="conformance-testing.html">Conformance Testing</a></td>
 <td>Test requirements plus the fixture-driven runner model used in this repo</td>
 <td>Draft</td>
@@ -167,24 +167,24 @@
 <h3 id="plugin--adapter-contracts">Plugin &amp; Adapter Contracts</h3>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Document</th>
 <th>Description</th>
 <th>Status</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><a href="plugin-contracts.html">Plugin Interface Contracts</a></td>
 <td>What each plugin type MUST provide</td>
 <td>Draft (MVP)</td>
 </tr>
-<tr class="even">
+<tr>
 <td><a href="adapter/element-type.html">Element Type Specification</a></td>
 <td>Declarative adapter schema format</td>
 <td>Draft (MVP)</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><a href="adapter/discovery-bundle.html">MCP Server Discovery Bundle</a></td>
 <td>Raw capture + normalized bundle contract for generator pipelines</td>
 <td>Draft</td>
@@ -194,39 +194,39 @@
 <h3 id="features">Features</h3>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Document</th>
 <th>Description</th>
 <th>Impl Status</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><a href="features/field-selection.html">Field Selection</a></td>
 <td>GraphQL-style response filtering</td>
 <td>Implemented</td>
 </tr>
-<tr class="even">
+<tr>
 <td><a href="features/collection-querying.html">Collection Querying</a></td>
 <td>Preferred query contract for list/search/query operations</td>
 <td>Draft</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><a href="features/aggregations.html">Aggregations</a></td>
 <td>Server-side summaries for collection queries</td>
 <td>Draft</td>
 </tr>
-<tr class="even">
+<tr>
 <td><a href="features/computed-fields.html">Computed Fields</a></td>
 <td>Adapter-declared derived values and <code>_computed.</code> paths</td>
 <td>Draft</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><a href="features/pagination.html">Pagination</a></td>
 <td>Cursor-based pagination semantics and response shape</td>
 <td>Draft</td>
 </tr>
-<tr class="even">
+<tr>
 <td><a href="features/relationship-queries.html">Relationship Queries</a></td>
 <td>Graph traversal and relationship query conventions</td>
 <td>Draft</td>
@@ -236,14 +236,14 @@
 <h3 id="security">Security</h3>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Document</th>
 <th>Description</th>
 <th>Impl Status</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><a href="security/gatekeeper.html">Gatekeeper</a></td>
 <td>Multi-layer access control</td>
 <td>Implemented</td>
@@ -253,25 +253,25 @@
 <h3 id="process">Process</h3>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Document</th>
 <th>Description</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><a href="process/rfc-process.html">RFC Process</a></td>
 <td>How to propose specification changes</td>
 </tr>
-<tr class="even">
+<tr>
 <td><a href="process/breaking-changes.html">Breaking Changes</a></td>
 <td>Policy for handling breaking changes</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><a href="process/versioning.html">Versioning</a></td>
 <td>Version numbering and release process</td>
 </tr>
-<tr class="even">
+<tr>
 <td><a href="process/preliminary-public-launch-checklist.html">Preliminary Launch Checklist</a></td>
 <td>Coordinated draft-launch criteria</td>
 </tr>
@@ -280,17 +280,17 @@
 <h3 id="guides">Guides</h3>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Document</th>
 <th>Description</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><a href="guides/protocol-comparison.html">Protocol Comparison</a></td>
 <td>MCP-AQL vs other protocols</td>
 </tr>
-<tr class="even">
+<tr>
 <td><a href="guides/cross-domain-implementation.html">Cross-Domain Implementation</a></td>
 <td>Step-by-step guide for adapting MCP-AQL to domains beyond Dollhouse-style element management</td>
 </tr>
@@ -338,7 +338,7 @@
 <p>MCP-AQL follows a four-level protocol model:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Level</th>
 <th>What</th>
 <th>Normative?</th>
@@ -346,25 +346,25 @@
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>1. Wire format</td>
 <td>Request/response JSON, error codes, introspection</td>
 <td>MUST</td>
 <td><strong>this repo</strong></td>
 </tr>
-<tr class="even">
+<tr>
 <td>2. Schema semantics</td>
 <td>Operation declarations, params, auth, target</td>
 <td>MUST/SHOULD</td>
 <td><strong>this repo</strong></td>
 </tr>
-<tr class="odd">
+<tr>
 <td>3. Canonical format</td>
 <td>Markdown + YAML front matter interchange format</td>
 <td>SHOULD</td>
 <td><strong>this repo</strong></td>
 </tr>
-<tr class="even">
+<tr>
 <td>4. Implementation guidance</td>
 <td>Runtime architecture, plugin pipeline, dispatch</td>
 <td>Non-normative</td>

--- a/public/spec/README.html
+++ b/public/spec/README.html
@@ -7,7 +7,9 @@
   <title>MCP-AQL Spec | MCP-AQL Specification Documentation</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="../css/style.css">
 </head>
 <body>
@@ -409,6 +411,6 @@
     </div>
   </footer>
 
-  <script src="../js/search.js"></script>
+  <script src="../js/search.js" defer></script>
 </body>
 </html>

--- a/public/spec/adapter/danger-levels.html
+++ b/public/spec/adapter/danger-levels.html
@@ -155,7 +155,7 @@
 <h3 id="21-danger-level-values">2.1 Danger Level Values</h3>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Level</th>
 <th>Value</th>
 <th>Name</th>
@@ -163,31 +163,31 @@
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>0</td>
 <td><code>safe</code></td>
 <td>Safe</td>
 <td>No restrictions</td>
 </tr>
-<tr class="even">
+<tr>
 <td>1</td>
 <td><code>reversible</code></td>
 <td>Reversible</td>
 <td>Standard confirmation</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>2</td>
 <td><code>destructive</code></td>
 <td>Destructive</td>
 <td>Enhanced confirmation</td>
 </tr>
-<tr class="even">
+<tr>
 <td>3</td>
 <td><code>dangerous</code></td>
 <td>Dangerous</td>
 <td>Explicit unlock required</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>4</td>
 <td><code>forbidden</code></td>
 <td>Forbidden</td>
@@ -333,34 +333,34 @@
 <p>When <code>danger.level</code> is not specified, defaults are inferred:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>CRUDE Category</th>
 <th>Default Danger Level</th>
 <th>Rationale</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>Read</td>
 <td><code>safe</code> (0)</td>
 <td>No state modification</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Create</td>
 <td><code>reversible</code> (1)</td>
 <td>Adds data, reversible by delete</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Update</td>
 <td><code>reversible</code> (1)</td>
 <td>Modifies data, often reversible</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Delete</td>
 <td><code>destructive</code> (2)</td>
 <td>Removes data</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Execute</td>
 <td><code>reversible</code> (1)</td>
 <td>Depends on operation</td>
@@ -399,7 +399,7 @@
 <p>The combination of adapter trust level and operation danger level determines behavior:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Danger Level</th>
 <th>untested</th>
 <th>generated</th>
@@ -409,7 +409,7 @@
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>safe (0)</td>
 <td>introspect_only</td>
 <td>allow</td>
@@ -417,7 +417,7 @@
 <td>allow</td>
 <td>allow</td>
 </tr>
-<tr class="even">
+<tr>
 <td>reversible (1)</td>
 <td>deny</td>
 <td>deny</td>
@@ -425,7 +425,7 @@
 <td>allow</td>
 <td>allow</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>destructive (2)</td>
 <td>deny</td>
 <td>deny</td>
@@ -433,7 +433,7 @@
 <td>allow</td>
 <td>allow</td>
 </tr>
-<tr class="even">
+<tr>
 <td>dangerous (3)</td>
 <td>deny</td>
 <td>deny</td>
@@ -441,7 +441,7 @@
 <td>confirm</td>
 <td>allow</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>forbidden (4)</td>
 <td>deny</td>
 <td>deny</td>
@@ -454,25 +454,25 @@
 <h3 id="42-behavior-definitions">4.2 Behavior Definitions</h3>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Behavior</th>
 <th>Description</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>allow</code></td>
 <td>Operation executes without additional gates</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>confirm</code></td>
 <td>Operation requires explicit user confirmation</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>deny</code></td>
 <td>Operation blocked with error response</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>introspect_only</code></td>
 <td>Only introspection operations permitted; all other operations (including safe ones) are blocked</td>
 </tr>
@@ -580,44 +580,44 @@
 <p>Operations matching these patterns SHOULD default to <code>dangerous</code>:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Pattern</th>
 <th>Description</th>
 <th>Examples</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>force_*</code></td>
 <td>Force operations bypassing safety</td>
 <td><code>force_push</code>, <code>force_delete</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>*_permanently</code></td>
 <td>Permanent/irreversible actions</td>
 <td><code>remove_permanently</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>bulk_delete*</code></td>
 <td>Mass deletion operations</td>
 <td><code>bulk_delete_users</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>override_*</code></td>
 <td>Safety override operations</td>
 <td><code>override_validation</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>bypass_*</code></td>
 <td>Validation bypass</td>
 <td><code>bypass_approval</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>*_without_backup</code></td>
 <td>Operations skipping backup</td>
 <td><code>delete_without_backup</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>purge_*</code></td>
 <td>Purge/clean operations</td>
 <td><code>purge_logs</code>, <code>purge_cache</code></td>
@@ -628,44 +628,44 @@
 <p>Operations matching these patterns SHOULD default to <code>forbidden</code>:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Pattern</th>
 <th>Description</th>
 <th>Examples</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>drop_*</code></td>
 <td>Drop database/table/collection</td>
 <td><code>drop_table</code>, <code>drop_database</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>delete_all*</code></td>
 <td>Delete all records</td>
 <td><code>delete_all_users</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>truncate_*</code></td>
 <td>Truncate operations</td>
 <td><code>truncate_table</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>reset_*</code></td>
 <td>Reset to empty/factory state</td>
 <td><code>reset_database</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>destroy_*</code></td>
 <td>Complete destruction</td>
 <td><code>destroy_environment</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>wipe_*</code></td>
 <td>Wipe operations</td>
 <td><code>wipe_data</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>*_production</code></td>
 <td>Production mutations</td>
 <td><code>deploy_production</code></td>
@@ -676,39 +676,39 @@
 <p>Operations matching these patterns are confirmed <code>safe</code>:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Pattern</th>
 <th>Description</th>
 <th>Examples</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>get_*</code></td>
 <td>Retrieve single resource</td>
 <td><code>get_user</code>, <code>get_repo</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>list_*</code></td>
 <td>List resources</td>
 <td><code>list_repos</code>, <code>list_users</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>search_*</code></td>
 <td>Search operations</td>
 <td><code>search_issues</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>count_*</code></td>
 <td>Count operations</td>
 <td><code>count_records</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>check_*</code></td>
 <td>Validation checks</td>
 <td><code>check_status</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>introspect*</code></td>
 <td>Introspection</td>
 <td><code>introspect</code></td>
@@ -763,7 +763,7 @@
 <p>The Autonomy Evaluator maps danger levels to safety tiers using a numeric risk score (0-100):</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Danger Level</th>
 <th>Risk Score Range</th>
 <th>Safety Tier</th>
@@ -771,31 +771,31 @@
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>safe (0)</td>
 <td>0-15</td>
 <td><code>advisory</code></td>
 <td>No intervention</td>
 </tr>
-<tr class="even">
+<tr>
 <td>reversible (1)</td>
 <td>16-40</td>
 <td><code>advisory</code> or <code>confirm</code></td>
 <td>Depends on risk tolerance</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>destructive (2)</td>
 <td>41-60</td>
 <td><code>confirm</code></td>
 <td>Requires approval</td>
 </tr>
-<tr class="even">
+<tr>
 <td>dangerous (3)</td>
 <td>61-85</td>
 <td><code>verify</code></td>
 <td>Mandatory pause + approval</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>forbidden (4)</td>
 <td>86-100</td>
 <td><code>danger_zone</code></td>

--- a/public/spec/adapter/danger-levels.html
+++ b/public/spec/adapter/danger-levels.html
@@ -7,7 +7,9 @@
   <title>MCP-AQL Spec | Dangerous Operation Classification Specification</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="../../css/style.css">
 </head>
 <body>
@@ -922,6 +924,6 @@
     </div>
   </footer>
 
-  <script src="../../js/search.js"></script>
+  <script src="../../js/search.js" defer></script>
 </body>
 </html>

--- a/public/spec/adapter/discovery-bundle.html
+++ b/public/spec/adapter/discovery-bundle.html
@@ -7,7 +7,9 @@
   <title>MCP-AQL Spec | MCP Server Discovery Bundle</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="../../css/style.css">
 </head>
 <body>
@@ -253,6 +255,6 @@
     </div>
   </footer>
 
-  <script src="../../js/search.js"></script>
+  <script src="../../js/search.js" defer></script>
 </body>
 </html>

--- a/public/spec/adapter/element-type.html
+++ b/public/spec/adapter/element-type.html
@@ -7,7 +7,9 @@
   <title>MCP-AQL Spec | Adapter Element Type Specification</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="../../css/style.css">
 </head>
 <body>
@@ -590,6 +592,6 @@
     </div>
   </footer>
 
-  <script src="../../js/search.js"></script>
+  <script src="../../js/search.js" defer></script>
 </body>
 </html>

--- a/public/spec/adapter/element-type.html
+++ b/public/spec/adapter/element-type.html
@@ -425,39 +425,39 @@
 <p><strong>Supported types:</strong></p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Type</th>
 <th>Description</th>
 <th>Example</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>string</code></td>
 <td>Text value</td>
 <td><code>"hello"</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>integer</code></td>
 <td>Whole number</td>
 <td><code>42</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>number</code></td>
 <td>Decimal number</td>
 <td><code>3.14</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>boolean</code></td>
 <td>True/false</td>
 <td><code>true</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>array</code></td>
 <td>List of values</td>
 <td><code>[1, 2, 3]</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>object</code></td>
 <td>Key-value map</td>
 <td><code>{"key": "value"}</code></td>

--- a/public/spec/adapter/generator.html
+++ b/public/spec/adapter/generator.html
@@ -7,7 +7,9 @@
   <title>MCP-AQL Spec | Adapter Generator Specification</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="../../css/style.css">
 </head>
 <body>
@@ -1164,6 +1166,6 @@
     </div>
   </footer>
 
-  <script src="../../js/search.js"></script>
+  <script src="../../js/search.js" defer></script>
 </body>
 </html>

--- a/public/spec/adapter/generator.html
+++ b/public/spec/adapter/generator.html
@@ -125,24 +125,24 @@
 <h3 id="12-generator-types">1.2 Generator Types</h3>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Type</th>
 <th>Description</th>
 <th>Use Case</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><strong>Schema-to-Code</strong></td>
 <td>Generates adapter source code from schema</td>
 <td>Development workflow</td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>Schema-to-Runtime</strong></td>
 <td>Generates runtime configuration</td>
 <td>Dynamic adapter loading</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><strong>Code-to-Schema</strong></td>
 <td>Extracts schema from existing adapter</td>
 <td>Migration, documentation</td>
@@ -267,34 +267,34 @@
 <p><strong>Validation error codes:</strong></p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Validation</th>
 <th>Error Code</th>
 <th>Example Message</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>Missing required field</td>
 <td><code>SCHEMA_MISSING_FIELD</code></td>
 <td>"Required field 'adapter.name' is missing"</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Type mismatch</td>
 <td><code>SCHEMA_INVALID_TYPE</code></td>
 <td>"Field 'params[0].required' expected boolean, got string"</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Unresolved reference</td>
 <td><code>SCHEMA_UNRESOLVED_REF</code></td>
 <td>"Type reference 'Repository' not found in types"</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Duplicate name</td>
 <td><code>SCHEMA_DUPLICATE_NAME</code></td>
 <td>"Operation 'get_user' defined multiple times in read endpoint"</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Invalid naming</td>
 <td><code>SCHEMA_INVALID_NAME</code></td>
 <td>"Parameter name 'userName' must be snake_case (try 'user_name')"</td>
@@ -419,24 +419,24 @@
 <p><strong>Evolution strategy:</strong></p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Change Type</th>
 <th>Version Increment</th>
 <th>Example</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>Breaking schema changes</td>
 <td>Major (<code>1.0</code> → <code>2.0</code>)</td>
 <td>Removing required fields, restructuring <code>endpoints</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td>New optional features</td>
 <td>Minor (<code>1.0</code> → <code>1.1</code>)</td>
 <td>Adding <code>auth.config.scopes</code> field</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Clarifications, fixes</td>
 <td>No change</td>
 <td>Documentation updates, validation improvements</td>
@@ -584,24 +584,24 @@
 <p>Generators MUST include the following licensing files:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>File</th>
 <th>Content</th>
 <th>Notes</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>LICENSE</code></td>
 <td>AGPL-3.0 full text</td>
 <td>Standard AGPL-3.0 license</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>NOTICE.md</code></td>
 <td>Attribution notice</td>
 <td>Credits MCP-AQL project</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>COMMERCIAL-LICENSE.md</code></td>
 <td>Commercial options</td>
 <td>Contact information</td>
@@ -791,39 +791,39 @@
 <p>Generators SHOULD support multiple target languages:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Language</th>
 <th>Status</th>
 <th>Template ID</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>TypeScript</td>
 <td>Required</td>
 <td><code>typescript</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td>JavaScript</td>
 <td>Required</td>
 <td><code>javascript</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Python</td>
 <td>Recommended</td>
 <td><code>python</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td>Go</td>
 <td>Optional</td>
 <td><code>go</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Rust</td>
 <td>Optional</td>
 <td><code>rust</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td>Java</td>
 <td>Optional</td>
 <td><code>java</code></td>
@@ -879,34 +879,34 @@
 <p>Generators MAY support template customization:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Option</th>
 <th>Description</th>
 <th>Default</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>strict_mode</code></td>
 <td>Enable strict type checking</td>
 <td><code>true</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>include_tests</code></td>
 <td>Generate test stubs</td>
 <td><code>true</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>inline_docs</code></td>
 <td>Include JSDoc/docstrings</td>
 <td><code>true</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>error_handling</code></td>
 <td>Error handling style</td>
 <td><code>structured</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>http_client</code></td>
 <td>HTTP client library</td>
 <td>Language default</td>
@@ -921,19 +921,19 @@
 <h3 id="72-required-arguments">7.2 Required Arguments</h3>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Argument</th>
 <th>Description</th>
 <th>Example</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>--schema</code>, <code>-s</code></td>
 <td>Path to the input schema file (YAML or JSON)</td>
 <td><code>--schema adapter.yaml</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>--target</code>, <code>-t</code></td>
 <td>Target language/platform</td>
 <td><code>--target typescript</code></td>
@@ -943,54 +943,54 @@
 <h3 id="73-optional-arguments">7.3 Optional Arguments</h3>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Argument</th>
 <th>Description</th>
 <th>Default</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>--output</code>, <code>-o</code></td>
 <td>Output directory for generated code</td>
 <td><code>./generated</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>--config</code>, <code>-c</code></td>
 <td>Path to generator configuration file</td>
 <td>None</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>--output-format</code></td>
 <td>Output format (<code>human</code> or <code>json</code>)</td>
 <td><code>human</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>--strict</code></td>
 <td>Enable strict validation mode (fail on warnings, enforce all optional constraints)</td>
 <td><code>false</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>--dry-run</code></td>
 <td>Validate schema without generating output</td>
 <td><code>false</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>--verbose</code>, <code>-v</code></td>
 <td>Enable verbose output</td>
 <td><code>false</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>--quiet</code>, <code>-q</code></td>
 <td>Suppress non-error output</td>
 <td><code>false</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>--version</code></td>
 <td>Print generator version and exit</td>
 <td>-</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>--help</code>, <code>-h</code></td>
 <td>Print help message and exit</td>
 <td>-</td>
@@ -1006,39 +1006,39 @@
 <p>Generators MUST use consistent exit codes:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Code</th>
 <th>Meaning</th>
 <th>Description</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>0</code></td>
 <td>Success</td>
 <td>Generation completed successfully</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>1</code></td>
 <td>Internal error</td>
 <td>Unexpected error (assertion failures, uncaught exceptions)</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>2</code></td>
 <td>Schema validation error</td>
 <td>Input schema is invalid</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>3</code></td>
 <td>Configuration error</td>
 <td>Invalid generator configuration</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>4</code></td>
 <td>I/O error</td>
 <td>File read/write failure</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>5</code></td>
 <td>Template error</td>
 <td>Language template processing failed</td>

--- a/public/spec/adapter/rate-limiting.html
+++ b/public/spec/adapter/rate-limiting.html
@@ -323,24 +323,24 @@
 <h3 id="32-threshold-behaviors">3.2 Threshold Behaviors</h3>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Threshold</th>
 <th>Behavior</th>
 <th>User Experience</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>warn</code></td>
 <td>Log warning, continue</td>
 <td>Notification displayed</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>pause</code></td>
 <td>Require confirmation</td>
 <td>"Continue?" prompt</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>hard_stop</code></td>
 <td>Block all requests</td>
 <td>Error response</td>
@@ -474,29 +474,29 @@
 <h3 id="51-rate-limit-error-codes">5.1 Rate Limit Error Codes</h3>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Code</th>
 <th>Description</th>
 <th>Recovery</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>RATE_LIMIT_EXCEEDED</code></td>
 <td>Target API rate limit reached</td>
 <td>Wait for reset</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>RATE_LIMIT_QUOTA_PAUSE</code></td>
 <td>User quota pause threshold</td>
 <td>Confirm to continue</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>RATE_LIMIT_QUOTA_EXHAUSTED</code></td>
 <td>User quota hard stop</td>
 <td>Wait for reset</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>RATE_LIMIT_QUOTA_WARNING</code></td>
 <td>Approaching limit (in warnings)</td>
 <td>Consider slowing</td>
@@ -573,25 +573,25 @@
 <h3 id="63-status-values">6.3 Status Values</h3>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Status</th>
 <th>Meaning</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>ok</code></td>
 <td>Below warn threshold</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>warn</code></td>
 <td>Above warn, below pause</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>paused</code></td>
 <td>At pause threshold, confirmation required</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>exhausted</code></td>
 <td>At hard stop, requests blocked</td>
 </tr>

--- a/public/spec/adapter/rate-limiting.html
+++ b/public/spec/adapter/rate-limiting.html
@@ -7,7 +7,9 @@
   <title>MCP-AQL Spec | Rate Limiting and Quota Management Specification</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="../../css/style.css">
 </head>
 <body>
@@ -720,6 +722,6 @@
     </div>
   </footer>
 
-  <script src="../../js/search.js"></script>
+  <script src="../../js/search.js" defer></script>
 </body>
 </html>

--- a/public/spec/adapter/trust-levels.html
+++ b/public/spec/adapter/trust-levels.html
@@ -148,34 +148,34 @@
 <h3 id="21-trust-level-values">2.1 Trust Level Values</h3>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Level</th>
 <th>Value</th>
 <th>Description</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>Untested</td>
 <td><code>untested</code></td>
 <td>Newly created, no validation performed</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Generated</td>
 <td><code>generated</code></td>
 <td>Programmatically generated, basic schema validation passed</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Validated</td>
 <td><code>validated</code></td>
 <td>Passed programmatic test harness</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Community Reviewed</td>
 <td><code>community_reviewed</code></td>
 <td>Validated plus community vetting process</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Certified</td>
 <td><code>certified</code></td>
 <td>Official verification by vendor or trusted authority</td>
@@ -319,34 +319,34 @@
 <p><strong>Fields:</strong></p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Field</th>
 <th>Type</th>
 <th>Description</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>tests_passed</code></td>
 <td>integer</td>
 <td>Number of tests that passed</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>tests_total</code></td>
 <td>integer</td>
 <td>Total number of tests executed</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>endpoints_verified</code></td>
 <td>integer</td>
 <td>Number of API endpoints tested</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>coverage_percent</code></td>
 <td>number</td>
 <td>Percentage of operations covered by tests</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>last_api_response</code></td>
 <td>string</td>
 <td>Timestamp of last successful API response</td>
@@ -369,34 +369,34 @@
 <p><strong>Promotion record fields:</strong></p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Field</th>
 <th>Type</th>
 <th>Description</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>from</code></td>
 <td>string</td>
 <td>Previous trust level</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>to</code></td>
 <td>string</td>
 <td>New trust level</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>at</code></td>
 <td>string</td>
 <td>ISO 8601 timestamp</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>by</code></td>
 <td>string</td>
 <td>Tool or person identifier</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>reason</code></td>
 <td>string</td>
 <td>Optional explanation</td>
@@ -417,39 +417,39 @@
 <p><strong>Certification fields:</strong></p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Field</th>
 <th>Type</th>
 <th>Description</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>authority</code></td>
 <td>string</td>
 <td>Certifying organization name</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>signature</code></td>
 <td>string</td>
 <td>Cryptographic signature (base64)</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>certificate_id</code></td>
 <td>string</td>
 <td>Unique certificate identifier</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>issued_at</code></td>
 <td>string</td>
 <td>When certification was granted</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>expires_at</code></td>
 <td>string</td>
 <td>When certification expires</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>scope</code></td>
 <td>array</td>
 <td>What the certification covers</td>
@@ -465,29 +465,29 @@
 <h3 id="42-promotion-triggers">4.2 Promotion Triggers</h3>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Transition</th>
 <th>Trigger</th>
 <th>Requirements</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>untested → generated</td>
 <td>Schema validation</td>
 <td>YAML parses, required fields present, valid structure</td>
 </tr>
-<tr class="even">
+<tr>
 <td>generated → validated</td>
 <td>Test harness pass</td>
 <td>All read ops succeed, representative create/update tested</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>validated → community_reviewed</td>
 <td>Community review</td>
 <td>N reviewers approve, no security flags</td>
 </tr>
-<tr class="even">
+<tr>
 <td>community_reviewed → certified</td>
 <td>Vendor attestation</td>
 <td>Signed certificate from recognized authority</td>
@@ -518,25 +518,25 @@
 <p>Adapters SHOULD be periodically re-validated to maintain trust level:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Trust Level</th>
 <th>Recommended Re-validation</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>generated</td>
 <td>On each use (schema check)</td>
 </tr>
-<tr class="even">
+<tr>
 <td>validated</td>
 <td>Weekly or on API version change</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>community_reviewed</td>
 <td>Monthly</td>
 </tr>
-<tr class="even">
+<tr>
 <td>certified</td>
 <td>Per certification terms</td>
 </tr>
@@ -548,33 +548,33 @@
 <p>Systems SHOULD enforce minimum trust levels for operations based on risk:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Operation Category</th>
 <th>Minimum Trust Level</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>Introspection</td>
 <td><code>untested</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td>Read operations</td>
 <td><code>generated</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Safe create operations</td>
 <td><code>validated</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td>Update operations</td>
 <td><code>validated</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Delete operations</td>
 <td><code>community_reviewed</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td>Dangerous operations</td>
 <td><code>certified</code></td>
 </tr>

--- a/public/spec/adapter/trust-levels.html
+++ b/public/spec/adapter/trust-levels.html
@@ -7,7 +7,9 @@
   <title>MCP-AQL Spec | Trust Levels Specification</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="../../css/style.css">
 </head>
 <body>
@@ -729,6 +731,6 @@
     </div>
   </footer>
 
-  <script src="../../js/search.js"></script>
+  <script src="../../js/search.js" defer></script>
 </body>
 </html>

--- a/public/spec/adr/ADR-001-crude-pattern.html
+++ b/public/spec/adr/ADR-001-crude-pattern.html
@@ -114,29 +114,29 @@
 <p>Traditional CRUD (Create, Read, Update, Delete) operations are well-suited for managing resource definitions and state. However, MCP-AQL needs to support runtime execution operations that have fundamentally different characteristics:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Characteristic</th>
 <th>CRUD Operations</th>
 <th>Execution Operations</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>Idempotency</td>
 <td>Generally idempotent</td>
 <td>Non-idempotent</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Target</td>
 <td>Element definitions</td>
 <td>Runtime state</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Lifecycle</td>
 <td>Discrete operations</td>
 <td>Stateful lifecycle</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Side effects</td>
 <td>Predictable</td>
 <td>Unbounded</td>

--- a/public/spec/adr/ADR-001-crude-pattern.html
+++ b/public/spec/adr/ADR-001-crude-pattern.html
@@ -7,7 +7,9 @@
   <title>MCP-AQL Spec | ADR-001: CRUDE Pattern (Extending CRUD with Execute)</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="../../css/style.css">
 </head>
 <body>
@@ -206,6 +208,6 @@
     </div>
   </footer>
 
-  <script src="../../js/search.js"></script>
+  <script src="../../js/search.js" defer></script>
 </body>
 </html>

--- a/public/spec/adr/ADR-002-graphql-style-input.html
+++ b/public/spec/adr/ADR-002-graphql-style-input.html
@@ -7,7 +7,9 @@
   <title>MCP-AQL Spec | ADR-002: GraphQL-Style Input Objects for Updates</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="../../css/style.css">
 </head>
 <body>
@@ -206,6 +208,6 @@
     </div>
   </footer>
 
-  <script src="../../js/search.js"></script>
+  <script src="../../js/search.js" defer></script>
 </body>
 </html>

--- a/public/spec/adr/ADR-003-snake-case-parameters.html
+++ b/public/spec/adr/ADR-003-snake-case-parameters.html
@@ -7,7 +7,9 @@
   <title>MCP-AQL Spec | ADR-003: snake_case Parameter Convention</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="../../css/style.css">
 </head>
 <body>
@@ -184,6 +186,6 @@
     </div>
   </footer>
 
-  <script src="../../js/search.js"></script>
+  <script src="../../js/search.js" defer></script>
 </body>
 </html>

--- a/public/spec/adr/ADR-004-schema-driven-operations.html
+++ b/public/spec/adr/ADR-004-schema-driven-operations.html
@@ -7,7 +7,9 @@
   <title>MCP-AQL Spec | ADR-004: Schema-Driven Operation Definitions</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="../../css/style.css">
 </head>
 <body>
@@ -219,6 +221,6 @@
     </div>
   </footer>
 
-  <script src="../../js/search.js"></script>
+  <script src="../../js/search.js" defer></script>
 </body>
 </html>

--- a/public/spec/adr/ADR-005-introspection-system.html
+++ b/public/spec/adr/ADR-005-introspection-system.html
@@ -7,7 +7,9 @@
   <title>MCP-AQL Spec | ADR-005: GraphQL-Style Introspection System</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="../../css/style.css">
 </head>
 <body>
@@ -199,6 +201,6 @@
     </div>
   </footer>
 
-  <script src="../../js/search.js"></script>
+  <script src="../../js/search.js" defer></script>
 </body>
 </html>

--- a/public/spec/adr/ADR-006-discriminated-responses.html
+++ b/public/spec/adr/ADR-006-discriminated-responses.html
@@ -7,7 +7,9 @@
   <title>MCP-AQL Spec | ADR-006: Discriminated Response Format</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="../../css/style.css">
 </head>
 <body>
@@ -211,6 +213,6 @@
     </div>
   </footer>
 
-  <script src="../../js/search.js"></script>
+  <script src="../../js/search.js" defer></script>
 </body>
 </html>

--- a/public/spec/adr/README.html
+++ b/public/spec/adr/README.html
@@ -7,7 +7,9 @@
   <title>MCP-AQL Spec | Architecture Decision Records</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="../../css/style.css">
 </head>
 <body>
@@ -123,6 +125,6 @@
     </div>
   </footer>
 
-  <script src="../../js/search.js"></script>
+  <script src="../../js/search.js" defer></script>
 </body>
 </html>

--- a/public/spec/adr/index.html
+++ b/public/spec/adr/index.html
@@ -7,7 +7,9 @@
   <title>MCP-AQL Spec | Architecture Decision Records</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="../../css/style.css">
 </head>
 <body>
@@ -219,6 +221,6 @@
     </div>
   </footer>
 
-  <script src="../../js/search.js"></script>
+  <script src="../../js/search.js" defer></script>
 </body>
 </html>

--- a/public/spec/adr/index.html
+++ b/public/spec/adr/index.html
@@ -113,7 +113,7 @@
 <h2 id="adr-index">ADR Index</h2>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>ADR</th>
 <th>Title</th>
 <th>Status</th>
@@ -121,37 +121,37 @@
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><a href="ADR-001-crude-pattern.html">ADR-001</a></td>
 <td>CRUDE Pattern</td>
 <td>Accepted</td>
 <td>Extends CRUD with Execute endpoint for runtime operations</td>
 </tr>
-<tr class="even">
+<tr>
 <td><a href="ADR-002-graphql-style-input.html">ADR-002</a></td>
 <td>GraphQL-Style Input Objects</td>
 <td>Accepted</td>
 <td>Nested <code>input</code> objects for update operations</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><a href="ADR-003-snake-case-parameters.html">ADR-003</a></td>
 <td>snake_case Parameters</td>
 <td>Accepted</td>
 <td>Standardizes on snake_case for LLM compatibility</td>
 </tr>
-<tr class="even">
+<tr>
 <td><a href="ADR-004-schema-driven-operations.html">ADR-004</a></td>
 <td>Schema-Driven Operations</td>
 <td>Accepted</td>
 <td>Declarative operation definitions as single source of truth</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><a href="ADR-005-introspection-system.html">ADR-005</a></td>
 <td>Introspection System</td>
 <td>Accepted</td>
 <td>GraphQL-style runtime discovery via <code>introspect</code> operation</td>
 </tr>
-<tr class="even">
+<tr>
 <td><a href="ADR-006-discriminated-responses.html">ADR-006</a></td>
 <td>Discriminated Responses</td>
 <td>Accepted</td>

--- a/public/spec/architecture/README.html
+++ b/public/spec/architecture/README.html
@@ -100,25 +100,25 @@
 <h2 id="moved-documents">Moved Documents</h2>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Former Location</th>
 <th>New Location</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>overview.md</code></td>
 <td><a href="https://github.com/MCPAQL/mcpaql-adapter/blob/develop/docs/architecture/overview.md">mcpaql-adapter/docs/architecture/overview.md</a></td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>adapter-runtime.md</code></td>
 <td><a href="https://github.com/MCPAQL/mcpaql-adapter/blob/develop/docs/architecture/runtime.md">mcpaql-adapter/docs/architecture/runtime.md</a></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>plugin-interface.md</code></td>
 <td>Split: normative contracts in <a href="../plugin-contracts.html">plugin-contracts.md</a>, implementation in <a href="https://github.com/MCPAQL/mcpaql-adapter/blob/develop/docs/architecture/plugin-system.md">mcpaql-adapter/docs/architecture/plugin-system.md</a></td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>schema-driven-dispatch.md</code></td>
 <td><a href="https://github.com/MCPAQL/mcpaql-adapter/blob/develop/docs/architecture/dispatch.md">mcpaql-adapter/docs/architecture/dispatch.md</a></td>
 </tr>

--- a/public/spec/architecture/README.html
+++ b/public/spec/architecture/README.html
@@ -7,7 +7,9 @@
   <title>MCP-AQL Spec | Architecture Documentation</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="../../css/style.css">
 </head>
 <body>
@@ -158,6 +160,6 @@
     </div>
   </footer>
 
-  <script src="../../js/search.js"></script>
+  <script src="../../js/search.js" defer></script>
 </body>
 </html>

--- a/public/spec/conformance-testing.html
+++ b/public/spec/conformance-testing.html
@@ -7,7 +7,9 @@
   <title>MCP-AQL Spec | MCP-AQL Conformance Testing Specification</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="../css/style.css">
 </head>
 <body>
@@ -717,6 +719,6 @@ MCP-AQL Level 2 Conformant</code></pre>
     </div>
   </footer>
 
-  <script src="../js/search.js"></script>
+  <script src="../js/search.js" defer></script>
 </body>
 </html>

--- a/public/spec/conformance-testing.html
+++ b/public/spec/conformance-testing.html
@@ -131,25 +131,25 @@
 <h3 id="13-test-result-classifications">1.3 Test Result Classifications</h3>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Result</th>
 <th>Meaning</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><strong>PASS</strong></td>
 <td>Test criteria fully satisfied</td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>FAIL</strong></td>
 <td>Test criteria not met, conformance blocked</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><strong>WARN</strong></td>
 <td>Test criteria partially met, conformance not blocked</td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>SKIP</strong></td>
 <td>Test not applicable to this implementation</td>
 </tr>
@@ -162,33 +162,33 @@
 <p><strong>Requirements:</strong></p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Requirement</th>
 <th>Description</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>Introspect (operations)</td>
 <td><code>introspect</code> operation with <code>query: "operations"</code> implemented</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Introspect (types)</td>
 <td><code>introspect</code> operation with <code>query: "types"</code> implemented</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Endpoint routing</td>
 <td>Operations routed to the correct documented semantic endpoint family in semantic endpoint mode</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Response format</td>
 <td>Discriminated union responses (<code>{ success, data }</code> or <code>{ success, error }</code>)</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Error handling</td>
 <td>Structured error responses with code and message</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Parameter naming</td>
 <td>snake_case parameter naming convention</td>
 </tr>
@@ -206,29 +206,29 @@
 <p><strong>Requirements:</strong></p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Requirement</th>
 <th>Description</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>Level 1</td>
 <td>All Level 1 requirements</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Endpoint modes</td>
 <td><code>crude</code> semantic endpoint mode and <code>single</code> mode supported</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Field selection</td>
 <td><code>fields</code> parameter on READ operations, with preset-name support documented where implemented</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Batch operations</td>
 <td>Multi-operation batching with individual results</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Cross-cutting params</td>
 <td>Consistent documentation for collection-query controls such as <code>query</code>, <code>filter</code>, pagination, field selection, and sorting</td>
 </tr>
@@ -363,29 +363,29 @@ MCP-AQL Level 2 Conformant</code></pre>
 <p>The following test categories MUST pass for Level 1 conformance:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Category</th>
 <th>Tests</th>
 <th>Rationale</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>Introspection Fidelity</td>
 <td>4</td>
 <td>LLMs must trust introspection</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Parameter Handling</td>
 <td>4</td>
 <td>Consistent behavior across operations</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Error Quality</td>
 <td>3</td>
 <td>Usable error messages</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Round-Trip Integrity</td>
 <td>2</td>
 <td>Data consistency guarantee</td>
@@ -397,24 +397,24 @@ MCP-AQL Level 2 Conformant</code></pre>
 <p>The following test categories SHOULD pass for Level 2 conformance:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Category</th>
 <th>Tests</th>
 <th>Rationale</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>Constraint Documentation</td>
 <td>2</td>
 <td>Discoverable constraints</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Level 2 Features</td>
 <td>3</td>
 <td>Endpoint modes, field selection, and batch operations</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Semantic Evaluation</td>
 <td>Per implementation</td>
 <td>LLM discoverability</td>
@@ -467,29 +467,29 @@ MCP-AQL Level 2 Conformant</code></pre>
 <h3 id="53-test-categories-requiring-semantic-evaluation">5.3 Test Categories Requiring Semantic Evaluation</h3>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Category</th>
 <th>Example Prompt</th>
 <th>Why Semantic Matters</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>Introspection Discovery</td>
 <td>"List available operations"</td>
 <td>LLM may describe operations differently</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Field Selection Discovery</td>
 <td>"Does search support field selection?"</td>
 <td>Affirmative answer may use varied phrasing</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Error Understanding</td>
 <td>"Handle this error gracefully"</td>
 <td>Recovery strategies may vary</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Operation Selection</td>
 <td>"Create an element"</td>
 <td>Correct tool choice matters more than exact call format</td>
@@ -550,29 +550,29 @@ MCP-AQL Level 2 Conformant</code></pre>
 <h3 id="72-commands">7.2 Commands</h3>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Command</th>
 <th>Description</th>
 <th>Example</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>test</code></td>
 <td>Run conformance tests against a fixture evidence bundle</td>
 <td><code>node scripts/run-conformance-tests.mjs test tests/conformance/evidence/reference-level2.json --level 2</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>verify-fixtures</code></td>
 <td>Verify all repository reference fixtures against their expected exit codes</td>
 <td><code>node scripts/run-conformance-tests.mjs verify-fixtures</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>report</code></td>
 <td>Generate formatted output from a JSON results file</td>
 <td><code>node scripts/run-conformance-tests.mjs report ./results.json --format markdown</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>version</code></td>
 <td>Print tool version</td>
 <td><code>node scripts/run-conformance-tests.mjs version</code></td>
@@ -583,34 +583,34 @@ MCP-AQL Level 2 Conformant</code></pre>
 <h3 id="73-test-command-options">7.3 Test Command Options</h3>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Option</th>
 <th>Description</th>
 <th>Default</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>--level</code>, <code>-l</code></td>
 <td>Conformance level to test (1 or 2)</td>
 <td><code>1</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>--output</code>, <code>-o</code></td>
 <td>Output file for results</td>
 <td>stdout</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>--format</code>, <code>-f</code></td>
 <td>Output format (<code>json</code>, <code>text</code>, <code>markdown</code>)</td>
 <td><code>text</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>--tier</code></td>
 <td>Evaluation tier (<code>1</code>, <code>2</code>, <code>both</code>)</td>
 <td><code>both</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>--category</code>, <code>-c</code></td>
 <td>Run specific test category only</td>
 <td>All</td>
@@ -621,29 +621,29 @@ MCP-AQL Level 2 Conformant</code></pre>
 <h3 id="74-exit-codes">7.4 Exit Codes</h3>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Code</th>
 <th>Meaning</th>
 <th>Description</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>0</code></td>
 <td>All tests passed</td>
 <td>Conformance achieved at requested level</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>1</code></td>
 <td>Tests failed</td>
 <td>One or more MUST PASS tests failed</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>2</code></td>
 <td>Tests warned</td>
 <td>All MUST PASS passed, but SHOULD PASS tests warned</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>3</code></td>
 <td>Configuration error</td>
 <td>Invalid fixture/report path, malformed JSON, unknown command, or invalid report input</td>

--- a/public/spec/crude-pattern.html
+++ b/public/spec/crude-pattern.html
@@ -366,34 +366,34 @@ mcp_aql_execute  - EXECUTE operations</code></pre>
 <p>Each endpoint has canonical verbs that adapters SHOULD use for standard operations:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Endpoint</th>
 <th>Canonical Verb</th>
 <th>Example Operation</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>CREATE</td>
 <td><code>create</code></td>
 <td><code>create_user</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td>READ</td>
 <td><code>get</code> (single), <code>list</code> (multiple)</td>
 <td><code>get_document</code>, <code>list_users</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td>UPDATE</td>
 <td><code>update</code></td>
 <td><code>update_profile</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td>DELETE</td>
 <td><code>delete</code></td>
 <td><code>delete_account</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td>EXECUTE</td>
 <td><code>execute</code> (initiate), <code>cancel</code> (terminate)</td>
 <td><code>execute_workflow</code>, <code>cancel_task</code></td>

--- a/public/spec/crude-pattern.html
+++ b/public/spec/crude-pattern.html
@@ -7,7 +7,9 @@
   <title>MCP-AQL Spec | MCP-AQL CRUDE Pattern Specification</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="../css/style.css">
 </head>
 <body>
@@ -464,6 +466,6 @@ mcp_aql_execute  - EXECUTE operations</code></pre>
     </div>
   </footer>
 
-  <script src="../js/search.js"></script>
+  <script src="../js/search.js" defer></script>
 </body>
 </html>

--- a/public/spec/endpoint-modes.html
+++ b/public/spec/endpoint-modes.html
@@ -136,37 +136,37 @@
 <h3 id="13-terminology">1.3 Terminology</h3>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Term</th>
 <th>Definition</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><strong>Semantic Endpoint Mode</strong></td>
 <td>Multiple exposed MCP tools whose names and purposes are semantically legible to clients</td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>Semantic Endpoint Profile</strong></td>
 <td>A specific semantic set exposed in Semantic Endpoint mode (for example CRUDE)</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><strong>CRUDE Profile</strong></td>
 <td>The standard five-endpoint semantic profile: Create, Read, Update, Delete, Execute</td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>Single Mode</strong></td>
 <td>One unified MCP tool that routes internally</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><strong>Endpoint Family</strong></td>
 <td>A named MCP tool or logical grouping that contains one or more operations</td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>Semantic Category</strong></td>
 <td>One of the standardized effect categories: CREATE, READ, UPDATE, DELETE, EXECUTE</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><strong>Operation</strong></td>
 <td>A named action exposed by the adapter</td>
 </tr>
@@ -177,39 +177,39 @@
 <h3 id="21-summary">2.1 Summary</h3>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Aspect</th>
 <th>Semantic Endpoint Mode</th>
 <th>Single Mode</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><strong>Exposed tools</strong></td>
 <td>Multiple semantic endpoint tools</td>
 <td>1 unified tool</td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>Semantic categories</strong></td>
 <td>Still standardized per operation</td>
 <td>Routed internally</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><strong>Routing</strong></td>
 <td>Client chooses endpoint family</td>
 <td>Server routes internally</td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>Permission control</strong></td>
 <td>Endpoint-level granularity</td>
 <td>Operation-level only</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><strong>Token cost</strong></td>
 <td>Low to medium</td>
 <td>Lowest</td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>Best fit</strong></td>
 <td>When endpoint semantics should remain visible to the client</td>
 <td>Minimal tool surface</td>
@@ -243,24 +243,24 @@ mcp_aql_operate</code></pre>
 <p>Endpoint consolidation provides significant token reduction compared to fully discrete tools:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Configuration</th>
 <th>Typical Token Cost</th>
 <th>Reduction</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>Discrete tools (e.g., 40+ tools)</td>
 <td>~30,000 tokens</td>
 <td>baseline</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Semantic endpoint mode (4-8 tools typical)</td>
 <td>~4,300-6,500 tokens</td>
 <td>~78-85%</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Single mode (1 tool)</td>
 <td>~1,100 tokens</td>
 <td>~96%</td>
@@ -279,21 +279,21 @@ mcp_aql_operate</code></pre>
 <p><strong>Values:</strong></p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Value</th>
 <th>Behavior</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>semantic</code></td>
 <td>Register the active semantic-endpoint profile</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>single</code></td>
 <td>Register 1 unified endpoint</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>all</code></td>
 <td>Register the active semantic-endpoint profile plus the unified endpoint</td>
 </tr>
@@ -315,34 +315,34 @@ mcp_aql_operate</code></pre>
 <p>In the standard CRUDE profile, five MCP tools are registered:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Tool Name</th>
 <th>Semantic Category</th>
 <th>Operations</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>mcp_aql_create</code></td>
 <td>CREATE</td>
 <td>Create, add, register</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>mcp_aql_read</code></td>
 <td>READ</td>
 <td>List, get, search, introspect</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>mcp_aql_update</code></td>
 <td>UPDATE</td>
 <td>Edit, modify, update</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>mcp_aql_delete</code></td>
 <td>DELETE</td>
 <td>Delete, remove, clear</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>mcp_aql_execute</code></td>
 <td>EXECUTE</td>
 <td>Run, start, stop, cancel</td>
@@ -463,13 +463,13 @@ mcp_aql_publish   - Imports, indexing jobs, publishing, review actions</code></p
 <p>In Single mode, one MCP tool is registered:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Tool Name</th>
 <th>Purpose</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>mcp_aql</code></td>
 <td>All operations through a unified entry point</td>
 </tr>
@@ -555,34 +555,34 @@ Use introspection to discover available operations:
 <h3 id="63-security-trade-offs">6.3 Security Trade-offs</h3>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Security Aspect</th>
 <th>Semantic Endpoint Mode</th>
 <th>Single Mode</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>Endpoint-level blocking</td>
 <td>Yes</td>
 <td>No</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Client error prevention</td>
 <td>Better</td>
 <td>Worse</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Attack surface</td>
 <td>Larger</td>
 <td>Smaller</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Audit granularity</td>
 <td>Endpoint family + operation</td>
 <td>Operation only</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Bypass resistance</td>
 <td>Adapter-enforced</td>
 <td>Adapter-enforced</td>

--- a/public/spec/endpoint-modes.html
+++ b/public/spec/endpoint-modes.html
@@ -7,7 +7,9 @@
   <title>MCP-AQL Spec | MCP-AQL Endpoint Modes Specification</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="../css/style.css">
 </head>
 <body>
@@ -708,6 +710,6 @@ Use introspection to discover available operations:
     </div>
   </footer>
 
-  <script src="../js/search.js"></script>
+  <script src="../js/search.js" defer></script>
 </body>
 </html>

--- a/public/spec/error-codes.html
+++ b/public/spec/error-codes.html
@@ -7,7 +7,9 @@
   <title>MCP-AQL Spec | Structured Error Codes Specification</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="../css/style.css">
 </head>
 <body>
@@ -1229,6 +1231,6 @@
     </div>
   </footer>
 
-  <script src="../js/search.js"></script>
+  <script src="../js/search.js" defer></script>
 </body>
 </html>

--- a/public/spec/error-codes.html
+++ b/public/spec/error-codes.html
@@ -225,49 +225,49 @@
 <h3 id="32-category-prefixes">3.2 Category Prefixes</h3>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Category</th>
 <th>Description</th>
 <th>HTTP Range</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>VALIDATION_</code></td>
 <td>Input validation errors</td>
 <td>400, 422</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>NOT_FOUND_</code></td>
 <td>Resource not found</td>
 <td>404</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>PERMISSION_</code></td>
 <td>Authentication/authorization</td>
 <td>401, 403</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>CONFLICT_</code></td>
 <td>Resource conflicts</td>
 <td>409</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>RATE_LIMIT_</code></td>
 <td>Rate limiting</td>
 <td>429</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>TOKEN_</code></td>
 <td>Confirmation token errors</td>
 <td>400, 403</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>SCHEMA_</code></td>
 <td>Schema validation errors (generators)</td>
 <td>N/A</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>INTERNAL_</code></td>
 <td>Server errors</td>
 <td>500+</td>
@@ -283,54 +283,54 @@
 <p>The MVP includes 8 essential error codes:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Code</th>
 <th>Category</th>
 <th>Description</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>VALIDATION_MISSING_PARAM</code></td>
 <td>Validation</td>
 <td>Required parameter not provided</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>VALIDATION_INVALID_TYPE</code></td>
 <td>Validation</td>
 <td>Parameter has wrong type</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>VALIDATION_UNKNOWN_PARAM</code></td>
 <td>Validation</td>
 <td>Request contains parameter not defined in operation schema</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>VALIDATION_INVALID_ENCODING</code></td>
 <td>Validation</td>
 <td>Request contains invalid character encoding</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>VALIDATION_PAYLOAD_TOO_LARGE</code></td>
 <td>Validation</td>
 <td>Request or response exceeds size limits</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>NOT_FOUND_OPERATION</code></td>
 <td>Not Found</td>
 <td>Requested operation does not exist</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>NOT_FOUND_RESOURCE</code></td>
 <td>Not Found</td>
 <td>Target resource not found (HTTP 404)</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>PERMISSION_DENIED</code></td>
 <td>Permission</td>
 <td>Access denied (HTTP 401/403)</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>INTERNAL_ERROR</code></td>
 <td>Internal</td>
 <td>Server error or unexpected failure</td>
@@ -605,64 +605,64 @@
 <h3 id="51-phase-1-error-code-registry">5.1 Phase 1 Error Code Registry</h3>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Code</th>
 <th>Category</th>
 <th>Description</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>PERMISSION_TRUST_LEVEL_INSUFFICIENT</code></td>
 <td>Permission</td>
 <td>Adapter trust level too low for operation</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>PERMISSION_DANGER_LEVEL_DENIED</code></td>
 <td>Permission</td>
 <td>Operation danger level exceeds trust allowance</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>CONFIRMATION_REQUIRED</code></td>
 <td>Permission</td>
 <td>Dangerous operation requires user confirmation</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>RATE_LIMIT_EXCEEDED</code></td>
 <td>Rate Limit</td>
 <td>Target API rate limit reached</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>RATE_LIMIT_QUOTA_PAUSE</code></td>
 <td>Rate Limit</td>
 <td>User quota pause threshold reached</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>RATE_LIMIT_QUOTA_EXHAUSTED</code></td>
 <td>Rate Limit</td>
 <td>User quota hard stop reached</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>RATE_LIMIT_QUOTA_WARNING</code></td>
 <td>Rate Limit</td>
 <td>Approaching quota limit (warning)</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>TOKEN_INVALID</code></td>
 <td>Token</td>
 <td>Confirmation token not found or malformed</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>TOKEN_EXPIRED</code></td>
 <td>Token</td>
 <td>Confirmation token has expired</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>TOKEN_ALREADY_USED</code></td>
 <td>Token</td>
 <td>Confirmation token has already been redeemed</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>TOKEN_SCOPE_MISMATCH</code></td>
 <td>Token</td>
 <td>Token issued for different operation or parameters</td>
@@ -1011,64 +1011,64 @@
 <p>The runtime maps HTTP status codes to MCP-AQL error codes:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>HTTP Status</th>
 <th>Error Code</th>
 <th>Description</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>400</td>
 <td><code>VALIDATION_INVALID_TYPE</code></td>
 <td>Bad request (default for validation errors)</td>
 </tr>
-<tr class="even">
+<tr>
 <td>400</td>
 <td><code>VALIDATION_MISSING_PARAM</code></td>
 <td>Bad request (missing required parameter)</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>400</td>
 <td><code>VALIDATION_UNKNOWN_PARAM</code></td>
 <td>Bad request (unknown parameter)</td>
 </tr>
-<tr class="even">
+<tr>
 <td>401</td>
 <td><code>PERMISSION_DENIED</code></td>
 <td>Authentication required</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>403</td>
 <td><code>PERMISSION_DENIED</code></td>
 <td>Forbidden</td>
 </tr>
-<tr class="even">
+<tr>
 <td>404</td>
 <td><code>NOT_FOUND_RESOURCE</code></td>
 <td>Not found</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>422</td>
 <td><code>VALIDATION_INVALID_TYPE</code></td>
 <td>Unprocessable entity</td>
 </tr>
-<tr class="even">
+<tr>
 <td>500</td>
 <td><code>INTERNAL_ERROR</code></td>
 <td>Internal server error</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>502</td>
 <td><code>INTERNAL_ERROR</code></td>
 <td>Bad gateway</td>
 </tr>
-<tr class="even">
+<tr>
 <td>503</td>
 <td><code>INTERNAL_ERROR</code></td>
 <td>Service unavailable</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>504</td>
 <td><code>INTERNAL_ERROR</code></td>
 <td>Gateway timeout</td>

--- a/public/spec/features/aggregations.html
+++ b/public/spec/features/aggregations.html
@@ -142,33 +142,33 @@
 <p>The preferred aggregation vocabulary is:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Key</th>
 <th>Meaning</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>count</code></td>
 <td>Count matching records</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>group_by</code></td>
 <td>Group records by a field</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>sum</code></td>
 <td>Sum a numeric field</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>avg</code></td>
 <td>Average a numeric field</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>min</code></td>
 <td>Minimum value for a field</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>max</code></td>
 <td>Maximum value for a field</td>
 </tr>

--- a/public/spec/features/aggregations.html
+++ b/public/spec/features/aggregations.html
@@ -7,7 +7,9 @@
   <title>MCP-AQL Spec | MCP-AQL Aggregations</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="../../css/style.css">
 </head>
 <body>
@@ -262,6 +264,6 @@
     </div>
   </footer>
 
-  <script src="../../js/search.js"></script>
+  <script src="../../js/search.js" defer></script>
 </body>
 </html>

--- a/public/spec/features/collection-querying.html
+++ b/public/spec/features/collection-querying.html
@@ -7,7 +7,9 @@
   <title>MCP-AQL Spec | MCP-AQL Collection Querying</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="../../css/style.css">
 </head>
 <body>
@@ -393,6 +395,6 @@
     </div>
   </footer>
 
-  <script src="../../js/search.js"></script>
+  <script src="../../js/search.js" defer></script>
 </body>
 </html>

--- a/public/spec/features/collection-querying.html
+++ b/public/spec/features/collection-querying.html
@@ -121,24 +121,24 @@
 <p>MCP-AQL commonly exposes three collection-oriented READ patterns:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Pattern</th>
 <th>Purpose</th>
 <th>Typical Example</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>list_*</code></td>
 <td>Enumerate a collection without requiring text search</td>
 <td><code>list_elements</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>search_*</code></td>
 <td>Free-text retrieval over a collection</td>
 <td><code>search_elements</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>query_*</code></td>
 <td>Structured or adapter-defined query grammar</td>
 <td><code>query_elements</code></td>
@@ -227,29 +227,29 @@
 <p>Preferred cursor parameters:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Parameter</th>
 <th>Type</th>
 <th>Meaning</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>first</code></td>
 <td>number</td>
 <td>Number of items from the start</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>after</code></td>
 <td>string</td>
 <td>Cursor to continue after</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>last</code></td>
 <td>number</td>
 <td>Number of items from the end</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>before</code></td>
 <td>string</td>
 <td>Cursor to continue before</td>
@@ -268,7 +268,7 @@
 <p>The following matrix describes the preferred forward direction for collection-returning READ operations:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Operation Family</th>
 <th><code>query</code></th>
 <th><code>filter</code></th>
@@ -279,7 +279,7 @@
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>list_*</code></td>
 <td>Not required</td>
 <td>SHOULD support</td>
@@ -288,7 +288,7 @@
 <td>SHOULD support</td>
 <td>SHOULD support</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>search_*</code></td>
 <td>SHOULD support as the canonical text parameter</td>
 <td>SHOULD support</td>
@@ -297,7 +297,7 @@
 <td>SHOULD support</td>
 <td>SHOULD support</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>query_*</code></td>
 <td>MUST document grammar</td>
 <td>SHOULD document composition rules</td>

--- a/public/spec/features/computed-fields.html
+++ b/public/spec/features/computed-fields.html
@@ -7,7 +7,9 @@
   <title>MCP-AQL Spec | MCP-AQL Computed Fields</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="../../css/style.css">
 </head>
 <body>
@@ -232,6 +234,6 @@
     </div>
   </footer>
 
-  <script src="../../js/search.js"></script>
+  <script src="../../js/search.js" defer></script>
 </body>
 </html>

--- a/public/spec/features/computed-fields.html
+++ b/public/spec/features/computed-fields.html
@@ -177,25 +177,25 @@
 <h2 id="5-common-patterns">5. Common Patterns</h2>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Pattern</th>
 <th>Examples</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>Time-derived</td>
 <td><code>age_days</code>, <code>time_until_due</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td>Counts</td>
 <td><code>child_count</code>, <code>reference_count</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Status-derived</td>
 <td><code>is_stale</code>, <code>needs_attention</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td>Size-derived</td>
 <td><code>estimated_tokens</code>, <code>size_human</code></td>
 </tr>

--- a/public/spec/features/field-selection.html
+++ b/public/spec/features/field-selection.html
@@ -127,7 +127,7 @@
 <h3 id="13-token-impact">1.3 Token Impact</h3>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Scenario</th>
 <th>Without Selection</th>
 <th>With Selection</th>
@@ -135,19 +135,19 @@
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>List 10 items (full)</td>
 <td>~2,500 tokens</td>
 <td>~800 tokens</td>
 <td>~68%</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Get single item (full)</td>
 <td>~350 tokens</td>
 <td>~120 tokens</td>
 <td>~65%</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Search results (20 items)</td>
 <td>~4,000 tokens</td>
 <td>~1,200 tokens</td>

--- a/public/spec/features/field-selection.html
+++ b/public/spec/features/field-selection.html
@@ -7,7 +7,9 @@
   <title>MCP-AQL Spec | Field Selection Specification</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="../../css/style.css">
 </head>
 <body>
@@ -369,6 +371,6 @@
     </div>
   </footer>
 
-  <script src="../../js/search.js"></script>
+  <script src="../../js/search.js" defer></script>
 </body>
 </html>

--- a/public/spec/features/pagination.html
+++ b/public/spec/features/pagination.html
@@ -7,7 +7,9 @@
   <title>MCP-AQL Spec | Cursor-Based Pagination Specification</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="../../css/style.css">
 </head>
 <body>
@@ -729,6 +731,6 @@
     </div>
   </footer>
 
-  <script src="../../js/search.js"></script>
+  <script src="../../js/search.js" defer></script>
 </body>
 </html>

--- a/public/spec/features/pagination.html
+++ b/public/spec/features/pagination.html
@@ -175,29 +175,29 @@
 <h3 id="22-parameter-combinations">2.2 Parameter Combinations</h3>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Parameters</th>
 <th>Behavior</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>first</code></td>
 <td>First N items from start</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>first</code> + <code>after</code></td>
 <td>First N items after cursor</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>last</code></td>
 <td>Last N items from end</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>last</code> + <code>before</code></td>
 <td>Last N items before cursor</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>None</td>
 <td>Default page size from start</td>
 </tr>
@@ -295,34 +295,34 @@
 <h3 id="32-pageinfo-requirements">3.2 PageInfo Requirements</h3>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Field</th>
 <th>Required</th>
 <th>Notes</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>hasNextPage</code></td>
 <td>Yes</td>
 <td>Always include, even if false</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>hasPreviousPage</code></td>
 <td>Yes</td>
 <td>Always include, even if false</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>startCursor</code></td>
 <td>Conditional</td>
 <td>Required when results are returned (<code>items.length &gt; 0</code> or <code>edges.length &gt; 0</code>)</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>endCursor</code></td>
 <td>Conditional</td>
 <td>Required when results are returned (<code>items.length &gt; 0</code> or <code>edges.length &gt; 0</code>)</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>totalCount</code></td>
 <td>No</td>
 <td>Include when available without performance impact</td>
@@ -439,25 +439,25 @@
 <h3 id="44-choosing-response-format">4.4 Choosing Response Format</h3>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Use Case</th>
 <th>Recommended Format</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>Simple listing</td>
 <td><code>items</code> array</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Modify during iteration</td>
 <td><code>edges</code> with cursors</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>LLM context (minimize tokens)</td>
 <td><code>items</code> array</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Resume from specific item</td>
 <td><code>edges</code> with cursors</td>
 </tr>
@@ -507,34 +507,34 @@
 <p>The following operation types SHOULD support pagination:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Operation</th>
 <th>Required</th>
 <th>Notes</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>list_elements</code></td>
 <td>Yes</td>
 <td>Core element listing</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>search_elements</code></td>
 <td>Yes</td>
 <td>Search results</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>query_elements</code></td>
 <td>Yes</td>
 <td>Complex queries</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>list_*</code></td>
 <td>Yes</td>
 <td>Any list operation</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>search_*</code></td>
 <td>Yes</td>
 <td>Any search operation</td>
@@ -545,21 +545,21 @@
 <p>When pagination parameters are omitted:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Aspect</th>
 <th>Default</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>Page size</td>
 <td>Implementation-defined (RECOMMENDED: 20)</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Direction</td>
 <td>Forward (from start)</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Cursor</td>
 <td>None (first page)</td>
 </tr>

--- a/public/spec/features/relationship-queries.html
+++ b/public/spec/features/relationship-queries.html
@@ -133,39 +133,39 @@
 <h2 id="2-core-parameters">2. Core Parameters</h2>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Parameter</th>
 <th>Required</th>
 <th>Meaning</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>root</code></td>
 <td>Yes</td>
 <td>Starting resource for the traversal</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>direction</code></td>
 <td>Yes</td>
 <td><code>incoming</code>, <code>outgoing</code>, or <code>both</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>relationship</code></td>
 <td>No</td>
 <td>Relationship type to match</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>depth</code></td>
 <td>No</td>
 <td>Maximum traversal depth</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>include</code></td>
 <td>No</td>
 <td>Optional response-section selector for <code>root</code>, <code>relationships</code>, <code>graph.nodes</code>, and <code>graph.edges</code>; all sections returned if omitted</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>first</code> / <code>after</code></td>
 <td>No</td>
 <td>Optional pagination controls when traversals are large</td>

--- a/public/spec/features/relationship-queries.html
+++ b/public/spec/features/relationship-queries.html
@@ -7,7 +7,9 @@
   <title>MCP-AQL Spec | MCP-AQL Relationship Queries</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="../../css/style.css">
 </head>
 <body>
@@ -289,6 +291,6 @@
     </div>
   </footer>
 
-  <script src="../../js/search.js"></script>
+  <script src="../../js/search.js" defer></script>
 </body>
 </html>

--- a/public/spec/features/warnings.html
+++ b/public/spec/features/warnings.html
@@ -7,7 +7,9 @@
   <title>MCP-AQL Spec | Warnings Array Specification</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="../../css/style.css">
 </head>
 <body>
@@ -834,6 +836,6 @@
     </div>
   </footer>
 
-  <script src="../../js/search.js"></script>
+  <script src="../../js/search.js" defer></script>
 </body>
 </html>

--- a/public/spec/features/warnings.html
+++ b/public/spec/features/warnings.html
@@ -139,34 +139,34 @@
 <h3 id="13-relationship-to-errors">1.3 Relationship to Errors</h3>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Aspect</th>
 <th>Error</th>
 <th>Warning</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>Response success</td>
 <td><code>false</code></td>
 <td><code>true</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td>Operation completed</td>
 <td>No</td>
 <td>Yes</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Client action</td>
 <td>Required</td>
 <td>Optional</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Blocks execution</td>
 <td>Yes</td>
 <td>No</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Schema structure</td>
 <td><code>error</code> object</td>
 <td><code>warnings</code> array</td>
@@ -288,24 +288,24 @@
 <p>The optional <code>severity</code> field helps clients prioritize warnings when multiple are present:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Level</th>
 <th>Description</th>
 <th>Example Use Cases</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>high</code></td>
 <td>Requires immediate attention; may affect operations soon</td>
 <td>Quota nearly exhausted, imminent deprecation removal</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>medium</code></td>
 <td>Should be addressed but not urgent</td>
 <td>Approaching limits, scheduled deprecation</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>low</code></td>
 <td>Informational; can be safely deferred or filtered</td>
 <td>Performance hints, soft deprecation notices</td>
@@ -316,24 +316,24 @@
 <p>For sorting, filtering, and programmatic comparison, implementations SHOULD use this numeric mapping:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Severity</th>
 <th>Numeric Value</th>
 <th>Sort Order</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>high</code></td>
 <td>0</td>
 <td>First (most urgent)</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>medium</code></td>
 <td>1</td>
 <td>Second</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>low</code></td>
 <td>2</td>
 <td>Third (least urgent)</td>
@@ -387,29 +387,29 @@
 <h3 id="34-warning-categories">3.4 Warning Categories</h3>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Category</th>
 <th>Description</th>
 <th>Example</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>RATE_LIMIT_</code></td>
 <td>Approaching rate/quota limits</td>
 <td><code>RATE_LIMIT_QUOTA_WARNING</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>DEPRECATION_</code></td>
 <td>Deprecated feature usage</td>
 <td><code>DEPRECATION_WARNING</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>VALIDATION_</code></td>
 <td>Data quality issues</td>
 <td><code>VALIDATION_TRUNCATED_WARNING</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>PERFORMANCE_</code></td>
 <td>Performance concerns</td>
 <td><code>PERFORMANCE_SLOW_QUERY_WARNING</code></td>
@@ -425,19 +425,19 @@
 <p><strong>Severity recommendations:</strong></p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Condition</th>
 <th>Severity</th>
 <th>Rationale</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>&gt;90% of quota consumed</td>
 <td><code>high</code></td>
 <td>Imminent limit, requires immediate attention</td>
 </tr>
-<tr class="even">
+<tr>
 <td>At warn_threshold (default 80%)</td>
 <td><code>medium</code></td>
 <td>Standard warning, action advisable</td>
@@ -475,24 +475,24 @@
 <p><strong>Severity recommendations:</strong></p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Condition</th>
 <th>Severity</th>
 <th>Rationale</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>Within 30 days of removal_date</td>
 <td><code>high</code></td>
 <td>Urgent migration required</td>
 </tr>
-<tr class="even">
+<tr>
 <td>More than 30 days from removal_date</td>
 <td><code>medium</code></td>
 <td>Migration advisable</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>No removal_date set (soft deprecation)</td>
 <td><code>low</code></td>
 <td>Informational, no urgency</td>
@@ -530,19 +530,19 @@
 <p><strong>Severity recommendations:</strong></p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Condition</th>
 <th>Severity</th>
 <th>Rationale</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>Significant data loss (&gt;50% truncated)</td>
 <td><code>medium</code></td>
 <td>User may miss important data</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Minor truncation (≤50% truncated)</td>
 <td><code>low</code></td>
 <td>Informational, pagination available</td>
@@ -578,24 +578,24 @@
 <p><strong>Severity recommendations:</strong></p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Condition</th>
 <th>Severity</th>
 <th>Rationale</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>&gt;10x threshold exceeded</td>
 <td><code>high</code></td>
 <td>Severe degradation, may indicate systemic issue</td>
 </tr>
-<tr class="even">
+<tr>
 <td>2-10x threshold exceeded</td>
 <td><code>medium</code></td>
 <td>Notable slowdown, optimization recommended</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Just above threshold (&lt;2x)</td>
 <td><code>low</code></td>
 <td>Minor performance concern</td>
@@ -672,25 +672,25 @@
 <p>When displaying warnings to users:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Warning Category</th>
 <th>Display Recommendation</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>RATE_LIMIT_</code></td>
 <td>Prominent, real-time indicator</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>DEPRECATION_</code></td>
 <td>One-time notification per session</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>VALIDATION_</code></td>
 <td>Inline with affected data</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>PERFORMANCE_</code></td>
 <td>Status bar or background notification</td>
 </tr>
@@ -776,25 +776,25 @@
 <h4 id="deduplication-recommendations">Deduplication Recommendations</h4>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Context</th>
 <th>Recommendation</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>Single request</td>
 <td>Server SHOULD deduplicate identical warnings</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Batch operations</td>
 <td>Server SHOULD collapse per-item warnings into summary</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Client session</td>
 <td>Client MAY deduplicate across requests</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Long-running clients</td>
 <td>Client SHOULD use time-based expiration</td>
 </tr>

--- a/public/spec/guides/README.html
+++ b/public/spec/guides/README.html
@@ -7,7 +7,9 @@
   <title>MCP-AQL Spec | Developer Guides</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="../../css/style.css">
 </head>
 <body>
@@ -127,6 +129,6 @@
     </div>
   </footer>
 
-  <script src="../../js/search.js"></script>
+  <script src="../../js/search.js" defer></script>
 </body>
 </html>

--- a/public/spec/guides/cross-domain-implementation.html
+++ b/public/spec/guides/cross-domain-implementation.html
@@ -119,24 +119,24 @@
 <p>Before you name any operations, identify three core pieces:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Question</th>
 <th>What you are mapping</th>
 <th>Example</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>What are the primary resources?</td>
 <td>MCP-AQL resource or type names</td>
 <td><code>database</code>, <code>table</code>, <code>file</code>, <code>route</code>, <code>device</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td>How are they identified?</td>
 <td>Stable lookup parameters</td>
 <td><code>database_name</code>, <code>table_name</code>, <code>file_path</code>, <code>route_id</code>, <code>device_id</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Which actions matter most?</td>
 <td>MCP-AQL operations</td>
 <td><code>list_tables</code>, <code>get_file</code>, <code>update_route</code>, <code>execute_firmware_upgrade</code></td>
@@ -170,34 +170,34 @@
 <p>Map each real action to the endpoint that best reflects its effect:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Endpoint</th>
 <th>Use for</th>
 <th>Example</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>CREATE</code></td>
 <td>Additive changes</td>
 <td><code>create_route</code>, <code>create_table_snapshot</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>READ</code></td>
 <td>Safe lookups and queries</td>
 <td><code>list_tables</code>, <code>search_files</code>, <code>query_relationships</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>UPDATE</code></td>
 <td>Mutations to existing state</td>
 <td><code>update_device_config</code>, <code>update_route</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>DELETE</code></td>
 <td>Removals</td>
 <td><code>delete_route</code>, <code>delete_file_alias</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>EXECUTE</code></td>
 <td>Runtime or non-idempotent actions</td>
 <td><code>execute_backup</code>, <code>execute_firmware_upgrade</code></td>

--- a/public/spec/guides/cross-domain-implementation.html
+++ b/public/spec/guides/cross-domain-implementation.html
@@ -7,7 +7,9 @@
   <title>MCP-AQL Spec | Cross-Domain Implementation Guide</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="../../css/style.css">
 </head>
 <body>
@@ -493,6 +495,6 @@
     </div>
   </footer>
 
-  <script src="../../js/search.js"></script>
+  <script src="../../js/search.js" defer></script>
 </body>
 </html>

--- a/public/spec/guides/protocol-comparison.html
+++ b/public/spec/guides/protocol-comparison.html
@@ -7,7 +7,9 @@
   <title>MCP-AQL Spec | Protocol Comparison Guide</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="../../css/style.css">
 </head>
 <body>
@@ -1609,6 +1611,6 @@ GET /api/swagger.json HTTP/1.1</code></pre>
     </div>
   </footer>
 
-  <script src="../../js/search.js"></script>
+  <script src="../../js/search.js" defer></script>
 </body>
 </html>

--- a/public/spec/guides/protocol-comparison.html
+++ b/public/spec/guides/protocol-comparison.html
@@ -124,7 +124,7 @@
 <p>MCP-AQL supports multiple endpoint modes with different token trade-offs:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Mode</th>
 <th>Endpoints</th>
 <th>Token Cost</th>
@@ -133,21 +133,21 @@
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><strong>Discrete</strong></td>
 <td>Many individual tools</td>
 <td>~30,000</td>
 <td>Baseline</td>
 <td>Traditional MCP</td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>CRUDE</strong></td>
 <td>5 semantic endpoints</td>
 <td>~4,300</td>
 <td>~85%</td>
 <td>Host-level permission control</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><strong>Single</strong></td>
 <td>1 unified endpoint</td>
 <td>~1,100</td>
@@ -161,29 +161,29 @@
 <p>Developers often approach new protocols through the lens of what they already know. This guide provides mental models for understanding MCP-AQL by drawing parallels to:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Protocol</th>
 <th>Similarity to MCP-AQL</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><strong>GraphQL</strong></td>
 <td>Introspection, typed operations, nested input objects</td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>MongoDB</strong></td>
 <td>Document-based operations, flexible queries</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><strong>REST</strong></td>
 <td>Resource-oriented endpoints, HTTP-like semantics</td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>SQL</strong></td>
 <td>Structured queries, CRUD operations</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><strong>Classic MCP</strong></td>
 <td>Tool-based interface (what MCP-AQL can replace)</td>
 </tr>
@@ -202,7 +202,7 @@
 <h2 id="quick-reference-table">Quick Reference Table</h2>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Concept</th>
 <th>GraphQL</th>
 <th>MongoDB</th>
@@ -212,7 +212,7 @@
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><strong>Define Operation</strong></td>
 <td><code>mutation createUser</code></td>
 <td><code>db.users.insertOne()</code></td>
@@ -220,7 +220,7 @@
 <td><code>INSERT INTO users</code></td>
 <td><code>{ operation: "..." }</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>Specify Parameters</strong></td>
 <td><code>variables: { ... }</code></td>
 <td><code>{ filter: { ... } }</code></td>
@@ -228,7 +228,7 @@
 <td><code>WHERE clause</code></td>
 <td><code>params: { ... }</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><strong>Target Type</strong></td>
 <td>Type in schema</td>
 <td>Collection name</td>
@@ -236,7 +236,7 @@
 <td>Table name</td>
 <td>Implementation-defined</td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>Read One</strong></td>
 <td><code>query { user(id) }</code></td>
 <td><code>findOne({ _id })</code></td>
@@ -244,7 +244,7 @@
 <td><code>SELECT ... WHERE id=</code></td>
 <td>Read operation</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><strong>Read Many</strong></td>
 <td><code>query { users }</code></td>
 <td><code>find({})</code></td>
@@ -252,7 +252,7 @@
 <td><code>SELECT * FROM</code></td>
 <td>List operation</td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>Create</strong></td>
 <td><code>mutation { createUser }</code></td>
 <td><code>insertOne()</code></td>
@@ -260,7 +260,7 @@
 <td><code>INSERT INTO</code></td>
 <td>Create operation</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><strong>Update</strong></td>
 <td><code>mutation { updateUser }</code></td>
 <td><code>updateOne()</code></td>
@@ -268,7 +268,7 @@
 <td><code>UPDATE ... SET</code></td>
 <td>Update operation</td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>Delete</strong></td>
 <td><code>mutation { deleteUser }</code></td>
 <td><code>deleteOne()</code></td>
@@ -276,7 +276,7 @@
 <td><code>DELETE FROM</code></td>
 <td>Delete operation</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><strong>Search</strong></td>
 <td><code>query { search(q) }</code></td>
 <td><code>find({ $text })</code></td>
@@ -284,7 +284,7 @@
 <td><code>LIKE '%term%'</code></td>
 <td>Search operation</td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>Discover Schema</strong></td>
 <td><code>__schema</code> introspection</td>
 <td><code>db.getCollectionInfos()</code></td>
@@ -292,7 +292,7 @@
 <td><code>DESCRIBE table</code></td>
 <td><code>introspect</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><strong>Field Selection</strong></td>
 <td>Field list in query</td>
 <td>Projection <code>{ field: 1 }</code></td>
@@ -300,7 +300,7 @@
 <td><code>SELECT a, b</code></td>
 <td><code>fields</code> param or preset</td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>Response Format</strong></td>
 <td><code>{ data, errors }</code></td>
 <td>Document / cursor</td>
@@ -308,7 +308,7 @@
 <td>Result set</td>
 <td><code>{ success, data/error }</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><strong>Error Handling</strong></td>
 <td><code>errors</code> array</td>
 <td>Exception</td>
@@ -325,34 +325,34 @@
 <p>GraphQL separates read operations (queries) from write operations (mutations). MCP-AQL takes this further with the <strong>CRUDE pattern</strong> (5 semantic categories):</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>GraphQL</th>
 <th>MCP-AQL Endpoint</th>
 <th>Purpose</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>query</code></td>
 <td><code>mcp_aql_read</code></td>
 <td>Read-only operations</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>mutation</code> (create)</td>
 <td><code>mcp_aql_create</code></td>
 <td>Additive operations</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>mutation</code> (update)</td>
 <td><code>mcp_aql_update</code></td>
 <td>Modifying operations</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>mutation</code> (delete)</td>
 <td><code>mcp_aql_delete</code></td>
 <td>Destructive operations</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>subscription</code></td>
 <td><code>mcp_aql_execute</code></td>
 <td>Runtime/stateful operations</td>
@@ -380,21 +380,21 @@
 <p>In GraphQL, you query specific types (<code>User</code>, <code>Post</code>). In MCP-AQL, implementations define their own resource type parameter:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>GraphQL</th>
 <th>MCP-AQL Pattern</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>type User</code></td>
 <td><code>resource_type: "user"</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>type Post</code></td>
 <td><code>resource_type: "post"</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>type Comment</code></td>
 <td><code>resource_type: "comment"</code></td>
 </tr>
@@ -459,24 +459,24 @@
 <span id="cb8-7"><a href="#cb8-7" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Preset</th>
 <th>Description</th>
 <th>Typical Token Savings</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>minimal</code></td>
 <td>Only identifier and description</td>
 <td>~86%</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>standard</code></td>
 <td>Common fields for most use cases</td>
 <td>~73%</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>full</code></td>
 <td>All fields (default)</td>
 <td>0%</td>
@@ -486,34 +486,34 @@
 <h3 id="key-differences-from-graphql">Key Differences from GraphQL</h3>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Aspect</th>
 <th>GraphQL</th>
 <th>MCP-AQL</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><strong>Field Selection</strong></td>
 <td>Client selects specific fields</td>
 <td><code>fields</code> param or presets</td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>Subscriptions</strong></td>
 <td>Real-time WebSocket streams</td>
 <td>EXECUTE for stateful lifecycle</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><strong>Schema Definition</strong></td>
 <td>SDL files</td>
 <td>Declarative operation schemas</td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>Fragments/Aliases</strong></td>
 <td>Supported</td>
 <td>Not applicable</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><strong>Batching</strong></td>
 <td>DataLoader pattern</td>
 <td>Built-in batch operations</td>
@@ -527,25 +527,25 @@
 <p>MongoDB organizes documents into collections. MCP-AQL implementations define resource type parameters:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>MongoDB</th>
 <th>MCP-AQL Pattern</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>db.users</code></td>
 <td><code>resource_type: "user"</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>db.posts</code></td>
 <td><code>resource_type: "post"</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>db.comments</code></td>
 <td><code>resource_type: "comment"</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td>Collection name in method</td>
 <td>Passed as parameter</td>
 </tr>
@@ -554,33 +554,33 @@
 <h3 id="crud-method-mapping">CRUD Method Mapping</h3>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>MongoDB</th>
 <th>MCP-AQL</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>insertOne()</code></td>
 <td><code>create_resource</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>find()</code></td>
 <td><code>list_resources</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>findOne()</code></td>
 <td><code>get_resource</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>updateOne()</code></td>
 <td><code>update_resource</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>deleteOne()</code></td>
 <td><code>delete_resource</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>aggregate()</code></td>
 <td><code>search</code> or <code>query_resources</code></td>
 </tr>
@@ -642,34 +642,34 @@
 <h3 id="key-differences-from-mongodb">Key Differences from MongoDB</h3>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Aspect</th>
 <th>MongoDB</th>
 <th>MCP-AQL</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><strong>Query Operators</strong></td>
 <td>Rich ($gt, $in, $regex)</td>
 <td>Simplified search/filter</td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>Aggregation</strong></td>
 <td>Complex pipelines</td>
 <td>Normalized via <code>search</code> operation</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><strong>Indexes</strong></td>
 <td>User-defined</td>
 <td>Managed by server</td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>Transactions</strong></td>
 <td>Multi-document ACID</td>
 <td>Per-operation atomicity</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><strong>Cursors</strong></td>
 <td>Iterable result sets</td>
 <td>Paginated responses</td>
@@ -683,34 +683,34 @@
 <p>REST uses HTTP methods for semantics. MCP-AQL uses 5 semantic endpoints:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>HTTP Method</th>
 <th>MCP-AQL Endpoint</th>
 <th>Description</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>POST</code> (create)</td>
 <td><code>mcp_aql_create</code></td>
 <td>Create new resources</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>GET</code></td>
 <td><code>mcp_aql_read</code></td>
 <td>Read resources</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>PUT</code> / <code>PATCH</code></td>
 <td><code>mcp_aql_update</code></td>
 <td>Modify resources</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>DELETE</code></td>
 <td><code>mcp_aql_delete</code></td>
 <td>Remove resources</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>N/A</td>
 <td><code>mcp_aql_execute</code></td>
 <td>Runtime operations</td>
@@ -721,29 +721,29 @@
 <p>REST encodes resources in URLs. MCP-AQL uses <code>operation</code> plus implementation-defined parameters:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>REST Pattern</th>
 <th>MCP-AQL Pattern</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>GET /resources</code></td>
 <td><code>{ operation: "list_resources" }</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>GET /resources/:id</code></td>
 <td><code>{ operation: "get_resource", params: { id } }</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>POST /resources</code></td>
 <td><code>{ operation: "create_resource", params: { ... } }</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>PUT /resources/:id</code></td>
 <td><code>{ operation: "update_resource", params: { id, input } }</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>DELETE /resources/:id</code></td>
 <td><code>{ operation: "delete_resource", params: { id } }</code></td>
 </tr>
@@ -791,25 +791,25 @@ Content-Type: application/json
 <h3 id="error-handling">Error Handling</h3>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>REST</th>
 <th>MCP-AQL</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>HTTP 200 OK</td>
 <td><code>{ success: true, data: ... }</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td>HTTP 400 Bad Request</td>
 <td><code>{ success: false, error: "Invalid parameter..." }</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td>HTTP 404 Not Found</td>
 <td><code>{ success: false, error: "Resource not found..." }</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td>HTTP 500 Internal Error</td>
 <td><code>{ success: false, error: "..." }</code></td>
 </tr>
@@ -847,34 +847,34 @@ Content-Type: application/json
 <h3 id="key-differences-from-rest">Key Differences from REST</h3>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Aspect</th>
 <th>REST</th>
 <th>MCP-AQL</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><strong>Transport</strong></td>
 <td>HTTP</td>
 <td>MCP (stdio/SSE)</td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>Versioning</strong></td>
 <td>URL path (<code>/v1/...</code>)</td>
 <td>Schema version in response</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><strong>HATEOAS</strong></td>
 <td>Links in responses</td>
 <td>Introspection for discovery</td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>Caching</strong></td>
 <td>HTTP headers</td>
 <td>Server-managed</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><strong>Authentication</strong></td>
 <td>Headers (Bearer, API key)</td>
 <td>MCP session-based</td>
@@ -888,21 +888,21 @@ Content-Type: application/json
 <p>SQL organizes data into tables. MCP-AQL implementations define resource type parameters:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>SQL</th>
 <th>MCP-AQL Pattern</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>users</code> table</td>
 <td><code>resource_type: "user"</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>posts</code> table</td>
 <td><code>resource_type: "post"</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>SELECT * FROM users</code></td>
 <td><code>list_resources</code> with <code>resource_type</code></td>
 </tr>
@@ -911,33 +911,33 @@ Content-Type: application/json
 <h3 id="sql-statement-mapping">SQL Statement Mapping</h3>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>SQL</th>
 <th>MCP-AQL Pattern</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>INSERT INTO</code></td>
 <td>Create operation</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>SELECT * FROM</code></td>
 <td>List operation</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>SELECT ... WHERE id =</code></td>
 <td>Get operation</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>UPDATE ... SET</code></td>
 <td>Update operation</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>DELETE FROM</code></td>
 <td>Delete operation</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>SELECT ... WHERE ... LIKE</code></td>
 <td>Search operation</td>
 </tr>
@@ -997,17 +997,17 @@ Content-Type: application/json
 <h3 id="schema-discovery">Schema Discovery</h3>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>SQL</th>
 <th>MCP-AQL</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>DESCRIBE users</code></td>
 <td><code>introspect</code> with <code>query: "types"</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>SHOW TABLES</code></td>
 <td><code>introspect</code> with <code>query: "operations"</code></td>
 </tr>
@@ -1016,34 +1016,34 @@ Content-Type: application/json
 <h3 id="key-differences-from-sql">Key Differences from SQL</h3>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Aspect</th>
 <th>SQL</th>
 <th>MCP-AQL</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><strong>Query Language</strong></td>
 <td>Declarative SQL</td>
 <td>Structured JSON</td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>Joins</strong></td>
 <td>Complex multi-table joins</td>
 <td>Resource relationships via handlers</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><strong>Transactions</strong></td>
 <td>BEGIN/COMMIT/ROLLBACK</td>
 <td>Per-operation atomicity</td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>Indexes</strong></td>
 <td>User-defined CREATE INDEX</td>
 <td>Managed by server</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><strong>Stored Procedures</strong></td>
 <td>User-defined functions</td>
 <td>Agent execution</td>
@@ -1104,44 +1104,44 @@ mcp_aql_execute - EXECUTE operations (execute workflows, update state)</code></p
 <h3 id="tool-to-operation-mapping">Tool to Operation Mapping</h3>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Classic Tool Pattern</th>
 <th>MCP-AQL Operation Pattern</th>
 <th>Endpoint</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>create_&lt;type&gt;</code></td>
 <td><code>create_resource</code> + <code>resource_type</code></td>
 <td>CREATE</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>list_&lt;type&gt;s</code></td>
 <td><code>list_resources</code> + <code>resource_type</code></td>
 <td>READ</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>get_&lt;type&gt;</code></td>
 <td><code>get_resource</code> + <code>resource_type</code></td>
 <td>READ</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>edit_&lt;type&gt;</code></td>
 <td><code>update_resource</code> + <code>resource_type</code></td>
 <td>UPDATE</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>delete_&lt;type&gt;</code></td>
 <td><code>delete_resource</code> + <code>resource_type</code></td>
 <td>DELETE</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>search_&lt;type&gt;s</code></td>
 <td><code>search</code></td>
 <td>READ</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>execute_&lt;workflow&gt;</code></td>
 <td><code>execute_workflow</code></td>
 <td>EXECUTE</td>
@@ -1153,7 +1153,7 @@ mcp_aql_execute - EXECUTE operations (execute workflows, update state)</code></p
 <p><strong>After:</strong> Explicit CRUDE endpoint permissions:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Endpoint</th>
 <th>readOnly</th>
 <th>destructive</th>
@@ -1161,31 +1161,31 @@ mcp_aql_execute - EXECUTE operations (execute workflows, update state)</code></p
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>CREATE</td>
 <td>false</td>
 <td>false</td>
 <td>Additive, non-destructive</td>
 </tr>
-<tr class="even">
+<tr>
 <td>READ</td>
 <td>true</td>
 <td>false</td>
 <td>Safe, read-only</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>UPDATE</td>
 <td>false</td>
 <td>true</td>
 <td>Modifying</td>
 </tr>
-<tr class="even">
+<tr>
 <td>DELETE</td>
 <td>false</td>
 <td>true</td>
 <td>Destructive</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>EXECUTE</td>
 <td>false</td>
 <td>true</td>
@@ -1209,7 +1209,7 @@ mcp_aql_execute - EXECUTE operations (execute workflows, update state)</code></p
 <p>This table maps concepts across all compared protocols.</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Concept</th>
 <th>GraphQL</th>
 <th>MongoDB</th>
@@ -1219,7 +1219,7 @@ mcp_aql_execute - EXECUTE operations (execute workflows, update state)</code></p
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><strong>Namespace</strong></td>
 <td>Schema</td>
 <td>Database</td>
@@ -1227,7 +1227,7 @@ mcp_aql_execute - EXECUTE operations (execute workflows, update state)</code></p
 <td>Schema</td>
 <td>Implementation-defined</td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>Type/Entity</strong></td>
 <td>Type</td>
 <td>Collection</td>
@@ -1235,7 +1235,7 @@ mcp_aql_execute - EXECUTE operations (execute workflows, update state)</code></p
 <td>Table</td>
 <td>Resource type param</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><strong>Instance</strong></td>
 <td>Object</td>
 <td>Document</td>
@@ -1243,7 +1243,7 @@ mcp_aql_execute - EXECUTE operations (execute workflows, update state)</code></p
 <td>Row</td>
 <td>Resource</td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>Identifier</strong></td>
 <td>ID field</td>
 <td><code>_id</code></td>
@@ -1251,7 +1251,7 @@ mcp_aql_execute - EXECUTE operations (execute workflows, update state)</code></p
 <td>Primary key</td>
 <td>Resource ID</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><strong>Create</strong></td>
 <td>Mutation</td>
 <td><code>insertOne</code></td>
@@ -1259,7 +1259,7 @@ mcp_aql_execute - EXECUTE operations (execute workflows, update state)</code></p
 <td>INSERT</td>
 <td><code>create_*</code> operation</td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>Read One</strong></td>
 <td>Query</td>
 <td><code>findOne</code></td>
@@ -1267,7 +1267,7 @@ mcp_aql_execute - EXECUTE operations (execute workflows, update state)</code></p
 <td>SELECT ... WHERE</td>
 <td><code>get_*</code> operation</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><strong>Read Many</strong></td>
 <td>Query</td>
 <td><code>find</code></td>
@@ -1275,7 +1275,7 @@ mcp_aql_execute - EXECUTE operations (execute workflows, update state)</code></p
 <td>SELECT *</td>
 <td><code>list_*</code> operation</td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>Update</strong></td>
 <td>Mutation</td>
 <td><code>updateOne</code></td>
@@ -1283,7 +1283,7 @@ mcp_aql_execute - EXECUTE operations (execute workflows, update state)</code></p
 <td>UPDATE</td>
 <td><code>update_*</code> operation</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><strong>Delete</strong></td>
 <td>Mutation</td>
 <td><code>deleteOne</code></td>
@@ -1291,7 +1291,7 @@ mcp_aql_execute - EXECUTE operations (execute workflows, update state)</code></p
 <td>DELETE</td>
 <td><code>delete_*</code> operation</td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>Search</strong></td>
 <td>Query</td>
 <td><code>find</code>+text</td>
@@ -1299,7 +1299,7 @@ mcp_aql_execute - EXECUTE operations (execute workflows, update state)</code></p
 <td>LIKE/FTS</td>
 <td><code>search</code> operation</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><strong>Schema Discovery</strong></td>
 <td><code>__schema</code></td>
 <td><code>getCollectionInfos</code></td>
@@ -1307,7 +1307,7 @@ mcp_aql_execute - EXECUTE operations (execute workflows, update state)</code></p
 <td>DESCRIBE</td>
 <td><code>introspect</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>Parameters</strong></td>
 <td>Variables</td>
 <td>Filter/options</td>
@@ -1315,7 +1315,7 @@ mcp_aql_execute - EXECUTE operations (execute workflows, update state)</code></p
 <td>WHERE/VALUES</td>
 <td><code>params</code> object</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><strong>Response</strong></td>
 <td><code>{ data, errors }</code></td>
 <td>Document</td>
@@ -1323,7 +1323,7 @@ mcp_aql_execute - EXECUTE operations (execute workflows, update state)</code></p
 <td>Result set</td>
 <td><code>{ success, data/error }</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>Error</strong></td>
 <td><code>errors</code> array</td>
 <td>Exception</td>
@@ -1331,7 +1331,7 @@ mcp_aql_execute - EXECUTE operations (execute workflows, update state)</code></p
 <td>SQLSTATE</td>
 <td><code>{ success: false, error }</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><strong>Batch</strong></td>
 <td>N/A (single)</td>
 <td><code>insertMany</code></td>
@@ -1339,7 +1339,7 @@ mcp_aql_execute - EXECUTE operations (execute workflows, update state)</code></p
 <td>Transaction</td>
 <td><code>operations</code> array</td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>Pagination</strong></td>
 <td><code>first/after</code></td>
 <td><code>skip/limit</code></td>
@@ -1551,24 +1551,24 @@ GET /api/swagger.json HTTP/1.1</code></pre>
 <h3 id="token-efficiency-summary">Token Efficiency Summary</h3>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Feature</th>
 <th>Token Savings</th>
 <th>Description</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><strong>CRUDE Consolidation</strong></td>
 <td>~85-96%</td>
 <td>Semantic endpoints instead of discrete tools</td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>On-Demand Introspection</strong></td>
 <td>~95%</td>
 <td>Query schemas as needed vs. upfront parsing</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><strong>Field Selection</strong></td>
 <td>~70-90%</td>
 <td>Return only requested fields in responses</td>

--- a/public/spec/index.html
+++ b/public/spec/index.html
@@ -7,7 +7,9 @@
   <title>MCP-AQL Spec | Full Spec Reference</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="../css/style.css">
 </head>
 <body>
@@ -511,6 +513,6 @@
     </div>
   </footer>
 
-  <script src="../js/search.js"></script>
+  <script src="../js/search.js" defer></script>
 </body>
 </html>

--- a/public/spec/introspection.html
+++ b/public/spec/introspection.html
@@ -7,7 +7,9 @@
   <title>MCP-AQL Spec | MCP-AQL Introspection Specification</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="../css/style.css">
 </head>
 <body>
@@ -1111,6 +1113,6 @@ Missing required parameter &#39;source&#39;. Expected: string (URL or file path 
     </div>
   </footer>
 
-  <script src="../js/search.js"></script>
+  <script src="../js/search.js" defer></script>
 </body>
 </html>

--- a/public/spec/introspection.html
+++ b/public/spec/introspection.html
@@ -162,19 +162,19 @@
 <h3 id="22-query-types">2.2 Query Types</h3>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Query</th>
 <th>Description</th>
 <th>Optional <code>name</code> Parameter</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>operations</code></td>
 <td>List all available operations</td>
 <td>Get details for a specific operation</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>types</code></td>
 <td>List all available types</td>
 <td>Get details for a specific type</td>
@@ -317,44 +317,44 @@
 <p>Constraint fields are <strong>the highest-value properties in the introspection system</strong> - they prevent LLM hallucination by telling agents exactly what values are valid.</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Field</th>
 <th>Type</th>
 <th>Purpose</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>enum</code></td>
 <td>array</td>
 <td>Lists all valid values; LLM can select from these</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>minimum</code>/<code>maximum</code></td>
 <td>number</td>
 <td>Numeric bounds; LLM can generate values in range</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>minLength</code>/<code>maxLength</code></td>
 <td>integer</td>
 <td>String length limits</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>pattern</code></td>
 <td>string</td>
 <td>Regex pattern for validation</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>format</code></td>
 <td>string</td>
 <td>Semantic format hint (date-time, email, uri, uuid)</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>items</code></td>
 <td>object</td>
 <td>Element schema for array parameters</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>sensitive</code></td>
 <td>boolean</td>
 <td>Flag for passwords/API keys; clients SHOULD mask input</td>
@@ -509,7 +509,7 @@
 <p>The <code>_protocol</code> object in operations list responses provides version and capability information:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Field</th>
 <th>Type</th>
 <th>Required</th>
@@ -517,25 +517,25 @@
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>version</code></td>
 <td>string</td>
 <td>MUST</td>
 <td>MCP-AQL spec version (semver format)</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>conformance</code></td>
 <td>string</td>
 <td>SHOULD</td>
 <td>Conformance level ("level-1", "level-2")</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>mode</code></td>
 <td>string</td>
 <td>SHOULD</td>
 <td>Endpoint mode ("semantic", "single", "all")</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>capabilities</code></td>
 <td>object</td>
 <td>MAY</td>
@@ -547,45 +547,45 @@
 <p><strong>Capabilities flags:</strong></p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Capability</th>
 <th>Description</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>batch</code></td>
 <td>Supports batch operations</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>field_selection</code></td>
 <td>Supports field selection in responses</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>aggregations</code></td>
 <td>Supports server-side aggregation controls</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>computed_fields</code></td>
 <td>Exposes adapter-declared computed fields</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>pagination</code></td>
 <td>Supports cursor-based pagination</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>relationship_queries</code></td>
 <td>Supports graph and relationship traversal</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>warnings</code></td>
 <td>Includes warnings array in responses</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>confirmation</code></td>
 <td>Supports confirmation token flow</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>dangerous_operations</code></td>
 <td>Has danger level classification</td>
 </tr>
@@ -822,39 +822,39 @@
 <p>MCP-AQL defines these protocol-level types that adapters SHOULD include in their type registry:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Type Name</th>
 <th>Kind</th>
 <th>Description</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>SemanticCategory</code></td>
 <td>enum</td>
 <td>Standard categories: CREATE, READ, UPDATE, DELETE, EXECUTE</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>OperationInput</code></td>
 <td>object</td>
 <td>Standard input structure</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>OperationResult</code></td>
 <td>union</td>
 <td>Success or failure result</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>OperationSuccess</code></td>
 <td>object</td>
 <td>Successful result with data</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>OperationFailure</code></td>
 <td>object</td>
 <td>Failed result with error</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>EndpointPermissions</code></td>
 <td>object</td>
 <td>Permission flags for operations</td>
@@ -946,7 +946,7 @@ Step 3: Execute operation
 <h3 id="72-comparison-with-discrete-tools">7.2 Comparison with Discrete Tools</h3>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Approach</th>
 <th>Upfront Cost</th>
 <th>Per-Operation Cost</th>
@@ -954,13 +954,13 @@ Step 3: Execute operation
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>Discrete tools</td>
 <td>~29,600 tokens</td>
 <td>0</td>
 <td>~29,600</td>
 </tr>
-<tr class="even">
+<tr>
 <td>MCP-AQL + introspect</td>
 <td>~1,100 tokens</td>
 <td>~150 tokens</td>

--- a/public/spec/licensing-options.html
+++ b/public/spec/licensing-options.html
@@ -7,7 +7,9 @@
   <title>MCP-AQL Spec | MCP-AQL Licensing Options (Working Notes)</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="../css/style.css">
 </head>
 <body>
@@ -1057,6 +1059,6 @@ Canonical: https://mcpaql.org</code></pre>
     </div>
   </footer>
 
-  <script src="../js/search.js"></script>
+  <script src="../js/search.js" defer></script>
 </body>
 </html>

--- a/public/spec/mcp-integration.html
+++ b/public/spec/mcp-integration.html
@@ -7,7 +7,9 @@
   <title>MCP-AQL Spec | MCP Integration Specification</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="../css/style.css">
 </head>
 <body>
@@ -804,6 +806,6 @@ github_mcp_aql_execute</code></pre>
     </div>
   </footer>
 
-  <script src="../js/search.js"></script>
+  <script src="../js/search.js" defer></script>
 </body>
 </html>

--- a/public/spec/mcp-integration.html
+++ b/public/spec/mcp-integration.html
@@ -425,24 +425,24 @@ Use introspection to discover all available operations and their parameters.</co
 <h4 id="411-mapping-table">4.1.1 Mapping Table</h4>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>MCP-AQL Response</th>
 <th>MCP <code>isError</code></th>
 <th>Rationale</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>success: true</code></td>
 <td><code>false</code></td>
 <td>Normal success</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>success: false</code>, recoverable error</td>
 <td><code>false</code></td>
 <td>Domain-level error; agent should interpret and recover</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>success: false</code>, unrecoverable error</td>
 <td><code>true</code></td>
 <td>Protocol failure; agent cannot recover without intervention</td>
@@ -502,29 +502,29 @@ Use introspection to discover all available operations and their parameters.</co
 <p>MCP JSON-RPC errors (-32600 to -32603) are reserved for transport and protocol-level failures. MCP-AQL adapters MUST NOT use these codes for domain-level errors.</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>JSON-RPC Code</th>
 <th>Description</th>
 <th>When Used</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>-32600</td>
 <td>Invalid Request</td>
 <td>Malformed JSON-RPC request</td>
 </tr>
-<tr class="even">
+<tr>
 <td>-32601</td>
 <td>Method not found</td>
 <td>Unknown MCP method</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>-32602</td>
 <td>Invalid params</td>
 <td>Invalid MCP method parameters</td>
 </tr>
-<tr class="even">
+<tr>
 <td>-32603</td>
 <td>Internal error</td>
 <td>MCP server internal error</td>
@@ -536,49 +536,49 @@ Use introspection to discover all available operations and their parameters.</co
 <p>When adapters wrap HTTP APIs, HTTP status codes SHOULD be mapped to MCP-AQL error codes:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>HTTP Status</th>
 <th>MCP-AQL Error Code</th>
 <th>Notes</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>400</td>
 <td><code>VALIDATION_INVALID_TYPE</code></td>
 <td>Bad request</td>
 </tr>
-<tr class="even">
+<tr>
 <td>401</td>
 <td><code>PERMISSION_DENIED</code></td>
 <td>Authentication required</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>403</td>
 <td><code>PERMISSION_DENIED</code></td>
 <td>Forbidden</td>
 </tr>
-<tr class="even">
+<tr>
 <td>404</td>
 <td><code>NOT_FOUND_RESOURCE</code></td>
 <td>Not found</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>409</td>
 <td><code>CONFLICT_ALREADY_EXISTS</code></td>
 <td>Conflict</td>
 </tr>
-<tr class="even">
+<tr>
 <td>422</td>
 <td><code>VALIDATION_INVALID_TYPE</code></td>
 <td>Unprocessable entity</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>429</td>
 <td><code>RATE_LIMIT_EXCEEDED</code></td>
 <td>Rate limited</td>
 </tr>
-<tr class="even">
+<tr>
 <td>500+</td>
 <td><code>INTERNAL_ERROR</code></td>
 <td>Server errors</td>
@@ -624,24 +624,24 @@ Use introspection to discover all available operations and their parameters.</co
 <p>For EXECUTE operations with defined state machines, map states to progress:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>EXECUTE State</th>
 <th>Progress Range</th>
 <th>Description</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>Initializing</td>
 <td>0-10%</td>
 <td>Setting up execution context</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Running</td>
 <td>10-90%</td>
 <td>Main execution phase</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Completing</td>
 <td>90-100%</td>
 <td>Finalizing and cleaning up</td>

--- a/public/spec/operations.html
+++ b/public/spec/operations.html
@@ -138,7 +138,7 @@
 <h3 id="22-required-fields">2.2 Required Fields</h3>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Field</th>
 <th>Type</th>
 <th>Required</th>
@@ -146,13 +146,13 @@
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>operation</code></td>
 <td>string</td>
 <td>REQUIRED</td>
 <td>The operation to perform</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>params</code></td>
 <td>object</td>
 <td>OPTIONAL</td>
@@ -312,7 +312,7 @@
 <h4 id="441-standard-cross-cutting-parameters">4.4.1 Standard Cross-Cutting Parameters</h4>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Parameter</th>
 <th>Type</th>
 <th>Operations</th>
@@ -320,49 +320,49 @@
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>fields</code></td>
 <td><code>string | string[]</code></td>
 <td>All READ operations returning data</td>
 <td>Field selection: preset name or array of field paths</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>query</code></td>
 <td><code>string | object</code></td>
 <td><code>search_*</code> and <code>query_*</code> collection operations</td>
 <td>Free-text search input or documented structured query object</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>filter</code></td>
 <td><code>object</code></td>
 <td>List/search/query operations</td>
 <td>Structured filtering criteria</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>sort</code></td>
 <td><code>object</code></td>
 <td>List/search/query operations</td>
 <td>Sort object with <code>field</code> and <code>order</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>aggregate</code></td>
 <td><code>object</code></td>
 <td>Collection READ operations with aggregation support</td>
 <td>Named server-side summary expressions such as <code>count</code>, <code>group_by</code>, <code>sum</code>, <code>avg</code>, <code>min</code>, and <code>max</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>first</code>, <code>after</code>, <code>last</code>, <code>before</code></td>
 <td><code>number</code> / <code>string</code></td>
 <td>Cursor-paginated collection operations</td>
 <td>Cursor-based pagination parameters</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>limit</code>, <code>offset</code>, <code>page</code>, <code>page_size</code></td>
 <td><code>number</code></td>
 <td>Collection operations with adapter-specific pagination</td>
 <td>Offset or page-based compatibility parameters when documented</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>dry_run</code></td>
 <td><code>boolean</code></td>
 <td>All mutating operations</td>
@@ -491,24 +491,24 @@
 <p>Recommended metadata by pagination style:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Style</th>
 <th>Location</th>
 <th>Recommended Fields</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>Cursor</td>
 <td><code>data.pageInfo</code></td>
 <td><code>hasNextPage</code>, <code>hasPreviousPage</code>, <code>startCursor</code>, <code>endCursor</code>, optional <code>totalCount</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td>Page-based</td>
 <td><code>data.pagination</code></td>
 <td><code>page</code>, <code>page_size</code>, optional <code>total_items</code>, optional <code>total_pages</code>, optional <code>has_more</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Offset-based</td>
 <td><code>data.pagination</code></td>
 <td><code>limit</code>, <code>offset</code>, optional <code>returned</code>, optional <code>total_items</code>, optional <code>has_more</code></td>
@@ -582,7 +582,7 @@
 <p><strong>Schema Properties:</strong></p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Property</th>
 <th>Type</th>
 <th>Required</th>
@@ -590,37 +590,37 @@
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>semantic_category</code></td>
 <td>string</td>
 <td>REQUIRED</td>
 <td>Standard semantic category: CREATE, READ, UPDATE, DELETE, or EXECUTE</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>endpoint</code></td>
 <td>string</td>
 <td>REQUIRED in semantic endpoint mode</td>
 <td>Exposed endpoint family that receives the operation</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>description</code></td>
 <td>string</td>
 <td>REQUIRED</td>
 <td>Human-readable description</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>params</code></td>
 <td>object</td>
 <td>OPTIONAL</td>
 <td>Parameter definitions</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>handler</code></td>
 <td>string</td>
 <td>OPTIONAL</td>
 <td>Internal handler reference</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>dangerous</code></td>
 <td>boolean</td>
 <td>OPTIONAL</td>
@@ -632,7 +632,7 @@
 <p>Each parameter in the <code>params</code> object MUST include:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Property</th>
 <th>Type</th>
 <th>Required</th>
@@ -640,25 +640,25 @@
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>type</code></td>
 <td>string</td>
 <td>REQUIRED</td>
 <td>Data type: "string", "number", "boolean", "object", "array"</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>required</code></td>
 <td>boolean</td>
 <td>OPTIONAL</td>
 <td>Whether parameter is required (default: false)</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>description</code></td>
 <td>string</td>
 <td>OPTIONAL</td>
 <td>Human-readable description</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>default</code></td>
 <td>any</td>
 <td>OPTIONAL</td>
@@ -669,39 +669,39 @@
 <p>Additional properties MAY be included:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Property</th>
 <th>Type</th>
 <th>Description</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>mapTo</code></td>
 <td>string</td>
 <td>Internal parameter name mapping</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>sources</code></td>
 <td>array</td>
 <td>Ordered list of resolution paths</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>enum</code></td>
 <td>array</td>
 <td>Allowed values for string parameters</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>minimum</code></td>
 <td>number</td>
 <td>Minimum value for numeric parameters</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>maximum</code></td>
 <td>number</td>
 <td>Maximum value for numeric parameters</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>pattern</code></td>
 <td>string</td>
 <td>Regex pattern for string validation</td>
@@ -759,34 +759,34 @@
 <p>Operations MUST be assigned to endpoints based on their semantics:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Endpoint</th>
 <th>Semantics</th>
 <th>Characteristics</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><strong>CREATE</strong></td>
 <td>Additive, non-destructive</td>
 <td>Creates new resources; idempotent if duplicate detection enabled</td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>READ</strong></td>
 <td>Safe, read-only</td>
 <td>No side effects; cacheable; always safe to retry</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><strong>UPDATE</strong></td>
 <td>Modifying</td>
 <td>Changes existing resources; may be partially idempotent</td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>DELETE</strong></td>
 <td>Destructive</td>
 <td>Removes resources; potentially irreversible</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><strong>EXECUTE</strong></td>
 <td>Lifecycle, non-idempotent</td>
 <td>Triggers actions; manages runtime state</td>
@@ -797,24 +797,24 @@
 <p><strong>Standard and Alternate Semantic-Endpoint Profiles</strong></p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Profile</th>
 <th>Endpoint Set</th>
 <th>Typical Intent Split</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><strong>Standard CRUDE profile</strong></td>
 <td><code>create</code> / <code>read</code> / <code>update</code> / <code>delete</code> / <code>execute</code></td>
 <td>Direct alignment to the five standardized semantic categories</td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>Extended CRUDE-style profile</strong></td>
 <td><code>create</code> / <code>read</code> / <code>update</code> / <code>delete</code> / <code>execute</code> / <code>authorize</code></td>
 <td>Standard CRUDE plus a dedicated semantic endpoint for permissioning and approval workflows</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><strong>Alternative semantic profile</strong></td>
 <td><code>discover</code> / <code>query</code> / <code>manage</code> / <code>operate</code></td>
 <td>Discovery and inspection, retrieval and filtering, mutating and administrative changes, runtime and lifecycle actions</td>
@@ -826,34 +826,34 @@
 <p>Each endpoint has canonical verbs (shown in bold) that SHOULD be used for standard operations, plus additional verbs for domain-specific semantics. See <a href="versions/v1.0.0-draft.html#85-operation-naming-grammar">Section 8.5</a> of the normative specification for naming requirements.</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Endpoint</th>
 <th>Canonical</th>
 <th>Additional Verbs</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>CREATE</td>
 <td><strong>create</strong></td>
 <td>add, upload, register, import, insert</td>
 </tr>
-<tr class="even">
+<tr>
 <td>READ</td>
 <td><strong>get</strong>, <strong>list</strong></td>
 <td>search, find, export, count</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>UPDATE</td>
 <td><strong>update</strong></td>
 <td>edit, set, rename, move, patch, merge</td>
 </tr>
-<tr class="even">
+<tr>
 <td>DELETE</td>
 <td><strong>delete</strong></td>
 <td>remove, purge, unregister, clear, drop</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>EXECUTE</td>
 <td><strong>execute</strong>, <strong>cancel</strong></td>
 <td>run, start, stop, resume, trigger, invoke</td>
@@ -1045,44 +1045,44 @@
 <p>Adapters MUST categorize errors using structured error codes. The table below shows error categories and their corresponding codes:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Category</th>
 <th>Error Code</th>
 <th>Example Message</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>Missing Parameter</td>
 <td><code>VALIDATION_MISSING_PARAM</code></td>
 <td>"Missing required parameter 'name'"</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Invalid Type</td>
 <td><code>VALIDATION_INVALID_TYPE</code></td>
 <td>"Parameter 'price' expected 'number', got 'string'"</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Resource Not Found</td>
 <td><code>NOT_FOUND_RESOURCE</code></td>
 <td>"Item 'item_999' not found"</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Unknown Operation</td>
 <td><code>NOT_FOUND_OPERATION</code></td>
 <td>"Unknown operation: 'create_widget'"</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Permission Denied</td>
 <td><code>PERMISSION_DENIED</code></td>
 <td>"Permission denied: requires 'admin' scope"</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Rate Limited</td>
 <td><code>RATE_LIMIT_EXCEEDED</code></td>
 <td>"API rate limit exceeded"</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Internal Error</td>
 <td><code>INTERNAL_ERROR</code></td>
 <td>"Internal error: database connection failed"</td>
@@ -1114,37 +1114,37 @@
 <p>Adapters MUST use standardized error codes for programmatic handling. Common codes include:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Code</th>
 <th>Description</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>VALIDATION_MISSING_PARAM</code></td>
 <td>Required parameter not provided</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>VALIDATION_INVALID_TYPE</code></td>
 <td>Parameter type mismatch</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>NOT_FOUND_OPERATION</code></td>
 <td>Operation name not recognized</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>NOT_FOUND_RESOURCE</code></td>
 <td>Resource not found</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>PERMISSION_DENIED</code></td>
 <td>Operation not permitted</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>RATE_LIMIT_EXCEEDED</code></td>
 <td>Too many requests</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>INTERNAL_ERROR</code></td>
 <td>Server error</td>
 </tr>

--- a/public/spec/operations.html
+++ b/public/spec/operations.html
@@ -7,7 +7,9 @@
   <title>MCP-AQL Spec | MCP-AQL Operations Specification</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="../css/style.css">
 </head>
 <body>
@@ -1344,6 +1346,6 @@
     </div>
   </footer>
 
-  <script src="../js/search.js"></script>
+  <script src="../js/search.js" defer></script>
 </body>
 </html>

--- a/public/spec/overview.html
+++ b/public/spec/overview.html
@@ -7,7 +7,9 @@
   <title>MCP-AQL Spec | MCP-AQL Protocol Overview</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="../css/style.css">
 </head>
 <body>
@@ -458,6 +460,6 @@ mcp_aql_operate  - Runtime and lifecycle operations</code></pre>
     </div>
   </footer>
 
-  <script src="../js/search.js"></script>
+  <script src="../js/search.js" defer></script>
 </body>
 </html>

--- a/public/spec/overview.html
+++ b/public/spec/overview.html
@@ -154,7 +154,7 @@
 <p>MCP-AQL extends traditional CRUD with an <strong>EXECUTE</strong> endpoint, creating the CRUDE pattern:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Endpoint</th>
 <th>Safety</th>
 <th>Description</th>
@@ -162,31 +162,31 @@
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><strong>CREATE</strong></td>
 <td>Non-destructive</td>
 <td>Additive operations that create new state</td>
 <td><code>create_entity</code>, <code>import_resource</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>READ</strong></td>
 <td>Read-only</td>
 <td>Safe operations that query state</td>
 <td><code>list_entities</code>, <code>get_entity</code>, <code>search</code>, <code>introspect</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><strong>UPDATE</strong></td>
 <td>Modifying</td>
 <td>Operations that modify existing state</td>
 <td><code>update_entity</code>, <code>update_resource</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>DELETE</strong></td>
 <td>Destructive</td>
 <td>Operations that remove state</td>
 <td><code>delete_entity</code>, <code>clear</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><strong>EXECUTE</strong></td>
 <td>Runtime</td>
 <td>Lifecycle operations for executable elements</td>
@@ -198,34 +198,34 @@
 <p>Each endpoint MUST have defined permission characteristics:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Endpoint</th>
 <th>Read-Only</th>
 <th>Destructive</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>CREATE</td>
 <td>false</td>
 <td>false</td>
 </tr>
-<tr class="even">
+<tr>
 <td>READ</td>
 <td>true</td>
 <td>false</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>UPDATE</td>
 <td>false</td>
 <td>true</td>
 </tr>
-<tr class="even">
+<tr>
 <td>DELETE</td>
 <td>false</td>
 <td>true</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>EXECUTE</td>
 <td>false</td>
 <td>true</td>
@@ -298,24 +298,24 @@ mcp_aql_operate  - Runtime and lifecycle operations</code></pre>
 <p>The primary motivation for MCP-AQL is reducing the token cost of tool registration. Empirical measurements demonstrate:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Configuration</th>
 <th>Approximate Token Cost</th>
 <th>Reduction</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>Discrete Tools (50+)</td>
 <td>~30,000 tokens</td>
 <td>baseline</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Semantic Endpoint Mode (CRUDE profile, 5 endpoints)</td>
 <td>~4,300 tokens</td>
 <td>~85%</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Single Mode (1 endpoint)</td>
 <td>~1,100 tokens</td>
 <td>~96%</td>

--- a/public/spec/plugin-contracts.html
+++ b/public/spec/plugin-contracts.html
@@ -7,7 +7,9 @@
   <title>MCP-AQL Spec | Plugin Interface Contracts</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="../css/style.css">
 </head>
 <body>
@@ -614,6 +616,6 @@
     </div>
   </footer>
 
-  <script src="../js/search.js"></script>
+  <script src="../js/search.js" defer></script>
 </body>
 </html>

--- a/public/spec/plugin-contracts.html
+++ b/public/spec/plugin-contracts.html
@@ -137,25 +137,25 @@
 <p><strong>Included:</strong></p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Category</th>
 <th>Plugins</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>Transport</td>
 <td><code>http</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td>Protocol</td>
 <td><code>rest</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Serialization</td>
 <td><code>json</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td>Auth</td>
 <td><code>none</code>, <code>api_key</code>, <code>bearer</code></td>
 </tr>
@@ -164,29 +164,29 @@
 <p><strong>Deferred to future specifications:</strong></p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Category</th>
 <th>Deferred Plugins</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>Transport</td>
 <td><code>websocket</code>, <code>serial</code>, <code>native-*</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td>Protocol</td>
 <td><code>graphql</code>, <code>grpc</code>, <code>jsonrpc</code>, <code>custom</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Serialization</td>
 <td><code>xml</code>, <code>protobuf</code>, <code>msgpack</code>, <code>form</code>, <code>multipart</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td>Auth</td>
 <td><code>basic</code>, <code>oauth</code>, <code>mtls</code>, <code>aws-sig4</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Pagination</td>
 <td>All pagination plugins (see #37)</td>
 </tr>
@@ -199,29 +199,29 @@
 <h3 id="21-category-summary">2.1 Category Summary</h3>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Category</th>
 <th>Responsibility</th>
 <th>MVP Plugin</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>Transport</td>
 <td>Communication channel</td>
 <td><code>http</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td>Protocol</td>
 <td>Request/response structure</td>
 <td><code>rest</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Serialization</td>
 <td>Data encoding/decoding</td>
 <td><code>json</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td>Auth</td>
 <td>Credential attachment</td>
 <td><code>none</code>, <code>api_key</code>, <code>bearer</code></td>
@@ -510,69 +510,69 @@
 <h3 id="83-mvp-error-codes">8.3 MVP Error Codes</h3>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Code</th>
 <th>Category</th>
 <th>Description</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>PLUGIN_NOT_FOUND</code></td>
 <td>Runtime</td>
 <td>Requested plugin does not exist</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>TRANSPORT_DNS_ERROR</code></td>
 <td>Transport</td>
 <td>DNS resolution failed</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>TRANSPORT_CONNECTION_REFUSED</code></td>
 <td>Transport</td>
 <td>Connection refused</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>TRANSPORT_TIMEOUT</code></td>
 <td>Transport</td>
 <td>Request timed out</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>TRANSPORT_TLS_ERROR</code></td>
 <td>Transport</td>
 <td>TLS/SSL error</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>TRANSPORT_NETWORK_ERROR</code></td>
 <td>Transport</td>
 <td>General network error</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>PROTOCOL_INVALID_MAPPING</code></td>
 <td>Protocol</td>
 <td>Invalid maps_to format</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>PROTOCOL_MISSING_PARAM</code></td>
 <td>Protocol</td>
 <td>Path parameter missing</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>SERIALIZATION_CIRCULAR_REF</code></td>
 <td>Serialization</td>
 <td>Circular reference in data</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>SERIALIZATION_PARSE_ERROR</code></td>
 <td>Serialization</td>
 <td>Failed to parse response</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>AUTH_CONFIG_INVALID</code></td>
 <td>Auth</td>
 <td>Invalid auth configuration</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>AUTH_CREDENTIAL_MISSING</code></td>
 <td>Auth</td>
 <td>Credential not found</td>

--- a/public/spec/process/breaking-changes.html
+++ b/public/spec/process/breaking-changes.html
@@ -145,41 +145,41 @@
 <p><strong>Examples of Breaking Changes:</strong></p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Change Type</th>
 <th>Example</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>Removing required operations</td>
 <td>Removing the <code>introspect</code> operation</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Incompatible request structure changes</td>
 <td>Changing <code>operation</code> field to <code>op</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Incompatible response structure changes</td>
 <td>Restructuring the success/error envelope</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Removing CRUDE endpoints</td>
 <td>Eliminating the EXECUTE endpoint</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Changing introspection response format</td>
 <td>Altering the structure of OperationDetails</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Removing required fields from protocol types</td>
 <td>Removing <code>endpoint</code> from OperationInfo</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Changing field types incompatibly</td>
 <td>Changing <code>required</code> from boolean to string</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Changing endpoint routing rules</td>
 <td>Requiring different operation-to-endpoint mappings</td>
 </tr>
@@ -190,37 +190,37 @@
 <p><strong>Examples of Non-Breaking Changes:</strong></p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Change Type</th>
 <th>Example</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>Adding new optional operations</td>
 <td>New <code>validate</code> operation on READ endpoint</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Adding new optional parameters</td>
 <td>Adding <code>timeout</code> parameter to existing operations</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Adding new fields to responses (additive)</td>
 <td>Adding <code>deprecated</code> flag to OperationInfo</td>
 </tr>
-<tr class="even">
+<tr>
 <td>New optional features</td>
 <td>Field selection support</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Deprecating features (without removal)</td>
 <td>Marking an operation as deprecated</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Adding new optional protocol types</td>
 <td>New TypeInfo subtypes</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Extending enum values</td>
 <td>Adding new endpoint mode options</td>
 </tr>
@@ -231,33 +231,33 @@
 <p><strong>Examples of Patch Changes:</strong></p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Change Type</th>
 <th>Example</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>Clarifications that don't change behavior</td>
 <td>Explaining existing edge case handling</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Typo fixes</td>
 <td>Correcting spelling in specification text</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Example corrections</td>
 <td>Fixing incorrect JSON in examples</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Documentation improvements</td>
 <td>Adding diagrams or additional context</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Formatting changes</td>
 <td>Restructuring sections for clarity</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Non-normative additions</td>
 <td>Adding implementation notes</td>
 </tr>
@@ -308,7 +308,7 @@
 <p>When implementing deprecation warnings in introspection, include:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Field</th>
 <th>Type</th>
 <th>Required</th>
@@ -316,25 +316,25 @@
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>deprecated</code></td>
 <td>boolean</td>
 <td>Yes</td>
 <td>Whether the item is deprecated</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>deprecationMessage</code></td>
 <td>string</td>
 <td>Yes</td>
 <td>Human-readable explanation and alternative</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>deprecatedSince</code></td>
 <td>string</td>
 <td>No</td>
 <td>Version when deprecation began</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>removalVersion</code></td>
 <td>string</td>
 <td>No</td>

--- a/public/spec/process/breaking-changes.html
+++ b/public/spec/process/breaking-changes.html
@@ -7,7 +7,9 @@
   <title>MCP-AQL Spec | MCP-AQL Breaking Change Policy</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="../../css/style.css">
 </head>
 <body>
@@ -545,6 +547,6 @@
     </div>
   </footer>
 
-  <script src="../../js/search.js"></script>
+  <script src="../../js/search.js" defer></script>
 </body>
 </html>

--- a/public/spec/process/preliminary-public-launch-checklist.html
+++ b/public/spec/process/preliminary-public-launch-checklist.html
@@ -7,7 +7,9 @@
   <title>MCP-AQL Spec | Preliminary Public Launch Checklist</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="../../css/style.css">
 </head>
 <body>
@@ -192,6 +194,6 @@
     </div>
   </footer>
 
-  <script src="../../js/search.js"></script>
+  <script src="../../js/search.js" defer></script>
 </body>
 </html>

--- a/public/spec/process/rfc-process.html
+++ b/public/spec/process/rfc-process.html
@@ -7,7 +7,9 @@
   <title>MCP-AQL Spec | RFC Process for MCP-AQL Specification</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="../../css/style.css">
 </head>
 <body>
@@ -503,6 +505,6 @@
     </div>
   </footer>
 
-  <script src="../../js/search.js"></script>
+  <script src="../../js/search.js" defer></script>
 </body>
 </html>

--- a/public/spec/process/rfc-process.html
+++ b/public/spec/process/rfc-process.html
@@ -428,7 +428,7 @@
 <h2 id="quick-reference">Quick Reference</h2>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Stage</th>
 <th>Name</th>
 <th>Duration</th>
@@ -436,31 +436,31 @@
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>0</td>
 <td>Pre-RFC</td>
 <td>No minimum</td>
 <td>Ready to formalize</td>
 </tr>
-<tr class="even">
+<tr>
 <td>1</td>
 <td>Draft</td>
 <td>Immediate</td>
 <td>Complete submission</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>2</td>
 <td>Review</td>
 <td>14+ days</td>
 <td>Consensus reached</td>
 </tr>
-<tr class="even">
+<tr>
 <td>3</td>
 <td>Accepted</td>
 <td>Immediate</td>
 <td>Number assigned</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>4</td>
 <td>Integrated</td>
 <td>Varies</td>

--- a/public/spec/process/versioning.html
+++ b/public/spec/process/versioning.html
@@ -7,7 +7,9 @@
   <title>MCP-AQL Spec | Versioning Strategy</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="../../css/style.css">
 </head>
 <body>
@@ -376,6 +378,6 @@
     </div>
   </footer>
 
-  <script src="../../js/search.js"></script>
+  <script src="../../js/search.js" defer></script>
 </body>
 </html>

--- a/public/spec/process/versioning.html
+++ b/public/spec/process/versioning.html
@@ -117,25 +117,25 @@
 <h3 id="components">Components</h3>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Component</th>
 <th>Description</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>MAJOR</td>
 <td>Breaking changes that require implementation updates</td>
 </tr>
-<tr class="even">
+<tr>
 <td>MINOR</td>
 <td>New features, backward compatible</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>PATCH</td>
 <td>Bug fixes, clarifications, backward compatible</td>
 </tr>
-<tr class="even">
+<tr>
 <td>PRERELEASE</td>
 <td>Optional tag indicating release maturity</td>
 </tr>
@@ -144,29 +144,29 @@
 <h3 id="examples">Examples</h3>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Version</th>
 <th>Description</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>1.0.0-draft</code></td>
 <td>Current working draft</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>1.0.0</code></td>
 <td>First stable release</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>1.1.0</code></td>
 <td>New features added (backward compatible)</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>1.1.1</code></td>
 <td>Bug fixes or clarifications</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>2.0.0</code></td>
 <td>Breaking changes from v1.x</td>
 </tr>
@@ -277,21 +277,21 @@
 <p>Version information is maintained in the following locations:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Location</th>
 <th>Purpose</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>docs/versions/vX.Y.Z.md</code></td>
 <td>Full specification document for each version</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>CHANGELOG.md</code></td>
 <td>Complete version history with changes</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>README.md</code></td>
 <td>Version badge showing current stable version</td>
 </tr>

--- a/public/spec/reference/README.html
+++ b/public/spec/reference/README.html
@@ -7,7 +7,9 @@
   <title>MCP-AQL Spec | Reference Documentation</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="../../css/style.css">
 </head>
 <body>
@@ -123,6 +125,6 @@
     </div>
   </footer>
 
-  <script src="../../js/search.js"></script>
+  <script src="../../js/search.js" defer></script>
 </body>
 </html>

--- a/public/spec/repo/CHANGELOG.html
+++ b/public/spec/repo/CHANGELOG.html
@@ -7,7 +7,9 @@
   <title>MCP-AQL Spec | Changelog</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="../../css/style.css">
 </head>
 <body>
@@ -759,6 +761,6 @@
     </div>
   </footer>
 
-  <script src="../../js/search.js"></script>
+  <script src="../../js/search.js" defer></script>
 </body>
 </html>

--- a/public/spec/repo/README.html
+++ b/public/spec/repo/README.html
@@ -7,7 +7,9 @@
   <title>MCP-AQL Spec | MCP-AQL Specification</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="../../css/style.css">
 </head>
 <body>
@@ -362,6 +364,6 @@ discover / query / manage / operate</code></pre>
     </div>
   </footer>
 
-  <script src="../../js/search.js"></script>
+  <script src="../../js/search.js" defer></script>
 </body>
 </html>

--- a/public/spec/repo/README.html
+++ b/public/spec/repo/README.html
@@ -129,34 +129,34 @@
 <p>MCP-AQL supports semantic endpoint mode or a single unified endpoint. The standard semantic-endpoint profile extends traditional CRUD with an <strong>Execute</strong> endpoint, creating the CRUDE pattern:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Endpoint</th>
 <th>Safety</th>
 <th>Description</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><strong>Create</strong></td>
 <td>Non-destructive</td>
 <td>Additive operations that create new state</td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>Read</strong></td>
 <td>Read-only</td>
 <td>Safe operations that query state</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><strong>Update</strong></td>
 <td>Modifying</td>
 <td>Operations that modify existing state</td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>Delete</strong></td>
 <td>Destructive</td>
 <td>Operations that remove state</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><strong>Execute</strong></td>
 <td>Stateful</td>
 <td>Runtime lifecycle operations (non-idempotent)</td>
@@ -175,7 +175,7 @@ discover / query / manage / operate</code></pre>
 <p><strong>Per-tool overhead:</strong> A typical MCP tool definition consumes ~500-700 tokens in context.</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Configuration</th>
 <th>Tool Count</th>
 <th>Token Cost</th>
@@ -183,25 +183,25 @@ discover / query / manage / operate</code></pre>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>Discrete Tools</td>
 <td>~30 tools</td>
 <td>~18,000</td>
 <td>Baseline</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Discrete Tools</td>
 <td>~50 tools</td>
 <td>~30,000</td>
 <td>Baseline</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><strong>Semantic Endpoint Mode (CRUDE profile)</strong></td>
 <td>5 endpoints</td>
 <td>~4,300</td>
 <td>~80-85%</td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>Single Mode</strong></td>
 <td>1 endpoint</td>
 <td>~1,000</td>
@@ -243,61 +243,61 @@ discover / query / manage / operate</code></pre>
 <h2 id="specification-documents">Specification Documents</h2>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Document</th>
 <th>Description</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><a href="../versions/v1.0.0-draft.html">Specification v1.0.0-draft</a></td>
 <td>Current working draft</td>
 </tr>
-<tr class="even">
+<tr>
 <td><a href="../crude-pattern.html">CRUDE Pattern</a></td>
 <td>Standard semantic-endpoint profile</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><a href="../endpoint-modes.html">Endpoint Modes</a></td>
 <td>CRUDE, semantic-endpoint, and single endpoint configuration</td>
 </tr>
-<tr class="even">
+<tr>
 <td><a href="../introspection.html">Introspection</a></td>
 <td>Discovery system specification</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><a href="../operations.html">Operations Guide</a></td>
 <td>Operation design patterns</td>
 </tr>
-<tr class="even">
+<tr>
 <td><a href="../features/collection-querying.html">Collection Querying</a></td>
 <td>Preferred query contract for list/search/query operations</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><a href="../features/aggregations.html">Aggregations</a></td>
 <td>Preferred summary/query shape for server-side aggregations</td>
 </tr>
-<tr class="even">
+<tr>
 <td><a href="../features/computed-fields.html">Computed Fields</a></td>
 <td>Preferred <code>_computed.</code> convention for adapter-declared derived values</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><a href="../features/relationship-queries.html">Relationship Queries</a></td>
 <td>Preferred traversal contract for graph-style READ operations</td>
 </tr>
-<tr class="even">
+<tr>
 <td><a href="../adapter/discovery-bundle.html">MCP Server Discovery Bundle</a></td>
 <td>Interrogation bundle contract for MCP-to-MCP-AQL generation</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><a href="../guides/cross-domain-implementation.html">Cross-Domain Implementation Guide</a></td>
 <td>Step-by-step guide for adapting MCP-AQL to databases, filesystems, API gateways, IoT, and other domains</td>
 </tr>
-<tr class="even">
+<tr>
 <td><a href="../README.html">Documentation Index</a></td>
 <td>Full documentation structure</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><a href="CHANGELOG.html">Changelog</a></td>
 <td>Version history</td>
 </tr>

--- a/public/spec/research/mcp-vs-mcpaql-vs-a2a.html
+++ b/public/spec/research/mcp-vs-mcpaql-vs-a2a.html
@@ -182,7 +182,7 @@
 <h2 id="3-the-core-problem-each-solves">3. The Core Problem Each Solves</h2>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th></th>
 <th>MCP</th>
 <th>MCP-AQL</th>
@@ -190,19 +190,19 @@
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><strong>Core problem</strong></td>
 <td>Every AI app builds custom integrations for every tool/service (M x N explosion)</td>
 <td>LLMs can't reliably call arbitrary APIs -- they hallucinate parameters, miss constraints, and waste context on schemas</td>
 <td>Agents from different vendors/frameworks can't discover or collaborate with each other</td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>Solution</strong></td>
 <td>Standardize the connection protocol (one universal wire format)</td>
 <td>Translate any API into an LLM-native interface with self-describing operations, constraint metadata, and safety enforcement</td>
 <td>Standardize agent discovery and task delegation via Agent Cards and multi-turn task conversations</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><strong>Analogy</strong></td>
 <td>USB-C: a universal connector</td>
 <td>A universal interpreter that speaks every API dialect but presents one clean language</td>
@@ -298,7 +298,7 @@ Authorization: Bearer &lt;token&gt;</code></pre>
 <h3 id="discovery-and-self-description">Discovery and Self-Description</h3>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th></th>
 <th>MCP</th>
 <th>MCP-AQL</th>
@@ -306,25 +306,25 @@ Authorization: Bearer &lt;token&gt;</code></pre>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><strong>Discovery mechanism</strong></td>
 <td>Static -- client connects to pre-configured servers</td>
 <td>Runtime introspection -- <code>introspect</code> operation discovers operations on demand</td>
 <td>Agent Cards at well-known URLs</td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>Schema loading</strong></td>
 <td>All tool definitions loaded upfront into LLM context</td>
 <td>Progressive disclosure -- discover what you need, when you need it</td>
 <td>Agent Card skills are high-level descriptions, not detailed schemas</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><strong>Constraint metadata</strong></td>
 <td>Tool annotations (readOnly, destructive hints) + JSON Schema for inputs</td>
 <td>Rich constraints: enums, min/max, patterns, formats, sensitive markers, examples</td>
 <td>Minimal -- skill descriptions are natural language</td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>Token cost of discovery</strong></td>
 <td>~500-700 tokens per tool (50 tools = ~30,000 tokens upfront)</td>
 <td>~1,100 tokens total (single mode) for unlimited operations</td>
@@ -335,7 +335,7 @@ Authorization: Bearer &lt;token&gt;</code></pre>
 <h3 id="token-efficiency">Token Efficiency</h3>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th></th>
 <th>MCP</th>
 <th>MCP-AQL</th>
@@ -343,31 +343,31 @@ Authorization: Bearer &lt;token&gt;</code></pre>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><strong>Registration overhead</strong></td>
 <td>~30,000 tokens for 50 tools</td>
 <td>~1,100 (single mode) to ~4,300 (CRUDE mode) for 50+ operations</td>
 <td>N/A -- agents, not tools</td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>Reduction from baseline</strong></td>
 <td>Baseline (0%)</td>
 <td>85-96% reduction</td>
 <td>Not comparable</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><strong>Response efficiency</strong></td>
 <td>Raw tool output dumped to context</td>
 <td>Field selection (minimal/standard/full presets) provides 65-86% additional reduction</td>
 <td>Artifacts with structured Parts</td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>Repeated call optimization</strong></td>
 <td>Same cost every time</td>
 <td>"Ditto" shorthand pattern: 97% reduction on repeated calls (~15 tokens vs ~450)</td>
 <td>N/A</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><strong>Fire-and-forget</strong></td>
 <td>No -- every tool call requires full response processing</td>
 <td><code>notify</code> operation returns minimal <code>{ ack: true }</code> (~15 tokens)</td>
@@ -378,7 +378,7 @@ Authorization: Bearer &lt;token&gt;</code></pre>
 <h3 id="safety-and-security">Safety and Security</h3>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th></th>
 <th>MCP</th>
 <th>MCP-AQL</th>
@@ -386,43 +386,43 @@ Authorization: Bearer &lt;token&gt;</code></pre>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><strong>Safety model</strong></td>
 <td>Tool annotations are hints; client decides whether to honor them</td>
 <td><strong>Protocol-enforced Gatekeeper</strong> -- 4-layer defense-in-depth; server-side enforcement that LLM cannot bypass</td>
 <td>Agent can reject tasks; standard auth schemes</td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>Danger classification</strong></td>
 <td>Binary: readOnly or destructive annotation</td>
 <td>5-level system: safe → reversible → destructive → dangerous → forbidden</td>
 <td>N/A</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><strong>Trust model</strong></td>
 <td>Implicit trust in configured servers</td>
 <td>5-level trust: untested → generated → validated → community_reviewed → certified; gating matrix with danger levels</td>
 <td>Authentication schemes (OAuth, OIDC, mTLS)</td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>Hallucination prevention</strong></td>
 <td>Depends on tool description quality</td>
 <td>Unknown parameter rejection -- if LLM hallucinates <code>force: true</code>, adapter rejects and returns valid params</td>
 <td>Depends on Agent Card quality</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><strong>Confirmation workflow</strong></td>
 <td>Human-in-the-loop via Sampling</td>
 <td>Confirmation tokens for destructive operations; pattern-based auto-classification (<code>force_*</code> → dangerous, <code>drop_*</code> → forbidden)</td>
 <td>N/A</td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>Auth</strong></td>
 <td>OAuth 2.1 (as of Jun 2025)</td>
 <td>Inherits MCP + per-adapter auth plugins (API key, Bearer, OAuth, mTLS, AWS SigV4)</td>
 <td>OAuth 2.0, OIDC, mTLS, API keys, in-task auth escalation</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><strong>Core principle</strong></td>
 <td>Security by design (but client-enforced)</td>
 <td>"LLM instructions are suggestions. Adapter policies are enforcement."</td>
@@ -433,7 +433,7 @@ Authorization: Bearer &lt;token&gt;</code></pre>
 <h3 id="scope-and-reach">Scope and Reach</h3>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th></th>
 <th>MCP</th>
 <th>MCP-AQL</th>
@@ -441,25 +441,25 @@ Authorization: Bearer &lt;token&gt;</code></pre>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><strong>What it connects to</strong></td>
 <td>MCP-compatible servers</td>
 <td><strong>Any system with an API</strong>: REST, GraphQL, gRPC, MCP servers, OS native APIs, hardware (serial/USB), IoT, databases, file systems, other agents</td>
 <td>Other A2A-compatible agents</td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>Adapter creation</strong></td>
 <td>SDK integration + custom code per server</td>
 <td><strong>Declarative schema file</strong> (Markdown + YAML) -- no code generation, hot-reloadable</td>
 <td>SDK integration per agent</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><strong>Plugin system</strong></td>
 <td>N/A</td>
 <td>Transport (HTTP, WebSocket, serial, native OS), Protocol (REST, GraphQL, gRPC, JSON-RPC), Serialization (JSON, XML, Protobuf, MessagePack), Auth (multiple schemes), Pagination (cursor, offset, page)</td>
 <td>N/A</td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>Performance tiers</strong></td>
 <td>Single implementation</td>
 <td>Three-tier architecture planned: Standard (TypeScript) for MCP wrapping, Local Systems (Rust, 5-50x faster) for OS/hardware, Network API (Rust) for concurrent web API processing</td>
@@ -470,7 +470,7 @@ Authorization: Bearer &lt;token&gt;</code></pre>
 <h3 id="agent-to-agent-capabilities">Agent-to-Agent Capabilities</h3>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th></th>
 <th>MCP</th>
 <th>MCP-AQL</th>
@@ -478,25 +478,25 @@ Authorization: Bearer &lt;token&gt;</code></pre>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><strong>Agent-to-agent</strong></td>
 <td>No</td>
 <td>Yes -- via adapter chains, distributed tracing (W3C Trace Context), EXECUTE lifecycle</td>
 <td><strong>Primary purpose</strong></td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>Task delegation</strong></td>
 <td>No</td>
 <td>EXECUTE endpoint with state machine (pending → running → completed/failed/cancelled)</td>
 <td>First-class task lifecycle with 7-state machine and multi-turn conversation</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><strong>Multi-agent coordination</strong></td>
 <td>No</td>
 <td>Optimistic concurrency (ETags), notifications/telemetry for inter-agent signaling</td>
 <td>Discovery via Agent Cards, context IDs for conversation threading</td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>Distributed tracing</strong></td>
 <td>No</td>
 <td>W3C Trace Context propagation across adapter chains (traceId, spanId, parentSpanId)</td>
@@ -507,7 +507,7 @@ Authorization: Bearer &lt;token&gt;</code></pre>
 <h3 id="computational-middleware">Computational Middleware</h3>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th></th>
 <th>MCP</th>
 <th>MCP-AQL</th>
@@ -515,25 +515,25 @@ Authorization: Bearer &lt;token&gt;</code></pre>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><strong>Processing model</strong></td>
 <td>LLM calls tool → gets raw result → reasons about it</td>
 <td>Adapter can process server-side: computed fields, aggregations, multi-step API iteration <strong>without returning to the LLM</strong> -- LLM only sees final processed result</td>
 <td>Remote agent does all internal processing; returns artifacts</td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>Server-side computation</strong></td>
 <td>Not built in</td>
 <td>Computed fields (so LLM doesn't do math), server-side aggregations (counts, groupings without fetching all records)</td>
 <td>Agent handles internally</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><strong>Batch operations</strong></td>
 <td>No native batching</td>
 <td>Optional batch operations with per-item results, continueOnError, and atomic modes</td>
 <td>N/A</td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>Dry-run mode</strong></td>
 <td>No</td>
 <td>Preview consequences before committing, including policy checks and estimated token costs</td>
@@ -620,7 +620,7 @@ Authorization: Bearer &lt;token&gt;</code></pre>
 <p><strong>Partially, in a good way.</strong> There is genuine overlap at the agent-to-agent boundary:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Capability</th>
 <th>MCP-AQL</th>
 <th>A2A</th>
@@ -628,31 +628,31 @@ Authorization: Bearer &lt;token&gt;</code></pre>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>Agent discovery</td>
 <td>Introspection (what operations exist?)</td>
 <td>Agent Cards (what can this agent do?)</td>
 <td><strong>Complementary</strong> -- different granularity</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Task delegation</td>
 <td>EXECUTE endpoint with lifecycle states</td>
 <td>Task lifecycle with 7-state machine</td>
 <td><strong>Overlapping</strong> -- but MCP-AQL is structured/typed while A2A is conversational</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Multi-turn interaction</td>
 <td>Not native (each call is independent)</td>
 <td>First-class multi-turn with context IDs</td>
 <td><strong>A2A is stronger here</strong></td>
 </tr>
-<tr class="even">
+<tr>
 <td>Distributed tracing</td>
 <td>W3C Trace Context across adapter chains</td>
 <td>Not built in</td>
 <td><strong>MCP-AQL is stronger here</strong></td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Safety enforcement</td>
 <td>Gatekeeper with danger/trust levels</td>
 <td>Agent-level accept/reject</td>
@@ -675,29 +675,29 @@ Authorization: Bearer &lt;token&gt;</code></pre>
 <h3 id="gaps-in-mcp-addressed-by-the-other-two">Gaps in MCP (Addressed by the Other Two)</h3>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Gap</th>
 <th>Who fills it</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>Tool sprawl / context window bloat</td>
 <td><strong>MCP-AQL</strong> (85-96% token reduction)</td>
 </tr>
-<tr class="even">
+<tr>
 <td>No agent-to-agent communication</td>
 <td><strong>A2A</strong> (primary purpose) and <strong>MCP-AQL</strong> (via adapter chains)</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Safety is advisory, not enforced</td>
 <td><strong>MCP-AQL</strong> (Gatekeeper with server-side authority)</td>
 </tr>
-<tr class="even">
+<tr>
 <td>No progressive discovery</td>
 <td><strong>MCP-AQL</strong> (introspection on demand)</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Raw tool output wastes tokens</td>
 <td><strong>MCP-AQL</strong> (field selection, server-side computation)</td>
 </tr>
@@ -706,59 +706,59 @@ Authorization: Bearer &lt;token&gt;</code></pre>
 <h3 id="gaps-in-a2a-not-yet-addressed">Gaps in A2A (Not Yet Addressed)</h3>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Gap</th>
 <th>Description</th>
 <th>Potential fill</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><strong>No message persistence</strong></td>
 <td>The spec does not specify whether agents must persist messages after task completion, how long task state must be retained, or storage format. An A2A server could lose everything on restart and still be conformant.</td>
 <td><strong>COMMS element type</strong> (file-based, database, Redis backends)</td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>No message queuing</strong></td>
 <td>No guaranteed delivery, no ordering guarantees beyond streaming, no dead-letter queues, no backpressure mechanism. Push notification retry policy is the closest thing.</td>
 <td><strong>COMMS element type</strong> or external message broker</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><strong>No offline delivery</strong></td>
 <td>If the server agent is unreachable, the request fails. No store-and-forward, no inbox/outbox pattern.</td>
 <td><strong>COMMS element type</strong> (file-based persistence survives offline)</td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>No local agent-to-agent communication</strong></td>
 <td>All three standard bindings (JSON-RPC/HTTP, gRPC, REST) assume network communication. No Unix socket, shared memory, IPC, or localhost optimization.</td>
 <td><strong>COMMS element type</strong> (filesystem IPC at <code>~/.dollhouse/team-ipc/</code>)</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><strong>No state management between sessions</strong></td>
 <td>No session concept at the protocol level, no session tokens or resumption, no requirement that context IDs persist across restarts.</td>
 <td><strong>Memory elements</strong> + <strong>COMMS element type</strong></td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>No orchestration</strong></td>
 <td>No workflow definition, conditional branching, routing, fan-out/fan-in, saga patterns, circuit breakers, or load balancing. Explicitly out of scope.</td>
 <td>Application layer / <strong>TEAM element type</strong></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><strong>No discovery registry</strong></td>
 <td>Agent Cards at well-known URLs require knowing the URL in advance. No search, marketplace, or broadcast discovery.</td>
 <td><strong>MCP-AQL adapter registry</strong> / <strong>COMMS discovery</strong></td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>No distributed tracing</strong></td>
 <td>No built-in tracing format; metadata maps can carry trace IDs but nothing is standardized.</td>
 <td><strong>MCP-AQL</strong> (W3C Trace Context)</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><strong>No economics</strong></td>
 <td>No pricing, SLAs, inter-agent billing, or dispute resolution.</td>
 <td>Not addressed by any protocol yet</td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>No streaming client-to-server</strong></td>
 <td>Clients cannot stream large inputs during task execution; only agents stream output back.</td>
 <td>Not addressed</td>
@@ -768,29 +768,29 @@ Authorization: Bearer &lt;token&gt;</code></pre>
 <h3 id="gaps-in-mcp-aql-not-yet-addressed">Gaps in MCP-AQL (Not Yet Addressed)</h3>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Gap</th>
 <th>Description</th>
 <th>Potential fill</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><strong>Multi-turn conversational context</strong></td>
 <td>Each MCP-AQL call is independent; no built-in context threading across calls</td>
 <td><strong>A2A</strong> (context IDs, multi-turn tasks)</td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>Agent opaqueness</strong></td>
 <td>MCP-AQL introspection reveals operation details; no mechanism to hide internals when that's desirable</td>
 <td><strong>A2A</strong> (opaque by design)</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><strong>Multimodal content exchange</strong></td>
 <td>MCP-AQL responses are structured JSON; no native audio, video, or rich media support</td>
 <td><strong>A2A</strong> (multimodal Parts)</td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>Cross-vendor interoperability</strong></td>
 <td>MCP-AQL requires MCP as transport; cannot directly interoperate with non-MCP agents</td>
 <td><strong>A2A</strong> (framework-agnostic)</td>
@@ -804,21 +804,21 @@ Authorization: Bearer &lt;token&gt;</code></pre>
 <p>A2A is a <strong>real protocol with real wire bindings</strong>, not just a description. It has three layers:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Layer</th>
 <th>What A2A Defines</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><strong>Canonical Data Model</strong></td>
 <td>Protocol Buffers (<code>a2a.proto</code>) defining Task, Message, AgentCard, Artifact, Part types</td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>Abstract Operations</strong></td>
 <td>11 transport-agnostic operations (SendMessage, GetTask, ListTasks, CancelTask, SubscribeToTask, etc.)</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><strong>Protocol Bindings</strong></td>
 <td>Concrete mappings to JSON-RPC 2.0 over HTTP, gRPC over HTTP/2, and REST over HTTP</td>
 </tr>
@@ -829,45 +829,45 @@ Authorization: Bearer &lt;token&gt;</code></pre>
 <p>This is where the gaps are significant:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Concern</th>
 <th>A2A's Position</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><strong>Message persistence</strong></td>
 <td>Completely unspecified</td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>Message queuing / guaranteed delivery</strong></td>
 <td>Not addressed; push notification retry is closest</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><strong>Offline delivery</strong></td>
 <td>Not supported; synchronous with async extensions</td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>Local IPC (same machine)</strong></td>
 <td>Not addressed; all bindings assume network</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><strong>Session state management</strong></td>
 <td>Not specified; no session concept</td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>Orchestration / routing</strong></td>
 <td>Explicitly out of scope</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><strong>Agent registry / search</strong></td>
 <td>Not provided; must know URL to fetch Agent Card</td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>Distributed tracing</strong></td>
 <td>Not standardized; metadata can carry trace IDs</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><strong>Economics / billing</strong></td>
 <td>Not addressed</td>
 </tr>
@@ -893,44 +893,44 @@ Authorization: Bearer &lt;token&gt;</code></pre>
 <p><strong>Potential COMMS variants:</strong></p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Variant</th>
 <th>Protocol</th>
 <th>Use Case</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><strong>A2A comms</strong></td>
 <td>Google A2A</td>
 <td>Cross-vendor agent-to-agent delegation with task lifecycle</td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>TCP/IP comms</strong></td>
 <td>Raw TCP/IP</td>
 <td>Low-level network communication, custom protocols</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><strong>HTTP comms</strong></td>
 <td>HTTP/REST</td>
 <td>Direct web API messaging, webhooks</td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>SMTP comms</strong></td>
 <td>SMTP/email</td>
 <td>Email-based notifications and async communication</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><strong>WebSocket comms</strong></td>
 <td>WebSocket</td>
 <td>Real-time bidirectional messaging</td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>Filesystem comms</strong></td>
 <td>Local IPC</td>
 <td>Same-machine agent-to-agent via file-based messaging</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><strong>Mesh comms</strong></td>
 <td>WireGuard/Tailscale</td>
 <td>Encrypted multi-node agent mesh networking</td>
@@ -951,34 +951,34 @@ Authorization: Bearer &lt;token&gt;</code></pre>
 <h3 id="transport-mechanisms">Transport Mechanisms</h3>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Scope</th>
 <th>Likely Variant</th>
 <th>Mechanism</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>Same computer, different sessions</td>
 <td>Filesystem comms</td>
 <td>File-based IPC at <code>~/.dollhouse/team-ipc/</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td>Different computers (network)</td>
 <td>HTTP comms / A2A comms</td>
 <td>REST/HTTP or A2A task delegation</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Encrypted enterprise mesh</td>
 <td>Mesh comms</td>
 <td>WireGuard via Tailscale or Headscale (self-hosted)</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Cross-vendor agent collaboration</td>
 <td>A2A comms</td>
 <td>A2A protocol with Agent Cards and task lifecycle</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Async notifications</td>
 <td>SMTP comms / HTTP comms</td>
 <td>Email or webhook-based</td>
@@ -997,37 +997,37 @@ Authorization: Bearer &lt;token&gt;</code></pre>
 <p>A2A leaves significant infrastructure gaps (see Section 9). Different COMMS variants address different gaps:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>A2A Gap</th>
 <th>Which COMMS Variant Fills It</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><strong>No message persistence</strong></td>
 <td>Filesystem comms, database-backed variants</td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>No message queuing</strong></td>
 <td>Filesystem comms (natural queue semantics), database variants</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><strong>No offline delivery</strong></td>
 <td>Filesystem comms (persists regardless of recipient availability)</td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>No local IPC</strong></td>
 <td>Filesystem comms at <code>~/.dollhouse/team-ipc/</code> (sub-100ms)</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><strong>No state between sessions</strong></td>
 <td>Memory elements + any persistent COMMS variant</td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>No orchestration</strong></td>
 <td>TEAM element coordinates across COMMS variants</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><strong>No discovery on local network</strong></td>
 <td>TEAM session discovery protocol (planned)</td>
 </tr>
@@ -1036,29 +1036,29 @@ Authorization: Bearer &lt;token&gt;</code></pre>
 <h3 id="where-a2a-provides-what-comms-variants-dont">Where A2A Provides What COMMS Variants Don't</h3>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Gap</th>
 <th>What A2A Provides</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><strong>Cross-vendor interoperability</strong></td>
 <td>A2A works across any framework; COMMS variants are DollhouseMCP elements</td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>Standardized Agent Cards</strong></td>
 <td>A2A's discovery model is an industry standard</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><strong>Multi-turn conversational protocol</strong></td>
 <td>A2A has formal message/task/artifact semantics</td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>Multimodal content</strong></td>
 <td>A2A's Part type supports text, files, data, UI components</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><strong>Industry governance</strong></td>
 <td>A2A is under the Linux Foundation with 150+ backers</td>
 </tr>
@@ -1121,84 +1121,84 @@ Authorization: Bearer &lt;token&gt;</code></pre>
 <h2 id="12-scenario-guide">12. Scenario Guide</h2>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Scenario</th>
 <th>Best fit</th>
 <th>Why</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>Connect my LLM to a few specific tools quickly</td>
 <td><strong>MCP</strong></td>
 <td>Simple, direct, massive ecosystem</td>
 </tr>
-<tr class="even">
+<tr>
 <td>50+ MCP tools and context window is choking</td>
 <td><strong>MCP-AQL</strong></td>
 <td>85-96% token reduction; progressive disclosure</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>LLM needs to correctly call an unfamiliar REST API</td>
 <td><strong>MCP-AQL</strong></td>
 <td>Introspection with constraint metadata eliminates hallucination</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Sales agent delegates to a research agent</td>
 <td><strong>A2A</strong></td>
 <td>Agent discovery and multi-turn task delegation</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Agents from LangChain and CrewAI need to collaborate</td>
 <td><strong>A2A</strong></td>
 <td>Cross-framework interoperability</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Permission control over destructive operations</td>
 <td><strong>MCP-AQL</strong></td>
 <td>CRUDE + Gatekeeper + danger levels + confirmation tokens</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>LLM needs to interact with OS or hardware APIs</td>
 <td><strong>MCP-AQL</strong></td>
 <td>Plugin system with native transport; Rust adapters planned</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Multi-day async tasks across agent boundaries</td>
 <td><strong>A2A</strong></td>
 <td>First-class long-running task lifecycle with push notifications</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Wrap any API for LLM access with zero code</td>
 <td><strong>MCP-AQL</strong></td>
 <td>Declarative adapter schemas; hot-reloadable</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Trace operations across a chain of systems</td>
 <td><strong>MCP-AQL</strong></td>
 <td>W3C Trace Context propagation</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Agents reasoning together about ambiguous problems</td>
 <td><strong>A2A</strong></td>
 <td>Unstructured multi-turn conversation between opaque peers</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Same-machine agent-to-agent messaging</td>
 <td><strong>Filesystem comms</strong></td>
 <td>IPC, sub-100ms, no network overhead</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Agent communication with offline persistence</td>
 <td><strong>Filesystem comms</strong></td>
 <td>File/database-backed; survives restarts and outages</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Cross-vendor agent delegation over network</td>
 <td><strong>A2A comms</strong></td>
 <td>A2A protocol with Agent Cards and task lifecycle</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Enterprise multi-computer agent orchestration</td>
 <td><strong>Mesh comms + TEAM</strong></td>
 <td>Encrypted WireGuard mesh, hierarchical coordination</td>
@@ -1209,7 +1209,7 @@ Authorization: Bearer &lt;token&gt;</code></pre>
 <h2 id="13-maturity-and-adoption">13. Maturity and Adoption</h2>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th></th>
 <th>MCP</th>
 <th>MCP-AQL</th>
@@ -1217,43 +1217,43 @@ Authorization: Bearer &lt;token&gt;</code></pre>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><strong>Announced</strong></td>
 <td>November 2024</td>
 <td>2025</td>
 <td>April 2025</td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>Current version</strong></td>
 <td>2025-11-25 (4th revision)</td>
 <td>v1.0.0-draft</td>
 <td>v0.3</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><strong>Governance</strong></td>
 <td>Agentic AI Foundation (Linux Foundation)</td>
 <td>Independent</td>
 <td>Linux Foundation (LF AI &amp; Data)</td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>Spec maturity</strong></td>
 <td>Production-stable, widely adopted</td>
 <td>Nearing v1.0-rc; launch imminent</td>
 <td>Draft; breaking changes expected</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><strong>Ecosystem</strong></td>
 <td>10,000+ servers, 300+ clients</td>
 <td>1 reference impl (DollhouseMCP V2 private beta)</td>
 <td>150+ backing organizations, Python SDK</td>
 </tr>
-<tr class="even">
+<tr>
 <td><strong>SDK availability</strong></td>
 <td>TypeScript, Python, Java, C#, Go, Rust</td>
 <td>Via MCP SDKs (runs on MCP transport)</td>
 <td>Python</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><strong>Notable adopters</strong></td>
 <td>OpenAI, Google, Microsoft, AWS, Cloudflare</td>
 <td>DollhouseMCP</td>

--- a/public/spec/research/mcp-vs-mcpaql-vs-a2a.html
+++ b/public/spec/research/mcp-vs-mcpaql-vs-a2a.html
@@ -7,7 +7,9 @@
   <title>MCP-AQL Spec | Protocol Landscape: MCP vs MCP-AQL vs A2A</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="../../css/style.css">
 </head>
 <body>
@@ -1342,6 +1344,6 @@ Authorization: Bearer &lt;token&gt;</code></pre>
     </div>
   </footer>
 
-  <script src="../../js/search.js"></script>
+  <script src="../../js/search.js" defer></script>
 </body>
 </html>

--- a/public/spec/security/confirmation-tokens.html
+++ b/public/spec/security/confirmation-tokens.html
@@ -163,19 +163,19 @@ Client Retry (with token)
 <p>Tokens are opaque strings with a prefix indicating their purpose:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Prefix</th>
 <th>Purpose</th>
 <th>Example</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>conf_</code></td>
 <td>Dangerous operation confirmation</td>
 <td><code>conf_a1b2c3d4e5f6g7h8</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>quota_continue_</code></td>
 <td>Quota pause continuation</td>
 <td><code>quota_continue_def456</code></td>
@@ -232,21 +232,21 @@ identifier = 1*64(ALPHA / DIGIT / &quot;_&quot; / &quot;-&quot;)</code></pre>
 <p>Token identifiers MUST be generated with sufficient entropy to prevent guessing:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Requirement</th>
 <th>Specification</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>Minimum entropy</td>
 <td>128 bits</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Recommended</td>
 <td>256 bits</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Source</td>
 <td>Cryptographically secure random number generator (CSPRNG)</td>
 </tr>
@@ -313,39 +313,39 @@ identifier = 1*64(ALPHA / DIGIT / &quot;_&quot; / &quot;-&quot;)</code></pre>
 <p>Token validation MUST perform all of the following checks:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Check</th>
 <th>Error Code</th>
 <th>Description</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>Token exists</td>
 <td><code>TOKEN_INVALID</code></td>
 <td>Token ID not found in store</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Not expired</td>
 <td><code>TOKEN_EXPIRED</code></td>
 <td>Current time &gt; expires_at</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Not consumed</td>
 <td><code>TOKEN_ALREADY_USED</code></td>
 <td>Token already redeemed</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Operation matches</td>
 <td><code>TOKEN_SCOPE_MISMATCH</code></td>
 <td>Token issued for different operation</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Parameters match</td>
 <td><code>TOKEN_SCOPE_MISMATCH</code></td>
 <td>Critical parameters changed</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Adapter matches</td>
 <td><code>TOKEN_SCOPE_MISMATCH</code></td>
 <td>Token issued by different adapter</td>
@@ -401,24 +401,24 @@ identifier = 1*64(ALPHA / DIGIT / &quot;_&quot; / &quot;-&quot;)</code></pre>
 <p>Token expiration MUST be enforced:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Context</th>
 <th>Default TTL</th>
 <th>Maximum TTL</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>Dangerous operation (destructive/dangerous - levels 2-3)</td>
 <td>5 minutes</td>
 <td>15 minutes</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Dangerous operation (forbidden - level 4)</td>
 <td>2 minutes</td>
 <td>5 minutes</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Quota continuation</td>
 <td>5 minutes</td>
 <td>10 minutes</td>
@@ -436,7 +436,7 @@ identifier = 1*64(ALPHA / DIGIT / &quot;_&quot; / &quot;-&quot;)</code></pre>
 <p>Implementations SHOULD allow operators to configure the clock skew tolerance value:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Setting</th>
 <th>Default</th>
 <th>Range</th>
@@ -444,7 +444,7 @@ identifier = 1*64(ALPHA / DIGIT / &quot;_&quot; / &quot;-&quot;)</code></pre>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>clock_skew_tolerance_seconds</code></td>
 <td>30</td>
 <td>0-300</td>
@@ -462,34 +462,34 @@ identifier = 1*64(ALPHA / DIGIT / &quot;_&quot; / &quot;-&quot;)</code></pre>
 <p><strong>Deployment environment recommendations:</strong></p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Environment</th>
 <th>Recommended Value</th>
 <th>Rationale</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>Typical (NTP-synced)</td>
 <td>30s (default)</td>
 <td>Accommodates normal clock drift</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Air-gapped systems</td>
 <td>60-120s</td>
 <td>May have significant clock sync drift</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>IoT / embedded</td>
 <td>60-120s</td>
 <td>Often lack reliable NTP access</td>
 </tr>
-<tr class="even">
+<tr>
 <td>High-security</td>
 <td>0-5s</td>
 <td>Minimize replay attack window</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Zero-trust</td>
 <td>0s</td>
 <td>Strict timing, requires synchronized clocks</td>
@@ -582,21 +582,21 @@ identifier = 1*64(ALPHA / DIGIT / &quot;_&quot; / &quot;-&quot;)</code></pre>
 <h3 id="55-storage-requirements">5.5 Storage Requirements</h3>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Requirement</th>
 <th>Specification</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>Persistence</td>
 <td>At minimum, in-memory with TTL eviction</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Cleanup</td>
 <td>Expired tokens SHOULD be purged within 1 hour</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Capacity</td>
 <td>SHOULD support at least 1000 active tokens per adapter</td>
 </tr>

--- a/public/spec/security/confirmation-tokens.html
+++ b/public/spec/security/confirmation-tokens.html
@@ -7,7 +7,9 @@
   <title>MCP-AQL Spec | Confirmation Token Specification</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="../../css/style.css">
 </head>
 <body>
@@ -725,6 +727,6 @@ identifier = 1*64(ALPHA / DIGIT / &quot;_&quot; / &quot;-&quot;)</code></pre>
     </div>
   </footer>
 
-  <script src="../../js/search.js"></script>
+  <script src="../../js/search.js" defer></script>
 </body>
 </html>

--- a/public/spec/security/execution-safety-loop.html
+++ b/public/spec/security/execution-safety-loop.html
@@ -7,7 +7,9 @@
   <title>MCP-AQL Spec | Execution Safety Loop Specification</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="../../css/style.css">
 </head>
 <body>
@@ -953,6 +955,6 @@ Only proceed if the AutonomyDirective returns continue: true.</code></pre>
     </div>
   </footer>
 
-  <script src="../../js/search.js"></script>
+  <script src="../../js/search.js" defer></script>
 </body>
 </html>

--- a/public/spec/security/execution-safety-loop.html
+++ b/public/spec/security/execution-safety-loop.html
@@ -192,34 +192,34 @@
 <p>The safety dongle and a full MCP-AQL adapter are both valid configurations of the same protocol. They differ only in scope:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Aspect</th>
 <th>Safety Dongle</th>
 <th>Full MCP-AQL Adapter</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>Purpose</td>
 <td>Safety enforcement only</td>
 <td>Domain operations + safety</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Operations</td>
 <td>~7 (safety loop + introspection)</td>
 <td>Dozens (full CRUDE surface)</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Elements</td>
 <td>None</td>
 <td>Personas, skills, agents, etc.</td>
 </tr>
-<tr class="even">
+<tr>
 <td>State</td>
 <td>Execution state + policies only</td>
 <td>Full domain state</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Endpoints used</td>
 <td>CREATE, EXECUTE, READ (subset)</td>
 <td>All five CRUDE endpoints</td>
@@ -319,44 +319,44 @@
 <p>Key fields:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Field</th>
 <th>Type</th>
 <th>Description</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>continue</code></td>
 <td>boolean</td>
 <td>Whether the LLM may proceed with the reported action</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>factors</code></td>
 <td>string[]</td>
 <td>Human-readable explanations of the evaluation decision</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>stopped</code></td>
 <td>boolean</td>
 <td>Whether the agent has been hard-blocked (Danger Zone)</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>reason</code></td>
 <td>string</td>
 <td>Why the agent was paused or stopped</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>stepsRemaining</code></td>
 <td>number</td>
 <td>Steps remaining before mandatory pause</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>nextStepRisk</code></td>
 <td>SafetyTier</td>
 <td>Safety tier assigned to the reported action</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>notifications</code></td>
 <td>AgentNotification[]</td>
 <td>Gatekeeper blocks, danger alerts, and other events</td>
@@ -375,44 +375,44 @@
 <p>A safety dongle implements a minimal set of operations:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Operation</th>
 <th>Endpoint</th>
 <th>Purpose</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>execute_agent</code></td>
 <td>EXECUTE</td>
 <td>Start the execution safety loop</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>record_execution_step</code></td>
 <td>CREATE</td>
 <td>Report intended action, receive <code>AutonomyDirective</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>complete_execution</code></td>
 <td>EXECUTE</td>
 <td>Signal normal completion of the safety loop</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>abort_execution</code></td>
 <td>EXECUTE</td>
 <td>Signal abnormal termination</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>confirm_operation</code></td>
 <td>EXECUTE</td>
 <td>Confirm Gatekeeper blocks or Autonomy Evaluator <code>confirm</code> tier pauses</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>verify_challenge</code></td>
 <td>CREATE</td>
 <td>Submit out-of-band verification code (<code>verify</code> tier and Danger Zone)</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>introspect</code></td>
 <td>READ</td>
 <td>Discover available operations and capabilities</td>
@@ -424,7 +424,7 @@
 <p>The endpoint placement of these operations is critical to the permission architecture:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Endpoint</th>
 <th>Default Permission</th>
 <th>Operations</th>
@@ -432,19 +432,19 @@
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>READ</td>
 <td><code>AUTO_APPROVE</code></td>
 <td><code>introspect</code></td>
 <td>Zero friction for discovery</td>
 </tr>
-<tr class="even">
+<tr>
 <td>CREATE</td>
 <td><code>CONFIRM_SESSION</code></td>
 <td><code>record_execution_step</code>, <code>verify_challenge</code></td>
 <td>Approve once, then frictionless for the session</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>EXECUTE</td>
 <td><code>CONFIRM_SINGLE_USE</code></td>
 <td><code>execute_agent</code>, <code>complete_execution</code>, <code>abort_execution</code>, <code>confirm_operation</code></td>
@@ -532,24 +532,24 @@ EXECUTE (CONFIRM_SINGLE_USE)
 <p>Notification types:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Type</th>
 <th>Trigger</th>
 <th>Action Required</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>permission_pending</code></td>
 <td>Gatekeeper blocked an operation</td>
 <td>Call <code>confirm_operation</code> to approve</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>autonomy_pause</code></td>
 <td>Autonomy Evaluator returned <code>continue: false</code></td>
 <td>For <code>confirm</code> tier: call <code>confirm_operation</code>; for <code>verify</code> tier: out-of-band <code>verify_challenge</code> (Section 6)</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>danger_zone</code></td>
 <td>Hard block triggered (<code>danger_zone</code> tier or <code>deny</code> pattern)</td>
 <td>Out-of-band <code>verify_challenge</code> required (Section 6)</td>
@@ -563,29 +563,29 @@ EXECUTE (CONFIRM_SINGLE_USE)
 <p>When the Autonomy Evaluator assigns a high risk score to a <code>nextActionHint</code>, the action escalates through safety tiers defined in the <a href="../adapter/danger-levels.html">Danger Levels specification</a>:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Risk Score</th>
 <th>Tier</th>
 <th>Behavior</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>0-30</td>
 <td><code>advisory</code></td>
 <td>Log and continue</td>
 </tr>
-<tr class="even">
+<tr>
 <td>31-60</td>
 <td><code>confirm</code></td>
 <td>Pause for human review (<code>continue: false</code>)</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>61-85</td>
 <td><code>verify</code></td>
 <td>Pause + out-of-band verification via <code>verify_challenge</code> (Section 8.8)</td>
 </tr>
-<tr class="even">
+<tr>
 <td>86-100</td>
 <td><code>danger_zone</code></td>
 <td>Hard stop + out-of-band verification via <code>verify_challenge</code> (Section 8.8)</td>
@@ -813,104 +813,104 @@ Only proceed if the AutonomyDirective returns continue: true.</code></pre>
 <p>The following table maps each normative section to its corresponding Section 9 requirements, providing an audit trail for compliance verification.</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Normative Section</th>
 <th>Key Requirements</th>
 <th>Section 9 Coverage</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>8.6.1 Opt-In Activation</td>
 <td>MUST document support; SHOULD expose capability value</td>
 <td>9.1 (introspection); 9.2 (capability value)</td>
 </tr>
-<tr class="even">
+<tr>
 <td>8.6.2 Enforcement Boundary</td>
 <td>MUST report and evaluate all actions</td>
 <td>9.1 (operations, AutonomyDirective on every call)</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>8.6.3 Action Reporting</td>
 <td>MUST/SHOULD/MAY parameter requirements</td>
 <td>9.1 (operations — parameter validation is part of implementing <code>record_execution_step</code>)</td>
 </tr>
-<tr class="even">
+<tr>
 <td>8.6.4 Continuous Enforcement</td>
 <td>MUST NOT proceed after stop; SHOULD NOT after pause; MUST NOT <code>stopped</code> in monitoring</td>
 <td>9.1 (stop directive, monitoring mode); 9.2 (SHOULD NOT after pause)</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>8.6.5 Non-Bypass Property</td>
 <td>Agent MUST NOT act outside loop</td>
 <td>Agent-side protocol obligation (not adapter-specific)</td>
 </tr>
-<tr class="even">
+<tr>
 <td>8.6.6 Scope of Monitoring</td>
 <td>Monitors all actions (informative)</td>
 <td>Described in Sections 3.2, 2.2 of this document</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>8.6.7 Disabling</td>
 <td>MAY disable; MUST indicate via introspection</td>
 <td>9.1 (introspection); 9.2 (monitoring); 9.3 (logging)</td>
 </tr>
-<tr class="even">
+<tr>
 <td>8.7.1 AutonomyDirective</td>
 <td>MUST include <code>continue</code> + <code>factors</code></td>
 <td>9.1 (AutonomyDirective fields)</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>8.7.2 Pipeline Stages 1–5</td>
 <td>MUST step limit; SHOULD stages 2–3; MAY stages 4–5</td>
 <td>9.1 (step limit MUST); 9.2 (stage 1 documentation SHOULDs, stages 2–3 SHOULDs); 9.3 (stages 4–5)</td>
 </tr>
-<tr class="even">
+<tr>
 <td>8.7.3 Notifications</td>
 <td>MUST notification contents; MUST prevent self-approval</td>
 <td>9.1 (notifications, self-approval); 9.2 (non-hard-block notifications)</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>8.7.4 Configurable Elements</td>
 <td>SHOULD configurable; SHOULD document</td>
 <td>9.2 (configuration, introspection)</td>
 </tr>
-<tr class="even">
+<tr>
 <td>8.7.5 Minimum Viable</td>
 <td>MUST Step Limit; SHOULD Previous Outcome + Pattern Matching; MAY Safety Tier + Risk Tolerance</td>
 <td>9.1 (step limit); 9.2 (outcome, patterns); 9.3 (tier, tolerance)</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>8.8 Introduction</td>
 <td>MUST require OOB for <code>verify</code>/<code>danger_zone</code></td>
 <td>9.1 (OOB verification)</td>
 </tr>
-<tr class="even">
+<tr>
 <td>8.8.1 Trigger Conditions</td>
 <td>MUST <code>stopped: true</code> + <code>danger_zone</code> notification</td>
 <td>9.1 (<code>stopped: true</code>, notification broadcast)</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>8.8.2 Challenge Protocol</td>
 <td>MUST entropy, display, notification, expiration</td>
 <td>9.1 (code generation, display, challenge ID, expiration); 9.2 (timeout)</td>
 </tr>
-<tr class="even">
+<tr>
 <td>8.8.3 Blocking Semantics</td>
 <td>MUST reject, persist, no bypass; SHOULD verify behavior</td>
 <td>9.1 (blocking); 9.2 (verify tier)</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>8.8.4 Channel Separation</td>
 <td>MUST NOT expose code (5 specific prohibitions)</td>
 <td>9.1 (display/channel separation — consolidated)</td>
 </tr>
-<tr class="even">
+<tr>
 <td>8.8.5 Rate Limiting</td>
 <td>SHOULD rate-limit, persist, audit; MAY progressive lockout</td>
 <td>9.2 (rate limiting); 9.3 (lockout)</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>8.8.6 Implementation Flexibility</td>
 <td>MAY any display channel</td>
 <td>9.3 (display channels)</td>

--- a/public/spec/security/gatekeeper.html
+++ b/public/spec/security/gatekeeper.html
@@ -7,7 +7,9 @@
   <title>MCP-AQL Spec | Security Model: Gatekeeper Specification</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="../../css/style.css">
 </head>
 <body>
@@ -402,6 +404,6 @@
     </div>
   </footer>
 
-  <script src="../../js/search.js"></script>
+  <script src="../../js/search.js" defer></script>
 </body>
 </html>

--- a/public/spec/security/gatekeeper.html
+++ b/public/spec/security/gatekeeper.html
@@ -181,7 +181,7 @@
 <p><strong>Endpoint Safety Matrix:</strong></p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Endpoint</th>
 <th>readOnly</th>
 <th>destructive</th>
@@ -189,31 +189,31 @@
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>CREATE</td>
 <td>false</td>
 <td>false</td>
 <td>Additive only</td>
 </tr>
-<tr class="even">
+<tr>
 <td>READ</td>
 <td>true</td>
 <td>false</td>
 <td>No state changes</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>UPDATE</td>
 <td>false</td>
 <td>true</td>
 <td>May overwrite data</td>
 </tr>
-<tr class="even">
+<tr>
 <td>DELETE</td>
 <td>false</td>
 <td>true</td>
 <td>Removes data permanently</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>EXECUTE</td>
 <td>false</td>
 <td>true</td>
@@ -238,21 +238,21 @@
 <h3 id="31-permission-types">3.1 Permission Types</h3>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Permission</th>
 <th>Behavior</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>allow</code></td>
 <td>Operation proceeds without additional checks</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>deny</code></td>
 <td>Operation rejected with error</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>confirm</code></td>
 <td>Operation requires explicit confirmation</td>
 </tr>
@@ -298,21 +298,21 @@
 <p>Adapters implementing security SHOULD log:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Event</th>
 <th>Logged Data</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>OPERATION_DENIED</code></td>
 <td>Operation, reason</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>CONFIRMATION_REQUIRED</code></td>
 <td>Operation, token</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>CONFIRMATION_GRANTED</code></td>
 <td>Operation, token</td>
 </tr>

--- a/public/spec/versions/v1.0.0-draft.html
+++ b/public/spec/versions/v1.0.0-draft.html
@@ -7,7 +7,9 @@
   <title>MCP-AQL Spec | MCP-AQL Specification</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="../../css/style.css">
 </head>
 <body>
@@ -1849,6 +1851,6 @@ mcp_aql_operate   - Runtime and lifecycle operations</code></pre>
     </div>
   </footer>
 
-  <script src="../../js/search.js"></script>
+  <script src="../../js/search.js" defer></script>
 </body>
 </html>

--- a/public/spec/versions/v1.0.0-draft.html
+++ b/public/spec/versions/v1.0.0-draft.html
@@ -174,25 +174,25 @@
 <h4 id="232-session-boundaries">2.3.2 Session Boundaries</h4>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Event</th>
 <th>Session Impact</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>MCP <code>initialize</code> completes</td>
 <td>Session begins</td>
 </tr>
-<tr class="even">
+<tr>
 <td>MCP <code>shutdown</code> received</td>
 <td>Session ends gracefully</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Transport disconnect</td>
 <td>Session ends abruptly</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Transport reconnect</td>
 <td>New session begins</td>
 </tr>
@@ -497,34 +497,34 @@ mcp_aql_operate   - Runtime and lifecycle operations</code></pre>
 <p>Adapters MUST enforce payload size limits to prevent resource exhaustion:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Limit</th>
 <th>Default</th>
 <th>Configurable Range</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>Request payload</td>
 <td>1 MB</td>
 <td>64 KB – 10 MB</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Response payload</td>
 <td>10 MB</td>
 <td>1 MB – 100 MB</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Single string value</td>
 <td>1 MB</td>
 <td>64 KB – 10 MB</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Array elements</td>
 <td>10,000</td>
 <td>100 – 100,000</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Object nesting depth</td>
 <td>32 levels</td>
 <td>8 – 64 levels</td>
@@ -604,7 +604,7 @@ mcp_aql_operate   - Runtime and lifecycle operations</code></pre>
 <h3 id="61-standard-semantic-categories">6.1 Standard Semantic Categories</h3>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Category</th>
 <th>Read-Only</th>
 <th>Destructive</th>
@@ -612,31 +612,31 @@ mcp_aql_operate   - Runtime and lifecycle operations</code></pre>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>CREATE</td>
 <td>false</td>
 <td>false</td>
 <td>Additive operations</td>
 </tr>
-<tr class="even">
+<tr>
 <td>READ</td>
 <td>true</td>
 <td>false</td>
 <td>Query operations</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>UPDATE</td>
 <td>false</td>
 <td>true</td>
 <td>Modification operations</td>
 </tr>
-<tr class="even">
+<tr>
 <td>DELETE</td>
 <td>false</td>
 <td>true</td>
 <td>Removal operations</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>EXECUTE</td>
 <td>false</td>
 <td>true</td>
@@ -708,64 +708,64 @@ mcp_aql_operate   - Runtime and lifecycle operations</code></pre>
 <h3 id="82-classification-examples">8.2 Classification Examples</h3>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Operation</th>
 <th>Semantic Category</th>
 <th>Rationale</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>create_user</code></td>
 <td>CREATE</td>
 <td>Adds new user</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>upload_file</code></td>
 <td>CREATE</td>
 <td>Adds new file</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>list_users</code></td>
 <td>READ</td>
 <td>Queries without modification</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>search</code></td>
 <td>READ</td>
 <td>Queries without modification</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>get_status</code></td>
 <td>READ</td>
 <td>Retrieves state</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>update_profile</code></td>
 <td>UPDATE</td>
 <td>Modifies existing resource</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>rename_file</code></td>
 <td>UPDATE</td>
 <td>Modifies existing resource</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>delete_user</code></td>
 <td>DELETE</td>
 <td>Removes permanently</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>purge_cache</code></td>
 <td>DELETE</td>
 <td>Removes data</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>execute_job</code></td>
 <td>EXECUTE</td>
 <td>Starts runtime process</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>cancel_task</code></td>
 <td>EXECUTE</td>
 <td>Lifecycle management</td>
@@ -785,29 +785,29 @@ mcp_aql_operate   - Runtime and lifecycle operations</code></pre>
 <h4 id="841-core-states">8.4.1 Core States</h4>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>State</th>
 <th>Description</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>pending</code></td>
 <td>Execution created but not yet started</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>running</code></td>
 <td>Execution actively processing</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>completed</code></td>
 <td>Execution finished successfully</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>failed</code></td>
 <td>Execution terminated with error</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>cancelled</code></td>
 <td>Execution terminated by user request</td>
 </tr>
@@ -862,24 +862,24 @@ mcp_aql_operate   - Runtime and lifecycle operations</code></pre>
 <p>When <code>progress</code> is present, at least one of the following SHOULD be included:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Field</th>
 <th>Type</th>
 <th>Description</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>percentage</code></td>
 <td>number</td>
 <td>Completion percentage (0-100) — use for determinate progress</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>current</code> + <code>total</code></td>
 <td>number</td>
 <td>Current and total values — use when count information is available</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>message</code></td>
 <td>string</td>
 <td>Human-readable status — use for indeterminate progress or additional context</td>
@@ -946,34 +946,34 @@ mcp_aql_operate   - Runtime and lifecycle operations</code></pre>
 <p>Each endpoint has one or more canonical verbs that SHOULD be used for standard operations:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Endpoint</th>
 <th>Canonical Verb</th>
 <th>Usage</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>CREATE</td>
 <td><code>create</code></td>
 <td>Creating new resources</td>
 </tr>
-<tr class="even">
+<tr>
 <td>READ</td>
 <td><code>get</code> (single), <code>list</code> (multiple)</td>
 <td>Retrieving resources</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>UPDATE</td>
 <td><code>update</code></td>
 <td>Modifying existing resources</td>
 </tr>
-<tr class="even">
+<tr>
 <td>DELETE</td>
 <td><code>delete</code></td>
 <td>Removing resources</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>EXECUTE</td>
 <td><code>execute</code> (initiate), <code>cancel</code> (terminate)</td>
 <td>Lifecycle operations</td>
@@ -985,34 +985,34 @@ mcp_aql_operate   - Runtime and lifecycle operations</code></pre>
 <p>For developers familiar with REST conventions, the following mapping provides context:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Canonical Verb</th>
 <th>Typical HTTP Method</th>
 <th>Semantics</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>create</code></td>
 <td>POST</td>
 <td>Add new resource</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>get</code> / <code>list</code></td>
 <td>GET</td>
 <td>Retrieve resource(s)</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>update</code></td>
 <td>PUT / PATCH</td>
 <td>Modify resource</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>delete</code></td>
 <td>DELETE</td>
 <td>Remove resource</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>execute</code> / <code>cancel</code></td>
 <td>POST</td>
 <td>Lifecycle control</td>
@@ -1047,44 +1047,44 @@ mcp_aql_operate   - Runtime and lifecycle operations</code></pre>
 <p>The following operation names are reserved for protocol use and MUST NOT be used by adapters for other purposes:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Operation</th>
 <th>Endpoint</th>
 <th>Purpose</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>introspect</code></td>
 <td>READ</td>
 <td>Protocol introspection (Section 7)</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>execute_agent</code></td>
 <td>EXECUTE</td>
 <td>Start execution safety loop (Section 8.6)</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>record_execution_step</code></td>
 <td>CREATE</td>
 <td>Report intended action for safety evaluation (Section 8.6)</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>complete_execution</code></td>
 <td>EXECUTE</td>
 <td>Signal normal execution completion (Section 8.6)</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>abort_execution</code></td>
 <td>EXECUTE</td>
 <td>Signal abnormal execution termination (Section 8.6)</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>confirm_operation</code></td>
 <td>EXECUTE</td>
 <td>Confirm a Gatekeeper-blocked operation or Autonomy Evaluator <code>confirm</code> tier pause (Section 8.7.3)</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>verify_challenge</code></td>
 <td>CREATE</td>
 <td>Submit out-of-band verification code (Section 8.8)</td>
@@ -1114,25 +1114,25 @@ mcp_aql_operate   - Runtime and lifecycle operations</code></pre>
 <p>Valid values for <code>execution_safety_loop</code>:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Value</th>
 <th>Meaning</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>"enforcing"</code></td>
 <td>Full enforcement — actions are evaluated and directives are authoritative</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>"monitoring"</code></td>
 <td>Actions are evaluated but <code>continue</code> is always <code>true</code> (advisory only)</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>"logging"</code></td>
 <td>Actions are recorded for audit purposes without evaluation</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>"disabled"</code></td>
 <td>Safety loop is supported but currently disabled</td>
 </tr>
@@ -1166,7 +1166,7 @@ mcp_aql_operate   - Runtime and lifecycle operations</code></pre>
 <p>The <code>record_execution_step</code> operation accepts the following parameters:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Parameter</th>
 <th>Type</th>
 <th>Required</th>
@@ -1174,31 +1174,31 @@ mcp_aql_operate   - Runtime and lifecycle operations</code></pre>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>element_name</code></td>
 <td>string</td>
 <td>MUST</td>
 <td>The agent reporting the step</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>stepDescription</code></td>
 <td>string</td>
 <td>SHOULD</td>
 <td>Description of the action just completed</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>outcome</code></td>
 <td>string</td>
 <td>SHOULD</td>
 <td>Result of the previous step: <code>"success"</code>, <code>"failure"</code>, or <code>"skipped"</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>nextActionHint</code></td>
 <td>string</td>
 <td>MUST</td>
 <td>Description of the intended next action</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>findings</code></td>
 <td>string</td>
 <td>MAY</td>
@@ -1304,29 +1304,29 @@ mcp_aql_operate   - Runtime and lifecycle operations</code></pre>
 <p>Assigns a risk score (0-100) to the action and maps it to a safety tier:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Risk Score</th>
 <th>Tier</th>
 <th>Default Behavior</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>0-30</td>
 <td><code>advisory</code></td>
 <td>Continue (log only)</td>
 </tr>
-<tr class="even">
+<tr>
 <td>31-60</td>
 <td><code>confirm</code></td>
 <td>Pause for human review via <code>confirm_operation</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td>61-85</td>
 <td><code>verify</code></td>
 <td>Pause + out-of-band verification via <code>verify_challenge</code> (Section 8.8)</td>
 </tr>
-<tr class="even">
+<tr>
 <td>86-100</td>
 <td><code>danger_zone</code></td>
 <td>Hard stop + out-of-band verification via <code>verify_challenge</code> (Section 8.8)</td>
@@ -1339,24 +1339,24 @@ mcp_aql_operate   - Runtime and lifecycle operations</code></pre>
 <p>Compares the risk score against the agent's configured tolerance:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Tolerance</th>
 <th>Threshold</th>
 <th>Behavior</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>conservative</code></td>
 <td>25</td>
 <td>Pause for any risk above 25</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>moderate</code></td>
 <td>50</td>
 <td>Pause for risk above 50 (default)</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>aggressive</code></td>
 <td>75</td>
 <td>Pause only for high risk above 75</td>
@@ -1396,34 +1396,34 @@ mcp_aql_operate   - Runtime and lifecycle operations</code></pre>
 <p>The following elements of the evaluation pipeline SHOULD be configurable per agent or per adapter:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Element</th>
 <th>Type</th>
 <th>Description</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>maxAutonomousSteps</code></td>
 <td>number</td>
 <td>Maximum steps before mandatory pause</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>riskTolerance</code></td>
 <td>string</td>
 <td><code>"conservative"</code>, <code>"moderate"</code>, or <code>"aggressive"</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>deny</code></td>
 <td>string[]</td>
 <td>Glob patterns that trigger hard block and out-of-band verification (Section 8.8)</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>requiresApproval</code></td>
 <td>string[]</td>
 <td>Glob patterns that always require human review</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>autoApprove</code></td>
 <td>string[]</td>
 <td>Glob patterns that bypass evaluation</td>
@@ -1435,34 +1435,34 @@ mcp_aql_operate   - Runtime and lifecycle operations</code></pre>
 <p>Not all stages of the evaluation pipeline are equally important. The following defines the minimum requirements:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Stage</th>
 <th>Requirement</th>
 <th>Rationale</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>Step Limit</td>
 <td>MUST</td>
 <td>Prevents runaway autonomous execution</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Previous Outcome</td>
 <td>SHOULD</td>
 <td>Prevents cascading failures</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Pattern Matching</td>
 <td>SHOULD</td>
 <td>Primary safety control mechanism</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Safety Tier</td>
 <td>MAY</td>
 <td>Requires risk scoring capability</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Risk Tolerance</td>
 <td>MAY</td>
 <td>Depends on Safety Tier implementation</td>
@@ -1547,34 +1547,34 @@ mcp_aql_operate   - Runtime and lifecycle operations</code></pre>
 <p>This specification defines the <strong>verification protocol</strong>, not the display mechanism. Implementations MAY use any display channel that satisfies the channel separation requirements (Section 8.8.4):</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Channel</th>
 <th>Platform</th>
 <th>Notes</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>OS dialog</td>
 <td>Desktop</td>
 <td>AppleScript, zenity, PowerShell</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Hardware token</td>
 <td>Any</td>
 <td>Physical device with display</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>SMS/Email</td>
 <td>Any</td>
 <td>Requires operator contact info</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Security dashboard</td>
 <td>Web</td>
 <td>Dedicated approval interface</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Mobile push notification</td>
 <td>Any</td>
 <td>Requires companion app</td>
@@ -1599,25 +1599,25 @@ mcp_aql_operate   - Runtime and lifecycle operations</code></pre>
 <p>Adapters MUST document their concurrency behavior. The following concurrency categories are defined:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Category</th>
 <th>Description</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>serialized</code></td>
 <td>All requests processed sequentially in arrival order</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>read-concurrent</code></td>
 <td>READ operations may execute concurrently; writes serialized</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>fully-concurrent</code></td>
 <td>All operations may execute concurrently</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>resource-locked</code></td>
 <td>Concurrent on different resources; serialized per resource</td>
 </tr>
@@ -1696,7 +1696,7 @@ mcp_aql_operate   - Runtime and lifecycle operations</code></pre>
 <h3 id="a1-measured-token-costs">A.1 Measured Token Costs</h3>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Configuration</th>
 <th>Tools</th>
 <th>Tokens</th>
@@ -1704,19 +1704,19 @@ mcp_aql_operate   - Runtime and lifecycle operations</code></pre>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>Discrete Tools</td>
 <td>50+</td>
 <td>~29,600</td>
 <td>Baseline</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Semantic Endpoint Mode (CRUDE profile)</td>
 <td>5</td>
 <td>~4,300</td>
 <td>~85%</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Single Mode</td>
 <td>1</td>
 <td>~1,100</td>
@@ -1769,24 +1769,24 @@ mcp_aql_operate   - Runtime and lifecycle operations</code></pre>
 <h2 id="appendix-c-change-log">Appendix C: Change Log</h2>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Version</th>
 <th>Date</th>
 <th>Changes</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>1.0.0-draft</td>
 <td>2026-01-05</td>
 <td>Initial draft specification</td>
 </tr>
-<tr class="even">
+<tr>
 <td>1.0.0-draft</td>
 <td>2026-01-14</td>
 <td>Revised to be adapter-agnostic</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>1.0.0-draft</td>
 <td>2026-01-16</td>
 <td>Added schema references, updated documentation links, renamed EndpointCategory</td>
@@ -1798,25 +1798,25 @@ mcp_aql_operate   - Runtime and lifecycle operations</code></pre>
 <p>Formal JSON Schema definitions are provided for validation:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Schema</th>
 <th>Description</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><a href="https://github.com/MCPAQL/spec/blob/main/schemas/operation-input.schema.json">operation-input.schema.json</a></td>
 <td>Request format validation</td>
 </tr>
-<tr class="even">
+<tr>
 <td><a href="https://github.com/MCPAQL/spec/blob/main/schemas/operation-result.schema.json">operation-result.schema.json</a></td>
 <td>Response format validation</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><a href="https://github.com/MCPAQL/spec/blob/main/schemas/introspection-response.schema.json">introspection-response.schema.json</a></td>
 <td>Introspection response validation</td>
 </tr>
-<tr class="even">
+<tr>
 <td><a href="https://github.com/MCPAQL/spec/blob/main/schemas/danger-level.schema.json">danger-level.schema.json</a></td>
 <td>Operation danger classification</td>
 </tr>

--- a/scripts/generate-repo-docs.mjs
+++ b/scripts/generate-repo-docs.mjs
@@ -17,6 +17,8 @@ const siteRoot = path.resolve(__dirname, "..");
 const publicRoot = path.join(siteRoot, "public");
 const searchBasePath = path.join(siteRoot, "source", "search-index.base.json");
 const generatedSearchIndexPath = path.join(publicRoot, "data", "search-index.json");
+const fontStylesheetUrl =
+  "https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap";
 
 const args = process.argv.slice(2);
 const isCheck = args.includes("--check");
@@ -720,9 +722,7 @@ function wrapMirrorDocPage({ config, doc, navGroups, navSequence, bodyHtml, tocE
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="${escapeHtml(doc.summary)}">
   <title>${escapeHtml(config.siteSectionTitle)} | ${escapeHtml(doc.title)}</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  ${renderFontStylesheetTags()}
   <link rel="stylesheet" href="${relativeAssetPath(doc.outputRel, "css/style.css")}">
 </head>
 <body>
@@ -802,7 +802,7 @@ ${tocHtml ? `\n${indentBlock(tocHtml, 8)}\n` : ""}
     </div>
   </footer>
 
-  <script src="${relativeAssetPath(doc.outputRel, "js/search.js")}"></script>
+  <script src="${relativeAssetPath(doc.outputRel, "js/search.js")}" defer></script>
 </body>
 </html>
 `;
@@ -841,9 +841,7 @@ function wrapMirrorIndexPage(config, navGroups) {
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="${escapeHtml(config.indexDescription)}">
   <title>${escapeHtml(config.siteSectionTitle)} | ${escapeHtml(config.docCollectionLabel)}</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  ${renderFontStylesheetTags()}
   <link rel="stylesheet" href="${relativeAssetPath(config.indexOutputRel, "css/style.css")}">
 </head>
 <body>
@@ -922,10 +920,18 @@ function wrapMirrorIndexPage(config, navGroups) {
     </div>
   </footer>
 
-  <script src="${relativeAssetPath(config.indexOutputRel, "js/search.js")}"></script>
+  <script src="${relativeAssetPath(config.indexOutputRel, "js/search.js")}" defer></script>
 </body>
 </html>
 `;
+}
+
+function renderFontStylesheetTags() {
+  return `<link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="preload" as="style" href="${fontStylesheetUrl}">
+  <link href="${fontStylesheetUrl}" rel="stylesheet" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link href="${fontStylesheetUrl}" rel="stylesheet"></noscript>`;
 }
 
 function renderHeroActions(actions) {


### PR DESCRIPTION
## Summary
- regenerate the website-hosted spec mirror from the latest `MCPAQL/spec` `main`
- refresh website search entries for the generated spec pages

## Notes
- this PR was generated automatically by `.github/workflows/spec-sync.yml`
- adapter mirror content is intentionally left untouched by this workflow